### PR TITLE
minor refactor, changefeed as worker, capture as manager

### DIFF
--- a/cdc/server.go
+++ b/cdc/server.go
@@ -1,6 +1,7 @@
 package cdc
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -64,8 +65,11 @@ func NewServer(opt ...ServerOption) (*Server, error) {
 
 // Run runs the server.
 func (s *Server) Run() error {
-
-	return nil
+	capture, err := NewCapture()
+	if err != nil {
+		return err
+	}
+	return capture.Start(context.Background())
 }
 
 // Close closes the server.

--- a/cdc/subchangefeed.go
+++ b/cdc/subchangefeed.go
@@ -22,8 +22,8 @@ import (
 	"github.com/pingcap/tidb-cdc/cdc/roles"
 )
 
-// SubChangeFeed records the process information of a capture
-type SubChangeFeed struct {
+// SubChangeFeedInfo records the process information of a capture
+type SubChangeFeedInfo struct {
 	// The maximum event CommitTS that has been synchronized. This is updated by corresponding processor.
 	CheckPointTS uint64 `json:"checkpoint-ts"`
 	// The event that satisfies CommitTS <= ResolvedTS can be synchronized. This is updated by corresponding processor.
@@ -32,8 +32,8 @@ type SubChangeFeed struct {
 	TableInfos []*roles.ProcessTableInfo `json:"table-infos"`
 }
 
-func (scf *SubChangeFeed) String() string {
-	data, err := json.Marshal(scf)
+func (scfi *SubChangeFeedInfo) String() string {
+	data, err := json.Marshal(scfi)
 	if err != nil {
 		log.Error("fail to marshal ChangeFeedDetail to json", zap.Error(err))
 	}

--- a/cmd/cdc.go
+++ b/cmd/cdc.go
@@ -18,7 +18,7 @@ func feed() {
 		CreateTime:   time.Now(),
 	}
 
-	feed, err := cdc.NewChangeFeed([]string{"localhost:2379"}, detail)
+	feed, err := cdc.NewSubChangeFeed([]string{"localhost:2379"}, detail)
 	if err != nil {
 		log.Error("NewChangeFeed failed", zap.Error(err))
 		return

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/coreos/etcd v3.3.13+incompatible
 	github.com/go-sql-driver/mysql v1.4.1
+	github.com/google/uuid v1.1.1
 	github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8
 	github.com/pingcap/errors v0.11.4
 	github.com/pingcap/kvproto v0.0.0-20190816084801-93197044d6d7


### PR DESCRIPTION
According to our design, `Capture` manages 1-N `SubChangeFeed` (SubChangeFeed can be treated as task), `SubChangeFeed` manages TablePuller and DDLPuller if it is the owner.