### PR TITLE
config(ticdc): force enable old value for canal json protocol

### DIFF
--- a/pkg/cmd/cli/cli_changefeed_create.go
+++ b/pkg/cmd/cli/cli_changefeed_create.go
@@ -43,12 +43,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// forceEnableOldValueProtocols specifies which protocols need to be forced to enable old value.
-var forceEnableOldValueProtocols = []string{
-	"canal",
-	"maxwell",
-}
-
 // changefeedCommonOptions defines common changefeed flags.
 type changefeedCommonOptions struct {
 	noConfirm              bool
@@ -208,7 +202,7 @@ func (o *createChangefeedOptions) completeCfg(ctx context.Context, cmd *cobra.Co
 		if protocol != "" {
 			cfg.Sink.Protocol = protocol
 		}
-		for _, fp := range forceEnableOldValueProtocols {
+		for _, fp := range config.ForceEnableOldValueProtocols {
 			if cfg.Sink.Protocol == fp {
 				log.Warn("Attempting to replicate without old value enabled. CDC will enable old value and continue.", zap.String("protocol", cfg.Sink.Protocol))
 				cfg.EnableOldValue = true

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -21,6 +21,13 @@ import (
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 )
 
+// ForceEnableOldValueProtocols specifies which protocols need to be forced to enable old value.
+var ForceEnableOldValueProtocols = []string{
+	ProtocolCanal.String(),
+	ProtocolCanalJSON.String(),
+	ProtocolMaxwell.String(),
+}
+
 // SinkConfig represents sink config for a changefeed
 type SinkConfig struct {
 	DispatchRules   []*DispatchRule   `toml:"dispatchers" json:"dispatchers"`
@@ -40,14 +47,14 @@ type ColumnSelector struct {
 }
 
 func (s *SinkConfig) validate(enableOldValue bool) error {
-	protocol := s.Protocol
 	if !enableOldValue {
-		switch protocol {
-		case ProtocolCanal.String(), ProtocolCanalJSON.String(), ProtocolMaxwell.String():
-			log.Error(fmt.Sprintf("Old value is not enabled when using `%s` protocol. "+
-				"Please update changefeed config", protocol))
-			return cerror.WrapError(cerror.ErrKafkaInvalidConfig,
-				errors.New(fmt.Sprintf("%s protocol requires old value to be enabled", protocol)))
+		for _, protocolStr := range ForceEnableOldValueProtocols {
+			if protocolStr == s.Protocol {
+				log.Error(fmt.Sprintf("Old value is not enabled when using `%s` protocol. "+
+					"Please update changefeed config", s.Protocol))
+				return cerror.WrapError(cerror.ErrKafkaInvalidConfig,
+					errors.New(fmt.Sprintf("%s protocol requires old value to be enabled", s.Protocol)))
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

We should turn on the old value for canal json when we create the changefeed.

part of #3676

### What is changed and how it works?

force enable old value for canal json protocol
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (TODO)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

None

Related changes

 - Need to cherry-pick to the release branch(I will do it manually.)
 - Need to update the documentation

### Release note <!-- bugfixes or new feature need a release note -->

```release-note

```
