### PR TITLE
owner: dispatch new table when it changes from ineligible to eligible

### DIFF
--- a/cdc/owner.go
+++ b/cdc/owner.go
@@ -321,7 +321,6 @@ func (o *Owner) newChangeFeed(
 			continue
 		}
 
-		tables[tid] = table
 		schema, ok := schemaSnap.SchemaByTableID(tid)
 		if !ok {
 			log.Warn("schema not found for table", zap.Int64("tid", tid))
@@ -341,6 +340,8 @@ func (o *Owner) newChangeFeed(
 			log.Warn("skip ineligible table", zap.Int64("tid", tid), zap.Stringer("table", table))
 			continue
 		}
+		// Note we only add eligible tables to changefeed.tables
+		tables[tid] = table
 		// `existingTables` are tables dispatched to a processor, however the
 		// capture that this processor belongs to could have crashed or exited.
 		// So we check this before task dispatching, but after the update of

--- a/cdc/owner_test.go
+++ b/cdc/owner_test.go
@@ -765,13 +765,13 @@ func (s *ownerSuite) TestChangefeedApplyDDLJob(c *check.C) {
 				},
 			},
 			{
-				ID:       2,
+				ID:       3,
 				SchemaID: 1,
 				Type:     timodel.ActionCreateTable,
 				State:    timodel.JobStateSynced,
 				Query:    "create table t2 (id int primary key)",
 				BinlogInfo: &timodel.HistoryInfo{
-					SchemaVersion: 2,
+					SchemaVersion: 3,
 					DBInfo: &timodel.DBInfo{
 						ID:   1,
 						Name: timodel.NewCIStr("test"),
@@ -787,14 +787,14 @@ func (s *ownerSuite) TestChangefeedApplyDDLJob(c *check.C) {
 				},
 			},
 			{
-				ID:       2,
+				ID:       4,
 				SchemaID: 1,
 				TableID:  49,
 				Type:     timodel.ActionDropTable,
 				State:    timodel.JobStateSynced,
 				Query:    "drop table t2",
 				BinlogInfo: &timodel.HistoryInfo{
-					SchemaVersion: 3,
+					SchemaVersion: 4,
 					DBInfo: &timodel.DBInfo{
 						ID:   1,
 						Name: timodel.NewCIStr("test"),
@@ -806,14 +806,14 @@ func (s *ownerSuite) TestChangefeedApplyDDLJob(c *check.C) {
 				},
 			},
 			{
-				ID:       2,
+				ID:       5,
 				SchemaID: 1,
 				TableID:  47,
 				Type:     timodel.ActionTruncateTable,
 				State:    timodel.JobStateSynced,
 				Query:    "truncate table t1",
 				BinlogInfo: &timodel.HistoryInfo{
-					SchemaVersion: 4,
+					SchemaVersion: 5,
 					DBInfo: &timodel.DBInfo{
 						ID:   1,
 						Name: timodel.NewCIStr("test"),
@@ -829,14 +829,14 @@ func (s *ownerSuite) TestChangefeedApplyDDLJob(c *check.C) {
 				},
 			},
 			{
-				ID:       2,
+				ID:       6,
 				SchemaID: 1,
 				TableID:  51,
 				Type:     timodel.ActionDropTable,
 				State:    timodel.JobStateSynced,
 				Query:    "drop table t1",
 				BinlogInfo: &timodel.HistoryInfo{
-					SchemaVersion: 5,
+					SchemaVersion: 6,
 					DBInfo: &timodel.DBInfo{
 						ID:   1,
 						Name: timodel.NewCIStr("test"),
@@ -848,7 +848,65 @@ func (s *ownerSuite) TestChangefeedApplyDDLJob(c *check.C) {
 				},
 			},
 			{
-				ID:       2,
+				ID:       7,
+				SchemaID: 1,
+				Type:     timodel.ActionCreateTable,
+				State:    timodel.JobStateSynced,
+				Query:    "create table t3 (id int not null)",
+				BinlogInfo: &timodel.HistoryInfo{
+					SchemaVersion: 7,
+					DBInfo: &timodel.DBInfo{
+						ID:   1,
+						Name: timodel.NewCIStr("test"),
+					},
+					TableInfo: &timodel.TableInfo{
+						ID:         53,
+						Name:       timodel.NewCIStr("t3"),
+						PKIsHandle: true,
+						Columns: []*timodel.ColumnInfo{
+							{ID: 1, FieldType: types.FieldType{Flag: mysql.NotNullFlag}, State: timodel.StatePublic},
+						},
+					},
+				},
+			},
+			{
+				ID:       8,
+				State:    timodel.JobStateSynced,
+				SchemaID: 1,
+				TableID:  53,
+				Type:     timodel.ActionAddIndex,
+				BinlogInfo: &timodel.HistoryInfo{
+					SchemaVersion: 8,
+					DBInfo: &timodel.DBInfo{
+						ID:   1,
+						Name: timodel.NewCIStr("test"),
+					},
+					TableInfo: &timodel.TableInfo{
+						ID:         53,
+						Name:       timodel.NewCIStr("t3"),
+						PKIsHandle: true,
+						Columns: []*timodel.ColumnInfo{
+							{ID: 1, FieldType: types.FieldType{Flag: mysql.NotNullFlag | mysql.UniqueKeyFlag}, State: timodel.StatePublic},
+						},
+						Indices: []*timodel.IndexInfo{
+							{
+								Name:  timodel.NewCIStr("uniq_id"),
+								Table: timodel.NewCIStr("t3"),
+								Columns: []*timodel.IndexColumn{
+									{
+										Name:   timodel.NewCIStr("id"),
+										Offset: 0,
+									},
+								},
+								Unique: true,
+								State:  timodel.StatePublic,
+							},
+						},
+					},
+				},
+			},
+			{
+				ID:       9,
 				SchemaID: 1,
 				Type:     timodel.ActionDropSchema,
 				State:    timodel.JobStateSynced,
@@ -870,6 +928,8 @@ func (s *ownerSuite) TestChangefeedApplyDDLJob(c *check.C) {
 			{1: {47: struct{}{}}},
 			{1: {51: struct{}{}}},
 			{1: make(tableIDMap)},
+			{1: make(tableIDMap)},
+			{1: {53: struct{}{}}},
 			{},
 		}
 
@@ -880,6 +940,8 @@ func (s *ownerSuite) TestChangefeedApplyDDLJob(c *check.C) {
 			{47: {Schema: "test", Table: "t1"}},
 			{51: {Schema: "test", Table: "t1"}},
 			{},
+			{},
+			{53: {Schema: "test", Table: "t3"}},
 			{},
 		}
 	)

--- a/tests/eligible_table_trans/conf/diff_config.toml
+++ b/tests/eligible_table_trans/conf/diff_config.toml
@@ -1,0 +1,27 @@
+# diff Configuration.
+
+log-level = "info"
+chunk-size = 10
+check-thread-count = 4
+sample-percent = 100
+use-rowid = false
+use-checksum = true
+fix-sql-file = "fix.sql"
+
+# tables need to check.
+[[check-tables]]
+    schema = "eligible_table_trans"
+    tables = ["~t.*"]
+
+[[source-db]]
+    host = "127.0.0.1"
+    port = 4000
+    user = "root"
+    password = ""
+    instance-id = "source-1"
+
+[target-db]
+    host = "127.0.0.1"
+    port = 3306
+    user = "root"
+    password = ""

--- a/tests/eligible_table_trans/run.sh
+++ b/tests/eligible_table_trans/run.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -e
+
+CUR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+
+function run() {
+    rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+    start_tidb_cluster --workdir $WORK_DIR
+    cd $WORK_DIR
+
+    pd_addr="http://$UP_PD_HOST_1:$UP_PD_PORT_1"
+    TOPIC_NAME="eligible-table-trans-$RANDOM"
+    case $SINK_TYPE in
+        kafka) SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&kafka-version=${KAFKA_VERSION}";;
+        *) SINK_URI="mysql://root@127.0.0.1:3306/?max-txn-row=1";;
+    esac
+    if [ "$SINK_TYPE" == "kafka" ]; then
+      run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/$TOPIC_NAME?partition-num=4&version=${KAFKA_VERSION}"
+    fi
+
+    # These DDLs can't be replicated to downstream, so we run it in both upstream and downstream
+    run_sql "CREATE DATABASE eligible_table_trans;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "CREATE DATABASE eligible_table_trans;" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    run_sql "CREATE table eligible_table_trans.t1 (id int, unique uniq_id(id))" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "CREATE table eligible_table_trans.t1 (id int, unique uniq_id(id))" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    run_sql "CREATE table eligible_table_trans.t2 (id int not null)" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "CREATE table eligible_table_trans.t2 (id int not null)" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+
+    run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8300" --pd $pd_addr
+    cdc cli changefeed create --pd=$pd_addr --sink-uri="$SINK_URI" --no-confirm
+
+    # These DDLs can't be replicated to downstream, so we run it in both upstream and downstream
+    run_sql "CREATE table eligible_table_trans.t3 (id int, unique uniq_id(id))" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "CREATE table eligible_table_trans.t3 (id int, unique uniq_id(id))" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+    run_sql "CREATE table eligible_table_trans.t4 (id int not null)" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "CREATE table eligible_table_trans.t4 (id int not null)" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+
+    # run DDLs which can make some tables change from ineligible to eligible
+    run_sql "ALTER table eligible_table_trans.t1 modify column id int not null" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "ALTER table eligible_table_trans.t2 add unique uniq_id(id)" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "ALTER table eligible_table_trans.t3 modify column id int not null" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "ALTER table eligible_table_trans.t4 add unique uniq_id(id)" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+    run_sql "INSERT INTO eligible_table_trans.t1 values (1),(2),(4),(8),(1024),(2048),(4096),(2147483647)" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "INSERT INTO eligible_table_trans.t2 values (1),(2),(4),(8),(1024),(2048),(4096),(2147483647)" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "INSERT INTO eligible_table_trans.t3 values (1),(2),(4),(8),(1024),(2048),(4096),(2147483647)" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+    run_sql "INSERT INTO eligible_table_trans.t4 values (1),(2),(4),(8),(1024),(2048),(4096),(2147483647)" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+    check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+    cleanup_process $CDC_BINARY
+}
+
+trap stop_tidb_cluster EXIT
+run $*
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #1485

### What is changed and how it works?

- If a table changes from ineligible to eligible, it should be removed from the `ineligibleTableID` map of schema storage
- If a table changes from ineligible to eligible, dispatch a new table task from owner

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note

- Fix the bug that table is not replicated when it changes from ineligible to eligible by DDL

