### PR TITLE
kafka: update default max message bytes to 8MB

### DIFF
--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -58,8 +58,10 @@ type Config struct {
 func NewConfig() *Config {
 	return &Config{
 		Version: "2.4.0",
-		// MaxMessageBytes will be used to initialize producer, we set the default value (1M) identical to kafka broker.
-		MaxMessageBytes:   1 * 1024 * 1024,
+		// MaxMessageBytes will be used to initialize producer, we set the
+		// default value to (8M) because the max size limit of a single row in
+		// TiDB is 6M and we plus some overhead of kafka message.
+		MaxMessageBytes:   8 * 1024 * 1024,
 		ReplicationFactor: 1,
 		Compression:       "none",
 		Credential:        &security.Credential{},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

hotfix

### What is changed and how it works?

Increase the default value of max-message-bytes to 8MB, to be compatible with old version such as v5.1.2

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
