### PR TITLE
cdc/kafka: remove skip-auto-create failpoint in kafka test

### DIFF
--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tiflow/cdc/sink/codec"
 	"github.com/pingcap/tiflow/pkg/config"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
+	"github.com/pingcap/tiflow/pkg/kafka"
 	"github.com/pingcap/tiflow/pkg/notify"
 	"github.com/pingcap/tiflow/pkg/security"
 	"github.com/pingcap/tiflow/pkg/util"
@@ -470,105 +471,15 @@ func (k *kafkaSaramaProducer) run(ctx context.Context) error {
 	}
 }
 
-func topicPreProcess(topic string, config *Config, saramaConfig *sarama.Config) error {
-	// FIXME: find a way to remove this failpoint for workload the unit test
-	failpoint.Inject("SkipTopicAutoCreate", func() {
-		failpoint.Return(nil)
-	})
-	admin, err := sarama.NewClusterAdmin(config.BrokerEndpoints, saramaConfig)
-	if err != nil {
-		return cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
-	}
-	defer func() {
-		if err := admin.Close(); err != nil {
-			log.Warn("close kafka cluster admin failed", zap.Error(err))
-		}
-	}()
-
-	topics, err := admin.ListTopics()
-	if err != nil {
-		return cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
-	}
-
-	info, created := topics[topic]
-	// once we have found the topic, no matter `auto-create-topic`, make sure user input parameters are valid.
-	if created {
-		// make sure that producer's `MaxMessageBytes` smaller than topic's `max.message.bytes`
-		topicMaxMessageBytes, err := getTopicMaxMessageBytes(admin, info)
-		if err != nil {
-			return cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
-		}
-
-		if topicMaxMessageBytes < config.MaxMessageBytes {
-			log.Warn("topic's `max.message.bytes` less than the `max-message-bytes`,"+
-				"use topic's `max.message.bytes` to initialize the Kafka producer",
-				zap.Int("max.message.bytes", topicMaxMessageBytes),
-				zap.Int("max-message-bytes", config.MaxMessageBytes))
-			saramaConfig.Producer.MaxMessageBytes = topicMaxMessageBytes
-		}
-
-		// no need to create the topic, but we would have to log user if they found enter wrong topic name later
-		if config.AutoCreate {
-			log.Warn("topic already exist, TiCDC will not create the topic",
-				zap.String("topic", topic), zap.Any("detail", info))
-		}
-
-		if err := config.adjustPartitionNum(info.NumPartitions); err != nil {
-			return errors.Trace(err)
-		}
-
-		return nil
-	}
-
-	if !config.AutoCreate {
-		return cerror.ErrKafkaInvalidConfig.GenWithStack("`auto-create-topic` is false, and topic not found")
-	}
-
-	brokerMessageMaxBytes, err := getBrokerMessageMaxBytes(admin)
-	if err != nil {
-		log.Warn("TiCDC cannot find `message.max.bytes` from broker's configuration")
-		return errors.Trace(err)
-	}
-
-	// when create the topic, `max.message.bytes` is decided by the broker,
-	// it would use broker's `message.max.bytes` to set topic's `max.message.bytes`.
-	// TiCDC need to make sure that the producer's `MaxMessageBytes` won't larger than
-	// broker's `message.max.bytes`.
-	if brokerMessageMaxBytes < config.MaxMessageBytes {
-		log.Warn("broker's `message.max.bytes` less than the `max-message-bytes`,"+
-			"use broker's `message.max.bytes` to initialize the Kafka producer",
-			zap.Int("message.max.bytes", brokerMessageMaxBytes),
-			zap.Int("max-message-bytes", config.MaxMessageBytes))
-		saramaConfig.Producer.MaxMessageBytes = brokerMessageMaxBytes
-	}
-
-	// topic not created yet, and user does not specify the `partition-num` in the sink uri.
-	if config.PartitionNum == 0 {
-		config.PartitionNum = defaultPartitionNum
-		log.Warn("partition-num is not set, use the default partition count",
-			zap.String("topic", topic), zap.Int32("partitions", config.PartitionNum))
-	}
-
-	err = admin.CreateTopic(topic, &sarama.TopicDetail{
-		NumPartitions:     config.PartitionNum,
-		ReplicationFactor: config.ReplicationFactor,
-	}, false)
-	// TODO identify the cause of "Topic with this name already exists"
-	if err != nil && !strings.Contains(err.Error(), "already exists") {
-		return cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
-	}
-
-	log.Info("TiCDC create the topic",
-		zap.Int32("partition-num", config.PartitionNum),
-		zap.Int16("replication-factor", config.ReplicationFactor))
-
-	return nil
-}
-
-var newSaramaConfigImpl = newSaramaConfig
+var (
+	newSaramaConfigImpl = newSaramaConfig
+	// NewAdminClientImpl specifies the build method for the admin client.
+	NewAdminClientImpl kafka.ClusterAdminClientCreator = kafka.NewSaramaAdminClient
+)
 
 // NewKafkaSaramaProducer creates a kafka sarama producer
