### PR TITLE
Make capture ID accessible through context

### DIFF
--- a/cdc/server.go
+++ b/cdc/server.go
@@ -1,9 +1,24 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cdc
 
 import (
 	"context"
 	"net/http"
 	"strings"
+
+	"github.com/pingcap/ticdc/pkg/util"
 
 	"github.com/pingcap/log"
 	"go.uber.org/zap"
@@ -78,6 +93,7 @@ func NewServer(opt ...ServerOption) (*Server, error) {
 // Run runs the server.
 func (s *Server) Run(ctx context.Context) error {
 	s.startStatusHTTP()
+	ctx = util.PutCaptureIDInCtx(ctx, s.capture.info.ID)
 	return s.capture.Start(ctx)
 }
 

--- a/pkg/util/ctx.go
+++ b/pkg/util/ctx.go
@@ -1,0 +1,37 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import "context"
+
+type ctxKey string
+
+const (
+	ctxKeyCaptureID = ctxKey("captureID")
+)
+
+// CaptureIDFromCtx returns a capture ID stored in the specified context.
+// It returns an empty string if there's no valid capture ID found.
+func CaptureIDFromCtx(ctx context.Context) string {
+	captureID, ok := ctx.Value(ctxKeyCaptureID).(string)
+	if !ok {
+		return ""
+	}
+	return captureID
+}
+
+// PutCaptureIDInCtx returns a new child context with the specified capture ID stored.
+func PutCaptureIDInCtx(ctx context.Context, captureID string) context.Context {
+	return context.WithValue(ctx, ctxKeyCaptureID, captureID)
+}

--- a/pkg/util/ctx_test.go
+++ b/pkg/util/ctx_test.go
@@ -1,0 +1,35 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+
+	"github.com/pingcap/check"
+)
+
+type captureIDSuite struct{}
+
+var _ = check.Suite(&captureIDSuite{})
+
+func (s *captureIDSuite) TestShouldReturnCaptureID(c *check.C) {
+	ctx := PutCaptureIDInCtx(context.Background(), "ello")
+	c.Assert(CaptureIDFromCtx(ctx), check.Equals, "ello")
+}
+
+func (s *captureIDSuite) TestShouldReturnEmptyStr(c *check.C) {
+	c.Assert(CaptureIDFromCtx(context.Background()), check.Equals, "")
+	ctx := context.WithValue(context.Background(), ctxKeyCaptureID, 1321)
+	c.Assert(CaptureIDFromCtx(ctx), check.Equals, "")
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Deep down in the packages we may need to access information like capture ID.
But we can't pass the capture ID or a capture struct everywhere needed.


### What is changed and how it works?

Store capture ID in context so that we have access to it in all scope with the same context.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test