### PR TITLE
http_api (ticdc): fix http api 'get processor' panic.

### DIFF
--- a/cdc/capture/http_errors.go
+++ b/cdc/capture/http_errors.go
@@ -25,7 +25,7 @@ var httpBadRequestError = []*errors.Error{
 	cerror.ErrAPIInvalidParam, cerror.ErrSinkURIInvalid, cerror.ErrStartTsBeforeGC,
 	cerror.ErrChangeFeedNotExists, cerror.ErrTargetTsBeforeStartTs, cerror.ErrTableIneligible,
 	cerror.ErrFilterRuleInvalid, cerror.ErrChangefeedUpdateRefused, cerror.ErrMySQLConnectionError,
-	cerror.ErrMySQLInvalidConfig,
+	cerror.ErrMySQLInvalidConfig, cerror.ErrCaptureNotExist,
 }
 
 // IsHTTPBadRequestError check if a error is a http bad request error

--- a/cdc/capture/http_handler.go
+++ b/cdc/capture/http_handler.go
@@ -576,6 +576,7 @@ func (h *HTTPHandler) GetProcessor(c *gin.Context) {
 	status, exist := statuses[captureID]
 	if !exist {
 		_ = c.Error(cerror.ErrCaptureNotExist.GenWithStackByArgs(captureID))
+		return
 	}
 
 	positions, err := statusProvider.GetTaskPositions(ctx, changefeedID)
@@ -586,6 +587,7 @@ func (h *HTTPHandler) GetProcessor(c *gin.Context) {
 	position, exist := positions[captureID]
 	if !exist {
 		_ = c.Error(cerror.ErrCaptureNotExist.GenWithStackByArgs(captureID))
+		return
 	}
 
 	processorDetail := &model.ProcessorDetail{CheckPointTs: position.CheckPointTs, ResolvedTs: position.ResolvedTs, Error: position.Error}

--- a/tests/integration_tests/http_api/util/test_case.py
+++ b/tests/integration_tests/http_api/util/test_case.py
@@ -243,12 +243,10 @@ def list_processor():
 
 # must at least one table is sync will the test success
 def get_processor():
-    url = BASE_URL0 + "/processors"
     base_url = BASE_URL0 + "/processors"
-    resp = rq.get(url, cert=CERT, verify=VERIFY)
+    resp = rq.get(base_url, cert=CERT, verify=VERIFY)
     assert resp.status_code == rq.codes.ok
     data = resp.json()[0]
-    url = url + "/" + data["changefeed_id"] + "/" + data["capture_id"]
     url = base_url + "/" + data["changefeed_id"] + "/" + data["capture_id"]
     resp = rq.get(url, cert=CERT, verify=VERIFY)
     assert resp.status_code == rq.codes.ok

--- a/tests/integration_tests/http_api/util/test_case.py
+++ b/tests/integration_tests/http_api/util/test_case.py
@@ -244,12 +244,19 @@ def list_processor():
 # must at least one table is sync will the test success
 def get_processor():
     url = BASE_URL0 + "/processors"
+    base_url = BASE_URL0 + "/processors"
     resp = rq.get(url, cert=CERT, verify=VERIFY)
     assert resp.status_code == rq.codes.ok
     data = resp.json()[0]
     url = url + "/" + data["changefeed_id"] + "/" + data["capture_id"]
+    url = base_url + "/" + data["changefeed_id"] + "/" + data["capture_id"]
     resp = rq.get(url, cert=CERT, verify=VERIFY)
     assert resp.status_code == rq.codes.ok
+
+    # test capture_id error and cdc server no panic
+    url = base_url + "/" + data["changefeed_id"] + "/" + "non-exist-capture-id"
+    resp = rq.get(url, cert=CERT, verify=VERIFY)
+    assert resp.status_code == rq.codes.bad_request
 
     print("pass test: get processors")
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.


There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #3840 

### What is changed and how it works?
Return an error when the processor info not exists.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)


Code changes

Side effects


Related changes

 - Need to cherry-pick to the release branch


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the bug that http API panic when the processor info we want to get is not exist. 
```
