### PR TITLE
fix update statement execute error in safemode cause dm-worker panic(#4432)

### DIFF
--- a/dm/syncer/dml_worker.go
+++ b/dm/syncer/dml_worker.go
@@ -196,17 +196,28 @@ func (w *DMLWorker) executeJobs(queueID int, jobCh chan *job) {
 // executeBatchJobs execute jobs with batch size.
 func (w *DMLWorker) executeBatchJobs(queueID int, jobs []*job) {
 	var (
-		affect int
-		db     = w.toDBConns[queueID]
-		err    error
-		dmls   = make([]*DML, 0, len(jobs))
+		affect  int
+		queries []string
+		args    [][]interface{}
+		db      = w.toDBConns[queueID]
+		err     error
+		dmls    = make([]*DML, 0, len(jobs))
 	)
 
 	defer func() {
 		if err == nil {
 			w.successFunc(queueID, len(dmls), jobs)
 		} else {
-			w.fatalFunc(jobs[affect], err)
+			if len(queries) == len(jobs) {
+				w.fatalFunc(jobs[affect], err)
+			} else {
+				w.logger.Warn("length of queries not equals length of jobs, cannot determine which job failed", zap.Int("queries", len(queries)), zap.Int("jobs", len(jobs)))
+				newJob := job{
+					startLocation:   jobs[0].startLocation,
+					currentLocation: jobs[len(jobs)-1].currentLocation,
+				}
+				w.fatalFunc(&newJob, err)
+			}
 		}
 	}()
 
@@ -230,7 +241,7 @@ func (w *DMLWorker) executeBatchJobs(queueID int, jobs []*job) {
 	for _, j := range jobs {
 		dmls = append(dmls, j.dml)
 	}
-	queries, args := w.genSQLs(dmls)
+	queries, args = w.genSQLs(dmls)
 	failpoint.Inject("WaitUserCancel", func(v failpoint.Value) {
 		t := v.(int)
 		time.Sleep(time.Duration(t) * time.Second)
@@ -243,6 +254,13 @@ func (w *DMLWorker) executeBatchJobs(queueID int, jobs []*job) {
 		if intVal, ok := val.(int); ok && intVal == 4 && len(jobs) > 0 {
 			w.logger.Warn("fail to exec DML", zap.String("failpoint", "SafeModeExit"))
 			affect, err = 0, terror.ErrDBExecuteFailed.Delegate(errors.New("SafeModeExit"), "mock")
+		}
+	})
+
+	failpoint.Inject("ErrorOnLastDML", func(_ failpoint.Value) {
+		if len(queries) > len(jobs) {
+			w.logger.Error("error on last queries", zap.Int("queries", len(queries)), zap.Int("jobs", len(jobs)))
+			affect, err = len(queries)-1, terror.ErrDBExecuteFailed.Delegate(errors.New("ErrorOnLastDML"), "mock")
 		}
 	})
 }

--- a/dm/tests/shardddl1/run.sh
+++ b/dm/tests/shardddl1/run.sh
@@ -783,6 +783,32 @@ function DM_CAUSALITY_USE_DOWNSTREAM_SCHEMA() {
 		"clean_table" ""
 }
 
+function DM_DML_EXECUTE_ERROR_CASE() {
+	run_sql_source1 "insert into ${shardddl1}.${tb1}(a,b) values(1,1)"
+	run_sql_source1 "update ${shardddl1}.${tb1} set b=b+1 where a=1"
+
+	check_log_contain_with_retry "length of queries not equals length of jobs" $WORK_DIR/worker1/log/dm-worker.log $WORK_DIR/worker2/log/dm-worker.log
+	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
+		"query-status test" \
+		"\"RawCause\": \"ErrorOnLastDML\"" 1 \
+		"Paused" 1
+}
+
+function DM_DML_EXECUTE_ERROR() {
+	ps aux | grep dm-worker | awk '{print $2}' | xargs kill || true
+	check_port_offline $WORKER1_PORT 20
+	check_port_offline $WORKER2_PORT 20
+	export GO_FAILPOINTS='github.com/pingcap/tiflow/dm/syncer/ErrorOnLastDML=return()'
+	run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
+	run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
+	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT
+	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT
+
+	run_case DML_EXECUTE_ERROR "single-source-no-sharding" \
+		"run_sql_source1 \"create table ${shardddl1}.${tb1} (a int primary key, b int);\"" \
+		"clean_table" ""
+}
+
 function run() {
 	init_cluster
 	init_database
@@ -799,6 +825,7 @@ function run() {
 	DM_RestartMaster
 	DM_ADD_DROP_COLUMNS
 	DM_COLUMN_INDEX
+	DM_DML_EXECUTE_ERROR
 	start=1
 	end=5
 	for i in $(seq -f "%03g" ${start} ${end}); do


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
This is a manually cherry-pick of #4432, because ticdc test is failed in master now. 


### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.
There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4317 

### What is changed and how it works?
- when update job split into multiple dmls(delete + replace), len(dmls)>len(jobs), we should determine the error dml is generated from which job
- when in multipleRows mode, we combine multiple jobs into one dml, if dml execute failed, we cannot determine which job it is

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update key monitor metrics in both TiCDC document and official document

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix the issue that update statement execute error in safemode may cause DM-worker panic.
```
