### PR TITLE
ticdc/log: suppress duplicated log to avoid flooding

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -91,11 +91,13 @@ func (o *options) addFlags(cmd *cobra.Command) {
 // run runs the server cmd.
 func (o *options) run(cmd *cobra.Command) error {
 	cancel := util.InitCmd(cmd, &logutil.Config{
-		File:           o.serverConfig.LogFile,
-		Level:          o.serverConfig.LogLevel,
-		FileMaxSize:    o.serverConfig.Log.File.MaxSize,
-		FileMaxDays:    o.serverConfig.Log.File.MaxDays,
-		FileMaxBackups: o.serverConfig.Log.File.MaxBackups,
+		File:               o.serverConfig.LogFile,
+		Level:              o.serverConfig.LogLevel,
+		FileMaxSize:        o.serverConfig.Log.File.MaxSize,
+		FileMaxDays:        o.serverConfig.Log.File.MaxDays,
+		FileMaxBackups:     o.serverConfig.Log.File.MaxBackups,
+		SamplingInitial:    o.serverConfig.Log.Sampling.Initial,
+		SamplingThereafter: o.serverConfig.Log.Sampling.Thereafter,
 	})
 	defer cancel()
 

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -279,6 +279,10 @@ cleanup-speed-limit = 14
 				MaxDays:    1,
 				MaxBackups: 1,
 			},
+			Sampling: &config.LogSamplingConfig{
+				Initial:    100,
+				Thereafter: 100,
+			},
 		},
 		DataDir:                dataDir,
 		GcTTL:                  500,
@@ -399,6 +403,10 @@ cert-allowed-cn = ["dd","ee"]
 				MaxSize:    200,
 				MaxDays:    1,
 				MaxBackups: 1,
+			},
+			Sampling: &config.LogSamplingConfig{
+				Initial:    100,
+				Thereafter: 100,
 			},
 		},
 		DataDir:                dataDir,

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -161,6 +161,10 @@ func (s *serverSuite) TestParseCfg(c *check.C) {
 				MaxDays:    0,
 				MaxBackups: 0,
 			},
+			Sampling: &config.LogSamplingConfig{
+				Initial:    100,
+				Thereafter: 100,
+			},
 		},
 		DataDir:                dataDir,
 		GcTTL:                  10,
@@ -232,6 +236,10 @@ processor-flush-interval = "600ms"
 max-size = 200
 max-days = 1
 max-backups = 1
+
+[log.sampling]
+initial = 100
+thereafter = 100
 
 [sorter]
 chunk-size-limit = 10000000
@@ -350,6 +358,10 @@ processor-flush-interval = "600ms"
 max-size = 200
 max-days = 1
 max-backups = 1
+
+[log.sampling]
+initial = 100
+thereafter = 100
 
 [sorter]
 chunk-size-limit = 10000000

--- a/pkg/config/config_test_data.go
+++ b/pkg/config/config_test_data.go
@@ -78,6 +78,10 @@ const (
       "max-size": 300,
       "max-days": 0,
       "max-backups": 0
+    },
+    "sampling": {
+      "initial": 100,
+      "thereafter": 100
     }
   },
   "data-dir": "",

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -53,9 +53,15 @@ type LogFileConfig struct {
 	MaxBackups int `toml:"max-backups" json:"max-backups"`
 }
 
+type LogSamplingConfig struct {
+	Initial    int `toml:"initial" json:"initial"`
+	Thereafter int `toml:"thereafter" json:"thereafter"`
+}
+
 // LogConfig represents log config for server
 type LogConfig struct {
-	File *LogFileConfig `toml:"file" json:"file"`
+	File     *LogFileConfig     `toml:"file" json:"file"`
+	Sampling *LogSamplingConfig `toml:"sampling" json:"sampling"`
 }
 
 var defaultServerConfig = &ServerConfig{
@@ -68,6 +74,10 @@ var defaultServerConfig = &ServerConfig{
 			MaxSize:    300,
 			MaxDays:    0,
 			MaxBackups: 0,
+		},
+		Sampling: &LogSamplingConfig{
+			Initial:    100,
+			Thereafter: 100,
 		},
 	},
 	DataDir: "",

--- a/pkg/logutil/log_test.go
+++ b/pkg/logutil/log_test.go
@@ -89,7 +89,6 @@ func (s *logSuite) TestZapErrorFilter(c *check.C) {
 
 func getLinesCount(logFile string) (int, error) {
 	f, err := os.Open(logFile)
-	f.Name()
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
#3524 and https://github.com/pingcap/tiflow/issues/4006

### What is changed and how it works?
Add log sampling config items into cdc server config. We use [zap.SamplingConfig](https://pkg.go.dev/go.uber.org/zap#SamplingConfig) to efficiently determine whether to drop or write a log.
For example, we set the configs as follows:
```
server_configs:
  cdc:
    log.sampling.initial: 100
    log.sampling.thereafter: 100
```
And if the server wants to write 200 same messages into log, only 101 messages (indexed by [0~99, 199]) could be written to log, the remaining 99 messages are supposed to be dropped.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
