### PR TITLE
sink: unify the time zone between capture and downstream database automatically

### DIFF
--- a/cdc/cdc_test.go
+++ b/cdc/cdc_test.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	. "github.com/pingcap/check"
@@ -58,7 +57,7 @@ func NewCDCSuite() *CDCSuite {
 
 	cdcSuite.sink = sink.NewMySQLSinkUsingSchema(db, schemaStorage)
 
-	mounter := entry.NewTxnMounter(schemaStorage, time.Local)
+	mounter := entry.NewTxnMounter(schemaStorage)
 	cdcSuite.mounter = mounter
 	return cdcSuite
 }

--- a/cdc/entry/codec.go
+++ b/cdc/entry/codec.go
@@ -219,7 +219,7 @@ func decodeRow(b []byte) (map[int64]types.Datum, error) {
 }
 
 // unflatten converts a raw datum to a column datum.
-func unflatten(datum types.Datum, ft *types.FieldType, loc *time.Location) (types.Datum, error) {
+func unflatten(datum types.Datum, ft *types.FieldType) (types.Datum, error) {
 	if datum.IsNull() {
 		return datum, nil
 	}
@@ -240,12 +240,6 @@ func unflatten(datum types.Datum, ft *types.FieldType, loc *time.Location) (type
 		err = t.FromPackedUint(datum.GetUint64())
 		if err != nil {
 			return datum, errors.Trace(err)
-		}
-		if ft.Tp == mysql.TypeTimestamp && !t.IsZero() {
-			err = t.ConvertTimeZone(time.UTC, loc)
-			if err != nil {
-				return datum, errors.Trace(err)
-			}
 		}
 		datum.SetUint64(0)
 		datum.SetMysqlTime(t)

--- a/cdc/entry/kv_entry.go
+++ b/cdc/entry/kv_entry.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/pingcap/errors"
 	timodel "github.com/pingcap/parser/model"
@@ -64,7 +63,7 @@ type unknownKVEntry struct {
 	model.RawKVEntry
 }
 
-func (idx *indexKVEntry) unflatten(tableInfo *timodel.TableInfo, loc *time.Location) error {
+func (idx *indexKVEntry) unflatten(tableInfo *timodel.TableInfo) error {
 	if tableInfo.ID != idx.TableID {
 		return errors.New("wrong table info in unflatten")
 	}
@@ -76,7 +75,7 @@ func (idx *indexKVEntry) unflatten(tableInfo *timodel.TableInfo, loc *time.Locat
 	for i, v := range idx.IndexValue {
 		colOffset := index.Columns[i].Offset
 		fieldType := &tableInfo.Columns[colOffset].FieldType
-		datum, err := unflatten(v, fieldType, loc)
+		datum, err := unflatten(v, fieldType)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -100,13 +99,13 @@ func isDistinct(index *timodel.IndexInfo, indexValue []types.Datum) bool {
 	return false
 }
 
-func (row *rowKVEntry) unflatten(tableInfo *timodel.TableInfo, loc *time.Location) error {
+func (row *rowKVEntry) unflatten(tableInfo *timodel.TableInfo) error {
 	if tableInfo.ID != row.TableID {
 		return errors.New("wrong table info in unflatten")
 	}
 	for i, v := range row.Row {
 		fieldType := &tableInfo.Columns[i-1].FieldType
-		datum, err := unflatten(v, fieldType, loc)
+		datum, err := unflatten(v, fieldType)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cdc/entry/kv_entry_test.go
+++ b/cdc/entry/kv_entry_test.go
@@ -434,12 +434,12 @@ func checkDMLKVEntries(ctx context.Context, c *check.C, tableInfo *timodel.Table
 			c.Assert(err, check.IsNil)
 			switch e := entry.(type) {
 			case *rowKVEntry:
-				c.Assert(e.unflatten(tableInfo, time.UTC), check.IsNil)
+				c.Assert(e.unflatten(tableInfo), check.IsNil)
 				e.Ts = 0
 				assertIn(c, e, expect)
 				eventSum++
 			case *indexKVEntry:
-				c.Assert(e.unflatten(tableInfo, time.UTC), check.IsNil)
+				c.Assert(e.unflatten(tableInfo), check.IsNil)
 				e.Ts = 0
 				assertIn(c, e, expect)
 				eventSum++

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -1,8 +1,6 @@
 package entry
 
 import (
-	"time"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	timodel "github.com/pingcap/parser/model"
@@ -16,12 +14,11 @@ import (
 // Mounter is used to parse SQL events from KV events
 type Mounter struct {
 	schemaStorage *schema.Storage
-	loc           *time.Location
 }
 
 // NewTxnMounter creates a mounter
-func NewTxnMounter(schema *schema.Storage, loc *time.Location) *Mounter {
-	return &Mounter{schemaStorage: schema, loc: loc}
+func NewTxnMounter(schema *schema.Storage) *Mounter {
+	return &Mounter{schemaStorage: schema}
 }
 
 // Mount parses a raw transaction and returns a transaction
@@ -77,7 +74,7 @@ func (m *Mounter) mountRowKVEntry(row *rowKVEntry) (*model.DML, error) {
 		return nil, errors.Trace(err)
 	}
 
-	err = row.unflatten(tableInfo, m.loc)
+	err = row.unflatten(tableInfo)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -124,7 +121,7 @@ func (m *Mounter) mountIndexKVEntry(idx *indexKVEntry) (*model.DML, error) {
 		return nil, errors.Trace(err)
 	}
 
-	err = idx.unflatten(tableInfo, m.loc)
+	err = idx.unflatten(tableInfo)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"reflect"
 	"sync"
-	"time"
 
 	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
@@ -61,7 +60,7 @@ func (cs *mountTxnsSuite) TestInsertPkNotHandle(c *check.C) {
 	)
 	tableInfo := pm.GetTableInfo("testDB", "test1")
 	tableID := tableInfo.ID
-	mounter := NewTxnMounter(schema, time.UTC)
+	mounter := NewTxnMounter(schema)
 	plr := pm.CreatePuller(0, []util.Span{util.GetTableSpan(tableID, false)})
 
 	pm.MustExec("insert into testDB.test1 values('ttt',6)")
@@ -154,7 +153,7 @@ func (cs *mountTxnsSuite) TestInsertPkIsHandle(c *check.C) {
 	)
 	tableInfo := pm.GetTableInfo("testDB", "test1")
 	tableID := tableInfo.ID
-	mounter := NewTxnMounter(schema, time.UTC)
+	mounter := NewTxnMounter(schema)
 	plr := pm.CreatePuller(0, []util.Span{util.GetTableSpan(tableID, false)})
 
 	pm.MustExec("insert into testDB.test1 values(777,888)")
@@ -255,7 +254,7 @@ func (cs *mountTxnsSuite) TestLargeInteger(c *check.C) {
 	)
 	tableInfo := pm.GetTableInfo("testDB", "large_int")
 	tableID := tableInfo.ID
-	mounter := NewTxnMounter(schema, time.UTC)
+	mounter := NewTxnMounter(schema)
 	plr := pm.CreatePuller(0, []util.Span{util.GetTableSpan(tableID, false)})
 
 	pm.MustExec("insert into testDB.large_int values(?, ?)", uint64(math.MaxUint64), 123)
@@ -285,7 +284,7 @@ func (cs *mountTxnsSuite) TestLargeInteger(c *check.C) {
 	)
 	tableInfo = pm.GetTableInfo("testDB", "large_int")
 	tableID = tableInfo.ID
-	mounter = NewTxnMounter(schema, time.UTC)
+	mounter = NewTxnMounter(schema)
 	plr = pm.CreatePuller(0, []util.Span{util.GetTableSpan(tableID, false)})
 
 	pm.MustExec("insert into testDB.large_int values(?, ?)", int64(math.MinInt64), 123)

--- a/cdc/owner_operator.go
+++ b/cdc/owner_operator.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"database/sql"
 	"sync"
-	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
@@ -49,7 +48,7 @@ func newDDLHandler(pdCli pd.Client, checkpointTS uint64) *ddlHandler {
 	puller := puller.NewPuller(pdCli, checkpointTS, []util.Span{util.GetDDLSpan()}, false)
 	ctx, cancel := context.WithCancel(context.Background())
 	// TODO get time loc from config
-	txnMounter := entry.NewTxnMounter(nil, time.UTC)
+	txnMounter := entry.NewTxnMounter(nil)
 	h := &ddlHandler{
 		puller:  puller,
 		cancel:  cancel,

--- a/cdc/processor.go
+++ b/cdc/processor.go
@@ -232,7 +232,7 @@ func NewProcessor(pdEndpoints []string, changefeed model.ChangeFeedDetail, chang
 	ddlPuller := puller.NewPuller(pdCli, changefeed.GetCheckpointTs(), []util.Span{util.GetDDLSpan()}, false)
 
 	// TODO: get time zone from config
-	mounter := fNewMounter(schemaStorage, time.UTC)
+	mounter := fNewMounter(schemaStorage)
 
 	sink, err := fNewMySQLSink(changefeed.SinkURI, schemaStorage, changefeed.Opts)
 	if err != nil {
@@ -692,6 +692,6 @@ func (p *processor) startPuller(ctx context.Context, span util.Span, checkpointT
 	return puller
 }
 
-func newMounter(schema *schema.Storage, loc *time.Location) mounter {
-	return entry.NewTxnMounter(schema, loc)
+func newMounter(schema *schema.Storage) mounter {
+	return entry.NewTxnMounter(schema)
 }

--- a/cdc/processor_test.go
+++ b/cdc/processor_test.go
@@ -136,7 +136,7 @@ func runCase(c *check.C, cases *processorTestCase) {
 		return &mockTsRWriter{}, nil
 	}
 	origFNewMounter := fNewMounter
-	fNewMounter = func(schema *schema.Storage, loc *time.Location) mounter {
+	fNewMounter = func(schema *schema.Storage) mounter {
 		return mockMounter{}
 	}
 	origFNewSink := fNewMySQLSink

--- a/cdc/puller/mock_puller_test.go
+++ b/cdc/puller/mock_puller_test.go
@@ -48,7 +48,7 @@ func (s *mockPullerSuite) TestDDLPuller(c *check.C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ts := uint64(0)
-	txnMounter := entry.NewTxnMounter(nil, time.UTC)
+	txnMounter := entry.NewTxnMounter(nil)
 	go func() {
 		err := plr.CollectRawTxns(ctx, func(ctx context.Context, rawTxn model.RawTxn) error {
 			c.Assert(ts, check.Less, rawTxn.Ts)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
unify the time zone between capture and downstream database automatically

### What is changed and how it works?
using UTC TZ to parse time and set the TZ of downstream database UTC

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test