### PR TITLE
integration(test): fix sync_diff_inspector compatible error

### DIFF
--- a/tests/integration_tests/cyclic_ab/conf/diff_config.toml
+++ b/tests/integration_tests/cyclic_ab/conf/diff_config.toml
@@ -13,7 +13,7 @@ check-struct-only = false
 
     target-instance = "tidb0"
 
-    target-check-tables = ["test.?*"]
+    target-check-tables = ["test.?*", "!test.ineligible"]
 
 [data-sources]
 [data-sources.mysql1]


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->
Fix sync_diff_inspector compatible error for  cyclic.ab,
```
["failed to initialize diff process"] [error="from upstream: please make sure the filter is correct.: the target has no table to be compared. source-table is ``test`.`ineligible``"] [errorVerbose="the target has no table to be compared. source-table is ``test`.`ineligible`
```
Issue Number: close #4715

### What is changed and how it works
filter out ineligible tables

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
