### PR TITLE
cdc/sink: decouple opt out of statistics

### DIFF
--- a/cdc/sink/black_hole.go
+++ b/cdc/sink/black_hole.go
@@ -23,9 +23,9 @@ import (
 )
 
 // newBlackHoleSink creates a black hole sink
-func newBlackHoleSink(ctx context.Context, opts map[string]string) *blackHoleSink {
+func newBlackHoleSink(ctx context.Context) *blackHoleSink {
 	return &blackHoleSink{
-		statistics: NewStatistics(ctx, "blackhole", opts),
+		statistics: NewStatistics(ctx, "blackhole"),
 	}
 }
 

--- a/cdc/sink/buffer_sink_test.go
+++ b/cdc/sink/buffer_sink_test.go
@@ -38,7 +38,7 @@ func TestFlushTable(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
-	b := newBufferSink(newBlackHoleSink(ctx, make(map[string]string)), 5, make(chan drawbackMsg))
+	b := newBufferSink(newBlackHoleSink(ctx), 5, make(chan drawbackMsg))
 	go b.run(ctx, make(chan error))
 
 	require.Equal(t, uint64(5), b.getTableCheckpointTs(2))
@@ -82,7 +82,7 @@ func TestFlushFailed(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.TODO())
-	b := newBufferSink(newBlackHoleSink(ctx, make(map[string]string)), 5, make(chan drawbackMsg))
+	b := newBufferSink(newBlackHoleSink(ctx), 5, make(chan drawbackMsg))
 	go b.run(ctx, make(chan error))
 
 	checkpoint, err := b.FlushRowChangedEvents(ctx, 3, 8)

--- a/cdc/sink/mq.go
+++ b/cdc/sink/mq.go
@@ -135,7 +135,7 @@ func newMqSink(
 		resolvedNotifier: notifier,
 		resolvedReceiver: resolvedReceiver,
 
-		statistics: NewStatistics(ctx, "MQ", opts),
+		statistics: NewStatistics(ctx, "MQ"),
 
 		role: role,
 		id:   changefeedID,

--- a/cdc/sink/mysql.go
+++ b/cdc/sink/mysql.go
@@ -185,7 +185,7 @@ func newMySQLSink(
 		filter:                          filter,
 		cyclic:                          sinkCyclic,
 		txnCache:                        common.NewUnresolvedTxnCache(),
-		statistics:                      NewStatistics(ctx, "mysql", opts),
+		statistics:                      NewStatistics(ctx, "mysql"),
 		metricConflictDetectDurationHis: metricConflictDetectDurationHis,
 		metricBucketSizeCounters:        metricBucketSizeCounters,
 		errCh:                           make(chan error, 1),

--- a/cdc/sink/mysql_test.go
+++ b/cdc/sink/mysql_test.go
@@ -49,7 +49,7 @@ func newMySQLSink4Test(ctx context.Context, t *testing.T) *mysqlSink {
 	return &mysqlSink{
 		txnCache:   common.NewUnresolvedTxnCache(),
 		filter:     f,
-		statistics: NewStatistics(ctx, "test", make(map[string]string)),
+		statistics: NewStatistics(ctx, "test"),
 		params:     params,
 	}
 }

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -263,6 +263,9 @@ func (k *kafkaSaramaProducer) Close() error {
 			zap.String("changefeed", k.id), zap.Any("role", k.role))
 	}
 
+	k.metricsMonitor.Cleanup()
+
+	// adminClient should be closed last, since `metricsMonitor` would use it when `Cleanup`.
 	start = time.Now()
 	if err := k.admin.Close(); err != nil {
 		log.Warn("close kafka cluster admin with error", zap.Error(err),
@@ -273,7 +276,6 @@ func (k *kafkaSaramaProducer) Close() error {
 			zap.String("changefeed", k.id), zap.Any("role", k.role))
 	}
 
-	k.metricsMonitor.Cleanup()
 	return nil
 }
 

--- a/cdc/sink/sink.go
+++ b/cdc/sink/sink.go
@@ -89,7 +89,7 @@ func init() {
 	// register blackhole sink
 	sinkIniterMap["blackhole"] = func(ctx context.Context, changefeedID model.ChangeFeedID, sinkURI *url.URL,
 		filter *filter.Filter, config *config.ReplicaConfig, opts map[string]string, errCh chan error) (Sink, error) {
-		return newBlackHoleSink(ctx, opts), nil
+		return newBlackHoleSink(ctx), nil
 	}
 
 	// register mysql sink

--- a/cdc/sink/statistics.go
+++ b/cdc/sink/statistics.go
@@ -30,13 +30,12 @@ const (
 )
 
 // NewStatistics creates a statistics
-func NewStatistics(ctx context.Context, name string, opts map[string]string) *Statistics {
-	statistics := &Statistics{name: name, lastPrintStatusTime: time.Now()}
-	if cid, ok := opts[OptChangefeedID]; ok {
-		statistics.changefeedID = cid
-	}
-	if cid, ok := opts[OptCaptureAddr]; ok {
-		statistics.captureAddr = cid
+func NewStatistics(ctx context.Context, name string) *Statistics {
+	statistics := &Statistics{
+		name:                name,
+		captureAddr:         util.CaptureAddrFromCtx(ctx),
+		changefeedID:        util.ChangefeedIDFromCtx(ctx),
+		lastPrintStatusTime: time.Now(),
 	}
 	statistics.metricExecTxnHis = execTxnHistogram.WithLabelValues(statistics.captureAddr, statistics.changefeedID)
 	statistics.metricExecDDLHis = execDDLHistogram.WithLabelValues(statistics.captureAddr, statistics.changefeedID)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4607

### What is changed and how it works?

Remove `opt` from `statistics`.

We should avoid pass `opts` along the call chain, it's implicit and hard to reason about.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
