### PR TITLE
Encapsulate backoff to create a simple ctx-aware retry

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -7,6 +7,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pingcap/ticdc/pkg/retry"
+
 	"github.com/cenkalti/backoff"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/cdcpb"
@@ -198,7 +200,7 @@ func (c *CDCClient) partialRegionFeed(
 ) error {
 	ts := regionInfo.ts
 
-	berr := backoff.Retry(func() error {
+	berr := retry.Run(func() error {
 		var err error
 
 		if regionInfo.meta == nil {
@@ -243,7 +245,7 @@ func (c *CDCClient) partialRegionFeed(
 		}
 
 		return nil
-	}, backoff.NewExponentialBackOff())
+	}, 5)
 
 	if errors.Cause(berr) == context.Canceled {
 		return nil

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -1,0 +1,38 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retry
+
+import (
+	"context"
+
+	"github.com/cenkalti/backoff"
+	"github.com/pingcap/errors"
+)
+
+// Run retries the specified function on error for at most maxRetries times.
+// It stops retry if the returned error is context.Canceled or context.DeadlineExceeded.
+func Run(f func() error, maxRetries uint64) error {
+	retryCfg := backoff.WithMaxRetries(
+		backoff.NewExponentialBackOff(),
+		maxRetries,
+	)
+	return backoff.Retry(func() error {
+		err := f()
+		switch errors.Cause(err) {
+		case context.Canceled, context.DeadlineExceeded:
+			err = backoff.Permanent(err)
+		}
+		return err
+	}, retryCfg)
+}

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -1,0 +1,81 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/check"
+	"github.com/pingcap/errors"
+)
+
+func Test(t *testing.T) { check.TestingT(t) }
+
+type runSuite struct{}
+
+var _ = check.Suite(&runSuite{})
+
+func (s *runSuite) TestShouldRetryAtMostSpecifiedTimes(c *check.C) {
+	var callCount int
+	f := func() error {
+		callCount++
+		return errors.New("test")
+	}
+
+	err := Run(f, 3)
+	c.Assert(err, check.ErrorMatches, "test")
+	// It's weird that backoff may retry one more time than maxTries.
+	// Because the steps in backoff.Retry is:
+	// 1. Call function
+	// 2. Compare numTries and maxTries
+	// 3. Increment numTries
+	c.Assert(callCount, check.Equals, 3+1)
+}
+
+func (s *runSuite) TestShouldStopOnSuccess(c *check.C) {
+	var callCount int
+	f := func() error {
+		callCount++
+		if callCount == 2 {
+			return nil
+		}
+		return errors.New("test")
+	}
+
+	err := Run(f, 3)
+	c.Assert(err, check.IsNil)
+	c.Assert(callCount, check.Equals, 2)
+}
+
+func (s *runSuite) TestShouldBeCtxAware(c *check.C) {
+	var callCount int
+	f := func() error {
+		callCount++
+		return context.Canceled
+	}
+
+	err := Run(f, 3)
+	c.Assert(err, check.Equals, context.Canceled)
+	c.Assert(callCount, check.Equals, 1)
+
+	callCount = 0
+	f = func() error {
+		callCount++
+		return errors.Annotate(context.Canceled, "test")
+	}
+	err = Run(f, 3)
+	c.Assert(errors.Cause(err), check.Equals, context.Canceled)
+	c.Assert(callCount, check.Equals, 1)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

We have to repeatedly mark context errors as `Permanent` when using `backoff.Retry`.

### What is changed and how it works?

Encapsulate the retrying process as a simpler function that automatically handles `Permanent` for us.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test