### PR TITLE
sorter/leveldb(ticdc): fix system stop blocks forever

### DIFF
--- a/cdc/processor/pipeline/sorter.go
+++ b/cdc/processor/pipeline/sorter.go
@@ -55,8 +55,6 @@ type sorterNode struct {
 	eg     *errgroup.Group
 	cancel context.CancelFunc
 
-	cleanup func(context.Context) error
-
 	// The latest resolved ts that sorter has received.
 	resolvedTs model.Ts
 
@@ -119,7 +117,6 @@ func (n *sorterNode) start(ctx pipeline.NodeContext, isTableActorMode bool, eg *
 			if err != nil {
 				return errors.Trace(err)
 			}
-			n.cleanup = levelSorter.CleanupFunc()
 			eventSorter = levelSorter
 		} else {
 			// Sorter dir has been set and checked when server starts.
@@ -306,13 +303,6 @@ func (n *sorterNode) updateBarrierTs(barrierTs model.Ts) {
 
 func (n *sorterNode) releaseResource(ctx context.Context, changefeedID string) {
 	defer tableMemoryHistogram.DeleteLabelValues(changefeedID)
-	if n.cleanup != nil {
-		// Clean up data when the table sorter is canceled.
-		err := n.cleanup(ctx)
-		if err != nil {
-			log.Warn("schedule table cleanup task failed", zap.Error(err))
-		}
-	}
 	// Since the flowController is implemented by `Cond`, it is not cancelable by a context
 	// the flowController will be blocked in a background goroutine,
 	// We need to abort the flowController manually in the nodeRunner

--- a/cdc/processor/pipeline/sorter.go
+++ b/cdc/processor/pipeline/sorter.go
@@ -301,7 +301,7 @@ func (n *sorterNode) updateBarrierTs(barrierTs model.Ts) {
 	}
 }
 
-func (n *sorterNode) releaseResource(ctx context.Context, changefeedID string) {
+func (n *sorterNode) releaseResource(_ context.Context, changefeedID string) {
 	defer tableMemoryHistogram.DeleteLabelValues(changefeedID)
 	// Since the flowController is implemented by `Cond`, it is not cancelable by a context
 	// the flowController will be blocked in a background goroutine,

--- a/cdc/sorter/leveldb/leveldb.go
+++ b/cdc/sorter/leveldb/leveldb.go
@@ -244,6 +244,9 @@ func (ldb *DBActor) Poll(ctx context.Context, tasks []actormsg.Message) bool {
 			ldb.iterQ.push(task.UID, task.TableID, task.IterReq)
 			requireIter = true
 		}
+		if task.Test != nil {
+			time.Sleep(task.Test.Sleep)
+		}
 	}
 
 	// Force write only if there is a task requires an iterator.

--- a/cdc/sorter/leveldb/message/task.go
+++ b/cdc/sorter/leveldb/message/task.go
@@ -15,6 +15,7 @@ package message
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiflow/cdc/model"
@@ -44,6 +45,9 @@ type Task struct {
 	// Deletes all of the key-values in the range.
 	// reader -> leveldb and leveldb -> compactor
 	DeleteReq *DeleteRequest
+
+	// A test message.
+	Test *Test
 }
 
 // DeleteRequest a request to delete range.
@@ -70,6 +74,11 @@ type IterRequest struct {
 	// IterCallback is callback to send iterator back.
 	// It must be buffered channel to avoid blocking.
 	IterCallback func(*LimitedIterator) `json:"-"` // Make Task JSON printable.
+}
+
+// Test is a message for testing actors.
+type Test struct {
+	Sleep time.Duration
 }
 
 // Key is the key that is written to db.

--- a/cdc/sorter/leveldb/reader.go
+++ b/cdc/sorter/leveldb/reader.go
@@ -405,6 +405,11 @@ func (r *reader) Poll(ctx context.Context, msgs []actormsg.Message) (running boo
 		// Update the max commit ts and resolved ts of all received events.
 		ts := msgs[i].SorterTask.ReadTs
 		r.state.advanceMaxTs(ts.MaxCommitTs, ts.MaxResolvedTs)
+
+		// Test only message.
+		if msgs[i].SorterTask.Test != nil {
+			time.Sleep(msgs[i].SorterTask.Test.Sleep)
+		}
 	}
 
 	// Length of buffered resolved events.

--- a/cdc/sorter/leveldb/sorter.go
+++ b/cdc/sorter/leveldb/sorter.go
@@ -189,16 +189,16 @@ func (ls *Sorter) Run(ctx context.Context) error {
 	}
 	atomic.StoreInt32(&ls.closed, 1)
 	// We should never lost message, make sure StopMessage is sent.
-	ctxTODO := context.TODO()
+	ctx1 := context.TODO()
 	// As the context can't be cancelled. SendB can only return an error
 	// ActorStopped or ActorNotFound, and they mean actors have closed.
 	_ = ls.writerRouter.SendB(
-		ctxTODO, ls.writerActorID, actormsg.StopMessage())
+		ctx1, ls.writerActorID, actormsg.StopMessage())
 	_ = ls.readerRouter.SendB(
-		ctxTODO, ls.ReaderActorID, actormsg.StopMessage())
+		ctx1, ls.ReaderActorID, actormsg.StopMessage())
 	ls.closedWg.Wait()
 
-	_ = ls.cleanup(ctxTODO)
+	_ = ls.cleanup(ctx1)
 	return errors.Trace(err)
 }
 

--- a/cdc/sorter/leveldb/system/system.go
+++ b/cdc/sorter/leveldb/system/system.go
@@ -206,7 +206,7 @@ func (s *System) Stop() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	// TODO: compact is not context-awared, it may block.
+	// TODO: compact is not context-aware, it may block.
 	err = s.compactSystem.Stop()
 	if err != nil {
 		return errors.Trace(err)

--- a/cdc/sorter/leveldb/system/system_test.go
+++ b/cdc/sorter/leveldb/system/system_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tiflow/cdc/sorter/leveldb"
 	"github.com/pingcap/tiflow/cdc/sorter/leveldb/message"
 	"github.com/pingcap/tiflow/pkg/actor"
 	actormsg "github.com/pingcap/tiflow/pkg/actor/message"
@@ -108,5 +109,58 @@ func TestSystemStopMailboxFull(t *testing.T) {
 			break
 		}
 	}
+	require.Nil(t, sys.Stop())
+}
+
+func TestSystemStopWithManyTablesAndFewStragglers(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cfg := config.GetDefaultServerConfig().Clone().Debug.DB
+	cfg.Count = 8
+
+	sys := NewSystem(t.TempDir(), 1, cfg)
+	require.Nil(t, sys.Start(ctx))
+
+	ss := make([]*leveldb.Sorter, 0, 1000)
+	scancels := make([]context.CancelFunc, 0, 1000)
+	for i := uint64(0); i < 1000; i++ {
+		dbActorID := sys.DBActorID(uint64(i))
+		s, err := leveldb.NewSorter(
+			ctx, int64(i), i, sys.DBRouter, dbActorID,
+			sys.WriterSystem, sys.WriterRouter,
+			sys.ReaderSystem, sys.ReaderRouter,
+			sys.CompactScheduler(), cfg)
+		require.Nil(t, err)
+		ss = append(ss, s)
+		sctx, scancel := context.WithCancel(ctx)
+		scancels = append(scancels, scancel)
+		go func() {
+			_ = s.Run(sctx)
+		}()
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	// Close 100 tables ahead.
+	for i := 0; i < 100; i++ {
+		scancels[i]()
+	}
+	// 10 stragglers
+	for i := 100; i < 110; i++ {
+		id := ss[i].ReaderActorID
+		sleep := message.Task{Test: &message.Test{Sleep: 2 * time.Second}}
+		require.Nil(t, sys.ReaderRouter.SendB(ctx, id, actormsg.SorterMessage(sleep)))
+		if i%2 == 0 {
+			continue
+		}
+		// Make it channel full.
+		for {
+			err := sys.ReaderRouter.Send(id, actormsg.SorterMessage(message.Task{}))
+			if err != nil {
+				break
+			}
+		}
+	}
+	// Close system.
 	require.Nil(t, sys.Stop())
 }

--- a/cdc/sorter/leveldb/system/system_test.go
+++ b/cdc/sorter/leveldb/system/system_test.go
@@ -125,7 +125,7 @@ func TestSystemStopWithManyTablesAndFewStragglers(t *testing.T) {
 	ss := make([]*leveldb.Sorter, 0, 1000)
 	scancels := make([]context.CancelFunc, 0, 1000)
 	for i := uint64(0); i < 1000; i++ {
-		dbActorID := sys.DBActorID(uint64(i))
+		dbActorID := sys.DBActorID(i)
 		s, err := leveldb.NewSorter(
 			ctx, int64(i), i, sys.DBRouter, dbActorID,
 			sys.WriterSystem, sys.WriterRouter,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #4699

Needs to merge #4819 first.

### What is changed and how it works?

StopMessage maybe lost if the total broadcast time exceeds  1s.
If sorter system actors does not close in time, systeam.closedWg is blocked.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix an issue that TiCDC can not exit.
```
