### PR TITLE
bugfix: fix update statement execute error in safemode cause dm-worker panic

### DIFF
--- a/dm/syncer/dml_worker.go
+++ b/dm/syncer/dml_worker.go
@@ -247,8 +247,9 @@ func (w *DMLWorker) executeBatchJobs(queueID int, jobs []*job) {
 	})
 
 	failpoint.Inject("ErrorOnLastDML", func(_ failpoint.Value) {
-		if len(dmls) > len(jobs) {
-			affect, err = len(dmls), terror.ErrDBExecuteFailed.Delegate(errors.New("ErrorOnLastDML"), "mock")
+		if len(queries) > len(jobs) {
+			w.logger.Error("error on last queries", zap.Int("queries", len(queries)), zap.Int("jobs", len(jobs)))
+			affect, err = len(queries)-1, terror.ErrDBExecuteFailed.Delegate(errors.New("ErrorOnLastDML"), "mock")
 		}
 	})
 }

--- a/dm/syncer/dml_worker.go
+++ b/dm/syncer/dml_worker.go
@@ -245,6 +245,12 @@ func (w *DMLWorker) executeBatchJobs(queueID int, jobs []*job) {
 			affect, err = 0, terror.ErrDBExecuteFailed.Delegate(errors.New("SafeModeExit"), "mock")
 		}
 	})
+
+	failpoint.Inject("ErrorOnLastDML", func(_ failpoint.Value) {
+		if len(dmls) > len(jobs) {
+			affect, err = len(dmls), terror.ErrDBExecuteFailed.Delegate(errors.New("ErrorOnLastDML"), "mock")
+		}
+	})
 }
 
 // genSQLs generate SQLs in single row mode or multiple rows mode.

--- a/dm/syncer/dml_worker.go
+++ b/dm/syncer/dml_worker.go
@@ -211,8 +211,12 @@ func (w *DMLWorker) executeBatchJobs(queueID int, jobs []*job) {
 			if len(queries) == len(jobs) {
 				w.fatalFunc(jobs[affect], err)
 			} else {
-				w.logger.Warn("length of queries not equals length of jobs, cannot determine which job failed, use first one instead", zap.Int("queries", len(queries)), zap.Int("jobs", len(jobs)))
-				w.fatalFunc(jobs[0], err)
+				w.logger.Warn("length of queries not equals length of jobs, cannot determine which job failed", zap.Int("queries", len(queries)), zap.Int("jobs", len(jobs)))
+				newJob := job{
+					startLocation:   jobs[0].startLocation,
+					currentLocation: jobs[len(jobs)-1].currentLocation,
+				}
+				w.fatalFunc(&newJob, err)
 			}
 		}
 	}()

