### PR TITLE
owner: skip DDL with finishTs less than changefeed startTs

### DIFF
--- a/cdc/model/owner.go
+++ b/cdc/model/owner.go
@@ -97,6 +97,7 @@ type ChangeFeedInfo struct {
 	SinkURI      string           `json:"sink-uri"`
 	ResolvedTs   uint64           `json:"resolved-ts"`
 	CheckpointTs uint64           `json:"checkpoint-ts"`
+	StartTs      uint64           `json:"-"`
 	TargetTs     uint64           `json:"-"`
 
 	ProcessorInfos  ProcessorsInfos `json:"-"`

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -23,12 +23,14 @@ func init() {
 	cliCmd.Flags().StringSliceVar(&tables, "tables", []string{"test.t"}, "all tables provided will be collected in changefeed")
 	cliCmd.Flags().StringSliceVar(&databases, "databases", []string{"test"}, "all tables in given databases will be collected in changefeed")
 	cliCmd.Flags().StringVar(&pdAddress, "pd-addr", "localhost:2379", "address of PD")
+	cliCmd.Flags().Uint64Var(&startTs, "start-ts", 0, "start ts of changefeed")
 }
 
 var (
 	tables    []string
 	databases []string
 	pdAddress string
+	startTs   uint64
 )
 
 var cliCmd = &cobra.Command{
@@ -114,6 +116,7 @@ var cliCmd = &cobra.Command{
 			Opts:       make(map[string]string),
 			CreateTime: time.Now(),
 			TableIDs:   ids,
+			StartTs:    startTs,
 		}
 		fmt.Printf("create changefeed detail %+v\n", detail)
 		return kv.SaveChangeFeedDetail(context.Background(), cli, detail, id)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

We don't need to execute all DDL in DDL history. This PR deals with `start-ts` only, doesn't concern the error scenario such as owner transfer, etc. (A test-oriented update)

### What is changed and how it works?

ignore all DDL jobs with finishTs less than changefeed startTs

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test