### PR TITLE
owner: store sink uri in changefeed status

### DIFF
--- a/cdc/roles/owner.go
+++ b/cdc/roles/owner.go
@@ -112,7 +112,8 @@ func (o *ownerImpl) loadChangeFeedInfos(ctx context.Context) error {
 			cfInfo.ProcessorInfos = etcdChangeFeedInfo
 		} else {
 			var targetTs uint64
-			if changefeed, ok := changefeeds[changeFeedID]; !ok {
+			changefeed, ok := changefeeds[changeFeedID]
+			if !ok {
 				return errors.Annotatef(model.ErrChangeFeedNotExists, "id:%s", changeFeedID)
 			} else if changefeed.TargetTs == uint64(0) {
 				targetTs = uint64(math.MaxUint64)
@@ -121,6 +122,7 @@ func (o *ownerImpl) loadChangeFeedInfos(ctx context.Context) error {
 			}
 			o.changeFeedInfos[changeFeedID] = &model.ChangeFeedInfo{
 				Status:          model.ChangeFeedSyncDML,
+				SinkURI:         changefeed.SinkURI,
 				ResolvedTs:      0,
 				CheckpointTs:    0,
 				TargetTs:        targetTs,
@@ -358,6 +360,7 @@ func (o *ownerImpl) assignChangeFeed(ctx context.Context, changefeedID string) (
 		&model.ChangeFeedInfo{
 			CheckpointTs: cinfo.StartTs,
 			ResolvedTs:   0,
+			SinkURI:      cinfo.SinkURI,
 		})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`SinkURI` is used in owner when executing DDL, but not stored in etcd now. This field is already declared in `model.ChangeFeedInfo`


### What is changed and how it works?

Add `SinkURI` when constructing a new `model.ChangeFeedInfo`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test