### PR TITLE
owner: update checkpointTs too when updating resolveTs

### DIFF
--- a/cdc/roles/owner.go
+++ b/cdc/roles/owner.go
@@ -179,11 +179,15 @@ func (o *ownerImpl) calcResolvedTs() error {
 			continue
 		}
 		minResolvedTs := cfInfo.TargetTs
+		minCheckpointTs := cfInfo.TargetTs
 
 		// calc the min of all resolvedTs in captures
 		for _, pStatus := range cfInfo.ProcessorInfos {
 			if minResolvedTs > pStatus.ResolvedTs {
 				minResolvedTs = pStatus.ResolvedTs
+			}
+			if minCheckpointTs > pStatus.CheckPointTs {
+				minCheckpointTs = pStatus.CheckPointTs
 			}
 		}
 
@@ -208,6 +212,7 @@ func (o *ownerImpl) calcResolvedTs() error {
 			cfInfo.Status = model.ChangeFeedWaitToExecDDL
 		}
 		cfInfo.ResolvedTs = minResolvedTs
+		cfInfo.CheckpointTs = minCheckpointTs
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Current the global checkpoint ts is not updated in memory

### What is changed and how it works?

Update checkpointTs stored in changefeed info during `calcResolvedTs`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test