### PR TITLE
Add a unit test which can test the combination between `txnMounter` and `mysqlSink` 

### DIFF
--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -16,17 +16,14 @@ package cdc
 import (
 	"context"
 	"fmt"
-	"sort"
 	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
-	"github.com/pingcap/parser/model"
 	pd "github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb-cdc/cdc/util"
 	"github.com/pingcap/tidb-cdc/pkg/flags"
 	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/store"
 	"github.com/pingcap/tidb/store/tikv"
 	"go.uber.org/zap"
@@ -73,7 +70,7 @@ func NewCapture(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	jobs, err := loadHistoryDDLJobs(kvStore)
+	jobs, err := util.LoadHistoryDDLJobs(kvStore)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -188,35 +185,4 @@ func createTiStore(urls string) (kv.Storage, error) {
 	}
 
 	return tiStore, nil
-}
-
-// loadHistoryDDLJobs loads all history DDL jobs from TiDB
-func loadHistoryDDLJobs(tiStore kv.Storage) ([]*model.Job, error) {
-	snapMeta, err := getSnapshotMeta(tiStore)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	jobs, err := snapMeta.GetAllHistoryDDLJobs()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	// jobs from GetAllHistoryDDLJobs are sorted by job id, need sorted by schema version
-	sort.Slice(jobs, func(i, j int) bool {
-		return jobs[i].BinlogInfo.FinishedTS < jobs[j].BinlogInfo.FinishedTS
-	})
-
-	return jobs, nil
-}
-
-func getSnapshotMeta(tiStore kv.Storage) (*meta.Meta, error) {
-	version, err := tiStore.CurrentVersion()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	snapshot, err := tiStore.GetSnapshot(version)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return meta.NewSnapshotMeta(snapshot), nil
 }

--- a/cdc/cdc_test.go
+++ b/cdc/cdc_test.go
@@ -1,0 +1,101 @@
+package cdc
+
+import (
+	"context"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb-cdc/cdc/kv"
+	"github.com/pingcap/tidb-cdc/cdc/mock"
+	"github.com/pingcap/tidb-cdc/cdc/util"
+	"go.uber.org/zap"
+)
+
+type CDCSuite struct {
+	database string
+	puller   *mock.MockTiDB
+	mock     sqlmock.Sqlmock
+	mounter  *TxnMounter
+	sink     Sink
+}
+
+var _ = Suite(NewCDCSuite())
+
+func NewCDCSuite() *CDCSuite {
+	// create a mock puller
+	puller, err := mock.NewMockPuller()
+	if err != nil {
+		panic(err.Error())
+	}
+	cdcSuite := &CDCSuite{
+		database: "test",
+		puller:   puller,
+	}
+	jobs, err := puller.GetAllHistoryDDLJobs()
+	if err != nil {
+		panic(err.Error())
+	}
+	// create a schema
+	schema, err := NewSchema(jobs, false)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		panic(err.Error())
+	}
+	cdcSuite.mock = mock
+
+	sink := &mysqlSink{
+		db:           db,
+		infoGetter:   schema,
+		tblInspector: newCachedInspector(db),
+	}
+	cdcSuite.sink = sink
+
+	mounter, err := NewTxnMounter(schema, time.UTC)
+	if err != nil {
+		panic(err.Error())
+	}
+	cdcSuite.mounter = mounter
+	return cdcSuite
+}
+
+func (s *CDCSuite) Forward(span util.Span, ts uint64) bool {
+	return true
+}
+
+func (s *CDCSuite) RunAndCheckSync(c *C, execute func(func(string, ...interface{})), expect func(sqlmock.Sqlmock)) {
+	expect(s.mock)
+	var rawKVs []*kv.RawKVEntry
+	executeSql := func(sql string, args ...interface{}) {
+		log.Info("b rawKVs", zap.Reflect("rawKVs", rawKVs), zap.String("sql", sql))
+		kvs := s.puller.MustExec(c, sql, args...)
+		log.Info("kvs", zap.Reflect("kvs", kvs), zap.Int("len", len(kvs)))
+		rawKVs = append(rawKVs, kvs...)
+		log.Info("c rawKVs", zap.Reflect("rawKVs", rawKVs))
+	}
+	execute(executeSql)
+	log.Info("all kvs", zap.Int("len", len(rawKVs)))
+	txn, err := s.mounter.Mount(RawTxn{ts: rawKVs[len(rawKVs)-1].Ts, entries: rawKVs})
+	c.Assert(err, IsNil)
+	log.Info("txn", zap.Reflect("txn", txn))
+	err = s.sink.Emit(context.Background(), *txn)
+	c.Assert(err, IsNil)
+	err = s.mock.ExpectationsWereMet()
+	c.Assert(err, IsNil)
+}
+
+func (s *CDCSuite) TestSimple(c *C) {
+	s.RunAndCheckSync(c, func(execute func(string, ...interface{})) {
+		execute("create table test.simple_test (id bigint primary key)")
+	}, func(mock sqlmock.Sqlmock) {
+		mock.ExpectBegin()
+		mock.ExpectExec("USE `test`;").WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec("create table test.simple_test (id bigint primary key)").WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectCommit()
+	})
+}

