### PR TITLE
sorter(ticdc): fix the issue of using wrong values for writeCount and dataSize

### DIFF
--- a/cdc/http_test.go
+++ b/cdc/http_test.go
@@ -20,9 +20,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/pingcap/failpoint"
-
 	"github.com/gin-gonic/gin"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tiflow/cdc/capture"
 	"github.com/stretchr/testify/require"
 )

--- a/cdc/sorter/unified/file_backend.go
+++ b/cdc/sorter/unified/file_backend.go
@@ -386,11 +386,11 @@ func (w *fileBackEndWriter) writeNext(event *model.PolymorphicEvent) error {
 }
 
 func (w *fileBackEndWriter) writtenCount() int {
-	return int(w.bytesWritten)
+	return int(w.eventsWritten)
 }
 
 func (w *fileBackEndWriter) dataSize() uint64 {
-	return uint64(w.eventsWritten)
+	return uint64(w.bytesWritten)
 }
 
 func (w *fileBackEndWriter) flushAndClose() error {

--- a/cdc/sorter/unified/file_backend_test.go
+++ b/cdc/sorter/unified/file_backend_test.go
@@ -33,7 +33,7 @@ func TestWrapIOError(t *testing.T) {
 	_, err = fullFile.WriteString("test")
 	wrapped := wrapIOError(err)
 	// tests that the error message gives the user some informative description
-	require.Regexp(t, wrapped, ".*no space.*")
+	require.Regexp(t, wrapped, "no space")
 
 	eof := wrapIOError(io.EOF)
 	// tests that the function does not change io.EOF
@@ -54,7 +54,7 @@ func TestNoSpace(t *testing.T) {
 		err = w.flushAndClose()
 	}
 
-	require.Regexp(t, err, ".*no space.*")
+	require.Regexp(t, err, "no space")
 	require.True(t, cerrors.ErrUnifiedSorterIOError.Equal(err))
 }
 

--- a/cdc/sorter/unified/file_backend_test.go
+++ b/cdc/sorter/unified/file_backend_test.go
@@ -33,7 +33,7 @@ func TestWrapIOError(t *testing.T) {
 	_, err = fullFile.WriteString("test")
 	wrapped := wrapIOError(err)
 	// tests that the error message gives the user some informative description
-	require.Regexp(t, wrapped, ".*review the settings.*no space.*")
+	require.Regexp(t, wrapped, ".*no space.*")
 
 	eof := wrapIOError(io.EOF)
 	// tests that the function does not change io.EOF
@@ -54,7 +54,7 @@ func TestNoSpace(t *testing.T) {
 		err = w.flushAndClose()
 	}
 
-	require.Regexp(t, err, ".*review the settings.*no space.*")
+	require.Regexp(t, err, ".*no space.*")
 	require.True(t, cerrors.ErrUnifiedSorterIOError.Equal(err))
 }
 

--- a/cdc/sorter/unified/file_backend_test.go
+++ b/cdc/sorter/unified/file_backend_test.go
@@ -33,7 +33,7 @@ func TestWrapIOError(t *testing.T) {
 	_, err = fullFile.WriteString("test")
 	wrapped := wrapIOError(err)
 	// tests that the error message gives the user some informative description
-	require.Regexp(t, wrapped, "no space")
+	require.Regexp(t, ".*review the settings.*no space.*", wrapped.Error())
 
 	eof := wrapIOError(io.EOF)
 	// tests that the function does not change io.EOF
@@ -54,7 +54,7 @@ func TestNoSpace(t *testing.T) {
 		err = w.flushAndClose()
 	}
 
-	require.Regexp(t, err, "no space")
+	require.Regexp(t, ".*review the settings.*no space.*", err.Error())
 	require.True(t, cerrors.ErrUnifiedSorterIOError.Equal(err))
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/3206

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - [x] Unit test

Code changes

None

Side effects

None

Related changes

None

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
