### PR TITLE
processor: fix dead lock when dmls execute failed

### DIFF
--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -96,7 +96,7 @@ func (p *txnChannel) Forward(ctx context.Context, tableID int64, ts uint64, entr
 			return
 		}
 		p.putBackTxn = nil
-		p.PushProcessorEntry(ctx, entryC, NewProcessorTxnEntry(t))
+		pushProcessorEntry(ctx, entryC, NewProcessorTxnEntry(t))
 	}
 	for {
 		select {
@@ -111,12 +111,12 @@ func (p *txnChannel) Forward(ctx context.Context, tableID int64, ts uint64, entr
 				p.PutBack(t)
 				return
 			}
-			p.PushProcessorEntry(ctx, entryC, NewProcessorTxnEntry(t))
+			pushProcessorEntry(ctx, entryC, NewProcessorTxnEntry(t))
 		}
 	}
 }
 
-func (p *txnChannel) PushProcessorEntry(ctx context.Context, entryC chan<- ProcessorEntry, e ProcessorEntry) {
+func pushProcessorEntry(ctx context.Context, entryC chan<- ProcessorEntry, e ProcessorEntry) {
 	select {
 	case <-ctx.Done():
 		log.Info("lost processor entry during canceling", zap.Any("entry", e))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
when dmls execute failed, the processor will get a deadlock, this pr fix it
