### PR TITLE
github: replace pingcap/ticdc with pingcap/tiflow in workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaking-test.yml
+++ b/.github/ISSUE_TEMPLATE/flaking-test.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       value: |
         Please only use this template for submitting reports about flaky tests or jobs (pass or fail with no underlying change in code) in DM/TiCDC CI.
-        Please link this report to https://github.com/pingcap/ticdc/issues/2246 as a subtask.
+        Please link this report to https://github.com/pingcap/tiflow/issues/2246 as a subtask.
   - type: textarea
     id: jobs
     attributes:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -11,7 +11,7 @@ body:
           required: true
         - label: Googled your question
           required: true
-        - label: Searched open and closed [GitHub issues](https://github.com/pingcap/ticdc/issues?q=is%3Aissue)
+        - label: Searched open and closed [GitHub issues](https://github.com/pingcap/tiflow/issues?q=is%3Aissue)
           required: true
         - label:  Read the [documentation](https://docs.pingcap.com/tidb/stable)
           required: true

--- a/.github/workflows/assign_bugs_questions_project.yaml
+++ b/.github/workflows/assign_bugs_questions_project.yaml
@@ -16,5 +16,5 @@ jobs:
         if: |
           contains(github.event.issue.labels.*.name, 'type/bug')
         with:
-          project: 'https://github.com/pingcap/ticdc/projects/13'
+          project: 'https://github.com/pingcap/tiflow/projects/13'
           column_name: 'Need Triage'

--- a/.github/workflows/dm_binlog_999999.yaml
+++ b/.github/workflows/dm_binlog_999999.yaml
@@ -117,7 +117,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_NOTIFY }}
         uses: Ilshidur/action-slack@2.1.0
         with:
-          args: "chaos job failed, see https://github.com/pingcap/ticdc/actions/runs/{{ GITHUB_RUN_ID }}"
+          args: "chaos job failed, see https://github.com/pingcap/tiflow/actions/runs/{{ GITHUB_RUN_ID }}"
 
       # Debug via SSH if previous steps failed
       - name: Set up tmate session

--- a/.github/workflows/dm_chaos.yaml
+++ b/.github/workflows/dm_chaos.yaml
@@ -304,7 +304,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_NOTIFY }}
         uses: Ilshidur/action-slack@2.1.0
         with:
-          args: "chaos job failed, see https://github.com/pingcap/ticdc/actions/runs/{{ GITHUB_RUN_ID }}"
+          args: "chaos job failed, see https://github.com/pingcap/tiflow/actions/runs/{{ GITHUB_RUN_ID }}"
 
       # Debug via SSH if previous steps failed
       - name: Set up tmate session

--- a/.github/workflows/dm_upstream_switch.yaml
+++ b/.github/workflows/dm_upstream_switch.yaml
@@ -81,7 +81,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_NOTIFY }}
         uses: Ilshidur/action-slack@2.1.0
         with:
-          args: "upstream-switch job failed, see https://github.com/pingcap/ticdc/actions/runs/{{ GITHUB_RUN_ID }}"
+          args: "upstream-switch job failed, see https://github.com/pingcap/tiflow/actions/runs/{{ GITHUB_RUN_ID }}"
 
       # Debug via SSH if previous steps failed
       - name: Set up tmate session

--- a/.github/workflows/upgrade_dm_via_tiup.yaml
+++ b/.github/workflows/upgrade_dm_via_tiup.yaml
@@ -26,7 +26,7 @@ jobs:
     name: From V1
     runs-on: ubuntu-18.04
     env:
-      working-directory: ${{ github.workspace }}/go/src/github.com/pingcap/ticdc
+      working-directory: ${{ github.workspace }}/go/src/github.com/pingcap/tiflow
 
     steps:
       - name: Set up Go 1.16
@@ -37,13 +37,13 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
         with:
-          path: go/src/github.com/pingcap/ticdc
+          path: go/src/github.com/pingcap/tiflow
 
       - name: Check out code by workflow dispatch
         if: ${{ github.event.inputs.pr != '' }}
         uses: actions/checkout@v2
         with:
-          path: go/src/github.com/pingcap/ticdc
+          path: go/src/github.com/pingcap/tiflow
           ref: refs/pull/${{ github.event.inputs.pr }}/head
 
       - name: Setup containers
@@ -56,7 +56,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
         run: |
           cd ${{ env.working-directory }}/dm/tests/tiup/docker
-          docker-compose exec -T control bash -c "cd /go/src/github.com/pingcap/ticdc/dm && ./tests/tiup/upgrade-from-v1.sh"
+          docker-compose exec -T control bash -c "cd /go/src/github.com/pingcap/tiflow/dm && ./tests/tiup/upgrade-from-v1.sh"
 
       # send Slack notify if failed.
       # NOTE: With the exception of `GITHUB_TOKEN`, secrets are not passed to the runner when a workflow is triggered from a forked repository.
@@ -66,7 +66,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_NOTIFY }}
         uses: Ilshidur/action-slack@2.1.0
         with:
