### PR TITLE
ticdc(sink): remove useless AppendResolvedEvent

### DIFF
--- a/cdc/sink/codec/avro.go
+++ b/cdc/sink/codec/avro.go
@@ -129,11 +129,6 @@ func (a *AvroEventBatchEncoder) AppendRowChangedEvent(e *model.RowChangedEvent) 
 	return EncoderNeedAsyncWrite, nil
 }
 
-// AppendResolvedEvent is no-op for Avro
-func (a *AvroEventBatchEncoder) AppendResolvedEvent(ts uint64) (EncoderResult, error) {
-	return EncoderNoOperation, nil
-}
-
 // EncodeCheckpointEvent is no-op for now
 func (a *AvroEventBatchEncoder) EncodeCheckpointEvent(ts uint64) (*MQMessage, error) {
 	return nil, nil

--- a/cdc/sink/codec/canal.go
+++ b/cdc/sink/codec/canal.go
@@ -396,12 +396,6 @@ type CanalEventBatchEncoder struct {
 	entryBuilder *canalEntryBuilder
 }
 
-// AppendResolvedEvent appends a resolved event to the encoder
-// TODO TXN support
-func (d *CanalEventBatchEncoder) AppendResolvedEvent(ts uint64) (EncoderResult, error) {
-	return EncoderNoOperation, nil
-}
-
 // EncodeCheckpointEvent implements the EventBatchEncoder interface
 func (d *CanalEventBatchEncoder) EncodeCheckpointEvent(ts uint64) (*MQMessage, error) {
 	// For canal now, there is no such a corresponding type to ResolvedEvent so far.

--- a/cdc/sink/codec/canal_flat_test.go
+++ b/cdc/sink/codec/canal_flat_test.go
@@ -163,10 +163,6 @@ func (s *canalFlatSuite) TestNewCanalFlatEventBatchDecoder4RowMessage(c *check.C
 		c.Assert(err, check.IsNil)
 		c.Assert(result, check.Equals, EncoderNoOperation)
 
-		result, err = encoder.AppendResolvedEvent(417318403368288260)
-		c.Assert(err, check.IsNil)
-		c.Assert(result, check.Equals, EncoderNeedAsyncWrite)
-
 		mqMessages := encoder.Build()
 		c.Assert(len(mqMessages), check.Equals, 1)
 
@@ -308,11 +304,6 @@ func (s *canalFlatSuite) TestBatching(c *check.C) {
 			if i == 999 {
 				resolvedTs = 999
 			}
-			result, err := encoder.AppendResolvedEvent(resolvedTs)
-
-			c.Assert(err, check.IsNil)
-			c.Assert(result, check.Equals, EncoderNeedAsyncWrite)
-
 			msgs := encoder.Build()
 			c.Assert(msgs, check.NotNil)
 			c.Assert(msgs, check.HasLen, int(resolvedTs-lastResolved))
@@ -331,8 +322,7 @@ func (s *canalFlatSuite) TestBatching(c *check.C) {
 		}
 	}
 
-	c.Assert(encoder.unresolvedBuf, check.HasLen, 0)
-	c.Assert(encoder.resolvedBuf, check.HasLen, 0)
+	c.Assert(encoder.messageBuf, check.HasLen, 0)
 }
 
 func (s *canalFlatSuite) TestEncodeCheckpointEvent(c *check.C) {

--- a/cdc/sink/codec/canal_flat_test.go
+++ b/cdc/sink/codec/canal_flat_test.go
@@ -291,22 +291,17 @@ func (s *canalFlatSuite) TestBatching(c *check.C) {
 	c.Assert(encoder, check.NotNil)
 
 	updateCase := *testCaseUpdate
-	lastResolved := uint64(0)
-	for i := 1; i < 1000; i++ {
+	for i := 1; i <= 1000; i++ {
 		ts := uint64(i)
 		updateCase.CommitTs = ts
 		result, err := encoder.AppendRowChangedEvent(&updateCase)
 		c.Assert(err, check.IsNil)
 		c.Assert(result, check.Equals, EncoderNoOperation)
 
-		if i >= 100 && (i%100 == 0 || i == 999) {
-			resolvedTs := uint64(i - 50)
-			if i == 999 {
-				resolvedTs = 999
-			}
+		if i%100 == 0 {
 			msgs := encoder.Build()
 			c.Assert(msgs, check.NotNil)
-			c.Assert(msgs, check.HasLen, int(resolvedTs-lastResolved))
+			c.Assert(msgs, check.HasLen, 100)
 
 			for j := range msgs {
 				c.Assert(msgs[j].GetRowsCount(), check.Equals, 1)
@@ -315,10 +310,7 @@ func (s *canalFlatSuite) TestBatching(c *check.C) {
 				err := json.Unmarshal(msgs[j].Value, &msg)
 				c.Assert(err, check.IsNil)
 				c.Assert(msg.EventType, check.Equals, "UPDATE")
-				c.Assert(msg.ExecutionTime, check.Equals, convertToCanalTs(lastResolved+uint64(i)))
 			}
-
-			lastResolved = resolvedTs
 		}
 	}
 

--- a/cdc/sink/codec/craft.go
+++ b/cdc/sink/codec/craft.go
@@ -62,11 +62,6 @@ func (e *CraftEventBatchEncoder) AppendRowChangedEvent(ev *model.RowChangedEvent
 	return EncoderNoOperation, nil
 }
 
-// AppendResolvedEvent is no-op
-func (e *CraftEventBatchEncoder) AppendResolvedEvent(ts uint64) (EncoderResult, error) {
-	return EncoderNoOperation, nil
-}
-
 // EncodeDDLEvent implements the EventBatchEncoder interface
 func (e *CraftEventBatchEncoder) EncodeDDLEvent(ev *model.DDLEvent) (*MQMessage, error) {
 	return newDDLMQMessage(config.ProtocolCraft, nil, craft.NewDDLEventEncoder(e.allocator, ev).Encode(), ev), nil

--- a/cdc/sink/codec/interface.go
+++ b/cdc/sink/codec/interface.go
@@ -33,9 +33,6 @@ type EventBatchEncoder interface {
 	EncodeCheckpointEvent(ts uint64) (*MQMessage, error)
 	// AppendRowChangedEvent appends a row changed event into the batch
 	AppendRowChangedEvent(e *model.RowChangedEvent) (EncoderResult, error)
-	// AppendResolvedEvent appends a resolved event into the batch.
-	// This event is used to tell the encoder that no event prior to ts will be sent.
-	AppendResolvedEvent(ts uint64) (EncoderResult, error)
 	// EncodeDDLEvent appends a DDL event into the batch
 	EncodeDDLEvent(e *model.DDLEvent) (*MQMessage, error)
 	// Build builds the batch and returns the bytes of key and value.
@@ -47,7 +44,6 @@ type EventBatchEncoder interface {
 	// TODO decouple it out
 	MixedBuild(withVersion bool) []byte
 	// Size returns the size of the batch(bytes)
-	// Deprecated: Size is deprecated
 	Size() int
 	// Reset reset the kv buffer
 	Reset()

--- a/cdc/sink/codec/json.go
+++ b/cdc/sink/codec/json.go
@@ -400,11 +400,6 @@ func (d *JSONEventBatchEncoder) SetMixedBuildSupport(enabled bool) {
 	d.supportMixedBuild = enabled
 }
 
-// AppendResolvedEvent is no-op
-func (d *JSONEventBatchEncoder) AppendResolvedEvent(ts uint64) (EncoderResult, error) {
-	return EncoderNoOperation, nil
-}
-
 // EncodeCheckpointEvent implements the EventBatchEncoder interface
 func (d *JSONEventBatchEncoder) EncodeCheckpointEvent(ts uint64) (*MQMessage, error) {
 	keyMsg := newResolvedMessage(ts)

--- a/cdc/sink/codec/maxwell.go
+++ b/cdc/sink/codec/maxwell.go
@@ -85,11 +85,6 @@ func (d *MaxwellEventBatchEncoder) EncodeCheckpointEvent(ts uint64) (*MQMessage,
 	return nil, nil
 }
 
-// AppendResolvedEvent implements the EventBatchEncoder interface
-func (d *MaxwellEventBatchEncoder) AppendResolvedEvent(ts uint64) (EncoderResult, error) {
-	return EncoderNoOperation, nil
-}
-
 func rowEventToMaxwellMessage(e *model.RowChangedEvent) (*mqMessageKey, *maxwellMessage) {
 	var partition *int64
 	if e.Table.IsPartition {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref https://github.com/pingcap/tiflow/issues/4423

### What is changed and how it works?

Remove useless AppendResolvedEvent API.

Most protocols don't implement it, and its original purpose was to ensure the order of dml and ddl. But now buffersink already guarantees it. So we can remove it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change

Side effects
None

Related changes

None

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
