### PR TITLE
scheduler: add Relay as a worker stage and fix bug

### DIFF
--- a/dm/_utils/terror_gen/errors_release.txt
+++ b/dm/_utils/terror_gen/errors_release.txt
@@ -518,7 +518,7 @@ ErrSchedulerSourceOpRelayExist,[code=46023:class=scheduler:scope=internal:level=
 ErrSchedulerLatchInUse,[code=46024:class=scheduler:scope=internal:level=low], "Message: when %s, resource %s is in use by other client, Workaround: Please try again later"
 ErrSchedulerSourceCfgUpdate,[code=46025:class=scheduler:scope=internal:level=low], "Message: source can only update relay-log related parts for now"
 ErrSchedulerWrongWorkerInput,[code=46026:class=scheduler:scope=internal:level=medium], "Message: require DM master to modify worker [%s] with source [%s], but currently the worker is bound to source [%s]"
-ErrSchedulerCantTransferToRelayWorker,[code=46027:class=scheduler:scope=internal:level=medium], "Message: require DM worker to be bound to source [%s], but it has been started relay for source [%s]"
+ErrSchedulerBoundDiffWithStartedRelay,[code=46027:class=scheduler:scope=internal:level=medium], "Message: require DM worker [%s] to be bound to source [%s], but it has been started relay for source [%s], Workaround: If you intend to bind the source with worker, you can stop-relay for current source."
 ErrCtlGRPCCreateConn,[code=48001:class=dmctl:scope=internal:level=high], "Message: can not create grpc connection, Workaround: Please check your network connection."
 ErrCtlInvalidTLSCfg,[code=48002:class=dmctl:scope=internal:level=medium], "Message: invalid TLS config, Workaround: Please check the `ssl-ca`, `ssl-cert` and `ssl-key` config in command line."
 ErrCtlLoadTLSCfg,[code=48003:class=dmctl:scope=internal:level=high], "Message: can not load tls config, Workaround: Please ensure that the tls certificate is accessible on the node currently running dmctl."

--- a/dm/dm/master/scheduler/worker.go
+++ b/dm/dm/master/scheduler/worker.go
@@ -18,10 +18,13 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/pingcap/ticdc/dm/dm/config"
 	"github.com/pingcap/ticdc/dm/dm/master/metrics"
 	"github.com/pingcap/ticdc/dm/dm/master/workerrpc"
 	"github.com/pingcap/ticdc/dm/pkg/ha"
+	"github.com/pingcap/ticdc/dm/pkg/log"
 	"github.com/pingcap/ticdc/dm/pkg/terror"
 )
 
@@ -32,15 +35,28 @@ type WorkerStage string
 // valid transformation:
 //   - Offline -> Free, receive keep-alive.
 //   - Free -> Offline, lost keep-alive.
-//   - Free -> Bound, schedule source.
-//   - Bound -> Offline, lost keep-live, when receive keep-alive again, it should become Free.
-//   - Bound -> Free, revoke source scheduler.
+//   - Free -> Bound, bind source.
+//   - Free -> Relay, start relay for a source.
+//   - Bound -> Offline, lost keep-alive, when receive keep-alive again, it should become Free.
+//   - Bound -> Free, unbind source.
+//   - Bound -> Relay, commands like transfer-source that gracefully unbind a worker which has started relay.
+//   - Relay -> Offline, lost keep-alive.
+//   - Relay -> Free, stop relay.
+//   - Relay -> Bound, old bound worker becomes offline so bind source to this worker, which has started relay.
 // invalid transformation:
 //   - Offline -> Bound, must become Free first.
+//   - Offline -> Relay, must become Free first.
+// in Bound stage relay can be turned on/off, the difference with Bound-Relay transformation is
+//   - Bound stage turning on/off represents a bound DM worker receives start-relay/stop-relay, source bound relation is
+//     not changed.
+//   - Bound-Relay transformation represents source bound relation is changed.
+// caller should ensure the correctness when invoke below transformation methods successively. For example, call ToBound
+//   twice with different arguments.
 const (
 	WorkerOffline WorkerStage = "offline" // the worker is not online yet.
 	WorkerFree    WorkerStage = "free"    // the worker is online, but no upstream source assigned to it yet.
 	WorkerBound   WorkerStage = "bound"   // the worker is online, and one upstream source already assigned to it.
+	WorkerRelay   WorkerStage = "relay"   // the worker is online, pulling relay log but not responsible for migrating.
 )
 
 var (
@@ -50,6 +66,7 @@ var (
 		WorkerOffline: 0.0,
 		WorkerFree:    1.0,
 		WorkerBound:   2.0,
+		WorkerRelay:   1.5,
 	}
 	unrecognizedState = -1.0
 )
