### PR TITLE
The pd addr needs a scheme prefix to work now

### DIFF
--- a/cmd/cdc.go
+++ b/cmd/cdc.go
@@ -18,7 +18,7 @@ func feed() {
 		CreateTime:   time.Now(),
 	}
 
-	feed, err := cdc.NewSubChangeFeed([]string{"localhost:2379"}, detail)
+	feed, err := cdc.NewSubChangeFeed([]string{"http://localhost:2379"}, detail)
 	if err != nil {
 		log.Error("NewChangeFeed failed", zap.Error(err))
 		return


### PR DESCRIPTION
Maybe we should abandon the binlog way of processing addresses later