### PR TITLE
kv/client: clear token related metrics when kv client exits

### DIFF
--- a/cdc/kv/token_region.go
+++ b/cdc/kv/token_region.go
@@ -104,6 +104,7 @@ func (r *sizedRegionRouter) AddRegion(sri singleRegionInfo) {
 		r.buffer[id] = append(r.buffer[id], sri)
 		if _, ok := r.metrics.cachedRegions[id]; !ok {
 			r.metrics.cachedRegions[id] = cachedRegionSize.WithLabelValues(id, r.metrics.changefeed, r.metrics.capture)
+			r.metrics.cachedRegions[id].Set(0)
 		}
 		r.metrics.cachedRegions[id].Inc()
 	}
@@ -118,6 +119,7 @@ func (r *sizedRegionRouter) Acquire(id string) {
 	r.tokens[id]++
 	if _, ok := r.metrics.tokens[id]; !ok {
 		r.metrics.tokens[id] = clientRegionTokenSize.WithLabelValues(id, r.metrics.changefeed, r.metrics.capture)
+		r.metrics.tokens[id].Set(0)
 	}
 	r.metrics.tokens[id].Inc()
 }
@@ -130,6 +132,7 @@ func (r *sizedRegionRouter) Release(id string) {
 	r.tokens[id]--
 	if _, ok := r.metrics.tokens[id]; !ok {
 		r.metrics.tokens[id] = clientRegionTokenSize.WithLabelValues(id, r.metrics.changefeed, r.metrics.capture)
+		r.metrics.tokens[id].Set(0)
 	}
 	r.metrics.tokens[id].Dec()
 }
@@ -140,9 +143,6 @@ func (r *sizedRegionRouter) Run(ctx context.Context) error {
 		ticker.Stop()
 		r.lock.Lock()
 		defer r.lock.Unlock()
-		for _, m := range r.metrics.tokens {
-			m.Set(0)
-		}
 		for _, m := range r.metrics.cachedRegions {
 			m.Set(0)
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

reset token related metrics when kv client exists

### What is changed and how it works?

reset token related metrics when kv client exists


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
