### PR TITLE
kv(ticdc): replace the connArray with the connHeap

### DIFF
--- a/cdc/kv/grpc_pool_impl_test.go
+++ b/cdc/kv/grpc_pool_impl_test.go
@@ -21,10 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Use clientSuite for some special reasons, the embed etcd uses zap as the only candidate
-// logger and in the logger initialization it also initializes the grpclog/loggerv2, which
-// is not a thread-safe operation and it must be called before any gRPC functions
-// ref: https://github.com/grpc/grpc-go/blob/master/grpclog/loggerv2.go#L67-L72
 func TestConnArray(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?
Replace the connArray with the connHeap in cdc/kv/grpc_pool_impl.go

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
 `None`
```