--- a/dm/tests/shardddl1/run.sh
+++ b/dm/tests/shardddl1/run.sh
@@ -784,9 +784,10 @@ function DM_CAUSALITY_USE_DOWNSTREAM_SCHEMA() {
 }
 
 function DM_DML_EXECUTE_ERROR_CASE() {
-	run_sql_source1 "insert into ${shardddl1}.${tb1}(a,b,c) values(1,1,1)"
-	run_sql_source1 "update ${shardddl1}.${tb1} set a=a+1, b=b+1, c=c+1 where a=1"
+	run_sql_source1 "insert into ${shardddl1}.${tb1}(a,b) values(1,1)"
+	run_sql_source1 "update ${shardddl1}.${tb1} set b=b+1 where a=1"
 	check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
+	read v1
 }
 
 function DM_DML_EXECUTE_ERROR() {
@@ -801,14 +802,13 @@ function DM_DML_EXECUTE_ERROR() {
 	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT
 
 	run_case DML_EXECUTE_ERROR "single-source-no-sharding" \
-		"run_sql_source1 \"create table ${shardddl1}.${tb1} (a int primary key, b int unique, c int);\"" \
+		"run_sql_source1 \"create table ${shardddl1}.${tb1} (a int primary key, b int);\"" \
 		"clean_table" ""
 }
 
 function run() {
 	init_cluster
 	init_database
-
 
 	DM_DML_EXECUTE_ERROR
 	start=1

--- a/dm/tests/shardddl1/run.sh
+++ b/dm/tests/shardddl1/run.sh
@@ -786,12 +786,15 @@ function DM_CAUSALITY_USE_DOWNSTREAM_SCHEMA() {
 function DM_DML_EXECUTE_ERROR_CASE() {
 	run_sql_source1 "insert into ${shardddl1}.${tb1}(a,b) values(1,1)"
 	run_sql_source1 "update ${shardddl1}.${tb1} set b=b+1 where a=1"
-	check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
-	read v1
+
+	check_log_contain_with_retry "length of queries not equals length of jobs" $WORK_DIR/worker1/log/dm-worker.log $WORK_DIR/worker2/log/dm-worker.log
+	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
+		"query-status test" \
+		"\"RawCause\": \"ErrorOnLastDML\"" 1 \
+		"Paused" 1
 }
 
 function DM_DML_EXECUTE_ERROR() {
-	# mock downstream has a high latency and upstream has a high workload
 	ps aux | grep dm-worker | awk '{print $2}' | xargs kill || true
 	check_port_offline $WORKER1_PORT 20
 	check_port_offline $WORKER2_PORT 20
@@ -810,6 +813,18 @@ function run() {
 	init_cluster
 	init_database
 
+	DM_COMPACT
+	DM_COMPACT_USE_DOWNSTREAM_SCHEMA
+	DM_MULTIPLE_ROWS
+	DM_CAUSALITY
+	DM_CAUSALITY_USE_DOWNSTREAM_SCHEMA
+	DM_UpdateBARule
+	DM_RENAME_TABLE
+	DM_RENAME_COLUMN_OPTIMISTIC
+	DM_RemoveLock
+	DM_RestartMaster
+	DM_ADD_DROP_COLUMNS
+	DM_COLUMN_INDEX
 	DM_DML_EXECUTE_ERROR
 	start=1
 	end=5

--- a/dm/tests/shardddl1/run.sh
+++ b/dm/tests/shardddl1/run.sh
@@ -794,13 +794,13 @@ function DM_DML_EXECUTE_ERROR() {
 	ps aux | grep dm-worker | awk '{print $2}' | xargs kill || true
 	check_port_offline $WORKER1_PORT 20
 	check_port_offline $WORKER2_PORT 20
-	export GO_FAILPOINTS='github.com/pingcap/tiflow/dm/syncer/ErrorOnLastDML'
+	export GO_FAILPOINTS='github.com/pingcap/tiflow/dm/syncer/ErrorOnLastDML=return()'
 	run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
 	run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
 	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT
 	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT
 
-	run_case COMPACT "single-source-no-sharding" \
+	run_case DML_EXECUTE_ERROR "single-source-no-sharding" \
 		"run_sql_source1 \"create table ${shardddl1}.${tb1} (a int primary key, b int unique, c int);\"" \
 		"clean_table" ""
 }
@@ -809,18 +809,7 @@ function run() {
 	init_cluster
 	init_database
 
-	DM_COMPACT
-	DM_COMPACT_USE_DOWNSTREAM_SCHEMA
-	DM_MULTIPLE_ROWS
-	DM_CAUSALITY
-	DM_CAUSALITY_USE_DOWNSTREAM_SCHEMA
-	DM_UpdateBARule
-	DM_RENAME_TABLE
-	DM_RENAME_COLUMN_OPTIMISTIC
-	DM_RemoveLock
-	DM_RestartMaster
-	DM_ADD_DROP_COLUMNS
-	DM_COLUMN_INDEX
+
 	DM_DML_EXECUTE_ERROR
 	start=1
 	end=5


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4317

### What is changed and how it works?

- when update job split into multiple dmls(delete + replace), len(dmls)>len(jobs), we should determine the error dml is generated from which job
- - when in multipleRows mode, we combine multiple jobs into one dml, if dml execute failed, we cannot determine which job it is 

so simply use the first job when meet error and `len(jobs)!=len(dmls)`, which not affect other feature.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update key monitor metrics in both TiCDC document and official document

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the issue that update statement execute error in safemode may cause DM-worker panic.
```
