### PR TITLE
Fix TableLock clone panic. Remove unused code in test client

### DIFF
--- a/cdc/model/owner.go
+++ b/cdc/model/owner.go
@@ -96,10 +96,14 @@ func (scfi *SubChangeFeedInfo) Clone() *SubChangeFeedInfo {
 		infos = append(infos, &c)
 	}
 	clone.TableInfos = infos
-	pLock := *scfi.TablePLock
-	clone.TablePLock = &pLock
-	cLock := *scfi.TableCLock
-	clone.TableCLock = &cLock
+	if scfi.TablePLock != nil {
+		pLock := *scfi.TablePLock
+		clone.TablePLock = &pLock
+	}
+	if scfi.TableCLock != nil {
+		cLock := *scfi.TableCLock
+		clone.TableCLock = &cLock
+	}
 	return &clone
 }
 

--- a/cdc/model/owner_test.go
+++ b/cdc/model/owner_test.go
@@ -35,7 +35,6 @@ func (s *cloneSubChangeFeedInfoSuite) TestShouldBeDeepCopy(c *check.C) {
 			{ID: 3},
 		},
 		TablePLock: &TableLock{Ts: 11},
-		TableCLock: &TableLock{Ts: 12},
 	}
 
 	clone := info.Clone()
@@ -47,7 +46,7 @@ func (s *cloneSubChangeFeedInfoSuite) TestShouldBeDeepCopy(c *check.C) {
 			c.Assert(info.ID, check.Equals, uint64(i+1))
 		}
 		c.Assert(clone.TablePLock.Ts, check.Equals, uint64(11))
-		c.Assert(clone.TableCLock.Ts, check.Equals, uint64(12))
+		c.Assert(clone.TableCLock, check.IsNil)
 	}
 
 	assertIsSnapshot()
@@ -55,7 +54,7 @@ func (s *cloneSubChangeFeedInfoSuite) TestShouldBeDeepCopy(c *check.C) {
 	info.CheckPointTs = 1111
 	info.TableInfos[2] = &ProcessTableInfo{ID: 1212}
 	info.TablePLock.Ts = 100
-	info.TableCLock.Ts = 100
+	info.TableCLock = &TableLock{Ts: 100}
 
 	assertIsSnapshot()
 }

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -17,15 +17,11 @@ import (
 func init() {
 	rootCmd.AddCommand(cliCmd)
 
-	cliCmd.Flags().StringSliceVar(&tables, "tables", []string{"test.t"}, "all tables provided will be collected in changefeed")
-	cliCmd.Flags().StringSliceVar(&databases, "databases", []string{"test"}, "all tables in given databases will be collected in changefeed")
 	cliCmd.Flags().StringVar(&pdAddress, "pd-addr", "localhost:2379", "address of PD")
 	cliCmd.Flags().Uint64Var(&startTs, "start-ts", 0, "start ts of changefeed")
 }
 
 var (
-	tables    []string
-	databases []string
 	pdAddress string
 	startTs   uint64
 )

--- a/tests/split_region/run.sh
+++ b/tests/split_region/run.sh
@@ -24,7 +24,7 @@ function run() {
     run_sql_file $CUR/data/prepare.sql ${US_TIDB_HOST} ${US_TIDB_PORT}
 
     cdc server --log-file $WORK_DIR/cdc.log --log-level info > $WORK_DIR/stdout.log 2>&1 &
-    cdc cli --start-ts=$start_ts --databases=split_region
+    cdc cli --start-ts=$start_ts
 
     # sync_diff can't check non-exist table, so we check expected tables are created in downstream first
     check_table_exists split_region.test1 ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. check TableLock is nil before cloning it
2. remove unused parameter in client cmd

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
   Integration test can run successfully now but has occasionally failure. Will dig it later