### PR TITLE
owner: create changefeed status before assigning table

### DIFF
--- a/cdc/kv/etcd.go
+++ b/cdc/kv/etcd.go
@@ -165,6 +165,7 @@ func GetSubChangeFeedInfos(ctx context.Context, client *clientv3.Client, changef
 	return pinfo, nil
 }
 
+// GetSubChangeFeedInfo queries subchangefeed info from etcd
 func GetSubChangeFeedInfo(
 	ctx context.Context,
 	client *clientv3.Client,
@@ -183,4 +184,21 @@ func GetSubChangeFeedInfo(
 	info := &model.SubChangeFeedInfo{}
 	err = info.Unmarshal(resp.Kvs[0].Value)
 	return resp.Header.Revision, info, errors.Trace(err)
+}
+
+// PutChangeFeedStatus puts changefeed synchronization status into etcd
+func PutChangeFeedStatus(
+	ctx context.Context,
+	client *clientv3.Client,
+	changefeedID string,
+	info *model.ChangeFeedInfo,
+	opts ...clientv3.OpOption,
+) error {
+	key := GetEtcdKeyChangeFeedStatus(changefeedID)
+	value, err := info.Marshal()
+	if err != nil {
+		return err
+	}
+	_, err = client.Put(ctx, key, value, opts...)
+	return errors.Trace(err)
 }

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -179,7 +179,7 @@ type processorImpl struct {
 	wg              *errgroup.Group
 }
 
-func NewProcessor(pdEndpoints []string, changefeed model.ChangeFeedDetail, captureID, changefeedID string) (Processor, error) {
+func NewProcessor(pdEndpoints []string, changefeed model.ChangeFeedDetail, changefeedID, captureID string) (Processor, error) {
 	pdCli, err := fNewPDCli(pdEndpoints, pd.SecurityOption{})
 	if err != nil {
 		return nil, errors.Annotatef(err, "create pd client failed, addr: %v", pdEndpoints)

--- a/cdc/roles/owner.go
+++ b/cdc/roles/owner.go
@@ -331,6 +331,16 @@ func (o *ownerImpl) assignChangeFeed(ctx context.Context, changefeedID string) (
 		})
 	}
 
+	// persist changefeed synchronization status to storage
+	err = kv.PutChangeFeedStatus(ctx, o.etcdClient, changefeedID,
+		&model.ChangeFeedInfo{
+			CheckpointTS: cinfo.StartTS,
+			ResolvedTS:   0,
+		})
+	if err != nil {
+		return nil, err
+	}
+
 	// create subchangefeed info and persist to storage
 	for i := range tableInfos {
 		key := kv.GetEtcdKeySubChangeFeed(changefeedID, captures[i].ID)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

As for one changefeed, after its related processor(s) starts, they will read the changefeed ts information from key `/tidb/cdc/changefeed/status/<changefeed-id>`, so we must create this kv before any processor starts.

### What is changed and how it works?

persist changefeed status to etcd before assigning any table into subchangefeed info

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test