### PR TITLE
*: register tikv store once in cdc server

### DIFF
--- a/cdc/capture.go
+++ b/cdc/capture.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pingcap/ticdc/pkg/flags"
 	tidbkv "github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store"
-	"github.com/pingcap/tidb/store/tikv"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -135,9 +134,6 @@ func createTiStore(urls string) (tidbkv.Storage, error) {
 		return nil, errors.Trace(err)
 	}
 
-	if err := store.Register("tikv", tikv.Driver{}); err != nil {
-		return nil, errors.Trace(err)
-	}
 	tiPath := fmt.Sprintf("tikv://%s?disableGC=true", urlv.HostString())
 	tiStore, err := store.New(tiPath)
 	if err != nil {

--- a/cdc/server.go
+++ b/cdc/server.go
@@ -5,7 +5,10 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/store"
+	"github.com/pingcap/tidb/store/tikv"
 	"go.uber.org/zap"
 )
 
@@ -66,6 +69,10 @@ func NewServer(opt ...ServerOption) (*Server, error) {
 	capture, err := NewCapture(strings.Split(opts.pdEndpoints, ","))
 	if err != nil {
 		return nil, err
+	}
+	err = store.Register("tikv", tikv.Driver{})
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	s := &Server{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix following error, tikv store should be registered only once.

```
[2019/11/19 11:55:15.080 +08:00] [ERROR] [server.go:74] ["run server"] [error="tikv is already registered\ngithub.com/pingcap/tidb/store.Register\n\tgithub.com/pingcap/tidb@v1.1.0-beta.0.20191017064824-e1ba309148ad/store/store.go:34\ngithub.com/pingcap/ticdc/cdc.createTiStore\n\tgithub.com/pingcap/ticdc@/cdc/capture.go:138\ngithub.com/pingcap/ticdc/cdc.createSchemaStore\n\tgithub.com/pingcap/ticdc@/cdc/processor.go:542\ngithub.com/pingcap/ticdc/cdc.NewProcessor\n\tgithub.com/pingcap/ticdc@/cdc/processor.go:225\ngithub.com/pingcap/ticdc/cdc.realRunProcessor\n\tgithub.com/pingcap/ticdc@/cdc/scheduler.go:285\ngithub.com/pingcap/ticdc/cdc.(*ProcessorWatcher).Watch\n\tgithub.com/pingcap/ticdc@/cdc/scheduler.go:230\nruntime.goexit\n\truntime/asm_amd64.s:1357"]
```

### What is changed and how it works?

Move tikv store registration to cdc server initialization function.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test