-          args: "upgrade job failed, see https://github.com/pingcap/ticdc/actions/runs/{{ GITHUB_RUN_ID }}"
+          args: "upgrade job failed, see https://github.com/pingcap/tiflow/actions/runs/{{ GITHUB_RUN_ID }}"
 
       # Debug via SSH if previous steps failed
       - name: Set up tmate session
@@ -78,7 +78,7 @@ jobs:
     name: From V2
     runs-on: ubuntu-18.04
     env:
-      working-directory: ${{ github.workspace }}/go/src/github.com/pingcap/ticdc
+      working-directory: ${{ github.workspace }}/go/src/github.com/pingcap/tiflow
     strategy:
       fail-fast: false
       matrix:
@@ -94,13 +94,13 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
         with:
-          path: go/src/github.com/pingcap/ticdc
+          path: go/src/github.com/pingcap/tiflow
       
       - name: Check out code by workflow dispatch
         if: ${{ github.event.inputs.pr != '' }}
         uses: actions/checkout@v2
         with:
-          path: go/src/github.com/pingcap/ticdc
+          path: go/src/github.com/pingcap/tiflow
           ref: refs/pull/${{ github.event.inputs.pr }}/head
 
       - name: Build
@@ -154,7 +154,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
         run: |
           cd ${{ env.working-directory }}/dm/tests/tiup/docker
-          docker-compose exec -e ref=${{ github.ref }} -e id=${{ github.event.inputs.pr }} -T control bash -c "cd /go/src/github.com/pingcap/ticdc/dm && ./tests/tiup/upgrade-from-v2.sh ${{ matrix.previous_v2 }} nightly"
+          docker-compose exec -e ref=${{ github.ref }} -e id=${{ github.event.inputs.pr }} -T control bash -c "cd /go/src/github.com/pingcap/tiflow/dm && ./tests/tiup/upgrade-from-v2.sh ${{ matrix.previous_v2 }} nightly"
 
       # if above step is passed, logs will be removed by tiup dm destroy
       - name: Copy logs to hack permission
@@ -184,7 +184,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_NOTIFY }}
         uses: Ilshidur/action-slack@2.1.0
         with:
-          args: "upgrade-via-tiup job failed, see https://github.com/pingcap/ticdc/actions/runs/{{ GITHUB_RUN_ID }}"
+          args: "upgrade-via-tiup job failed, see https://github.com/pingcap/tiflow/actions/runs/{{ GITHUB_RUN_ID }}"
 
       # Debug via SSH if previous steps failed
       - name: Set up tmate session
@@ -196,7 +196,7 @@ jobs:
     name: Upgrade TiDB
     runs-on: ubuntu-18.04
     env:
-      working-directory: ${{ github.workspace }}/go/src/github.com/pingcap/ticdc
+      working-directory: ${{ github.workspace }}/go/src/github.com/pingcap/tiflow
     steps:
       - name: Set up Go 1.16
         uses: actions/setup-go@v2
@@ -206,7 +206,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
         with:
-          path: go/src/github.com/pingcap/ticdc
+          path: go/src/github.com/pingcap/tiflow
 
       # TODO: support more versions
       - name: Setup containers
@@ -220,7 +220,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
         run: |
           cd ${{ env.working-directory }}/dm/tests/tiup/docker
-          docker-compose exec -T control bash -c "cd /go/src/github.com/pingcap/ticdc && ./dm/tests/tiup/upgrade-tidb.sh before_upgrade nightly"
+          docker-compose exec -T control bash -c "cd /go/src/github.com/pingcap/tiflow && ./dm/tests/tiup/upgrade-tidb.sh before_upgrade nightly"
 
       - name: Upgrade TiDB
         working-directory: ${{ env.working-directory }}
@@ -233,7 +233,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
         run: |
           cd ${{ env.working-directory }}/dm/tests/tiup/docker
-          docker-compose exec -T control bash -c "source /root/.profile && cd /go/src/github.com/pingcap/ticdc && ./dm/tests/tiup/upgrade-tidb.sh after_upgrade nightly"
+          docker-compose exec -T control bash -c "source /root/.profile && cd /go/src/github.com/pingcap/tiflow && ./dm/tests/tiup/upgrade-tidb.sh after_upgrade nightly"
 
       # send Slack notify if failed.
       # NOTE: With the exception of `GITHUB_TOKEN`, secrets are not passed to the runner when a workflow is triggered from a forked repository.
@@ -243,7 +243,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_NOTIFY }}
         uses: Ilshidur/action-slack@2.1.0
         with:
-          args: "upgrade job failed, see https://github.com/pingcap/ticdc/actions/runs/{{ GITHUB_RUN_ID }}"
+          args: "upgrade job failed, see https://github.com/pingcap/tiflow/actions/runs/{{ GITHUB_RUN_ID }}"
 
       # Debug via SSH if previous steps failed
       - name: Set up tmate session


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Some remaining `pingcap/ticdc`, finished the remaining problem-2 in https://github.com/pingcap/tiflow/issues/3749

**The DM github action tests are verified in #3966.**

These files were introduced from `v5.3.0`, so cherry pick to `release-5.3` is enough.

### What is changed and how it works?

replace `pingcap/ticdc` with `pingcap/tiflow` in files from `.github` dir

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 
```release-note
None
```