--- a/cdc/mock/mock_tidb_test.go
+++ b/cdc/mock/mock_tidb_test.go
@@ -1,9 +1,10 @@
 package mock
 
 import (
+	"testing"
+
 	"github.com/pingcap/check"
 	"github.com/pingcap/tidb-cdc/cdc/kv"
-	"testing"
 )
 
 func Test(t *testing.T) { check.TestingT(t) }
@@ -14,19 +15,19 @@ type mockTiDBsuite struct {
 var _ = check.Suite(&mockTiDBsuite{})
 
 func (s *mockTiDBsuite) TestCanGetKVEntrys(c *check.C) {
-	puller, err := NewMockPuller(c)
+	puller, err := NewMockPuller()
 	c.Assert(err, check.IsNil)
 
 	var entrys []*kv.RawKVEntry
-	entrys = puller.MustExec("create table test.test(id varchar(255) primary key, a int)")
+	entrys = puller.MustExec(c, "create table test.test(id varchar(255) primary key, a int)")
 	c.Assert(len(entrys), check.Greater, 0)
 	c.Log(len(entrys))
 
-	entrys = puller.MustExec("insert into test.test(id, a) values(?, ?)", 1, 1)
+	entrys = puller.MustExec(c, "insert into test.test(id, a) values(?, ?)", 1, 1)
 	c.Assert(len(entrys), check.Greater, 0)
 	c.Logf("%+v", entrys)
 
-	entrys = puller.MustExec("delete from test.test")
+	entrys = puller.MustExec(c, "delete from test.test")
 	c.Assert(len(entrys), check.Greater, 0)
 	c.Logf("%+v", entrys)
 }

--- a/cdc/util/util.go
+++ b/cdc/util/util.go
@@ -2,8 +2,12 @@ package util
 
 import (
 	"bytes"
+	"sort"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/parser/model"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/meta"
 )
 
 // Span represents a arbitrary kv range
@@ -94,4 +98,35 @@ func Intersect(lhs Span, rhs Span) (span Span, err error) {
 	}
 
 	return Span{start, end}, nil
+}
+
+// LoadHistoryDDLJobs loads all history DDL jobs from TiDB
+func LoadHistoryDDLJobs(tiStore kv.Storage) ([]*model.Job, error) {
+	snapMeta, err := getSnapshotMeta(tiStore)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	jobs, err := snapMeta.GetAllHistoryDDLJobs()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// jobs from GetAllHistoryDDLJobs are sorted by job id, need sorted by schema version
+	sort.Slice(jobs, func(i, j int) bool {
+		return jobs[i].BinlogInfo.FinishedTS < jobs[j].BinlogInfo.FinishedTS
+	})
+
+	return jobs, nil
+}
+
+func getSnapshotMeta(tiStore kv.Storage) (*meta.Meta, error) {
+	version, err := tiStore.CurrentVersion()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	snapshot, err := tiStore.GetSnapshot(version)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return meta.NewSnapshotMeta(snapshot), nil
 }

