### PR TITLE
tests(cdc): fix data race in TestMessageClientBasics

### DIFF
--- a/pkg/p2p/client_test.go
+++ b/pkg/p2p/client_test.go
@@ -180,8 +180,7 @@ func TestMessageClientBasics(t *testing.T) {
 	sender.AssertExpectations(t)
 
 	// Test point 7: Interrupt the connection
-	grpcStream.ExpectedCalls = nil
-	grpcStream.Calls = nil
+	grpcStream.ResetMock()
 
 	sender.ExpectedCalls = nil
 	sender.Calls = nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #3825 

### What is changed and how it works?
- Made `mockSendMessageClient` thread-safe.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
