### PR TITLE
Revert "test(dm): fix unexpected sync-diff temporarily"

### DIFF
--- a/dm/tests/shardddl4/run.sh
+++ b/dm/tests/shardddl4/run.sh
@@ -31,9 +31,7 @@ function DM_119_CASE {
 	#         "query-status test" \
 	#         "because schema conflict detected" 1
 	# fi
-
-	# TODO: wait https://github.com/pingcap/tiflow/issues/4029 to close, then will revoke this comment
-	# check_sync_diff $WORK_DIR $cur/conf/diff_config.toml 10 "fail"
+	check_sync_diff $WORK_DIR $cur/conf/diff_config.toml 10 "fail"
 }
 
 # Add index with the same name but with different fields.
@@ -111,9 +109,7 @@ function DM_121_CASE {
 	#         "query-status test" \
 	#         "because schema conflict detected" 1
 	# fi
-
-	# TODO: wait https://github.com/pingcap/tiflow/issues/4029 to close, then will revoke this comment
-	# check_sync_diff $WORK_DIR $cur/conf/diff_config.toml 10 "fail"
+	check_sync_diff $WORK_DIR $cur/conf/diff_config.toml 10 "fail"
 }
 
 # Add index with the same name but with different fields.


### PR DESCRIPTION
Reverts pingcap/tiflow#4031

close https://github.com/pingcap/tiflow/issues/4029, because https://github.com/pingcap/tidb-tools/pull/576 has been merged

```release-note
None
```