### PR TITLE
OperateSchema: change default value of operate-schema --sync to true

### DIFF
--- a/dm/dm/ctl/master/operate_schema.go
+++ b/dm/dm/ctl/master/operate_schema.go
@@ -35,7 +35,7 @@ func NewOperateSchemaCmd() *cobra.Command {
 	cmd.Flags().StringP("database", "d", "", "database name of the table")
 	cmd.Flags().StringP("table", "t", "", "table name")
 	cmd.Flags().Bool("flush", true, "flush the table info and checkpoint immediately")
-	cmd.Flags().Bool("sync", false, "sync the table info to master to resolve shard ddl lock, only for optimistic mode now")
+	cmd.Flags().Bool("sync", true, "sync the table info to master to resolve shard ddl lock, only for optimistic mode now")
 	return cmd
 }
 
@@ -114,9 +114,6 @@ func operateSchemaCmd(cmd *cobra.Command, _ []string) error {
 	sync, err := cmd.Flags().GetBool("sync")
 	if err != nil {
 		return err
-	}
-	if sync && op != pb.SchemaOp_SetSchema {
-		return errors.New("--sync flag is only used to set schema")
 	}
 	request := &pb.OperateSchemaRequest{
 		Op:         op,

--- a/dm/dm/ctl/master/source_table_schema.go
+++ b/dm/dm/ctl/master/source_table_schema.go
@@ -150,7 +150,7 @@ func newSourceTableSchemaUpdateCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().Bool("flush", true, "flush the table info and checkpoint immediately")
-	cmd.Flags().Bool("sync", false, "sync the table info to master to resolve shard ddl lock, only for optimistic mode now")
+	cmd.Flags().Bool("sync", true, "sync the table info to master to resolve shard ddl lock, only for optimistic mode now")
 	cmd.Flags().Bool("from-source", false, "use the schema from upstream database as the schema of the specified tables")
 	cmd.Flags().Bool("from-target", false, "use the schema from downstream database as the schema of the specified tables")
 	return cmd

--- a/dm/syncer/schema.go
+++ b/dm/syncer/schema.go
@@ -146,7 +146,7 @@ func (s *Syncer) OperateSchema(ctx context.Context, req *pb.OperateWorkerSchemaR
 
 		if req.Sync {
 			if s.cfg.ShardMode != config.ShardOptimistic {
-				log.L().Warn("ignore --sync flag", zap.String("shard mode", s.cfg.ShardMode))
+				log.L().Info("ignore --sync flag", zap.String("shard mode", s.cfg.ShardMode))
 				break
 			}
 			targetTable := s.route(sourceTable)

--- a/dm/tests/shardddl1/run.sh
+++ b/dm/tests/shardddl1/run.sh
@@ -154,7 +154,7 @@ function DM_RENAME_COLUMN_OPTIMISTIC_CASE() {
 	# third, set schema to be same with upstream
 	echo 'CREATE TABLE `tb1` ( `c` int NOT NULL, `b` varchar(10) DEFAULT NULL, PRIMARY KEY (`c`)) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_bin' >${WORK_DIR}/schema1.sql
 	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
-		"binlog-schema update -s mysql-replica-02 test ${shardddl1} ${tb1} ${WORK_DIR}/schema1.sql --flush --sync" \
+		"binlog-schema update -s mysql-replica-02 test ${shardddl1} ${tb1} ${WORK_DIR}/schema1.sql --flush" \
 		"\"result\": true" 2
 
 	# fourth, resume-task. don't check "result: true" here, because worker may run quickly and meet the error from tb2
@@ -173,7 +173,7 @@ function DM_RENAME_COLUMN_OPTIMISTIC_CASE() {
 	# This may only work for a "rename ddl"
 	echo 'CREATE TABLE `tb2` ( `c` int NOT NULL, `b` varchar(10) DEFAULT NULL, PRIMARY KEY (`c`)) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_bin' >${WORK_DIR}/schema2.sql
 	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
-		"binlog-schema update -s mysql-replica-02 test ${shardddl1} ${tb2} ${WORK_DIR}/schema2.sql --flush --sync" \
+		"binlog-schema update -s mysql-replica-02 test ${shardddl1} ${tb2} ${WORK_DIR}/schema2.sql --flush" \
 		"\"result\": true" 2
 
 	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4547 

### What is changed and how it works?
change default value of operate-schema --sync to true

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update key monitor metrics in both TiCDC document and official document

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
sync schema to etcd when execute operate-schema command by default.
```