--- a/tests/cdc/cdc.go
+++ b/tests/cdc/cdc.go
@@ -20,7 +20,6 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
-	"github.com/pingcap/tidb-cdc/tests/dailytest"
 	"github.com/pingcap/tidb-cdc/tests/util"
 )
 
@@ -67,5 +66,5 @@ func main() {
 	}()
 
 	//dailytest.RunMultiSource(sourceDBs, targetDB, cfg.SourceDBCfg.Name)
-	dailytest.Run(sourceDB, targetDB, cfg.SourceDBCfg.Name, cfg.WorkerCount, cfg.JobCount, cfg.Batch)
+	//dailytest.Run(sourceDB, targetDB, cfg.SourceDBCfg.Name, cfg.WorkerCount, cfg.JobCount, cfg.Batch)
 }

--- a/tests/dailytest/case.go
+++ b/tests/dailytest/case.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"math/rand"
 	"strings"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
@@ -188,105 +189,105 @@ func RunCase(src *sql.DB, dst *sql.DB, schema string) {
 
 	runPKorUKcases(tr)
 
-	//tr.execSQLs(caseMultiDataType)
-	//tr.execSQLs(caseMultiDataTypeClean)
-	//
-	//tr.execSQLs(caseUKWithNoPK)
-	//tr.execSQLs(caseUKWithNoPKClean)
-	//
-	//// run casePKAddDuplicateUK
-	//tr.run(func(src *sql.DB) {
-	//	err := execSQLs(src, casePKAddDuplicateUK)
-	//	if err != nil && !strings.Contains(err.Error(), "Duplicate for key") {
-	//		log.S().Fatal(err)
-	//	}
-	//})
-	//tr.execSQLs(casePKAddDuplicateUKClean)
-	//
-	//// run caseInsertBit
-	//tr.execSQLs(caseInsertBit)
-	//tr.execSQLs(caseInsertBitClean)
-	//
-	//// run caseRecoverAndInsert
-	//tr.execSQLs(caseRecoverAndInsert)
-	//tr.execSQLs(caseRecoverAndInsertClean)
-	//
-	//tr.run(caseTblWithGeneratedCol)
-	//tr.execSQLs([]string{"DROP TABLE gen_contacts;"})
-	//
-	//tr.run(caseCreateView)
-	//tr.execSQLs([]string{"DROP TABLE base_for_view;"})
-	//tr.execSQLs([]string{"DROP VIEW view_user_sum;"})
-	//
-	//// random op on have both pk and uk table
-	//tr.run(func(src *sql.DB) {
-	//	start := time.Now()
-	//
-	//	err := updatePKUK(src, 1000)
-	//	if err != nil {
-	//		log.S().Fatal(errors.ErrorStack(err))
-	//	}
-	//
-	//	log.S().Info(" updatePKUK take: ", time.Since(start))
-	//})
-	//
-	//// swap unique index value
-	//tr.run(func(src *sql.DB) {
-	//	mustExec(src, "create table uindex(id int primary key, a1 int unique)")
-	//
-	//	mustExec(src, "insert into uindex(id, a1) values(1, 10), (2, 20)")
-	//
-	//	tx, err := src.Begin()
-	//	if err != nil {
-	//		log.S().Fatal(err)
-	//	}
-	//
-	//	_, err = tx.Exec("update uindex set a1 = 30 where id = 1")
-	//	if err != nil {
-	//		log.S().Fatal(err)
-	//	}
-	//
-	//	_, err = tx.Exec("update uindex set a1 = 10 where id = 2")
-	//	if err != nil {
-	//		log.S().Fatal(err)
-	//	}
-	//
-	//	_, err = tx.Exec("update uindex set a1 = 20 where id = 1")
-	//	if err != nil {
-	//		log.S().Fatal(err)
-	//	}
-	//
-	//	err = tx.Commit()
-	//	if err != nil {
-	//		log.S().Fatal(err)
-	//	}
-	//
-	//	mustExec(src, "drop table uindex")
-	//})
-	//
-	//// test big cdc msg
-	//tr.run(func(src *sql.DB) {
-	//	mustExec(src, "create table binlog_big(id int primary key, data longtext);")
-	//
-	//	tx, err := src.Begin()
-	//	if err != nil {
-	//		log.S().Fatal(err)
-	//	}
-	//	// insert 5 * 1M
-	//	// note limitation of TiDB: https://github.com/pingcap/docs/blob/733a5b0284e70c5b4d22b93a818210a3f6fbb5a0/FAQ.md#the-error-message-transaction-too-large-is-displayed
-	//	var data = make([]byte, 1<<20)
-	//	for i := 0; i < 5; i++ {
-	//		_, err = tx.Query("INSERT INTO binlog_big(id, data) VALUES(?, ?);", i, data)
-	//		if err != nil {
-	//			log.S().Fatal(err)
-	//		}
-	//	}
-	//	err = tx.Commit()
-	//	if err != nil {
-	//		log.S().Fatal(err)
-	//	}
-	//})
-	//tr.execSQLs([]string{"DROP TABLE binlog_big;"})
+	tr.execSQLs(caseMultiDataType)
+	tr.execSQLs(caseMultiDataTypeClean)
+
+	tr.execSQLs(caseUKWithNoPK)
+	tr.execSQLs(caseUKWithNoPKClean)
+
+	// run casePKAddDuplicateUK
+	tr.run(func(src *sql.DB) {
+		err := execSQLs(src, casePKAddDuplicateUK)
+		if err != nil && !strings.Contains(err.Error(), "Duplicate for key") {
+			log.S().Fatal(err)
+		}
+	})
+	tr.execSQLs(casePKAddDuplicateUKClean)
+
+	// run caseInsertBit
+	tr.execSQLs(caseInsertBit)
+	tr.execSQLs(caseInsertBitClean)
+
+	// run caseRecoverAndInsert
+	tr.execSQLs(caseRecoverAndInsert)
+	tr.execSQLs(caseRecoverAndInsertClean)
+
+	tr.run(caseTblWithGeneratedCol)
+	tr.execSQLs([]string{"DROP TABLE gen_contacts;"})
+
+	tr.run(caseCreateView)
+	tr.execSQLs([]string{"DROP TABLE base_for_view;"})
+	tr.execSQLs([]string{"DROP VIEW view_user_sum;"})
+
+	// random op on have both pk and uk table
+	tr.run(func(src *sql.DB) {
+		start := time.Now()
+
+		err := updatePKUK(src, 1000)
+		if err != nil {
+			log.S().Fatal(errors.ErrorStack(err))
+		}
+
+		log.S().Info(" updatePKUK take: ", time.Since(start))
+	})
+
+	// swap unique index value
+	tr.run(func(src *sql.DB) {
+		mustExec(src, "create table uindex(id int primary key, a1 int unique)")
+
+		mustExec(src, "insert into uindex(id, a1) values(1, 10), (2, 20)")
+
+		tx, err := src.Begin()
+		if err != nil {
+			log.S().Fatal(err)
+		}
+
+		_, err = tx.Exec("update uindex set a1 = 30 where id = 1")
+		if err != nil {
+			log.S().Fatal(err)
+		}
+
+		_, err = tx.Exec("update uindex set a1 = 10 where id = 2")
+		if err != nil {
+			log.S().Fatal(err)
+		}
+
+		_, err = tx.Exec("update uindex set a1 = 20 where id = 1")
+		if err != nil {
+			log.S().Fatal(err)
+		}
+
+		err = tx.Commit()
+		if err != nil {
+			log.S().Fatal(err)
+		}
+
+		mustExec(src, "drop table uindex")
+	})
+
+	// test big cdc msg
+	tr.run(func(src *sql.DB) {
+		mustExec(src, "create table binlog_big(id int primary key, data longtext);")
+
+		tx, err := src.Begin()
+		if err != nil {
+			log.S().Fatal(err)
+		}
+		// insert 5 * 1M
+		// note limitation of TiDB: https://github.com/pingcap/docs/blob/733a5b0284e70c5b4d22b93a818210a3f6fbb5a0/FAQ.md#the-error-message-transaction-too-large-is-displayed
+		var data = make([]byte, 1<<20)
+		for i := 0; i < 5; i++ {
+			_, err = tx.Query("INSERT INTO binlog_big(id, data) VALUES(?, ?);", i, data)
+			if err != nil {
+				log.S().Fatal(err)
+			}
+		}
+		err = tx.Commit()
+		if err != nil {
+			log.S().Fatal(err)
+		}
+	})
+	tr.execSQLs([]string{"DROP TABLE binlog_big;"})
 }
 
 // caseTblWithGeneratedCol creates a table with generated column,

