### PR TITLE
owner, processor(cdc): fix reporting ErrPeerMessageClientClosed to user erroneously

### DIFF
--- a/cdc/owner/scheduler_test.go
+++ b/cdc/owner/scheduler_test.go
@@ -40,6 +40,11 @@ func TestSchedulerBasics(t *testing.T) {
 		_ = failpoint.Disable("github.com/pingcap/tiflow/pkg/p2p/ClientInjectSendMessageTryAgain")
 	}()
 
+	_ = failpoint.Enable("github.com/pingcap/tiflow/pkg/p2p/ClientInjectClosed", "5*return(true)")
+	defer func() {
+		_ = failpoint.Disable("github.com/pingcap/tiflow/pkg/p2p/ClientInjectClosed")
+	}()
+
 	stdCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/cdc/processor/agent_test.go
+++ b/cdc/processor/agent_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tiflow/cdc/model"
 	pscheduler "github.com/pingcap/tiflow/cdc/scheduler"
 	cdcContext "github.com/pingcap/tiflow/pkg/context"
@@ -333,4 +334,46 @@ func TestAgentNoOwnerAtStartUp(t *testing.T) {
 	// double close
 	err = agent.Close()
 	require.NoError(t, err)
+}
+
+func TestAgentTolerateClientClosed(t *testing.T) {
+	suite := newAgentTestSuite(t)
+	defer suite.Close()
+
+	suite.etcdKVClient.On("Get", mock.Anything, etcd.CaptureOwnerKey, mock.Anything).Return(&clientv3.GetResponse{
+		Kvs: []*mvccpb.KeyValue{
+			{
+				Key:         []byte(etcd.CaptureOwnerKey),
+				Value:       []byte(ownerCaptureID),
+				ModRevision: 1,
+			},
+		},
+	}, nil).Once()
+
+	// Test Point 1: Create an agent.
+	agent, err := suite.CreateAgent(t)
+	require.NoError(t, err)
+
+	_ = failpoint.Enable("github.com/pingcap/tiflow/pkg/p2p/ClientInjectClosed", "5*return(true)")
+	defer func() {
+		_ = failpoint.Disable("github.com/pingcap/tiflow/pkg/p2p/ClientInjectClosed")
+	}()
+
+	// Test Point 2: We should tolerate the error ErrPeerMessageClientClosed
+	for i := 0; i < 6; i++ {
+		err = agent.Tick(suite.cdcCtx)
+		require.NoError(t, err)
+	}
+
+	select {
+	case <-suite.ctx.Done():
+		require.Fail(t, "context should not be canceled")
+	case syncMsg := <-suite.syncCh:
+		require.Equal(t, &model.SyncMessage{
+			ProcessorVersion: version.ReleaseSemver(),
+			Running:          nil,
+			Adding:           nil,
+			Removing:         nil,
+		}, syncMsg)
+	}
 }

--- a/dm/tests/README.md
+++ b/dm/tests/README.md
@@ -33,7 +33,7 @@
 
 1. Run `make dm_integration_test_build` to generate DM related binary for integration test
 
-2. Setup two MySQL servers (the first one: 5.6 ~ 5.7; the second one: 8.0) with [binlog enabled first](https://dev.mysql.com/doc/refman/5.7/en/replication-howto-masterbaseconfig.html) and [set `GTID_MODE=ON`](https://dev.mysql.com/doc/refman/5.7/en/replication-mode-change-online-enable-gtids.html), You need set the mysql port and root password according to the following table.
+2. Setup two MySQL servers (the first one: 5.6 ~ 5.7; the second one: 8.0.21, suggest you are same as [CI](https://github.com/PingCAP-QE/ci/blob/main/jenkins/pipelines/ci/dm/dm_ghpr_new_test.groovy#L164-L172)) with [binlog enabled first](https://dev.mysql.com/doc/refman/5.7/en/replication-howto-masterbaseconfig.html) and [set `GTID_MODE=ON`](https://dev.mysql.com/doc/refman/5.7/en/replication-mode-change-online-enable-gtids.html), You need set the mysql port and root password according to the following table.
 
     | MySQL | Host | Port| PASSWORD |
     | :------------ | :---------- | :------ | :---- |

--- a/pkg/p2p/client.go
+++ b/pkg/p2p/client.go
@@ -394,6 +394,11 @@ func (c *MessageClient) TrySendMessage(ctx context.Context, topic Topic, value i
 		failpoint.Return(0, cerrors.ErrPeerMessageSendTryAgain.GenWithStackByArgs())
 	})
 
+	// FIXME (zixiong): This is a temporary way for testing whether the caller can handler this error.
+	failpoint.Inject("ClientInjectClosed", func() {
+		failpoint.Return(0, cerrors.ErrPeerMessageClientClosed.GenWithStackByArgs())
+	})
+
 	return c.sendMessage(ctx, topic, value, true)
 }
 

--- a/pkg/p2p/client_test.go
+++ b/pkg/p2p/client_test.go
@@ -300,7 +300,7 @@ func TestClientSendAnomalies(t *testing.T) {
 	client.connector = connector
 	connector.On("Connect", mock.Anything).Return(grpcClient, func() {}, nil)
 
-	grpcStream := newMockSendMessageClient(ctx)
+	grpcStream := newMockSendMessageClient(runCtx)
 	grpcClient.On("SendMessage", mock.Anything, []grpc.CallOption(nil)).Return(
 		grpcStream,
 		nil,
@@ -315,7 +315,6 @@ func TestClientSendAnomalies(t *testing.T) {
 			ClientVersion:        "v5.4.0",
 			SenderAdvertisedAddr: "fake-addr:8300",
 		}, packet.Meta)
-		closeClient()
 	})
 
 	grpcStream.On("Recv").Return(nil, nil)
@@ -335,11 +334,14 @@ func TestClientSendAnomalies(t *testing.T) {
 	require.Regexp(t, ".*ErrPeerMessageSendTryAgain.*", err.Error())
 
 	// Test point 2: close the client while SendMessage is blocking.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		closeClient()
+	}()
 	_, err = client.SendMessage(ctx, "test-topic", &testMessage{Value: 1})
 	require.Error(t, err)
 	require.Regexp(t, ".*ErrPeerMessageClientClosed.*", err.Error())
 
-	closeClient()
 	wg.Wait()
 
 	// Test point 3: call SendMessage after the client is closed.


### PR DESCRIPTION
**This is a bug fix on unreleased code.**
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close #3972 
- This error should not be directly reported to the user since it may not represent an actual failure.

### What is changed and how it works?
- Do not report ErrPeerMessageClientClosed

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
