### PR TITLE
worker(dm): worker has higher priority to config relay dir

### DIFF
--- a/dm/dm/worker/config.go
+++ b/dm/dm/worker/config.go
@@ -99,6 +99,8 @@ type Config struct {
 	KeepAliveTTL      int64 `toml:"keepalive-ttl" json:"keepalive-ttl"`
 	RelayKeepAliveTTL int64 `toml:"relay-keepalive-ttl" json:"relay-keepalive-ttl"`
 
+	RelayDir string `toml:"relay-dir" json:"relay-dir"`
+
 	// tls config
 	config.Security
 

--- a/dm/dm/worker/dm-worker.toml
+++ b/dm/dm/worker/dm-worker.toml
@@ -8,3 +8,5 @@ log-file = "dm-worker.log"
 worker-addr = ":8262"
 advertise-addr = "127.0.0.1:8262"
 join = "127.0.0.1:8261"
+
+relay-dir = "/tmp/relay"

--- a/dm/dm/worker/relay.go
+++ b/dm/dm/worker/relay.go
@@ -342,7 +342,7 @@ func NewDummyRelayHolderWithRelayBinlog(cfg *config.SourceConfig, relayBinlog st
 }
 
 // NewDummyRelayHolderWithInitError creates a new RelayHolder with init error.
-func NewDummyRelayHolderWithInitError(cfg *config.SourceConfig, _ string) RelayHolder {
+func NewDummyRelayHolderWithInitError(cfg *config.SourceConfig) RelayHolder {
 	return &dummyRelayHolder{
 		initError: errors.New("init error"),
 		cfg:       cfg,

--- a/dm/dm/worker/relay.go
+++ b/dm/dm/worker/relay.go
@@ -342,7 +342,7 @@ func NewDummyRelayHolderWithRelayBinlog(cfg *config.SourceConfig, relayBinlog st
 }
 
 // NewDummyRelayHolderWithInitError creates a new RelayHolder with init error.
-func NewDummyRelayHolderWithInitError(cfg *config.SourceConfig) RelayHolder {
+func NewDummyRelayHolderWithInitError(cfg *config.SourceConfig, _ string) RelayHolder {
 	return &dummyRelayHolder{
 		initError: errors.New("init error"),
 		cfg:       cfg,

--- a/dm/dm/worker/server.go
+++ b/dm/dm/worker/server.go
@@ -622,7 +622,6 @@ func (s *Server) operateSourceBound(bound ha.SourceBound) error {
 	if !ok {
 		return terror.ErrWorkerFailToGetSourceConfigFromEtcd.Generate(bound.Source)
 	}
-	// clean old worker's relay dir
 	return s.enableHandleSubtasks(sourceCfg, true)
 }
 

--- a/dm/dm/worker/server.go
+++ b/dm/dm/worker/server.go
@@ -622,6 +622,7 @@ func (s *Server) operateSourceBound(bound ha.SourceBound) error {
 	if !ok {
 		return terror.ErrWorkerFailToGetSourceConfigFromEtcd.Generate(bound.Source)
 	}
+	// clean old worker's relay dir
 	return s.enableHandleSubtasks(sourceCfg, true)
 }
 
@@ -822,7 +823,7 @@ func (s *Server) getOrStartWorker(cfg *config.SourceConfig, needLock bool) (*Sou
 	}
 
 	log.L().Info("will start a new worker", zap.String("sourceID", cfg.SourceID))
-	w, err := NewSourceWorker(cfg, s.etcdClient, s.cfg.Name)
+	w, err := NewSourceWorker(cfg, s.etcdClient, s.cfg.Name, s.cfg.RelayDir)
 	if err != nil {
 		return nil, err
 	}

--- a/dm/dm/worker/source_worker_test.go
+++ b/dm/dm/worker/source_worker_test.go
@@ -79,12 +79,12 @@ func (t *testServer) testWorker(c *C) {
 	defer func() {
 		NewRelayHolder = NewRealRelayHolder
 	}()
-	w, err := NewSourceWorker(cfg, etcdCli, "")
+	w, err := NewSourceWorker(cfg, etcdCli, "", "")
 	c.Assert(err, IsNil)
 	c.Assert(w.EnableRelay(false), ErrorMatches, "init error")
 
 	NewRelayHolder = NewDummyRelayHolder
-	w, err = NewSourceWorker(cfg, etcdCli, "")
+	w, err = NewSourceWorker(cfg, etcdCli, "", "")
 	c.Assert(err, IsNil)
 	c.Assert(w.GetUnitAndSourceStatusJSON("", nil), HasLen, emptyWorkerStatusInfoJSONLength)
 
@@ -292,7 +292,7 @@ func (t *testWorkerFunctionalities) TestWorkerFunctionalities(c *C) {
 	c.Assert(err, IsNil)
 
 	// start worker
-	w, err := NewSourceWorker(sourceCfg, etcdCli, "")
+	w, err := NewSourceWorker(sourceCfg, etcdCli, "", "")
 	c.Assert(err, IsNil)
 	defer w.Close()
 	go func() {
@@ -463,7 +463,7 @@ func (t *testWorkerEtcdCompact) TestWatchSubtaskStageEtcdCompact(c *C) {
 	sourceCfg.EnableRelay = false
 
 	// step 1: start worker
-	w, err := NewSourceWorker(sourceCfg, etcdCli, "")
+	w, err := NewSourceWorker(sourceCfg, etcdCli, "", "")
 	c.Assert(err, IsNil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -582,7 +582,7 @@ func (t *testWorkerEtcdCompact) TestWatchRelayStageEtcdCompact(c *C) {
 	sourceCfg.MetaDir = c.MkDir()
 
 	// step 1: start worker
-	w, err := NewSourceWorker(sourceCfg, etcdCli, "")
+	w, err := NewSourceWorker(sourceCfg, etcdCli, "", "")
 	c.Assert(err, IsNil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/dm/dm/worker/task_checker_test.go
+++ b/dm/dm/worker/task_checker_test.go
@@ -89,7 +89,7 @@ func (s *testTaskCheckerSuite) TestCheck(c *check.C) {
 	cfg := loadSourceConfigWithoutPassword(c)
 	cfg.RelayDir = dir
 	cfg.MetaDir = dir
-	w, err := NewSourceWorker(cfg, nil, "")
+	w, err := NewSourceWorker(cfg, nil, "", "")
 	c.Assert(err, check.IsNil)
 	w.closed.Store(false)
 
@@ -204,7 +204,7 @@ func (s *testTaskCheckerSuite) TestCheckTaskIndependent(c *check.C) {
 	cfg := loadSourceConfigWithoutPassword(c)
 	cfg.RelayDir = dir
 	cfg.MetaDir = dir
-	w, err := NewSourceWorker(cfg, nil, "")
+	w, err := NewSourceWorker(cfg, nil, "", "")
 	c.Assert(err, check.IsNil)
 	w.closed.Store(false)
 

--- a/dm/tests/dmctl_basic/conf/get_worker1.toml
+++ b/dm/tests/dmctl_basic/conf/get_worker1.toml
@@ -9,6 +9,7 @@ advertise-addr = "127.0.0.1:8262"
 config-file = "/tmp/dm_test/dmctl_basic/worker1/dm-worker.toml"
 keepalive-ttl = 60
 relay-keepalive-ttl = 1800
+relay-dir = ""
 ssl-ca = ""
 ssl-cert = ""
 ssl-key = ""

--- a/dm/tests/dmctl_basic/conf/get_worker2.toml
+++ b/dm/tests/dmctl_basic/conf/get_worker2.toml
@@ -9,6 +9,7 @@ advertise-addr = "127.0.0.1:8263"
 config-file = "/tmp/dm_test/dmctl_basic/worker2/dm-worker.toml"
 keepalive-ttl = 60
 relay-keepalive-ttl = 1800
+relay-dir = ""
 ssl-ca = ""
 ssl-cert = ""
 ssl-key = ""

--- a/dm/tests/print_status/conf/dm-worker1.toml
+++ b/dm/tests/print_status/conf/dm-worker1.toml
@@ -1,2 +1,3 @@
 name = "worker1"
 join = "127.0.0.1:8261"
+relay-dir = "placeholder"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Support different worker has different path to store relay log

### What is changed and how it works?
as title

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change
 - Has persistent data change

Side effects


Related changes

 - Need to update the documentation

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
DM-worker can specify a path to store its relay log
```