--- a/tests/dailytest/dailytest.go
+++ b/tests/dailytest/dailytest.go
@@ -27,49 +27,49 @@ func RunMultiSource(srcs []*sql.DB, targetDB *sql.DB, schema string) {
 // Run runs the daily test
 func Run(sourceDB *sql.DB, targetDB *sql.DB, schema string, workerCount int, jobCount int, batch int) {
 
-	//	TableSQLs := []string{`
-	//create table ptest(
-	//	a int primary key,
-	//	b double NOT NULL DEFAULT 2.0,
-	//	c varchar(10) NOT NULL,
-	//	d time unique
-	//);
-	//`,
-	//		`
-	//create table itest(
-	//	a int,
-	//	b double NOT NULL DEFAULT 2.0,
-	//	c varchar(10) NOT NULL,
-	//	d time unique,
-	//	PRIMARY KEY(a, b)
-	//);
-	//`,
-	//		`
-	//create table ntest(
-	//	a int,
-	//	b double NOT NULL DEFAULT 2.0,
-	//	c varchar(10) NOT NULL,
-	//	d time unique
-	//);
-	//`}
+	TableSQLs := []string{`
+	create table ptest(
+		a int primary key,
+		b double NOT NULL DEFAULT 2.0,
+		c varchar(10) NOT NULL,
+		d time unique
+	);
+	`,
+		`
+	create table itest(
+		a int,
+		b double NOT NULL DEFAULT 2.0,
+		c varchar(10) NOT NULL,
+		d time unique,
+		PRIMARY KEY(a, b)
+	);
+	`,
+		`
+	create table ntest(
+		a int,
+		b double NOT NULL DEFAULT 2.0,
+		c varchar(10) NOT NULL,
+		d time unique
+	);
+	`}
 
 	// run the simple test case
 	RunCase(sourceDB, targetDB, schema)
 
-	//RunTest(sourceDB, targetDB, schema, func(src *sql.DB) {
-	//	// generate insert/update/delete sqls and execute
-	//	RunDailyTest(sourceDB, TableSQLs, workerCount, jobCount, batch)
-	//})
-	//
-	//RunTest(sourceDB, targetDB, schema, func(src *sql.DB) {
-	//	// truncate test data
-	//	TruncateTestTable(sourceDB, TableSQLs)
-	//})
-	//
-	//RunTest(sourceDB, targetDB, schema, func(src *sql.DB) {
-	//	// drop test table
-	//	DropTestTable(sourceDB, TableSQLs)
-	//})
+	RunTest(sourceDB, targetDB, schema, func(src *sql.DB) {
+		// generate insert/update/delete sqls and execute
+		RunDailyTest(sourceDB, TableSQLs, workerCount, jobCount, batch)
+	})
+
+	RunTest(sourceDB, targetDB, schema, func(src *sql.DB) {
+		// truncate test data
+		TruncateTestTable(sourceDB, TableSQLs)
+	})
+
+	RunTest(sourceDB, targetDB, schema, func(src *sql.DB) {
+		// drop test table
+		DropTestTable(sourceDB, TableSQLs)
+	})
 
 	log.S().Info("test pass!!!")
 


### PR DESCRIPTION
1. move `loadHistoryDDLJobs` to `util` package
2. add `CDCSuite` for test
3. edit interface of `MockPuller`
4. switch on all test in `tests/dailytest/case.go` and `tests/dailytest/dailytest.go`. those test can't be pass anyway.


here I only add a simple test case in `TestSimple`, I will port the test cases of integration tests from `binlog` project after this pr merged