### PR TITLE
owner: fix debug info API returns empty owner info

### DIFF
--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -15,6 +15,7 @@ package owner
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
 	"time"
 
@@ -96,6 +97,16 @@ func newChangefeed4Test(
 	c.newDDLPuller = newDDLPuller
 	c.newSink = newSink
 	return c
+}
+
+// debugInfo returns debug info or a changefeed
+// TODO: refine debug info, this function is not thread-safe
+func (c *changefeed) debugInfo() ([]byte, error) {
+	return json.Marshal(map[string]interface{}{
+		"id":          c.id,
+		"state":       c.state,
+		"initialized": c.initialized,
+	})
 }
 
 func (c *changefeed) Tick(ctx cdcContext.Context, state *orchestrator.ChangefeedReactorState, captures map[model.CaptureID]*model.CaptureInfo) {

--- a/cdc/owner/owner.go
+++ b/cdc/owner/owner.go
@@ -293,7 +293,10 @@ func (o *Owner) handleJobs() {
 		case ownerJobTypeRebalance:
 			cfReactor.scheduler.Rebalance()
 		case ownerJobTypeDebugInfo:
-			job.debugInfoWriter.Write(o.debugInfo())
+			_, err := job.debugInfoWriter.Write(o.debugInfo())
+			if err != nil {
+				log.Warn("write debug info failed", zap.Error(err))
+			}
 		}
 		close(job.done)
 	}

--- a/pkg/orchestrator/reactor_state.go
+++ b/pkg/orchestrator/reactor_state.go
@@ -111,11 +111,11 @@ func (s *GlobalReactorState) GetPatches() [][]DataPatch {
 
 // ChangefeedReactorState represents a changefeed state which stores all key-value pairs of a changefeed in ETCD
 type ChangefeedReactorState struct {
-	ID            model.ChangeFeedID
-	Info          *model.ChangeFeedInfo
-	Status        *model.ChangeFeedStatus
-	TaskPositions map[model.CaptureID]*model.TaskPosition
-	TaskStatuses  map[model.CaptureID]*model.TaskStatus
+	ID            model.ChangeFeedID                      `json:"id"`
+	Info          *model.ChangeFeedInfo                   `json:"info"`
+	Status        *model.ChangeFeedStatus                 `json:"status"`
+	TaskPositions map[model.CaptureID]*model.TaskPosition `json:"task-positions"`
+	TaskStatuses  map[model.CaptureID]*model.TaskStatus   `json:"task-statuses"`
 	Workloads     map[model.CaptureID]model.TaskWorkload
 
 	pendingPatches        []DataPatch


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

owner debug info is not available in new owner implement, the debug info API will delay `1s`, and fix the following error

`[2021/09/26 11:05:04.892 +08:00] [WARN] [owner.go:282] ["changefeed not found when handle a job"] [job={}]`

### What is changed and how it works?

- Add `debugInfo` API to owner and changefeed

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
