### PR TITLE
test(ticdc): skip kafka test for integration test clustered_index temporarily

### DIFF
--- a/tests/integration_tests/clustered_index/run.sh
+++ b/tests/integration_tests/clustered_index/run.sh
@@ -44,7 +44,10 @@ function run() {
 	cleanup_process $CDC_BINARY
 }
 
-trap stop_tidb_cluster EXIT
-run $*
-check_logs $WORK_DIR
-echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"
+# kafka is not supported yet.
+if [ "$SINK_TYPE" != "kafka" ]; then
+	trap stop_tidb_cluster EXIT
+	run $*
+	check_logs $WORK_DIR
+	echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"
+fi

--- a/tests/integration_tests/clustered_index/run.sh
+++ b/tests/integration_tests/clustered_index/run.sh
@@ -45,9 +45,12 @@ function run() {
 }
 
 # kafka is not supported yet.
-if [ "$SINK_TYPE" != "kafka" ]; then
-	trap stop_tidb_cluster EXIT
-	run $*
-	check_logs $WORK_DIR
-	echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"
+# ref to issue: https://github.com/pingcap/tiflow/issues/3421
+if [ "$SINK_TYPE" = "kafka" ]; then
+	echo "[$(date)] <<<<<< skip test case $TEST_NAME for kafka! >>>>>>"
+	exit 0
 fi
+trap stop_tidb_cluster EXIT
+run $*
+check_logs $WORK_DIR
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4727 

### What is changed and how it works?
Remove integration test clustered_index temporarily since kafka test fail

### Check List <!--REMOVE the items that are not applicable-->

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
