### PR TITLE
bugfix: Should keep retrying singleEventFeed

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -244,7 +244,7 @@ func (c *CDCClient) partialRegionFeed(
 		}
 
 		return nil
-	}, 5)
+	}, 0)
 
 	if errors.Cause(berr) == context.Canceled {
 		return nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`partialRegionFeed` should keep retrying `singleEventFeed` until the region is no longer valid.
So the `maxRetries` parameter should be set to 0.

### What is changed and how it works?

Set `maxRetries` to be 0.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test