### PR TITLE
tracker(dm): respect CHARSET when build TableInfo

### DIFF
--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -487,6 +487,7 @@ func (tr *Tracker) getTableInfoByCreateStmt(tctx *tcontext.Context, tableID stri
 	if err != nil {
 		return nil, dmterror.ErrSchemaTrackerCannotMockDownstreamTable.Delegate(err, createStr)
 	}
+	ti.State = model.StatePublic
 	return ti, nil
 }
 

--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -34,7 +34,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util/mock"
 	"go.uber.org/zap"
 
 	tcontext "github.com/pingcap/tiflow/dm/pkg/context"
@@ -484,7 +483,7 @@ func (tr *Tracker) getTableInfoByCreateStmt(tctx *tcontext.Context, tableID stri
 		return nil, dmterror.ErrSchemaTrackerInvalidCreateTableStmt.Delegate(err, createStr)
 	}
 
-	ti, err := ddl.MockTableInfo(mock.NewContext(), stmtNode.(*ast.CreateTableStmt), mockTableID)
+	ti, err := ddl.BuildTableInfoFromAST(stmtNode.(*ast.CreateTableStmt))
 	if err != nil {
 		return nil, dmterror.ErrSchemaTrackerCannotMockDownstreamTable.Delegate(err, createStr)
 	}

--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -46,8 +46,6 @@ import (
 const (
 	// TiDBClusteredIndex is the variable name for clustered index.
 	TiDBClusteredIndex = "tidb_enable_clustered_index"
-	// downstream mock table id, consists of serial numbers of letters.
-	mockTableID = 121402101900011104
 )
 
 var (

--- a/dm/pkg/schema/tracker_test.go
+++ b/dm/pkg/schema/tracker_test.go
@@ -852,7 +852,7 @@ func (s *trackerSuite) TestGetDownStreamIndexInfo(c *C) {
 	delete(tracker.dsTracker.tableInfos, tableID)
 }
 
-func (s *trackerSuite) TestGetAvailableDownStreanUKIndexInfo(c *C) {
+func (s *trackerSuite) TestGetAvailableDownStreamUKIIndexInfo(c *C) {
 	log.SetLevel(zapcore.ErrorLevel)
 
 	// origin table info
@@ -1038,5 +1038,41 @@ func (s *trackerSuite) TestReTrackDownStreamIndex(c *C) {
 	_, err = tracker.GetDownStreamTableInfo(tcontext.Background(), tableID, oriTi)
 	c.Assert(err, IsNil)
 	_, ok = tracker.dsTracker.tableInfos[tableID]
+	c.Assert(ok, IsTrue)
+}
+
+func (s *trackerSuite) TestVarchar20000(c *C) {
+	log.SetLevel(zapcore.ErrorLevel)
+
+	// origin table info
+	p := parser.New()
+	node, err := p.ParseOneStmt("create table t(c varchar(20000)) charset=utf8", "", "")
+	c.Assert(err, IsNil)
+	oriTi, err := ddl.BuildTableInfoFromAST(node.(*ast.CreateTableStmt))
+	c.Assert(err, IsNil)
+
+	// tracker and sqlmock
+	db, mock, err := sqlmock.New()
+	c.Assert(err, IsNil)
+	defer db.Close()
+	con, err := db.Conn(context.Background())
+	c.Assert(err, IsNil)
+	baseConn := conn.NewBaseConn(con, nil)
+	dbConn := &dbconn.DBConn{Cfg: s.cfg, BaseConn: baseConn}
+	tracker, err := NewTracker(context.Background(), "test-tracker", defaultTestSessionCfg, dbConn)
+	c.Assert(err, IsNil)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", mysql.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	tableID := "`test`.`test`"
+
+	mock.ExpectQuery("SHOW CREATE TABLE " + tableID).WillReturnRows(
+		sqlmock.NewRows([]string{"Table", "Create Table"}).
+			AddRow("test", "create table t(c varchar(20000)) charset=utf8"))
+	_, err = tracker.GetDownStreamTableInfo(tcontext.Background(), tableID, oriTi)
+	c.Assert(err, IsNil)
+	_, ok := tracker.dsTracker.tableInfos[tableID]
 	c.Assert(ok, IsTrue)
 }

--- a/dm/tests/downstream_diff_index/data/db1.increment.sql
+++ b/dm/tests/downstream_diff_index/data/db1.increment.sql
@@ -1,3 +1,4 @@
 use downstream_diff_index1;
 update t1 set c3 = '111' where c1 = 1;
 delete from t1 where c1 = 2;
+insert into varchar20000 values (1, '1');

--- a/dm/tests/downstream_diff_index/data/db1.prepare.sql
+++ b/dm/tests/downstream_diff_index/data/db1.prepare.sql
@@ -5,3 +5,4 @@ create table t1 (c1 int, c2 int, c3 varchar(10), primary key(c1));
 insert into t1 values(1, 1, '1');
 insert into t1 values(2, 2, '2');
 insert into t1 values(3, 3, '3');
+create table varchar20000 (c int primary key, c2 varchar(20000)) charset=utf8;

--- a/dm/tests/downstream_diff_index/run.sh
+++ b/dm/tests/downstream_diff_index/run.sh
@@ -66,6 +66,8 @@ function run() {
 	# check delete data
 	run_sql_tidb_with_retry "select count(1) from ${db}.${tb} where c1=1;" "count(1): 1"
 	check_log_contain_with_retry '\[DeleteWhereColumnsCheck\] \[Columns="\[c3\]"\]' $WORK_DIR/worker2/log/dm-worker.log
+
+	run_sql_tidb_with_retry "select count(1) from ${db}.varchar20000 where c=1;" "count(1): 1"
 }
 
 cleanup_data downstream_diff_index


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4637

### What is changed and how it works?

found that MockTableInfo will always use default charset and collation, BuildTableInfoFromAST is better

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects


Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix a bug that long varchar will report error of "Column length too big..."
```
