### PR TITLE
unit_test: fix concurrency test cause etcd race

### DIFF
--- a/dm/dm/master/shardddl/optimist_test.go
+++ b/dm/dm/master/shardddl/optimist_test.go
@@ -1092,7 +1092,7 @@ func (t *testOptimist) TestBuildLockJoinedAndTable(c *C) {
 	var (
 		logger           = log.L()
 		o                = NewOptimist(&logger, getDownstreamMeta)
-		task             = "task"
+		task             = "task-build-lock-joined-and-table"
 		source1          = "mysql-replica-1"
 		source2          = "mysql-replica-2"
 		downSchema       = "db"
@@ -1141,7 +1141,7 @@ func (t *testOptimist) TestBuildLockWithInitSchema(c *C) {
 	var (
 		logger     = log.L()
 		o          = NewOptimist(&logger, getDownstreamMeta)
-		task       = "task"
+		task       = "task-lock-with-init-schema"
 		source1    = "mysql-replica-1"
 		source2    = "mysql-replica-2"
 		downSchema = "db"

--- a/dm/dm/master/shardddl/optimist_test.go
+++ b/dm/dm/master/shardddl/optimist_test.go
@@ -200,6 +200,7 @@ func (t *testOptimist) TestOptimist(c *C) {
 	t.testOptimist(c, t.etcdTestCli, restartOnly)
 	t.testOptimist(c, t.etcdTestCli, restartNewInstance)
 	t.testSortInfos(c, t.etcdTestCli)
+	t.testBuildLockWithInitSchema(c, t.etcdTestCli)
 }
 
 func (t *testOptimist) testOptimist(c *C, cli *clientv3.Client, restart int) {
@@ -1135,7 +1136,7 @@ func (t *testOptimist) TestBuildLockJoinedAndTable(c *C) {
 	o.tk.Init(stm)
 }
 
-func (t *testOptimist) TestBuildLockWithInitSchema(c *C) {
+func (t *testOptimist) testBuildLockWithInitSchema(c *C, cli *clientv3.Client) {
 	defer t.clearOptimistTestSourceInfoOperation(c)
 
 	var (
@@ -1168,18 +1169,18 @@ func (t *testOptimist) TestBuildLockWithInitSchema(c *C) {
 	st1.AddTable("foo", "bar-1", downSchema, downTable)
 	st2.AddTable("foo", "bar-1", downSchema, downTable)
 
-	c.Assert(o.Start(ctx, t.etcdTestCli), IsNil)
-	_, err := optimism.PutSourceTables(t.etcdTestCli, st1)
+	c.Assert(o.Start(ctx, cli), IsNil)
+	_, err := optimism.PutSourceTables(cli, st1)
 	c.Assert(err, IsNil)
-	_, err = optimism.PutSourceTables(t.etcdTestCli, st2)
-	c.Assert(err, IsNil)
-
-	_, err = optimism.PutInfo(t.etcdTestCli, infoDropB)
-	c.Assert(err, IsNil)
-	_, err = optimism.PutInfo(t.etcdTestCli, infoDropC)
+	_, err = optimism.PutSourceTables(cli, st2)
 	c.Assert(err, IsNil)
 
-	stm, _, err := optimism.GetAllSourceTables(t.etcdTestCli)
+	_, err = optimism.PutInfo(cli, infoDropB)
+	c.Assert(err, IsNil)
+	_, err = optimism.PutInfo(cli, infoDropC)
+	c.Assert(err, IsNil)
+
+	stm, _, err := optimism.GetAllSourceTables(cli)
 	c.Assert(err, IsNil)
 	o.tk.Init(stm)
 }

--- a/dm/dm/master/shardddl/optimist_test.go
+++ b/dm/dm/master/shardddl/optimist_test.go
@@ -200,8 +200,6 @@ func (t *testOptimist) TestOptimist(c *C) {
 	t.testOptimist(c, t.etcdTestCli, restartOnly)
 	t.testOptimist(c, t.etcdTestCli, restartNewInstance)
 	t.testSortInfos(c, t.etcdTestCli)
-	t.testBuildLockJoinedAndTable(c, t.etcdTestCli)
-	t.testBuildLockWithInitSchema(c, t.etcdTestCli)
 }
 
 func (t *testOptimist) testOptimist(c *C, cli *clientv3.Client, restart int) {
@@ -1088,7 +1086,7 @@ func (t *testOptimist) testSortInfos(c *C, cli *clientv3.Client) {
 	c.Assert(infos[2], DeepEquals, i11)
 }
 
-func (t *testOptimist) testBuildLockJoinedAndTable(c *C, cli *clientv3.Client) {
+func (t *testOptimist) TestBuildLockJoinedAndTable(c *C) {
 	defer t.clearOptimistTestSourceInfoOperation(c)
 
 	var (
@@ -1121,23 +1119,23 @@ func (t *testOptimist) testBuildLockJoinedAndTable(c *C, cli *clientv3.Client) {
 	st1.AddTable("foo", "bar-1", downSchema, downTable)
 	st2.AddTable("foo", "bar-1", downSchema, downTable)
 
-	c.Assert(o.Start(ctx, cli), IsNil)
-	_, err := optimism.PutSourceTables(cli, st1)
+	c.Assert(o.Start(ctx, t.etcdTestCli), IsNil)
+	_, err := optimism.PutSourceTables(t.etcdTestCli, st1)
 	c.Assert(err, IsNil)
-	_, err = optimism.PutSourceTables(cli, st2)
-	c.Assert(err, IsNil)
-
-	_, err = optimism.PutInfo(cli, i21)
-	c.Assert(err, IsNil)
-	_, err = optimism.PutInfo(cli, i11)
+	_, err = optimism.PutSourceTables(t.etcdTestCli, st2)
 	c.Assert(err, IsNil)
 
-	stm, _, err := optimism.GetAllSourceTables(cli)
+	_, err = optimism.PutInfo(t.etcdTestCli, i21)
+	c.Assert(err, IsNil)
+	_, err = optimism.PutInfo(t.etcdTestCli, i11)
+	c.Assert(err, IsNil)
+
+	stm, _, err := optimism.GetAllSourceTables(t.etcdTestCli)
 	c.Assert(err, IsNil)
 	o.tk.Init(stm)
 }
 
-func (t *testOptimist) testBuildLockWithInitSchema(c *C, cli *clientv3.Client) {
+func (t *testOptimist) TestBuildLockWithInitSchema(c *C) {
 	defer t.clearOptimistTestSourceInfoOperation(c)
 
 	var (
@@ -1170,18 +1168,18 @@ func (t *testOptimist) testBuildLockWithInitSchema(c *C, cli *clientv3.Client) {
 	st1.AddTable("foo", "bar-1", downSchema, downTable)
 	st2.AddTable("foo", "bar-1", downSchema, downTable)
 
-	c.Assert(o.Start(ctx, cli), IsNil)
-	_, err := optimism.PutSourceTables(cli, st1)
+	c.Assert(o.Start(ctx, t.etcdTestCli), IsNil)
+	_, err := optimism.PutSourceTables(t.etcdTestCli, st1)
 	c.Assert(err, IsNil)
-	_, err = optimism.PutSourceTables(cli, st2)
-	c.Assert(err, IsNil)
-
-	_, err = optimism.PutInfo(cli, infoDropB)
-	c.Assert(err, IsNil)
-	_, err = optimism.PutInfo(cli, infoDropC)
+	_, err = optimism.PutSourceTables(t.etcdTestCli, st2)
 	c.Assert(err, IsNil)
 
-	stm, _, err := optimism.GetAllSourceTables(cli)
+	_, err = optimism.PutInfo(t.etcdTestCli, infoDropB)
+	c.Assert(err, IsNil)
+	_, err = optimism.PutInfo(t.etcdTestCli, infoDropC)
+	c.Assert(err, IsNil)
+
+	stm, _, err := optimism.GetAllSourceTables(t.etcdTestCli)
 	c.Assert(err, IsNil)
 	o.tk.Init(stm)
 }

--- a/dm/dm/master/shardddl/optimist_test.go
+++ b/dm/dm/master/shardddl/optimist_test.go
@@ -200,6 +200,7 @@ func (t *testOptimist) TestOptimist(c *C) {
 	t.testOptimist(c, t.etcdTestCli, restartOnly)
 	t.testOptimist(c, t.etcdTestCli, restartNewInstance)
 	t.testSortInfos(c, t.etcdTestCli)
+	t.testBuildLockJoinedAndTable(c, t.etcdTestCli)
 	t.testBuildLockWithInitSchema(c, t.etcdTestCli)
 }
 
@@ -1087,7 +1088,7 @@ func (t *testOptimist) testSortInfos(c *C, cli *clientv3.Client) {
 	c.Assert(infos[2], DeepEquals, i11)
 }
 
-func (t *testOptimist) TestBuildLockJoinedAndTable(c *C) {
+func (t *testOptimist) testBuildLockJoinedAndTable(c *C, cli *clientv3.Client) {
 	defer t.clearOptimistTestSourceInfoOperation(c)
 
 	var (
@@ -1120,18 +1121,18 @@ func (t *testOptimist) TestBuildLockJoinedAndTable(c *C) {
 	st1.AddTable("foo", "bar-1", downSchema, downTable)
 	st2.AddTable("foo", "bar-1", downSchema, downTable)
 
-	c.Assert(o.Start(ctx, t.etcdTestCli), IsNil)
-	_, err := optimism.PutSourceTables(t.etcdTestCli, st1)
+	c.Assert(o.Start(ctx, cli), IsNil)
+	_, err := optimism.PutSourceTables(cli, st1)
 	c.Assert(err, IsNil)
-	_, err = optimism.PutSourceTables(t.etcdTestCli, st2)
-	c.Assert(err, IsNil)
-
-	_, err = optimism.PutInfo(t.etcdTestCli, i21)
-	c.Assert(err, IsNil)
-	_, err = optimism.PutInfo(t.etcdTestCli, i11)
+	_, err = optimism.PutSourceTables(cli, st2)
 	c.Assert(err, IsNil)
 
-	stm, _, err := optimism.GetAllSourceTables(t.etcdTestCli)
+	_, err = optimism.PutInfo(cli, i21)
+	c.Assert(err, IsNil)
+	_, err = optimism.PutInfo(cli, i11)
+	c.Assert(err, IsNil)
+
+	stm, _, err := optimism.GetAllSourceTables(cli)
 	c.Assert(err, IsNil)
 	o.tk.Init(stm)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #4159 

### What is changed and how it works?
- execute test serially

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


```release-note
`None`.
```
