### PR TITLE
binlog(dm): fix update nil to MariaDB GTID set will error

### DIFF
--- a/dm/pkg/binlog/position.go
+++ b/dm/pkg/binlog/position.go
@@ -399,9 +399,18 @@ func (l *Location) ResetSuffix() {
 // SetGTID set new gtid for location
 // Use this func instead of GITSet.Set to avoid change other location.
 func (l *Location) SetGTID(gset gmysql.GTIDSet) error {
-	flavor := gmysql.MySQLFlavor
-	if _, ok := l.gtidSet.(*gtid.MariadbGTIDSet); ok {
+	var flavor string
+
+	switch gset.(type) {
+	case *gmysql.MysqlGTIDSet:
+		flavor = gmysql.MySQLFlavor
+	case *gmysql.MariadbGTIDSet:
 		flavor = gmysql.MariaDBFlavor
+	case nil:
+		l.gtidSet = nil
+		return nil
+	default:
+		return fmt.Errorf("unknown GTIDSet type: %T", gset)
 	}
 
 	newGTID := gtid.MinGTIDSet(flavor)

--- a/dm/pkg/binlog/position_test.go
+++ b/dm/pkg/binlog/position_test.go
@@ -763,6 +763,30 @@ func (t *testPositionSuite) TestSetGTID(c *C) {
 	c.Assert(loc.gtidSet.String(), Equals, GTIDSetStr2)
 	c.Assert(loc2.gtidSet.String(), Equals, GTIDSetStr)
 	c.Assert(CompareLocation(loc, loc2, true), Equals, 1)
+
+	loc2.gtidSet = nil
+	err = loc2.SetGTID(mysqlSet)
+	c.Assert(err, IsNil)
+	c.Assert(loc2.gtidSet.String(), Equals, GTIDSetStr)
+}
+
+func (t *testPositionSuite) TestSetGTIDMariaDB(c *C) {
+	gSetStr := "1-1-1,2-2-2"
+	gSet, err := gtid.ParserGTID("mariadb", gSetStr)
+	c.Assert(err, IsNil)
+	gSetOrigin := gSet.Origin()
+
+	loc := Location{
+		Position: gmysql.Position{
+			Name: "mysql-bin.00002",
+			Pos:  2333,
+		},
+		gtidSet: nil,
+		Suffix:  0,
+	}
+	err = loc.SetGTID(gSetOrigin)
+	c.Assert(err, IsNil)
+	c.Assert(loc.gtidSet.String(), Equals, gSetStr)
 }
 
 func (t *testPositionSuite) TestExtractSuffix(c *C) {


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4733

### What is changed and how it works?

cherry-pick from https://github.com/pingcap/tiflow/pull/4386

if when we want to update location A to B, we use A to determine flavor(MySQL or MariaDB). When A is nil we defaultly use MySQL flavor but the upstream may be MariaDB in fact. After this PR we use B to determine flavor

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects


Related changes


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix a bug that MariaDB upstream can show source status
```