-func NewKafkaSaramaProducer(ctx context.Context, topic string, config *Config, opts map[string]string, errCh chan error) (*kafkaSaramaProducer, error) {
+func NewKafkaSaramaProducer(ctx context.Context, topic string, config *Config,
+	opts map[string]string, errCh chan error) (*kafkaSaramaProducer, error) {
 	changefeedID := util.ChangefeedIDFromCtx(ctx)
 	role := util.RoleFromCtx(ctx)
 	log.Info("Starting kafka sarama producer ...", zap.Any("config", config),
@@ -579,10 +490,19 @@ func NewKafkaSaramaProducer(ctx context.Context, topic string, config *Config, o
 		return nil, err
 	}
 
-	if err := topicPreProcess(topic, config, cfg); err != nil {
+	admin, err := NewAdminClientImpl(config.BrokerEndpoints, cfg)
+	if err != nil {
 		return nil, cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
 	}
-	opts["max-message-bytes"] = strconv.Itoa(cfg.Producer.MaxMessageBytes)
+	defer func() {
+		if err := admin.Close(); err != nil {
+			log.Warn("close kafka cluster admin failed", zap.Error(err))
+		}
+	}()
+
+	if err := validateAndCreateTopic(admin, topic, config, cfg, opts); err != nil {
+		return nil, cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
+	}
 
 	client, err := sarama.NewClient(config.BrokerEndpoints, cfg)
 	if err != nil {
@@ -638,7 +558,6 @@ func NewKafkaSaramaProducer(ctx context.Context, topic string, config *Config, o
 			}
 		}
 	}()
-
 	return k, nil
 }
 
@@ -658,6 +577,99 @@ func kafkaClientID(role, captureAddr, changefeedID, configuredClientID string) (
 		return "", cerror.ErrKafkaInvalidClientID.GenWithStackByArgs(clientID)
 	}
 	return
+}
+
+func validateAndCreateTopic(admin kafka.ClusterAdminClient, topic string, config *Config, saramaConfig *sarama.Config,
+	opts map[string]string) error {
+	topics, err := admin.ListTopics()
+	if err != nil {
+		return cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
+	}
+
+	info, exists := topics[topic]
+	// once we have found the topic, no matter `auto-create-topic`, make sure user input parameters are valid.
+	if exists {
+		// make sure that producer's `MaxMessageBytes` smaller than topic's `max.message.bytes`
+		topicMaxMessageBytesStr, err := getTopicConfig(admin, info, kafka.TopicMaxMessageBytesConfigName,
+			kafka.BrokerMessageMaxBytesConfigName)
+		if err != nil {
+			return cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
+		}
+		topicMaxMessageBytes, err := strconv.Atoi(topicMaxMessageBytesStr)
+		if err != nil {
+			return cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
+		}
+
+		if topicMaxMessageBytes < config.MaxMessageBytes {
+			log.Warn("topic's `max.message.bytes` less than the `max-message-bytes`,"+
+				"use topic's `max.message.bytes` to initialize the Kafka producer",
+				zap.Int("max.message.bytes", topicMaxMessageBytes),
+				zap.Int("max-message-bytes", config.MaxMessageBytes))
+			saramaConfig.Producer.MaxMessageBytes = topicMaxMessageBytes
+		}
+		opts["max-message-bytes"] = strconv.Itoa(saramaConfig.Producer.MaxMessageBytes)
+
+		// no need to create the topic, but we would have to log user if they found enter wrong topic name later
+		if config.AutoCreate {
+			log.Warn("topic already exist, TiCDC will not create the topic",
+				zap.String("topic", topic), zap.Any("detail", info))
+		}
+
+		if err := config.setPartitionNum(info.NumPartitions); err != nil {
+			return errors.Trace(err)
+		}
+
+		return nil
+	}
+
+	if !config.AutoCreate {
+		return cerror.ErrKafkaInvalidConfig.GenWithStack("`auto-create-topic` is false, and topic not found")
+	}
+
+	brokerMessageMaxBytesStr, err := getBrokerConfig(admin, kafka.BrokerMessageMaxBytesConfigName)
+	if err != nil {
+		log.Warn("TiCDC cannot find `message.max.bytes` from broker's configuration")
+		return errors.Trace(err)
+	}
+	brokerMessageMaxBytes, err := strconv.Atoi(brokerMessageMaxBytesStr)
+	if err != nil {
+		return cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
+	}
+
+	// when create the topic, `max.message.bytes` is decided by the broker,
+	// it would use broker's `message.max.bytes` to set topic's `max.message.bytes`.
+	// TiCDC need to make sure that the producer's `MaxMessageBytes` won't larger than
+	// broker's `message.max.bytes`.
+	if brokerMessageMaxBytes < config.MaxMessageBytes {
+		log.Warn("broker's `message.max.bytes` less than the `max-message-bytes`,"+
+			"use broker's `message.max.bytes` to initialize the Kafka producer",
+			zap.Int("message.max.bytes", brokerMessageMaxBytes),
+			zap.Int("max-message-bytes", config.MaxMessageBytes))
+		saramaConfig.Producer.MaxMessageBytes = brokerMessageMaxBytes
+	}
+	opts["max-message-bytes"] = strconv.Itoa(saramaConfig.Producer.MaxMessageBytes)
+
+	// topic not exists yet, and user does not specify the `partition-num` in the sink uri.
+	if config.PartitionNum == 0 {
+		config.PartitionNum = defaultPartitionNum
+		log.Warn("partition-num is not set, use the default partition count",
+			zap.String("topic", topic), zap.Int32("partitions", config.PartitionNum))
+	}
+
+	err = admin.CreateTopic(topic, &sarama.TopicDetail{
+		NumPartitions:     config.PartitionNum,
+		ReplicationFactor: config.ReplicationFactor,
+	}, false)
+	// TODO identify the cause of "Topic with this name already exists"
+	if err != nil && !strings.Contains(err.Error(), "already exists") {
+		return cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
+	}
+
+	log.Info("TiCDC create the topic",
+		zap.Int32("partition-num", config.PartitionNum),
+		zap.Int16("replication-factor", config.ReplicationFactor))
+
+	return nil
 }
 
 func newSaramaConfig(ctx context.Context, c *Config) (*sarama.Config, error) {
@@ -803,7 +815,7 @@ func getTopicMaxMessageBytes(admin sarama.ClusterAdmin, info sarama.TopicDetail)
 }
 
 // adjust the partition-num by the topic's partition count
-func (c *Config) adjustPartitionNum(realPartitionCount int32) error {
+func (c *Config) setPartitionNum(realPartitionCount int32) error {
 	// user does not specify the `partition-num` in the sink-uri
 	if c.PartitionNum == 0 {
 		c.PartitionNum = realPartitionCount

--- a/cdc/sink/producer/kafka/kafka.go
+++ b/cdc/sink/producer/kafka/kafka.go
@@ -478,8 +478,7 @@ var (
 )
 
 // NewKafkaSaramaProducer creates a kafka sarama producer
-func NewKafkaSaramaProducer(ctx context.Context, topic string, config *Config,
-	opts map[string]string, errCh chan error) (*kafkaSaramaProducer, error) {
+func NewKafkaSaramaProducer(ctx context.Context, topic string, config *Config, opts map[string]string, errCh chan error) (*kafkaSaramaProducer, error) {
 	changefeedID := util.ChangefeedIDFromCtx(ctx)
 	role := util.RoleFromCtx(ctx)
 	log.Info("Starting kafka sarama producer ...", zap.Any("config", config),
@@ -805,7 +804,6 @@ func getTopicConfig(admin kafka.ClusterAdminClient, detail sarama.TopicDetail, t
 	return getBrokerConfig(admin, brokerConfigName)
 }
 
-// adjust the partition-num by the topic's partition count
 func (c *Config) setPartitionNum(realPartitionCount int32) error {
 	// user does not specify the `partition-num` in the sink-uri
 	if c.PartitionNum == 0 {

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -299,10 +298,8 @@ func (s *kafkaSuite) TestValidateAndCreateTopic(c *check.C) {
 	config.MaxMessageBytes = adminClient.GetDefaultMaxMessageBytes()
 	cfg, err := newSaramaConfigImpl(context.Background(), config)
 	c.Assert(err, check.IsNil)
-	opts := make(map[string]string)
-	err = validateAndCreateTopic(adminClient, adminClient.GetDefaultMockTopicName(), config, cfg, opts)
+	err = validateAndCreateTopic(adminClient, adminClient.GetDefaultMockTopicName(), config, cfg)
 	c.Assert(err, check.IsNil)
-	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
 
 	// When topic exists and max message bytes is not set correctly.
 	// use the smaller one.
@@ -310,27 +307,22 @@ func (s *kafkaSuite) TestValidateAndCreateTopic(c *check.C) {
 	config.MaxMessageBytes = defaultMaxMessageBytes + 1
 	cfg, err = newSaramaConfigImpl(context.Background(), config)
 	c.Assert(err, check.IsNil)
-	opts = make(map[string]string)
-	err = validateAndCreateTopic(adminClient, adminClient.GetDefaultMockTopicName(), config, cfg, opts)
+	err = validateAndCreateTopic(adminClient, adminClient.GetDefaultMockTopicName(), config, cfg)
 	c.Assert(err, check.IsNil)
 	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, defaultMaxMessageBytes)
-	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
 
 	config.MaxMessageBytes = defaultMaxMessageBytes - 1
 	cfg, err = newSaramaConfigImpl(context.Background(), config)
 	c.Assert(err, check.IsNil)
-	opts = make(map[string]string)
-	err = validateAndCreateTopic(adminClient, adminClient.GetDefaultMockTopicName(), config, cfg, opts)
+	err = validateAndCreateTopic(adminClient, adminClient.GetDefaultMockTopicName(), config, cfg)
 	c.Assert(err, check.IsNil)
 	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, config.MaxMessageBytes)
-	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
 
 	// When topic does not exist and auto-create is not enabled.
 	config.AutoCreate = false
 	cfg, err = newSaramaConfigImpl(context.Background(), config)
 	c.Assert(err, check.IsNil)
-	opts = make(map[string]string)
-	err = validateAndCreateTopic(adminClient, "non-exist", config, cfg, opts)
+	err = validateAndCreateTopic(adminClient, "non-exist", config, cfg)
 	c.Assert(
 		errors.Cause(err),
 		check.ErrorMatches,
@@ -343,11 +335,9 @@ func (s *kafkaSuite) TestValidateAndCreateTopic(c *check.C) {
 	config.MaxMessageBytes = defaultMaxMessageBytes - 1
 	cfg, err = newSaramaConfigImpl(context.Background(), config)
 	c.Assert(err, check.IsNil)
-	opts = make(map[string]string)
-	err = validateAndCreateTopic(adminClient, "create-random1", config, cfg, opts)
+	err = validateAndCreateTopic(adminClient, "create-random1", config, cfg)
 	c.Assert(err, check.IsNil)
 	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, config.MaxMessageBytes)
-	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
 
 	// When the topic does not exist, use the broker's configuration to create the topic.
 	// It is larger than the value of broker.
@@ -355,11 +345,9 @@ func (s *kafkaSuite) TestValidateAndCreateTopic(c *check.C) {
 	config.AutoCreate = true
 	cfg, err = newSaramaConfigImpl(context.Background(), config)
 	c.Assert(err, check.IsNil)
-	opts = make(map[string]string)
-	err = validateAndCreateTopic(adminClient, "create-random2", config, cfg, opts)
+	err = validateAndCreateTopic(adminClient, "create-random2", config, cfg)
 	c.Assert(err, check.IsNil)
 	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, defaultMaxMessageBytes)
-	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
 
 	// When the topic exists, but the topic does not store max message bytes info,
 	// the check of parameter succeeds.
@@ -374,11 +362,9 @@ func (s *kafkaSuite) TestValidateAndCreateTopic(c *check.C) {
 	}
 	err = adminClient.CreateTopic("test-topic", detail, false)
 	c.Assert(err, check.IsNil)
-	opts = make(map[string]string)
-	err = validateAndCreateTopic(adminClient, "test-topic", config, cfg, opts)
+	err = validateAndCreateTopic(adminClient, "test-topic", config, cfg)
 	c.Assert(err, check.IsNil)
 	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, config.MaxMessageBytes)
-	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
 
 	// When the topic exists, but the topic does not store max message bytes info,
 	// the check of parameter fails.
@@ -386,11 +372,9 @@ func (s *kafkaSuite) TestValidateAndCreateTopic(c *check.C) {
 	config.MaxMessageBytes = defaultMaxMessageBytes + 1
 	cfg, err = newSaramaConfigImpl(context.Background(), config)
 	c.Assert(err, check.IsNil)
-	opts = make(map[string]string)
-	err = validateAndCreateTopic(adminClient, "test-topic", config, cfg, opts)
+	err = validateAndCreateTopic(adminClient, "test-topic", config, cfg)
 	c.Assert(err, check.IsNil)
 	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, defaultMaxMessageBytes)
-	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
 }
 
 func (s *kafkaSuite) TestNewSaramaConfig(c *check.C) {

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -25,10 +26,10 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tiflow/cdc/sink/codec"
 	"github.com/pingcap/tiflow/pkg/config"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
+	"github.com/pingcap/tiflow/pkg/kafka"
 	"github.com/pingcap/tiflow/pkg/security"
 	"github.com/pingcap/tiflow/pkg/util"
 	"github.com/pingcap/tiflow/pkg/util/testleak"
@@ -143,7 +144,7 @@ func (s *kafkaSuite) TestSaramaProducer(c *check.C) {
 	defer testleak.AfterTest(c)()
 	ctx, cancel := context.WithCancel(context.Background())
 
-	topic := "unit_test_1"
+	topic := kafka.DefaultMockTopicName
 	leader := sarama.NewMockBroker(c, 2)
 	defer leader.Close()
 	metadataResponse := new(sarama.MetadataResponse)
@@ -179,11 +180,11 @@ func (s *kafkaSuite) TestSaramaProducer(c *check.C) {
 		cfg.Producer.Flush.MaxMessages = 1
 		return cfg, err
 	}
-	c.Assert(failpoint.Enable("github.com/pingcap/tiflow/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
+	NewAdminClientImpl = kafka.NewMockAdminClient
 	defer func() {
-		newSaramaConfigImpl = newSaramaConfigImplBak
-		_ = failpoint.Disable("github.com/pingcap/tiflow/cdc/sink/producer/kafka/SkipTopicAutoCreate")
+		NewAdminClientImpl = kafka.NewSaramaAdminClient
 	}()
+
 	opts := make(map[string]string)
 	ctx = util.PutRoleInCtx(ctx, util.RoleTester)
 	producer, err := NewKafkaSaramaProducer(ctx, topic, config, opts, errCh)
@@ -269,7 +270,7 @@ func (s *kafkaSuite) TestSaramaProducer(c *check.C) {
 	}
 }
 
-func (s *kafkaSuite) TestAdjustPartitionNum(c *check.C) {
+func (s *kafkaSuite) TestSetPartitionNum(c *check.C) {
 	defer testleak.AfterTest(c)()
 	config := NewConfig()
 	err := config.setPartitionNum(2)
@@ -286,37 +287,110 @@ func (s *kafkaSuite) TestAdjustPartitionNum(c *check.C) {
 	c.Assert(cerror.ErrKafkaInvalidPartitionNum.Equal(err), check.IsTrue)
 }
 
-func (s *kafkaSuite) TestTopicPreProcess(c *check.C) {
+func (s *kafkaSuite) TestValidateAndCreateTopic(c *check.C) {
 	defer testleak.AfterTest(c)
-	topic := "unit_test_2"
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	broker := sarama.NewMockBroker(c, 1)
-	defer broker.Close()
-	metaResponse := sarama.NewMockMetadataResponse(c).
-		SetBroker(broker.Addr(), broker.BrokerID()).
-		SetLeader(topic, 0, broker.BrokerID()).
-		SetLeader(topic, 1, broker.BrokerID()).
-		SetController(broker.BrokerID())
-	broker.SetHandlerByMap(map[string]sarama.MockResponse{
-		"MetadataRequest":        metaResponse,
-		"DescribeConfigsRequest": sarama.NewMockDescribeConfigsResponse(c),
-	})
 	config := NewConfig()
-	config.PartitionNum = int32(0)
-	config.BrokerEndpoints = strings.Split(broker.Addr(), ",")
-	config.AutoCreate = false
+	adminClient := kafka.NewClusterAdminClientMockImpl()
+	defer func() {
+		_ = adminClient.Close()
+	}()
 
-	cfg, err := newSaramaConfigImpl(ctx, config)
+	// When topic exists and max message bytes is set correctly.
+	config.MaxMessageBytes = adminClient.GetDefaultMaxMessageBytes()
+	cfg, err := newSaramaConfigImpl(context.Background(), config)
+	c.Assert(err, check.IsNil)
+	opts := make(map[string]string)
+	err = validateAndCreateTopic(adminClient, adminClient.GetDefaultMockTopicName(), config, cfg, opts)
+	c.Assert(err, check.IsNil)
+	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
+
+	// When topic exists and max message bytes is not set correctly.
+	// use the smaller one.
+	defaultMaxMessageBytes := adminClient.GetDefaultMaxMessageBytes()
+	config.MaxMessageBytes = defaultMaxMessageBytes + 1
+	cfg, err = newSaramaConfigImpl(context.Background(), config)
+	c.Assert(err, check.IsNil)
+	opts = make(map[string]string)
+	err = validateAndCreateTopic(adminClient, adminClient.GetDefaultMockTopicName(), config, cfg, opts)
+	c.Assert(err, check.IsNil)
+	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, defaultMaxMessageBytes)
+	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
+
+	config.MaxMessageBytes = defaultMaxMessageBytes - 1
+	cfg, err = newSaramaConfigImpl(context.Background(), config)
+	c.Assert(err, check.IsNil)
+	opts = make(map[string]string)
+	err = validateAndCreateTopic(adminClient, adminClient.GetDefaultMockTopicName(), config, cfg, opts)
 	c.Assert(err, check.IsNil)
 	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, config.MaxMessageBytes)
+	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
 
-	config.BrokerEndpoints = []string{""}
-	cfg.Metadata.Retry.Max = 1
+	// When topic does not exist and auto-create is not enabled.
+	config.AutoCreate = false
+	cfg, err = newSaramaConfigImpl(context.Background(), config)
+	c.Assert(err, check.IsNil)
+	opts = make(map[string]string)
+	err = validateAndCreateTopic(adminClient, "non-exist", config, cfg, opts)
+	c.Assert(
+		errors.Cause(err),
+		check.ErrorMatches,
+		".*auto-create-topic` is false, and topic not found.*",
+	)
 
-	err = topicPreProcess(topic, config, cfg)
-	c.Assert(errors.Cause(err), check.Equals, sarama.ErrOutOfBrokers)
+	// When the topic does not exist, use the broker's configuration to create the topic.
+	// It is less than the value of broker.
+	config.AutoCreate = true
+	config.MaxMessageBytes = defaultMaxMessageBytes - 1
+	cfg, err = newSaramaConfigImpl(context.Background(), config)
+	c.Assert(err, check.IsNil)
+	opts = make(map[string]string)
+	err = validateAndCreateTopic(adminClient, "create-random1", config, cfg, opts)
+	c.Assert(err, check.IsNil)
+	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, config.MaxMessageBytes)
+	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
+
+	// When the topic does not exist, use the broker's configuration to create the topic.
+	// It is larger than the value of broker.
+	config.MaxMessageBytes = defaultMaxMessageBytes + 1
+	config.AutoCreate = true
+	cfg, err = newSaramaConfigImpl(context.Background(), config)
+	c.Assert(err, check.IsNil)
+	opts = make(map[string]string)
+	err = validateAndCreateTopic(adminClient, "create-random2", config, cfg, opts)
+	c.Assert(err, check.IsNil)
+	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, defaultMaxMessageBytes)
+	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
+
+	// When the topic exists, but the topic does not store max message bytes info,
+	// the check of parameter succeeds.
+	// It is less than the value of broker.
+	config.MaxMessageBytes = defaultMaxMessageBytes - 1
+	cfg, err = newSaramaConfigImpl(context.Background(), config)
+	c.Assert(err, check.IsNil)
+	detail := &sarama.TopicDetail{
+		NumPartitions: 3,
+		// Does not contain max message bytes information.
+		ConfigEntries: make(map[string]*string),
+	}
+	err = adminClient.CreateTopic("test-topic", detail, false)
+	c.Assert(err, check.IsNil)
+	opts = make(map[string]string)
+	err = validateAndCreateTopic(adminClient, "test-topic", config, cfg, opts)
+	c.Assert(err, check.IsNil)
+	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, config.MaxMessageBytes)
+	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
+
+	// When the topic exists, but the topic does not store max message bytes info,
+	// the check of parameter fails.
+	// It is larger than the value of broker.
+	config.MaxMessageBytes = defaultMaxMessageBytes + 1
+	cfg, err = newSaramaConfigImpl(context.Background(), config)
+	c.Assert(err, check.IsNil)
+	opts = make(map[string]string)
+	err = validateAndCreateTopic(adminClient, "test-topic", config, cfg, opts)
+	c.Assert(err, check.IsNil)
+	c.Assert(cfg.Producer.MaxMessageBytes, check.Equals, defaultMaxMessageBytes)
+	c.Assert(opts["max-message-bytes"], check.Equals, strconv.Itoa(cfg.Producer.MaxMessageBytes))
 }
 
 func (s *kafkaSuite) TestNewSaramaConfig(c *check.C) {
@@ -383,17 +457,19 @@ func (s *kafkaSuite) TestCreateProducerFailed(c *check.C) {
 	config.Version = "invalid"
 	config.BrokerEndpoints = []string{"127.0.0.1:1111"}
 	topic := "topic"
-	c.Assert(failpoint.Enable("github.com/pingcap/tiflow/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
+	NewAdminClientImpl = kafka.NewMockAdminClient
+	defer func() {
+		NewAdminClientImpl = kafka.NewSaramaAdminClient
+	}()
+	opts := make(map[string]string)
 	ctx = util.PutRoleInCtx(ctx, util.RoleTester)
-	_, err := NewKafkaSaramaProducer(ctx, topic, config, map[string]string{}, errCh)
+	_, err := NewKafkaSaramaProducer(ctx, topic, config, opts, errCh)
 	c.Assert(errors.Cause(err), check.ErrorMatches, "invalid version.*")
-
-	_ = failpoint.Disable("github.com/pingcap/tiflow/cdc/sink/producer/kafka/SkipTopicAutoCreate")
 }
 
 func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
 	defer testleak.AfterTest(c)()
-	topic := "unit_test_4"
+	topic := kafka.DefaultMockTopicName
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
@@ -415,7 +491,10 @@ func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
 	config.AutoCreate = false
 	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
 
-	c.Assert(failpoint.Enable("github.com/pingcap/tiflow/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
+	NewAdminClientImpl = kafka.NewMockAdminClient
+	defer func() {
+		NewAdminClientImpl = kafka.NewSaramaAdminClient
+	}()
 
 	newSaramaConfigImplBak := newSaramaConfigImpl
 	newSaramaConfigImpl = func(ctx context.Context, config *Config) (*sarama.Config, error) {
@@ -431,10 +510,11 @@ func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
 	}()
 
 	errCh := make(chan error, 1)
+	opts := make(map[string]string)
 	ctx = util.PutRoleInCtx(ctx, util.RoleTester)
-	producer, err := NewKafkaSaramaProducer(ctx, topic, config, map[string]string{}, errCh)
+	producer, err := NewKafkaSaramaProducer(ctx, topic, config, opts, errCh)
+	c.Assert(opts, check.HasKey, "max-message-bytes")
 	defer func() {
-		_ = failpoint.Disable("github.com/pingcap/tiflow/cdc/sink/producer/kafka/SkipTopicAutoCreate")
 		err := producer.Close()
 		c.Assert(err, check.IsNil)
 	}()
@@ -472,7 +552,7 @@ func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
 
 func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
 	defer testleak.AfterTest(c)()
-	topic := "unit_test_4"
+	topic := kafka.DefaultMockTopicName
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
@@ -494,15 +574,19 @@ func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
 	config.AutoCreate = false
 	config.BrokerEndpoints = strings.Split(leader.Addr(), ",")
 
-	c.Assert(failpoint.Enable("github.com/pingcap/tiflow/cdc/sink/producer/kafka/SkipTopicAutoCreate", "return(true)"), check.IsNil)
+	NewAdminClientImpl = kafka.NewMockAdminClient
+	defer func() {
+		NewAdminClientImpl = kafka.NewSaramaAdminClient
+	}()
 
 	errCh := make(chan error, 1)
+	opts := make(map[string]string)
 	ctx = util.PutRoleInCtx(ctx, util.RoleTester)
-	producer, err := NewKafkaSaramaProducer(ctx, topic, config, map[string]string{}, errCh)
+	producer, err := NewKafkaSaramaProducer(ctx, topic, config, opts, errCh)
+	c.Assert(opts, check.HasKey, "max-message-bytes")
 	defer func() {
 		err := producer.Close()
 		c.Assert(err, check.IsNil)
-		_ = failpoint.Disable("github.com/pingcap/tiflow/cdc/sink/producer/kafka/SkipTopicAutoCreate")
 	}()
 
 	c.Assert(err, check.IsNil)

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -272,17 +272,17 @@ func (s *kafkaSuite) TestSaramaProducer(c *check.C) {
 func (s *kafkaSuite) TestAdjustPartitionNum(c *check.C) {
 	defer testleak.AfterTest(c)()
 	config := NewConfig()
-	err := config.adjustPartitionNum(2)
+	err := config.setPartitionNum(2)
 	c.Assert(err, check.IsNil)
 	c.Assert(config.PartitionNum, check.Equals, int32(2))
 
 	config.PartitionNum = 1
-	err = config.adjustPartitionNum(2)
+	err = config.setPartitionNum(2)
 	c.Assert(err, check.IsNil)
 	c.Assert(config.PartitionNum, check.Equals, int32(1))
 
 	config.PartitionNum = 3
-	err = config.adjustPartitionNum(2)
+	err = config.setPartitionNum(2)
 	c.Assert(cerror.ErrKafkaInvalidPartitionNum.Equal(err), check.IsTrue)
 }
 

--- a/pkg/kafka/cluster_admin_client.go
+++ b/pkg/kafka/cluster_admin_client.go
@@ -1,0 +1,46 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"github.com/Shopify/sarama"
+)
+
+// ClusterAdminClient is the administrative client for Kafka, which supports managing and inspecting topics,
+// brokers, configurations and ACLs.
+type ClusterAdminClient interface {
+	// ListTopics list the topics available in the cluster with the default options.
+	ListTopics() (map[string]sarama.TopicDetail, error)
+	// DescribeCluster gets information about the nodes in the cluster
+	DescribeCluster() (brokers []*sarama.Broker, controllerID int32, err error)
+	// DescribeConfig gets the configuration for the specified resources.
+	DescribeConfig(resource sarama.ConfigResource) ([]sarama.ConfigEntry, error)
+	// CreateTopic creates a new topic.
+	CreateTopic(topic string, detail *sarama.TopicDetail, validateOnly bool) error
+	// Close shuts down the admin and closes underlying client.
+	Close() error
+}
+
+// ClusterAdminClientCreator defines the type of cluster admin client crater.
+type ClusterAdminClientCreator func([]string, *sarama.Config) (ClusterAdminClient, error)
+
+// NewSaramaAdminClient constructs a ClusterAdminClient with sarama.
+func NewSaramaAdminClient(addrs []string, conf *sarama.Config) (ClusterAdminClient, error) {
+	return sarama.NewClusterAdmin(addrs, conf)
+}
+
+// NewMockAdminClient constructs a ClusterAdminClient with mock implementation.
+func NewMockAdminClient(_ []string, _ *sarama.Config) (ClusterAdminClient, error) {
+	return NewClusterAdminClientMockImpl(), nil
+}

--- a/pkg/kafka/cluster_admin_client_mock_impl.go
+++ b/pkg/kafka/cluster_admin_client_mock_impl.go
@@ -26,10 +26,8 @@ const (
 	defaultMockControllerID = 1
 )
 
-var (
-	// defaultMaxMessageBytes specifies the default max message bytes.
-	defaultMaxMessageBytes = "10485760"
-)
+// defaultMaxMessageBytes specifies the default max message bytes.
+var defaultMaxMessageBytes = "10485760"
 
 // ClusterAdminClientMockImpl mock implements the admin client interface.
 type ClusterAdminClientMockImpl struct {

--- a/pkg/kafka/cluster_admin_client_mock_impl.go
+++ b/pkg/kafka/cluster_admin_client_mock_impl.go
@@ -1,0 +1,127 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"strconv"
+
+	"github.com/Shopify/sarama"
+)
+
+const (
+	// DefaultMockTopicName specifies the default mock topic name.
+	DefaultMockTopicName = "mock_topic"
+	// defaultMockControllerID specifies the default mock controller ID.
+	defaultMockControllerID = 1
+)
+
+var (
+	// defaultMaxMessageBytes specifies the default max message bytes.
+	defaultMaxMessageBytes = "10485760"
+	// defaultMaxMessageBytes specifies the default min insync replicas for broker and default topic.
+	defaultMinInsyncReplicas = "1"
+)
+
+// ClusterAdminClientMockImpl mock implements the admin client interface.
+type ClusterAdminClientMockImpl struct {
+	topics map[string]sarama.TopicDetail
+	// Cluster controller ID.
+	controllerID  int32
+	brokerConfigs []sarama.ConfigEntry
+}
+
+// NewClusterAdminClientMockImpl news a ClusterAdminClientMockImpl struct with default configurations.
+func NewClusterAdminClientMockImpl() *ClusterAdminClientMockImpl {
+	topics := make(map[string]sarama.TopicDetail)
+	configEntries := make(map[string]*string)
+	configEntries[TopicMaxMessageBytesConfigName] = &defaultMaxMessageBytes
+	configEntries[MinInsyncReplicasConfigName] = &defaultMinInsyncReplicas
+	topics[DefaultMockTopicName] = sarama.TopicDetail{
+		NumPartitions: 3,
+		ConfigEntries: configEntries,
+	}
+
+	brokerConfigs := []sarama.ConfigEntry{
+		{
+			Name:  BrokerMessageMaxBytesConfigName,
+			Value: defaultMaxMessageBytes,
+		},
+		{
+			Name:  MinInsyncReplicasConfigName,
+			Value: defaultMinInsyncReplicas,
+		},
+	}
+
+	return &ClusterAdminClientMockImpl{
+		topics:        topics,
+		controllerID:  defaultMockControllerID,
+		brokerConfigs: brokerConfigs,
+	}
+}
+
+// ListTopics returns all topics directly.
+func (c *ClusterAdminClientMockImpl) ListTopics() (map[string]sarama.TopicDetail, error) {
+	return c.topics, nil
+}
+
+// DescribeCluster returns the controller ID.
+func (c *ClusterAdminClientMockImpl) DescribeCluster() (brokers []*sarama.Broker, controllerID int32, err error) {
+	return nil, c.controllerID, nil
+}
+
+// DescribeConfig return brokerConfigs directly.
+func (c *ClusterAdminClientMockImpl) DescribeConfig(resource sarama.ConfigResource) ([]sarama.ConfigEntry, error) {
+	var result []sarama.ConfigEntry
+	for _, name := range resource.ConfigNames {
+		for _, config := range c.brokerConfigs {
+			if name == config.Name {
+				result = append(result, config)
+			}
+		}
+	}
+	return result, nil
+}
+
+// CreateTopic adds topic into map.
+func (c *ClusterAdminClientMockImpl) CreateTopic(topic string, detail *sarama.TopicDetail, _ bool) error {
+	c.topics[topic] = *detail
+	return nil
+}
+
+// Close do nothing.
+func (c *ClusterAdminClientMockImpl) Close() error {
+	return nil
+}
+
+// SetMinInsyncReplicas sets the MinInsyncReplicas for broker and default topic.
+func (c *ClusterAdminClientMockImpl) SetMinInsyncReplicas(minInsyncReplicas string) {
+	c.topics[DefaultMockTopicName].ConfigEntries[MinInsyncReplicasConfigName] = &minInsyncReplicas
+
+	for i, config := range c.brokerConfigs {
+		if config.Name == MinInsyncReplicasConfigName {
+			c.brokerConfigs[i].Value = minInsyncReplicas
+		}
+	}
+}
+
+// GetDefaultMockTopicName returns the default topic name
+func (c *ClusterAdminClientMockImpl) GetDefaultMockTopicName() string {
+	return DefaultMockTopicName
+}
+
+// GetDefaultMaxMessageBytes returns defaultMaxMessageBytes as a number.
+func (c *ClusterAdminClientMockImpl) GetDefaultMaxMessageBytes() int {
+	topicMaxMessage, _ := strconv.Atoi(defaultMaxMessageBytes)
+	return topicMaxMessage
+}

--- a/pkg/kafka/cluster_admin_client_mock_impl.go
+++ b/pkg/kafka/cluster_admin_client_mock_impl.go
@@ -29,8 +29,6 @@ const (
 var (
 	// defaultMaxMessageBytes specifies the default max message bytes.
 	defaultMaxMessageBytes = "10485760"
-	// defaultMaxMessageBytes specifies the default min insync replicas for broker and default topic.
-	defaultMinInsyncReplicas = "1"
 )
 
 // ClusterAdminClientMockImpl mock implements the admin client interface.
@@ -46,7 +44,6 @@ func NewClusterAdminClientMockImpl() *ClusterAdminClientMockImpl {
 	topics := make(map[string]sarama.TopicDetail)
 	configEntries := make(map[string]*string)
 	configEntries[TopicMaxMessageBytesConfigName] = &defaultMaxMessageBytes
-	configEntries[MinInsyncReplicasConfigName] = &defaultMinInsyncReplicas
 	topics[DefaultMockTopicName] = sarama.TopicDetail{
 		NumPartitions: 3,
 		ConfigEntries: configEntries,
@@ -56,10 +53,6 @@ func NewClusterAdminClientMockImpl() *ClusterAdminClientMockImpl {
 		{
 			Name:  BrokerMessageMaxBytesConfigName,
 			Value: defaultMaxMessageBytes,
-		},
-		{
-			Name:  MinInsyncReplicasConfigName,
-			Value: defaultMinInsyncReplicas,
 		},
 	}
 
@@ -102,17 +95,6 @@ func (c *ClusterAdminClientMockImpl) CreateTopic(topic string, detail *sarama.To
 // Close do nothing.
 func (c *ClusterAdminClientMockImpl) Close() error {
 	return nil
-}
-
-// SetMinInsyncReplicas sets the MinInsyncReplicas for broker and default topic.
-func (c *ClusterAdminClientMockImpl) SetMinInsyncReplicas(minInsyncReplicas string) {
-	c.topics[DefaultMockTopicName].ConfigEntries[MinInsyncReplicasConfigName] = &minInsyncReplicas
-
-	for i, config := range c.brokerConfigs {
-		if config.Name == MinInsyncReplicasConfigName {
-			c.brokerConfigs[i].Value = minInsyncReplicas
-		}
-	}
 }
 
 // GetDefaultMockTopicName returns the default topic name

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -1,0 +1,30 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+const (
+	// BrokerMessageMaxBytesConfigName specifies the largest record batch size allowed by
+	// Kafka brokers.
+	// See: https://kafka.apache.org/documentation/#brokerconfigs_message.max.bytes
+	BrokerMessageMaxBytesConfigName = "message.max.bytes"
+	// TopicMaxMessageBytesConfigName specifies the largest record batch size allowed by
+	// Kafka topics.
+	// See: https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes
+	TopicMaxMessageBytesConfigName = "max.message.bytes"
+	// MinInsyncReplicasConfigName the minimum number of replicas that must acknowledge a write
+	// for the write to be considered successful. Only works if the producer's acks is "all" (or "-1").
+	// See: https://kafka.apache.org/documentation/#brokerconfigs_min.insync.replicas and
+	// https://kafka.apache.org/documentation/#topicconfigs_min.insync.replicas
+	MinInsyncReplicasConfigName = "min.insync.replicas"
+)

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -22,9 +22,4 @@ const (
 	// Kafka topics.
 	// See: https://kafka.apache.org/documentation/#topicconfigs_max.message.bytes
 	TopicMaxMessageBytesConfigName = "max.message.bytes"
-	// MinInsyncReplicasConfigName the minimum number of replicas that must acknowledge a write
-	// for the write to be considered successful. Only works if the producer's acks is "all" (or "-1").
-	// See: https://kafka.apache.org/documentation/#brokerconfigs_min.insync.replicas and
-	// https://kafka.apache.org/documentation/#topicconfigs_min.insync.replicas
-	MinInsyncReplicasConfigName = "min.insync.replicas"
 )


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4660

### What is changed and how it works?

port `ClusterAdminClientMockImpl` from master, with all necessary changes to test code 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

Side effects

Related changes

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
