### PR TITLE
Fix random failure in scheduler unit test

### DIFF
--- a/cdc/scheduler.go
+++ b/cdc/scheduler.go
@@ -237,6 +237,7 @@ func (w *SubChangeFeedWatcher) Watch(ctx context.Context, errCh chan<- error) {
 	}
 
 	cctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	feedErrCh, err := runSubChangeFeed(cctx, w.pdEndpoints, w.detail)
 	if err != nil {
 		errCh <- err
@@ -262,7 +263,6 @@ func (w *SubChangeFeedWatcher) Watch(ctx context.Context, errCh chan<- error) {
 			}
 			// subchangefeed has been removed from this capture, cancel the subchangefeed too
 			if resp.Count == 0 {
-				cancel()
 				return
 			}
 		}

--- a/cdc/scheduler_test.go
+++ b/cdc/scheduler_test.go
@@ -235,9 +235,11 @@ func (s *schedulerSuite) TestChangeFeedWatcher(c *check.C) {
 	// delete the changefeed
 	_, err = cli.Delete(context.Background(), key)
 	c.Assert(err, check.IsNil)
-	w.lock.RLock()
-	c.Assert(len(w.details), check.Equals, 0)
-	w.lock.RUnlock()
+	c.Assert(util.WaitSomething(10, time.Millisecond*50, func() bool {
+		w.lock.RLock()
+		defer w.lock.RUnlock()
+		return len(w.details) == 0
+	}), check.IsTrue)
 
 	cancel()
 	wg.Wait()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In `TestChangeFeedWatcher` test, check for `w.details` maybe before the `processDeleteKv` execution in the watcher, which leads to CI failed.

### What is changed and how it works?

- use `WaitSomething` in test case
- always cancel the context passed to `runSubChangeFeed` when the Watch loop of SubChangeFeedWatcher returns (This is a logic fix not relevant to CI failure)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
