### PR TITLE
docs: add design docs for column selector

### DIFF
--- a/docs/design/2021-10-13-ticdc-mq-sink-column-selector.md
+++ b/docs/design/2021-10-13-ticdc-mq-sink-column-selector.md
@@ -1,7 +1,7 @@
 # TiCDC Design Documents
 
 - Author(s): [hi-rustin](https://github.com/hi-rustin)
-- Tracking Issue:
+- Tracking Issue: https://github.com/pingcap/ticdc/issues/3082
 
 ## Table of Contents
 


### PR DESCRIPTION
Add design docs for column selector.

[Rendered](https://github.com/hi-rustin/ticdc/blob/rustin-patch-design/docs/design/2021-10-13-ticdc-mq-sink-column-selector.md)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
