### PR TITLE
Add tests for collectRawTxns and refactor it to be single threaded

### DIFF
--- a/cdc/capture_test.go
+++ b/cdc/capture_test.go
@@ -1,0 +1,87 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cdc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/pingcap/check"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { check.TestingT(t) }
+
+type CollectRawTxnsSuite struct{}
+
+var _ = check.Suite(&CollectRawTxnsSuite{})
+
+func (cs *CollectRawTxnsSuite) TestShouldOutputTxnsInOrder(c *check.C) {
+	var entries []BufferEntry
+	var startTs uint64 = 1024
+	var i uint64
+	for i = 0; i < 3; i++ {
+		for j := 0; j < 3; j++ {
+			e := BufferEntry{
+				KV: &RawKVEntry{
+					OpType: OpTypePut,
+					Key:    []byte(fmt.Sprintf("key-%d-%d", i, j)),
+					Ts:     startTs + i,
+				},
+			}
+			entries = append(entries, e)
+		}
+	}
+	// Only add resolved entry for the first 2 transaction
+	for i = 0; i < 2; i++ {
+		e := BufferEntry{
+			Resolved: &ResolvedSpan{Timestamp: startTs + i},
+		}
+		entries = append(entries, e)
+	}
+
+	cursor := 0
+	input := func(ctx context.Context) (BufferEntry, error) {
+		if cursor >= len(entries) {
+			return BufferEntry{}, errors.New("End")
+		}
+		e := entries[cursor]
+		cursor++
+		return e, nil
+	}
+
+	var rawTxns []RawTxn
+	output := func(ctx context.Context, txn RawTxn) error {
+		rawTxns = append(rawTxns, txn)
+		return nil
+	}
+
+	ctx := context.Background()
+	err := collectRawTxns(ctx, input, output)
+	c.Assert(err, check.ErrorMatches, "End")
+
+	c.Assert(rawTxns, check.HasLen, 2)
+	c.Assert(rawTxns[0].ts, check.Equals, startTs)
+	for i, e := range rawTxns[0].entries {
+		c.Assert(e.Ts, check.Equals, startTs)
+		c.Assert(string(e.Key), check.Equals, fmt.Sprintf("key-0-%d", i))
+	}
+	c.Assert(rawTxns[1].ts, check.Equals, startTs+1)
+	for i, e := range rawTxns[1].entries {
+		c.Assert(e.Ts, check.Equals, startTs+1)
+		c.Assert(string(e.Key), check.Equals, fmt.Sprintf("key-1-%d", i))
+	}
+}


### PR DESCRIPTION
When adding tests, I found out that there are some corner cases that are
hard to reach in the original implementation. For example, we need to
make sure that the goroutine exits correctly even when blocked
reading/writing.

Since the size of entries for a transaction can be really large, we are
unlikely to use a large buffered channel here anyway, so I just make it
single-threaded to simplify implementation and testing.