### PR TITLE
codec(cdc): fix encoder `max-message-bytes`

### DIFF
--- a/cdc/sink/codec/craft.go
+++ b/cdc/sink/codec/craft.go
@@ -103,7 +103,7 @@ func (e *CraftEventBatchEncoder) SetParams(params map[string]string) error {
 	var err error
 	maxMessageBytes, ok := params["max-message-bytes"]
 	if !ok {
-		return cerror.ErrSinkInvalidConfig.Wrap(errors.Errorf("max-message-bytes not found"))
+		return cerror.ErrSinkInvalidConfig.Wrap(errors.New("max-message-bytes not found"))
 	}
 
 	e.maxMessageBytes, err = strconv.Atoi(maxMessageBytes)

--- a/cdc/sink/codec/craft.go
+++ b/cdc/sink/codec/craft.go
@@ -108,7 +108,7 @@ func (e *CraftEventBatchEncoder) SetParams(params map[string]string) error {
 
 	e.maxMessageBytes, err = strconv.Atoi(maxMessageBytes)
 	if err != nil {
-		return cerror.ErrSinkInvalidConfig.Wrap(err)
+		return cerror.WrapError(cerror.ErrSinkInvalidConfig, err)
 	}
 	if e.maxMessageBytes <= 0 || e.maxMessageBytes > math.MaxInt32 {
 		return cerror.ErrSinkInvalidConfig.Wrap(errors.Errorf("invalid max-message-bytes %d", e.maxMessageBytes))

--- a/cdc/sink/codec/craft.go
+++ b/cdc/sink/codec/craft.go
@@ -110,7 +110,7 @@ func (e *CraftEventBatchEncoder) SetParams(params map[string]string) error {
 	if err != nil {
 		return cerror.ErrSinkInvalidConfig.Wrap(err)
 	}
-	if e.maxMessageBytes <= 0 {
+	if e.maxMessageBytes <= 0 || e.maxMessageBytes > math.MaxInt32 {
 		return cerror.ErrSinkInvalidConfig.Wrap(errors.Errorf("invalid max-message-bytes %d", e.maxMessageBytes))
 	}
 

--- a/cdc/sink/codec/craft.go
+++ b/cdc/sink/codec/craft.go
@@ -103,7 +103,7 @@ func (e *CraftEventBatchEncoder) SetParams(params map[string]string) error {
 	var err error
 	maxMessageBytes, ok := params["max-message-bytes"]
 	if !ok {
-		return cerror.ErrSinkInvalidConfig.Wrap(errors.New("max-message-bytes not found"))
+		return cerror.ErrSinkInvalidConfig.GenWithStack("max-message-bytes not found")
 	}
 
 	e.maxMessageBytes, err = strconv.Atoi(maxMessageBytes)

--- a/cdc/sink/codec/craft.go
+++ b/cdc/sink/codec/craft.go
@@ -101,15 +101,16 @@ func (e *CraftEventBatchEncoder) Reset() {
 // SetParams reads relevant parameters for craft protocol
 func (e *CraftEventBatchEncoder) SetParams(params map[string]string) error {
 	var err error
-
-	e.maxMessageBytes = config.DefaultMaxMessageBytes
-	if maxMessageBytes, ok := params["max-message-bytes"]; ok {
-		e.maxMessageBytes, err = strconv.Atoi(maxMessageBytes)
-		if err != nil {
-			return cerror.ErrSinkInvalidConfig.Wrap(err)
-		}
+	maxMessageBytes, ok := params["max-message-bytes"]
+	if !ok {
+		return cerror.ErrSinkInvalidConfig.Wrap(errors.Errorf("max-message-bytes not found"))
 	}
-	if e.maxMessageBytes <= 0 || e.maxMessageBytes > math.MaxInt32 {
+
+	e.maxMessageBytes, err = strconv.Atoi(maxMessageBytes)
+	if err != nil {
+		return cerror.ErrSinkInvalidConfig.Wrap(err)
+	}
+	if e.maxMessageBytes <= 0 {
 		return cerror.ErrSinkInvalidConfig.Wrap(errors.Errorf("invalid max-message-bytes %d", e.maxMessageBytes))
 	}
 

--- a/cdc/sink/codec/craft_test.go
+++ b/cdc/sink/codec/craft_test.go
@@ -139,7 +139,7 @@ func (s *craftBatchSuite) testBatchCodec(c *check.C, newEncoder func() EventBatc
 func (s *craftBatchSuite) TestParamsEdgeCases(c *check.C) {
 	defer testleak.AfterTest(c)()
 	encoder := NewCraftEventBatchEncoder().(*CraftEventBatchEncoder)
-	err := encoder.SetParams(map[string]string{})
+	err := encoder.SetParams(map[string]string{"max-message-bytes": "10485760"})
 	c.Assert(err, check.IsNil)
 	c.Assert(encoder.maxBatchSize, check.Equals, DefaultMaxBatchSize)
 	c.Assert(encoder.maxMessageBytes, check.Equals, config.DefaultMaxMessageBytes)
@@ -203,7 +203,7 @@ func (s *craftBatchSuite) TestMaxMessageBytes(c *check.C) {
 func (s *craftBatchSuite) TestMaxBatchSize(c *check.C) {
 	defer testleak.AfterTest(c)()
 	encoder := NewCraftEventBatchEncoder()
-	err := encoder.SetParams(map[string]string{"max-batch-size": "64"})
+	err := encoder.SetParams(map[string]string{"max-message-bytes": "1048576", "max-batch-size": "64"})
 	c.Check(err, check.IsNil)
 
 	testEvent := &model.RowChangedEvent{

--- a/cdc/sink/codec/craft_test.go
+++ b/cdc/sink/codec/craft_test.go
@@ -158,10 +158,10 @@ func (s *craftBatchSuite) TestParamsEdgeCases(c *check.C) {
 	err = encoder.SetParams(map[string]string{"max-message-bytes": strconv.Itoa(math.MaxUint32)})
 	c.Assert(err, check.NotNil)
 
-	err = encoder.SetParams(map[string]string{"max-batch-size": "0"})
+	err = encoder.SetParams(map[string]string{"max-message-bytes": strconv.Itoa(math.MaxUint32), "max-batch-size": "0"})
 	c.Assert(err, check.ErrorMatches, ".*invalid.*")
 
-	err = encoder.SetParams(map[string]string{"max-batch-size": "-1"})
+	err = encoder.SetParams(map[string]string{"max-message-bytes": strconv.Itoa(math.MaxUint32), "max-batch-size": "-1"})
 	c.Assert(err, check.ErrorMatches, ".*invalid.*")
 
 	err = encoder.SetParams(map[string]string{"max-message-bytes": "10485760", "max-batch-size": strconv.Itoa(math.MaxUint16)})

--- a/cdc/sink/codec/craft_test.go
+++ b/cdc/sink/codec/craft_test.go
@@ -164,15 +164,15 @@ func (s *craftBatchSuite) TestParamsEdgeCases(c *check.C) {
 	err = encoder.SetParams(map[string]string{"max-batch-size": "-1"})
 	c.Assert(err, check.ErrorMatches, ".*invalid.*")
 
-	err = encoder.SetParams(map[string]string{"max-batch-size": strconv.Itoa(math.MaxUint16)})
+	err = encoder.SetParams(map[string]string{"max-message-bytes": "10485760", "max-batch-size": strconv.Itoa(math.MaxUint16)})
 	c.Assert(err, check.IsNil)
 	c.Assert(encoder.maxBatchSize, check.Equals, int(math.MaxUint16))
 	c.Assert(encoder.maxMessageBytes, check.Equals, config.DefaultMaxMessageBytes)
 
-	err = encoder.SetParams(map[string]string{"max-batch-size": strconv.Itoa(math.MaxInt32)})
+	err = encoder.SetParams(map[string]string{"max-message-bytes": "10485760", "max-batch-size": strconv.Itoa(math.MaxInt32)})
 	c.Assert(err, check.NotNil)
 
-	err = encoder.SetParams(map[string]string{"max-batch-size": strconv.Itoa(math.MaxUint32)})
+	err = encoder.SetParams(map[string]string{"max-message-bytes": "10485760", "max-batch-size": strconv.Itoa(math.MaxUint32)})
 	c.Assert(err, check.NotNil)
 }
 
@@ -203,7 +203,7 @@ func (s *craftBatchSuite) TestMaxMessageBytes(c *check.C) {
 func (s *craftBatchSuite) TestMaxBatchSize(c *check.C) {
 	defer testleak.AfterTest(c)()
 	encoder := NewCraftEventBatchEncoder()
-	err := encoder.SetParams(map[string]string{"max-message-bytes": "1048576", "max-batch-size": "64"})
+	err := encoder.SetParams(map[string]string{"max-message-bytes": "10485760", "max-batch-size": "64"})
 	c.Check(err, check.IsNil)
 
 	testEvent := &model.RowChangedEvent{

--- a/cdc/sink/codec/json.go
+++ b/cdc/sink/codec/json.go
@@ -617,7 +617,7 @@ func (d *JSONEventBatchEncoder) SetParams(params map[string]string) error {
 
 	maxMessageBytes, ok := params["max-message-bytes"]
 	if !ok {
-		return cerror.ErrSinkInvalidConfig.Wrap(errors.Errorf("max-message-bytes not found"))
+		return cerror.ErrSinkInvalidConfig.Wrap(errors.New("max-message-bytes not found"))
 	}
 
 	d.maxMessageBytes, err = strconv.Atoi(maxMessageBytes)

--- a/cdc/sink/codec/json.go
+++ b/cdc/sink/codec/json.go
@@ -385,8 +385,8 @@ type JSONEventBatchEncoder struct {
 	maxBatchSize    int
 }
 
-// GetMaxMessageSize is only for unit testing.
-func (d *JSONEventBatchEncoder) GetMaxMessageSize() int {
+// GetMaxMessageBytes is only for unit testing.
+func (d *JSONEventBatchEncoder) GetMaxMessageBytes() int {
 	return d.maxMessageBytes
 }
 

--- a/cdc/sink/codec/json.go
+++ b/cdc/sink/codec/json.go
@@ -615,12 +615,14 @@ func (d *JSONEventBatchEncoder) Reset() {
 func (d *JSONEventBatchEncoder) SetParams(params map[string]string) error {
 	var err error
 
-	d.maxMessageBytes = config.DefaultMaxMessageBytes
-	if maxMessageBytes, ok := params["max-message-bytes"]; ok {
-		d.maxMessageBytes, err = strconv.Atoi(maxMessageBytes)
-		if err != nil {
-			return cerror.ErrSinkInvalidConfig.Wrap(err)
-		}
+	maxMessageBytes, ok := params["max-message-bytes"]
+	if !ok {
+		return cerror.ErrSinkInvalidConfig.Wrap(errors.Errorf("max-message-bytes not found"))
+	}
+
+	d.maxMessageBytes, err = strconv.Atoi(maxMessageBytes)
+	if err != nil {
+		return cerror.ErrSinkInvalidConfig.Wrap(err)
 	}
 	if d.maxMessageBytes <= 0 {
 		return cerror.ErrSinkInvalidConfig.Wrap(errors.Errorf("invalid max-message-bytes %d", d.maxMessageBytes))

--- a/cdc/sink/mq.go
+++ b/cdc/sink/mq.go
@@ -395,7 +395,7 @@ func newKafkaSaramaSink(ctx context.Context, sinkURI *url.URL, filter *filter.Fi
 		return nil, cerror.ErrKafkaInvalidConfig.GenWithStack("no topic is specified in sink-uri")
 	}
 
-	sProducer, err := kafka.NewKafkaSaramaProducer(ctx, topic, producerConfig, errCh)
+	sProducer, err := kafka.NewKafkaSaramaProducer(ctx, topic, producerConfig, opts, errCh)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cdc/sink/mq_test.go
+++ b/cdc/sink/mq_test.go
@@ -77,7 +77,7 @@ func (s mqSinkSuite) TestKafkaSink(c *check.C) {
 
 	c.Assert(encoder, check.FitsTypeOf, &codec.JSONEventBatchEncoder{})
 	c.Assert(encoder.(*codec.JSONEventBatchEncoder).GetMaxBatchSize(), check.Equals, 1)
-	c.Assert(encoder.(*codec.JSONEventBatchEncoder).GetMaxMessageSize(), check.Equals, 1048576)
+	c.Assert(encoder.(*codec.JSONEventBatchEncoder).GetMaxMessageBytes(), check.Equals, 1048576)
 
 	// mock kafka broker processes 1 row changed event
 	leader.Returns(prodSuccess)
@@ -234,7 +234,7 @@ func (s mqSinkSuite) TestPulsarSinkEncoderConfig(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(encoder, check.FitsTypeOf, &codec.JSONEventBatchEncoder{})
 	c.Assert(encoder.(*codec.JSONEventBatchEncoder).GetMaxBatchSize(), check.Equals, 1)
-	c.Assert(encoder.(*codec.JSONEventBatchEncoder).GetMaxMessageSize(), check.Equals, 4194304)
+	c.Assert(encoder.(*codec.JSONEventBatchEncoder).GetMaxMessageBytes(), check.Equals, 4194304)
 }
 
 func (s mqSinkSuite) TestFlushRowChangedEvents(c *check.C) {

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -311,7 +311,6 @@ func (s *kafkaSuite) TestCreateProducerFailed(c *check.C) {
 	}()
 	opts := make(map[string]string)
 	_, err := NewKafkaSaramaProducer(ctx, topic, config, opts, errCh)
-	c.Assert(opts, check.HasKey, "max-message-bytes")
 	c.Assert(errors.Cause(err), check.ErrorMatches, "invalid version.*")
 }
 

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -15,6 +15,7 @@ package kafka
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -106,9 +107,11 @@ func (s *kafkaSuite) TestNewSaramaProducer(c *check.C) {
 		NewAdminClientImpl = kafka.NewSaramaAdminClient
 	}()
 
-	producer, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
+	opts := make(map[string]string)
+	producer, err := NewKafkaSaramaProducer(ctx, topic, config, opts, errCh)
 	c.Assert(err, check.IsNil)
 	c.Assert(producer.GetPartitionNum(), check.Equals, int32(2))
+	c.Assert(opts, check.HasKey, "max-message-bytes")
 	for i := 0; i < 100; i++ {
 		err = producer.AsyncSendMessage(ctx, &codec.MQMessage{
 			Key:   []byte("test-key-1"),
@@ -200,8 +203,10 @@ func (s *kafkaSuite) TestValidateMaxMessageBytesAndCreateTopic(c *check.C) {
 	config.MaxMessageBytes = adminClient.GetDefaultMaxMessageBytes()
 	cfg, err := newSaramaConfigImpl(context.Background(), config)
 	c.Assert(err, check.IsNil)
-	err = validateMaxMessageBytesAndCreateTopic(adminClient, adminClient.GetDefaultMockTopicName(), config, cfg)
+	opts := make(map[string]string)
+	err = validateMaxMessageBytesAndCreateTopic(adminClient, adminClient.GetDefaultMockTopicName(), config, cfg, opts)
 	c.Assert(err, check.IsNil)
+	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
 
 	// When topic exists and max message bytes is not set correctly.
 	// use the smaller one.
@@ -209,22 +214,27 @@ func (s *kafkaSuite) TestValidateMaxMessageBytesAndCreateTopic(c *check.C) {
 	config.MaxMessageBytes = defaultMaxMessageBytes + 1
 	cfg, err = newSaramaConfigImpl(context.Background(), config)
 	c.Assert(err, check.IsNil)
-	err = validateMaxMessageBytesAndCreateTopic(adminClient, adminClient.GetDefaultMockTopicName(), config, cfg)
+	opts = make(map[string]string)
+	err = validateMaxMessageBytesAndCreateTopic(adminClient, adminClient.GetDefaultMockTopicName(), config, cfg, opts)
 	c.Assert(err, check.IsNil)
 	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, defaultMaxMessageBytes)
+	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
 
 	config.MaxMessageBytes = defaultMaxMessageBytes - 1
 	cfg, err = newSaramaConfigImpl(context.Background(), config)
 	c.Assert(err, check.IsNil)
-	err = validateMaxMessageBytesAndCreateTopic(adminClient, adminClient.GetDefaultMockTopicName(), config, cfg)
+	opts = make(map[string]string)
+	err = validateMaxMessageBytesAndCreateTopic(adminClient, adminClient.GetDefaultMockTopicName(), config, cfg, opts)
 	c.Assert(err, check.IsNil)
 	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, config.MaxMessageBytes)
+	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
 
 	// When topic does not exist and auto-create is not enabled.
 	config.AutoCreate = false
 	cfg, err = newSaramaConfigImpl(context.Background(), config)
 	c.Assert(err, check.IsNil)
-	err = validateMaxMessageBytesAndCreateTopic(adminClient, "non-exist", config, cfg)
+	opts = make(map[string]string)
+	err = validateMaxMessageBytesAndCreateTopic(adminClient, "non-exist", config, cfg, opts)
 	c.Assert(
 		errors.Cause(err),
 		check.ErrorMatches,
@@ -237,9 +247,11 @@ func (s *kafkaSuite) TestValidateMaxMessageBytesAndCreateTopic(c *check.C) {
 	config.MaxMessageBytes = defaultMaxMessageBytes - 1
 	cfg, err = newSaramaConfigImpl(context.Background(), config)
 	c.Assert(err, check.IsNil)
-	err = validateMaxMessageBytesAndCreateTopic(adminClient, "create-new-success", config, cfg)
+	opts = make(map[string]string)
+	err = validateMaxMessageBytesAndCreateTopic(adminClient, "create-new-success", config, cfg, opts)
 	c.Assert(err, check.IsNil)
 	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, config.MaxMessageBytes)
+	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
 
 	// When the topic does not exist, use the broker's configuration to create the topic.
 	// It is larger than the value of broker.
@@ -247,9 +259,11 @@ func (s *kafkaSuite) TestValidateMaxMessageBytesAndCreateTopic(c *check.C) {
 	config.AutoCreate = true
 	cfg, err = newSaramaConfigImpl(context.Background(), config)
 	c.Assert(err, check.IsNil)
-	err = validateMaxMessageBytesAndCreateTopic(adminClient, "create-new-fail", config, cfg)
+	opts = make(map[string]string)
+	err = validateMaxMessageBytesAndCreateTopic(adminClient, "create-new-fail", config, cfg, opts)
 	c.Assert(err, check.IsNil)
 	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, defaultMaxMessageBytes)
+	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
 
 	// When the topic exists, but the topic does not store max message bytes info,
 	// the check of parameter succeeds.
@@ -264,9 +278,11 @@ func (s *kafkaSuite) TestValidateMaxMessageBytesAndCreateTopic(c *check.C) {
 	}
 	err = adminClient.CreateTopic("test-topic", detail, false)
 	c.Assert(err, check.IsNil)
-	err = validateMaxMessageBytesAndCreateTopic(adminClient, "test-topic", config, cfg)
+	opts = make(map[string]string)
+	err = validateMaxMessageBytesAndCreateTopic(adminClient, "test-topic", config, cfg, opts)
 	c.Assert(err, check.IsNil)
 	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, config.MaxMessageBytes)
+	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
 
 	// When the topic exists, but the topic does not store max message bytes info,
 	// the check of parameter fails.
@@ -274,9 +290,11 @@ func (s *kafkaSuite) TestValidateMaxMessageBytesAndCreateTopic(c *check.C) {
 	config.MaxMessageBytes = defaultMaxMessageBytes + 1
 	cfg, err = newSaramaConfigImpl(context.Background(), config)
 	c.Assert(err, check.IsNil)
-	err = validateMaxMessageBytesAndCreateTopic(adminClient, "test-topic", config, cfg)
+	opts = make(map[string]string)
+	err = validateMaxMessageBytesAndCreateTopic(adminClient, "test-topic", config, cfg, opts)
 	c.Assert(err, check.IsNil)
 	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, defaultMaxMessageBytes)
+	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
 }
 
 func (s *kafkaSuite) TestCreateProducerFailed(c *check.C) {
@@ -291,7 +309,9 @@ func (s *kafkaSuite) TestCreateProducerFailed(c *check.C) {
 	defer func() {
 		NewAdminClientImpl = kafka.NewSaramaAdminClient
 	}()
-	_, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
+	opts := make(map[string]string)
+	_, err := NewKafkaSaramaProducer(ctx, topic, config, opts, errCh)
+	c.Assert(opts, check.HasKey, "max-message-bytes")
 	c.Assert(errors.Cause(err), check.ErrorMatches, "invalid version.*")
 }
 
@@ -338,7 +358,9 @@ func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
 	}()
 
 	errCh := make(chan error, 1)
-	producer, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
+	opts := make(map[string]string)
+	producer, err := NewKafkaSaramaProducer(ctx, topic, config, opts, errCh)
+	c.Assert(opts, check.HasKey, "max-message-bytes")
 	defer func() {
 		err := producer.Close()
 		c.Assert(err, check.IsNil)
@@ -405,7 +427,9 @@ func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
 	}()
 
 	errCh := make(chan error, 1)
-	producer, err := NewKafkaSaramaProducer(ctx, topic, config, errCh)
+	opts := make(map[string]string)
+	producer, err := NewKafkaSaramaProducer(ctx, topic, config, opts, errCh)
+	c.Assert(opts, check.HasKey, "max-message-bytes")
 	defer func() {
 		err := producer.Close()
 		c.Assert(err, check.IsNil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

when initializing the encoder, make sure `max-message-bytes` in the `opts`, and set identical to producer's configuration.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
