### PR TITLE
Use the Clone method to simplify the interface method for getting info

### DIFF
--- a/cdc/processor_test.go
+++ b/cdc/processor_test.go
@@ -67,8 +67,8 @@ func (s *mockTsRWriter) SetGlobalResolvedTs(ts uint64) {
 	s.globalResolvedTs = ts
 }
 
-func (s *mockTsRWriter) CloneSubChangeFeedInfo() (*model.SubChangeFeedInfo, error) {
-	return nil, nil
+func (s *mockTsRWriter) GetSubChangeFeedInfo() *model.SubChangeFeedInfo {
+	return nil
 }
 
 func (s *mockTsRWriter) WriteTableCLock(ctx context.Context, checkpointTs uint64) error {

--- a/cdc/roles/storage/etcd.go
+++ b/cdc/roles/storage/etcd.go
@@ -14,9 +14,7 @@
 package storage
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"sync"
 
 	"github.com/cenkalti/backoff"
@@ -258,16 +256,9 @@ func (rw *ProcessorTsEtcdRWriter) ReadGlobalResolvedTs(ctx context.Context) (uin
 	return info.ResolvedTs, nil
 }
 
-// CloneSubChangeFeedInfo returns a deep copy of *model.SubChangeFeedInfo stored in ProcessorTsEtcdRWriter
-func (rw *ProcessorTsEtcdRWriter) CloneSubChangeFeedInfo() (*model.SubChangeFeedInfo, error) {
-	var buf bytes.Buffer
-	err := json.NewEncoder(&buf).Encode(*rw.info)
-	if err != nil {
-		return nil, err
-	}
-	info := &model.SubChangeFeedInfo{}
-	err = json.Unmarshal(buf.Bytes(), &info)
-	return info, err
+// GetSubChangeFeedInfo returns a deep copy of *model.SubChangeFeedInfo stored in ProcessorTsEtcdRWriter
+func (rw *ProcessorTsEtcdRWriter) GetSubChangeFeedInfo() *model.SubChangeFeedInfo {
+	return rw.info.Clone()
 }
 
 // WriteTableCLock writes C-lock to etcd

--- a/cdc/roles/storage/etcd_test.go
+++ b/cdc/roles/storage/etcd_test.go
@@ -245,28 +245,6 @@ func (s *etcdSuite) TestProcessorTsReader(c *check.C) {
 	c.Assert(resolvedTs, check.Equals, info.ResolvedTs)
 }
 
-func (s *etcdSuite) TestCloneSubChangeFeedInfo(c *check.C) {
-	var (
-		changefeedID = "test-copy-changefeed"
-		captureID    = "test-copy-capture"
-		info         = &model.SubChangeFeedInfo{
-			TableInfos: []*model.ProcessTableInfo{
-				{ID: 1, StartTs: 1000},
-				{ID: 2, StartTs: 2000},
-			},
-		}
-	)
-	rw := NewProcessorTsEtcdRWriter(s.client, changefeedID, captureID)
-	rw.info = info
-	copyInfo, err := rw.CloneSubChangeFeedInfo()
-	c.Assert(err, check.IsNil)
-	c.Assert(rw.info, check.DeepEquals, copyInfo)
-
-	copyInfo.TableInfos = append(copyInfo.TableInfos, &model.ProcessTableInfo{ID: 3, StartTs: 3000})
-	c.Assert(rw.info, check.DeepEquals, info)
-	c.Assert(len(copyInfo.TableInfos), check.Greater, len(info.TableInfos))
-}
-
 func (s *etcdSuite) TestWriteTableCLock(c *check.C) {
 	var (
 		changefeedID = "test-write-clock-changefeed"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Current implementation clone the `SubChangeFeedInfo` by encoding to JSON and then decoding back.

### What is changed and how it works?

Use the Clone method.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test