### PR TITLE
test(ticdc): use mysql 2022 rpm GPG key

### DIFF
--- a/deployments/ticdc/docker/integration-test.Dockerfile
+++ b/deployments/ticdc/docker/integration-test.Dockerfile
@@ -40,7 +40,7 @@ RUN wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum install -y epel-release-latest-7.noarch.rpm
 RUN yum --enablerepo=epel install -y s3cmd
 # Install mysql client.
-RUN rpm -ivh https://repo.mysql.com//mysql57-community-release-el7-11.noarch.rpm
+RUN rpm -ivh https://repo.mysql.com/mysql57-community-release-el7-11.noarch.rpm
 # See: https://support.cpanel.net/hc/en-us/articles/4419382481815?input_string=gpg+keys+problem+with+mysql+5.7
 RUN rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
 RUN yum install mysql-community-client.x86_64 -y

--- a/deployments/ticdc/docker/integration-test.Dockerfile
+++ b/deployments/ticdc/docker/integration-test.Dockerfile
@@ -41,7 +41,8 @@ RUN yum install -y epel-release-latest-7.noarch.rpm
 RUN yum --enablerepo=epel install -y s3cmd
 # Install mysql client.
 RUN rpm -ivh https://repo.mysql.com//mysql57-community-release-el7-11.noarch.rpm
-RUN curl -i https://repo.mysql.com/RPM-GPG-KEY-mysql-2022 > /etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
+# See: https://support.cpanel.net/hc/en-us/articles/4419382481815?input_string=gpg+keys+problem+with+mysql+5.7
+RUN rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
 RUN yum install mysql-community-client.x86_64 -y
 
 # Copy go form downloader.

--- a/deployments/ticdc/docker/integration-test.Dockerfile
+++ b/deployments/ticdc/docker/integration-test.Dockerfile
@@ -39,9 +39,10 @@ RUN yum install -y \
 RUN wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum install -y epel-release-latest-7.noarch.rpm
 RUN yum --enablerepo=epel install -y s3cmd
-RUN wget -i -c http://dev.mysql.com/get/mysql57-community-release-el7-10.noarch.rpm
-RUN yum install -y mysql57-community-release-el7-10.noarch.rpm
-RUN yum install -y mysql-server
+# Install mysql client.
+RUN rpm -ivh https://repo.mysql.com//mysql57-community-release-el7-11.noarch.rpm
+RUN curl -i https://repo.mysql.com/RPM-GPG-KEY-mysql-2022 > /etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
+RUN yum install mysql-community-client.x86_64 -y
 
 # Copy go form downloader.
 COPY --from=downloader /usr/local/go /usr/local/go

--- a/scripts/canal/docker/Dockerfile
+++ b/scripts/canal/docker/Dockerfile
@@ -9,7 +9,8 @@ RUN yum makecache
 
 # Install mysql client.
 RUN rpm -ivh https://repo.mysql.com//mysql57-community-release-el7-11.noarch.rpm
-RUN curl -i https://repo.mysql.com/RPM-GPG-KEY-mysql-2022 > /etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
+# See: https://support.cpanel.net/hc/en-us/articles/4419382481815?input_string=gpg+keys+problem+with+mysql+5.7
+RUN rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
 RUN yum install mysql-community-client.x86_64 -y
 
 WORKDIR /root

--- a/scripts/canal/docker/Dockerfile
+++ b/scripts/canal/docker/Dockerfile
@@ -8,8 +8,8 @@ RUN yum clean all
 RUN yum makecache
 
 # Install mysql client.
-RUN wget https://dev.mysql.com/get/mysql57-community-release-el6-9.noarch.rpm
-RUN rpm -ivh mysql57-community-release-el6-9.noarch.rpm
+RUN rpm -ivh https://repo.mysql.com//mysql57-community-release-el7-11.noarch.rpm
+RUN curl -i https://repo.mysql.com/RPM-GPG-KEY-mysql-2022 > /etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
 RUN yum install mysql-community-client.x86_64 -y
 
 WORKDIR /root

--- a/scripts/canal/docker/Dockerfile
+++ b/scripts/canal/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN yum clean all
 RUN yum makecache
 
 # Install mysql client.
-RUN rpm -ivh https://repo.mysql.com//mysql57-community-release-el7-11.noarch.rpm
+RUN rpm -ivh https://repo.mysql.com/mysql57-community-release-el7-11.noarch.rpm
 # See: https://support.cpanel.net/hc/en-us/articles/4419382481815?input_string=gpg+keys+problem+with+mysql+5.7
 RUN rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
 RUN yum install mysql-community-client.x86_64 -y


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/4433

### What is changed and how it works?

use mysql 2022 rpm GPG key.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 None

Side effects

 None

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
 None
```
