### PR TITLE
Move processor.go to the cdc package to avoid circular dependency

### DIFF
--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -11,11 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package roles
+package cdc
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"strings"
 	"sync"
@@ -28,10 +27,6 @@ import (
 	"github.com/pingcap/tidb-cdc/cdc/model"
 	"github.com/pingcap/tidb-cdc/cdc/schema"
 	"github.com/pingcap/tidb-cdc/cdc/txn"
-	"github.com/pingcap/tidb-cdc/pkg/flags"
-	tidbkv "github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/store"
-	"github.com/pingcap/tidb/store/tikv"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
@@ -355,22 +350,4 @@ func createSchemaStore(pdEndpoints []string) (*schema.Schema, error) {
 		return nil, errors.Trace(err)
 	}
 	return schema, nil
-}
-
-func createTiStore(urls string) (tidbkv.Storage, error) {
-	urlv, err := flags.NewURLsValue(urls)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	if err := store.Register("tikv", tikv.Driver{}); err != nil {
-		return nil, errors.Trace(err)
-	}
-	tiPath := fmt.Sprintf("tikv://%s?disableGC=true", urlv.HostString())
-	tiStore, err := store.New(tiPath)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return tiStore, nil
 }

--- a/cdc/processor_test.go
+++ b/cdc/processor_test.go
@@ -1,4 +1,17 @@
-package roles
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cdc
 
 import (
 	"sort"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In TiDB, ddl worker doesn't have to know about things like owner election, so it lives with the core logic of ddl handling instead of the package that focus on election.

In our case, if processor lives as a separate role, we need to work hard to avoid circular dependency.

### What is changed and how it works?

Move processor.go and its test file to the cdc package.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects

Related changes