@@ -63,6 +80,9 @@ type Worker struct {
 	baseInfo ha.WorkerInfo  // the base information of the DM-worker instance.
 	bound    ha.SourceBound // the source bound relationship, null value if not bounded.
 	stage    WorkerStage    // the current stage.
+
+	// the source ID from which the worker is pulling relay log. should keep consistent with Scheduler.relayWorkers
+	relaySource string
 }
 
 // NewWorker creates a new Worker instance with Offline stage.
@@ -89,7 +109,7 @@ func (w *Worker) Close() {
 }
 
 // ToOffline transforms to Offline.
-// both Free and Bound can transform to Offline.
+// All available transitions can be found at the beginning of this file.
 func (w *Worker) ToOffline() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -98,28 +118,93 @@ func (w *Worker) ToOffline() {
 	w.bound = nullBound
 }
 
-// ToFree transforms to Free.
-// both Offline and Bound can transform to Free.
+// ToFree transforms to Free and clears the bound and relay information.
+// All available transitions can be found at the beginning of this file.
 func (w *Worker) ToFree() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.stage = WorkerFree
 	w.reportMetrics()
 	w.bound = nullBound
+	w.relaySource = ""
 }
 
 // ToBound transforms to Bound.
-// Free can transform to Bound, but Offline can't.
+// All available transitions can be found at the beginning of this file.
 func (w *Worker) ToBound(bound ha.SourceBound) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.stage == WorkerOffline {
 		return terror.ErrSchedulerWorkerInvalidTrans.Generate(w.BaseInfo(), WorkerOffline, WorkerBound)
 	}
+	if w.stage == WorkerRelay {
+		if w.relaySource != bound.Source {
+			return terror.ErrSchedulerBoundDiffWithStartedRelay.Generate(w.BaseInfo().Name, bound.Source, w.relaySource)
+		}
+	}
+
 	w.stage = WorkerBound
 	w.reportMetrics()
 	w.bound = bound
 	return nil
+}
+
+// Unbound changes worker's stage from Bound to Free or Relay.
+func (w *Worker) Unbound() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.stage != WorkerBound {
+		// caller should not do this.
+		return terror.ErrSchedulerWorkerInvalidTrans.Generatef("can't unbound a worker that is not in bound stage.")
+	}
+
+	w.bound = nullBound
+	if w.relaySource != "" {
+		w.stage = WorkerRelay
+	} else {
+		w.stage = WorkerFree
+	}
+	w.reportMetrics()
+	return nil
+}
+
+// StartRelay adds relay source information to a bound worker and calculates the stage.
+func (w *Worker) StartRelay(sourceID string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	switch w.stage {
+	case WorkerOffline, WorkerRelay:
+	case WorkerFree:
+		w.stage = WorkerRelay
+		w.reportMetrics()
+	case WorkerBound:
+		if w.bound.Source != sourceID {
+			return terror.ErrSchedulerRelayWorkersWrongBound.Generatef(
+				"can't turn on relay of source %s for worker %s, because the worker is bound to source %s",
+				sourceID, w.BaseInfo().Name, w.bound.Source)
+		}
+	}
+	w.relaySource = sourceID
+
+	return nil
+}
+
+// StopRelay clears relay source information of a bound worker and calculates the stage.
+func (w *Worker) StopRelay() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.relaySource = ""
+	switch w.stage {
+	case WorkerOffline, WorkerBound:
+	case WorkerFree:
+		log.L().DPanic("StopRelay for a Free worker should not happen",
+			zap.String("worker name", w.baseInfo.Name))
+	case WorkerRelay:
+		w.stage = WorkerFree
+		w.reportMetrics()
+	}
 }
 
 // BaseInfo returns the base info of the worker.
