### PR TITLE
Output fake txn when no entry event comes before a resolved event

### DIFF
--- a/cdc/txn/txn.go
+++ b/cdc/txn/txn.go
@@ -119,7 +119,6 @@ func CollectRawTxns(
 					delete(entryGroups, ts)
 				}
 			}
-			// TODO: Handle the case when readyTsList is empty
 			sort.Slice(readyTxns, func(i, j int) bool {
 				return readyTxns[i].TS < readyTxns[j].TS
 			})
@@ -128,6 +127,14 @@ func CollectRawTxns(
 				if err != nil {
 					return err
 				}
+			}
+			if len(readyTxns) == 0 {
+				log.Info("Forwarding fake txn", zap.Uint64("ts", resolvedTs))
+				fakeTxn := RawTxn{
+					TS:      resolvedTs,
+					Entries: nil,
+				}
+				outputFn(ctx, fakeTxn)
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

We need to make sure heartbeat events are forwarded.
When we receive a resolved event and there's no entry event that comes with a smaller ts before it, we take it as a heartbeat event.


### What is changed and how it works?

Wrap a resolved event as an empty RawTxn.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects

Related changes