@@ -141,6 +226,14 @@ func (w *Worker) Bound() ha.SourceBound {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 	return w.bound
+}
+
+// RelaySourceID returns the source ID from which this worker is pulling relay log,
+// returns empty string if not started relay.
+func (w *Worker) RelaySourceID() string {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.relaySource
 }
 
 // SendRequest sends request to the DM-worker instance.

--- a/dm/errors.toml
+++ b/dm/errors.toml
@@ -3119,9 +3119,9 @@ workaround = ""
 tags = ["internal", "medium"]
 
 [error.DM-scheduler-46027]
-message = "require DM worker to be bound to source [%s], but it has been started relay for source [%s]"
+message = "require DM worker [%s] to be bound to source [%s], but it has been started relay for source [%s]"
 description = ""
-workaround = ""
+workaround = "If you intend to bind the source with worker, you can stop-relay for current source."
 tags = ["internal", "medium"]
 
 [error.DM-dmctl-48001]

--- a/dm/pkg/terror/error_list.go
+++ b/dm/pkg/terror/error_list.go
@@ -1266,7 +1266,7 @@ var (
 	ErrSchedulerLatchInUse                = New(codeSchedulerLatchInUse, ClassScheduler, ScopeInternal, LevelLow, "when %s, resource %s is in use by other client", "Please try again later")
 	ErrSchedulerSourceCfgUpdate           = New(codeSchedulerSourceCfgUpdate, ClassScheduler, ScopeInternal, LevelLow, "source can only update relay-log related parts for now", "")
 	ErrSchedulerWrongWorkerInput          = New(codeSchedulerWrongWorkerInput, ClassScheduler, ScopeInternal, LevelMedium, "require DM master to modify worker [%s] with source [%s], but currently the worker is bound to source [%s]", "")
-	ErrSchedulerCantTransferToRelayWorker = New(codeSchedulerCantTransferToRelayWorker, ClassScheduler, ScopeInternal, LevelMedium, "require DM worker to be bound to source [%s], but it has been started relay for source [%s]", "")
+	ErrSchedulerBoundDiffWithStartedRelay = New(codeSchedulerCantTransferToRelayWorker, ClassScheduler, ScopeInternal, LevelMedium, "require DM worker [%s] to be bound to source [%s], but it has been started relay for source [%s]", "If you intend to bind the source with worker, you can stop-relay for current source.")
 
 	// dmctl.
 	ErrCtlGRPCCreateConn = New(codeCtlGRPCCreateConn, ClassDMCtl, ScopeInternal, LevelHigh, "can not create grpc connection", "Please check your network connection.")

--- a/dm/tests/all_mode/run.sh
+++ b/dm/tests/all_mode/run.sh
@@ -9,6 +9,7 @@ API_VERSION="v1alpha1"
 ILLEGAL_CHAR_NAME='t-Ë!s`t'
 
 function test_session_config() {
+	echo "[$(date)] <<<<<< start test_session_config >>>>>>"
 	run_sql_file $cur/data/db1.prepare.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1
 	check_contains 'Query OK, 2 rows affected'
 	run_sql_file $cur/data/db2.prepare.sql $MYSQL_HOST2 $MYSQL_PORT2 $MYSQL_PASSWORD2
@@ -58,9 +59,12 @@ function test_session_config() {
 
 	cleanup_data all_mode
 	cleanup_process
+	echo "[$(date)] <<<<<< finish test_session_config >>>>>>"
+
 }
 
 function test_query_timeout() {
+	echo "[$(date)] <<<<<< start test_query_timeout >>>>>>"
 	export GO_FAILPOINTS="github.com/pingcap/ticdc/dm/syncer/BlockSyncStatus=return(\"5s\")"
 
 	cp $cur/conf/dm-master.toml $WORK_DIR/dm-master.toml
@@ -105,7 +109,8 @@ function test_query_timeout() {
 	# start DM task only
 	cp $cur/conf/dm-task.yaml $WORK_DIR/dm-task.yaml
 	sed -i "s/name: test/name: $ILLEGAL_CHAR_NAME/g" $WORK_DIR/dm-task.yaml
-	dmctl_start_task "$WORK_DIR/dm-task.yaml" "--remove-meta"
+	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
+		"start-task $WORK_DIR/dm-task.yaml --remove-meta"
 	check_metric $WORKER1_PORT "dm_worker_task_state{source_id=\"mysql-replica-01\",task=\"$ILLEGAL_CHAR_NAME\",worker=\"worker1\"}" 10 1 3
 
 	# `query-status` timeout
@@ -140,9 +145,11 @@ function test_query_timeout() {
 	cleanup_process
 
 	export GO_FAILPOINTS=''
+	echo "[$(date)] <<<<<< finish test_query_timeout >>>>>>"
 }
 
 function test_stop_task_before_checkpoint() {
+	echo "[$(date)] <<<<<< start test_stop_task_before_checkpoint >>>>>>"
 	run_sql_file $cur/data/db1.prepare.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1
 	check_contains 'Query OK, 2 rows affected'
 	run_sql_file $cur/data/db2.prepare.sql $MYSQL_HOST2 $MYSQL_PORT2 $MYSQL_PASSWORD2
@@ -204,9 +211,11 @@ function test_stop_task_before_checkpoint() {
 	cleanup_process
 
 	export GO_FAILPOINTS=''
+	echo "[$(date)] <<<<<< finish test_stop_task_before_checkpoint >>>>>>"
 }
 
 function test_fail_job_between_event() {
+	echo "[$(date)] <<<<<< start test_fail_job_between_event >>>>>>"
 	run_sql_file $cur/data/db1.prepare.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1
 	check_contains 'Query OK, 2 rows affected'
 	run_sql_file $cur/data/db2.prepare.sql $MYSQL_HOST2 $MYSQL_PORT2 $MYSQL_PASSWORD2
@@ -262,9 +271,11 @@ function test_fail_job_between_event() {
 	cleanup_process
 
 	export GO_FAILPOINTS=''
+	echo "[$(date)] <<<<<< finish test_fail_job_between_event >>>>>>"
 }
 
 function test_expression_filter() {
+	echo "[$(date)] <<<<<< start test_expression_filter >>>>>>"
 	run_sql_file $cur/data/db1.prepare.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1
 	check_contains 'Query OK, 2 rows affected'
 	run_sql_file $cur/data/db2.prepare.sql $MYSQL_HOST2 $MYSQL_PORT2 $MYSQL_PASSWORD2
@@ -305,6 +316,7 @@ function test_expression_filter() {
 
 	cleanup_data all_mode
 	cleanup_process
+	echo "[$(date)] <<<<<< finish test_expression_filter >>>>>>"
 }
 
 function run() {

--- a/dm/tests/ha_cases/conf/dm-master-standalone.toml
+++ b/dm/tests/ha_cases/conf/dm-master-standalone.toml
@@ -1,0 +1,4 @@
+# Master Configuration.
+master-addr = ":8261"
+advertise-addr = "127.0.0.1:8261"
+auto-compaction-retention = "3s"

--- a/dm/tests/ha_cases/run.sh
+++ b/dm/tests/ha_cases/run.sh
@@ -270,7 +270,114 @@ function test_last_bound() {
 	echo "[$(date)] <<<<<< finish test_last_bound >>>>>>"
 }
 
+function test_exclusive_relay() {
+	echo "[$(date)] <<<<<< start test_exclusive_relay >>>>>>"
+
+	echo "start DM worker and master cluster"
+	run_dm_master $WORK_DIR/master1 $MASTER_PORT1 $cur/conf/dm-master-standalone.toml
+	check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT1
+
+	run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
+	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT
+	cp $cur/conf/source1.yaml $WORK_DIR/source1.yaml
+	cp $cur/conf/source2.yaml $WORK_DIR/source2.yaml
+	sed -i "/relay-binlog-name/i\relay-dir: $WORK_DIR/worker1/relay_log" $WORK_DIR/source1.yaml
+	sed -i "/relay-binlog-name/i\relay-dir: $WORK_DIR/worker2/relay_log" $WORK_DIR/source2.yaml
+	dmctl_operate_source create $WORK_DIR/source1.yaml $SOURCE_ID1
+
+	run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
+	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT
+
+	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
+		"start-relay -s $SOURCE_ID1 worker1 worker2" \
+		"\"result\": true" 1
+
+	dmctl_operate_source create $WORK_DIR/source2.yaml $SOURCE_ID2
+
+	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
+		"list-member --worker" \
+		"\"stage\": \"bound\"" 1 \
+		"\"stage\": \"relay\"" 1
+
+	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
+		"operate-source show -s $SOURCE_ID2" \
+		"\"msg\": \"source is added but there is no free worker to bound\"" 1
+
+	cleanup
+	echo "[$(date)] <<<<<< finish test_exclusive_relay >>>>>>"
+}
+
+function test_exclusive_relay_2() {
+	echo "[$(date)] <<<<<< start test_exclusive_relay_2 >>>>>>"
+
+	echo "start DM worker and master cluster"
+	run_dm_master $WORK_DIR/master1 $MASTER_PORT1 $cur/conf/dm-master-standalone.toml
+	check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT1
+
+	run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
+	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT
+	cp $cur/conf/source1.yaml $WORK_DIR/source1.yaml
+	cp $cur/conf/source2.yaml $WORK_DIR/source2.yaml
+	sed -i "/relay-binlog-name/i\relay-dir: $WORK_DIR/worker1/relay_log" $WORK_DIR/source1.yaml
+	sed -i "/relay-binlog-name/i\relay-dir: $WORK_DIR/worker2/relay_log" $WORK_DIR/source2.yaml
+	dmctl_operate_source create $WORK_DIR/source1.yaml $SOURCE_ID1
+
+	run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
+	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT
+	dmctl_operate_source create $WORK_DIR/source2.yaml $SOURCE_ID2
+
+	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
+		"start-relay -s $SOURCE_ID1 worker1" \
+		"\"result\": true" 1
+
+	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
+		"start-relay -s $SOURCE_ID2 worker2" \
+		"\"result\": true" 1
+
+	run_dm_worker $WORK_DIR/worker3 $WORKER3_PORT $cur/conf/dm-worker3.toml
+	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER3_PORT
+
+	# kill worker1, source1 should be bound to worker3
+	echo "kill dm-worker1"
+	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	check_port_offline $WORKER1_PORT 20
+	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT1" \
+		"list-member --name worker3" \
+		"\"source\": \"mysql-replica-01\"" 1
+
+	# worker1 online, nothing happened
+	run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
+	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT
+	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT1" \
+		"list-member --name worker3" \
+		"\"source\": \"mysql-replica-01\"" 1
+	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT1" \
+		"list-member --name worker1" \
+		"\"stage\": \"relay\"" 1
+
+	# kill worker2, source2 should not be bound
+	echo "kill dm-worker2"
+	ps aux | grep dm-worker2 | awk '{print $2}' | xargs kill || true
+	check_port_offline $WORKER2_PORT 20
+
+	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
+		"operate-source show -s $SOURCE_ID2" \
+		"\"msg\": \"source is added but there is no free worker to bound\"" 1
+
+	# worker2 online, bound to source2
+	run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
+	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT
+	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT1" \
+		"list-member --name worker2" \
+		"\"source\": \"mysql-replica-02\"" 1
+
+	cleanup
+	echo "[$(date)] <<<<<< finish test_exclusive_relay_2 >>>>>>"
+}
+
 function run() {
+	test_exclusive_relay
+	test_exclusive_relay_2
 	test_last_bound
 	test_config_name             # TICASE-915, 916, 954, 955
 	test_join_masters_and_worker # TICASE-928, 930, 931, 961, 932, 957


### PR DESCRIPTION
<!--
Thank you for contributing to DM! Please read DM's [CONTRIBUTING](https://github.com/pingcap/dm/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/dm/issues/2204

### What is changed and how it works?
Now scheduler of DM master will maintain DM worker in 4 stage: Offline, Free, Relay, Bound. Relay is newly added to easily and correctly handle some stage transition.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

 - Increased code complexity
 - Breaking backward compatibility (but fix a bug)

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation AND METRICS
 - Need to be included in the release note

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Avoid to schedule source to a DM-worker that has started relay for another source.
```
