### PR TITLE
cdc/consumer: fix kafka consumer ignore ddl since global resolved ts update too early.

### DIFF
--- a/cmd/kafka-consumer/main.go
+++ b/cmd/kafka-consumer/main.go
@@ -336,6 +336,7 @@ type Consumer struct {
 	ddlSink              sink.Sink
 	fakeTableIDGenerator *fakeTableIDGenerator
 
+	// initialize to 0 by default
 	globalResolvedTs uint64
 
 	protocol            config.Protocol
@@ -418,7 +419,6 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 	}
 
 	for message := range claim.Messages() {
-		log.Debug("Message claimed", zap.Int32("partition", message.Partition), zap.ByteString("key", message.Key), zap.ByteString("value", message.Value))
 		var (
 			decoder codec.EventBatchDecoder
 			err     error
@@ -502,8 +502,9 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 						zap.Uint64("ts", ts),
 						zap.Uint64("resolvedTs", resolvedTs),
 						zap.Int32("partition", partition))
-				} else if ts > resolvedTs {
-					log.Debug("update sink resolved ts",
+				}
+				if ts > resolvedTs {
+					log.Info("update sink resolved ts",
 						zap.Uint64("ts", ts),
 						zap.Int32("partition", partition))
 					atomic.StoreUint64(&sink.resolvedTs, ts)
@@ -523,23 +524,27 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 	return nil
 }
 
+// append DDL wait to be handled, only consider the constraint among DDLs.
+// for DDL a / b received in the order, a.CommitTs < b.CommitTs should be true.
 func (c *Consumer) appendDDL(ddl *model.DDLEvent) {
 	c.ddlListMu.Lock()
 	defer c.ddlListMu.Unlock()
-	if ddl.CommitTs <= c.maxDDLReceivedTs {
-		log.Info("ignore ddl event", zap.Uint64("maxDDLReceivedTs", c.maxDDLReceivedTs), zap.Any("ddl", ddl))
+	// DDL CommitTs fallback, just crash it to indicate the bug.
+	if ddl.CommitTs < c.maxDDLReceivedTs {
+		log.Panic("DDL CommitTs < maxDDLReceivedTs",
+			zap.Uint64("commitTs", ddl.CommitTs),
+			zap.Uint64("maxDDLReceivedTs", c.maxDDLReceivedTs),
+			zap.Any("DDL", ddl))
+	}
+
+	if ddl.CommitTs == c.maxDDLReceivedTs {
+		log.Info("ignore redundant DDL, CommitTs = maxDDLReceivedTs",
+			zap.Any("DDL", ddl))
 		return
 	}
-	globalResolvedTs := atomic.LoadUint64(&c.globalResolvedTs)
-	if ddl.CommitTs < globalResolvedTs {
-		log.Panic("unexpected ddl event, commitTs < globalResolvedTs", zap.Any("ddl", ddl))
-	}
-	if ddl.CommitTs == globalResolvedTs {
-		log.Warn("ignore redundant ddl event, commitTs == globalResolvedTs", zap.Any("ddl", ddl))
-		return
-	}
+
 	c.ddlList = append(c.ddlList, ddl)
-	log.Info("ddl event received", zap.Any("ddl", ddl))
+	log.Info("DDL event received", zap.Any("DDL", ddl))
 	c.maxDDLReceivedTs = ddl.CommitTs
 }
 
@@ -574,9 +579,20 @@ func (c *Consumer) forEachSink(fn func(sink *partitionSink) error) error {
 	return nil
 }
 
-// Run runs the Consumer
+func (c *Consumer) getMinPartitionResolvedTs() (result uint64, err error) {
+	result = uint64(math.MaxUint64)
+	err = c.forEachSink(func(sink *partitionSink) error {
+		a := atomic.LoadUint64(&sink.resolvedTs)
+		if a < result {
+			result = a
+		}
+		return nil
+	})
+	return result, err
+}
+
+// Run the Consumer
 func (c *Consumer) Run(ctx context.Context) error {
-	var lastGlobalResolvedTs uint64
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	for {
@@ -585,58 +601,55 @@ func (c *Consumer) Run(ctx context.Context) error {
 			return ctx.Err()
 		case <-ticker.C:
 		}
-		// initialize the `globalResolvedTs` as min of all partition's `ResolvedTs`
-		globalResolvedTs := uint64(math.MaxUint64)
-		err := c.forEachSink(func(sink *partitionSink) error {
-			resolvedTs := atomic.LoadUint64(&sink.resolvedTs)
-			if resolvedTs < globalResolvedTs {
-				globalResolvedTs = resolvedTs
-			}
-			return nil
-		})
+
+		minPartitionResolvedTs, err := c.getMinPartitionResolvedTs()
 		if err != nil {
 			return errors.Trace(err)
 		}
-		// handle ddl
+
+		// handle DDL
 		todoDDL := c.getFrontDDL()
-		if todoDDL != nil && globalResolvedTs >= todoDDL.CommitTs {
+		if todoDDL != nil && todoDDL.CommitTs <= minPartitionResolvedTs {
 			// flush DMLs
-			err := c.forEachSink(func(sink *partitionSink) error {
+			if err := c.forEachSink(func(sink *partitionSink) error {
 				return syncFlushRowChangedEvents(ctx, sink, todoDDL.CommitTs)
-			})
-			if err != nil {
+			}); err != nil {
 				return errors.Trace(err)
 			}
 
-			// execute ddl
-			err = c.ddlSink.EmitDDLEvent(ctx, todoDDL)
-			if err != nil {
+			// DDL can be executed, do it first.
+			if err := c.ddlSink.EmitDDLEvent(ctx, todoDDL); err != nil {
 				return errors.Trace(err)
 			}
 			c.popDDL()
+
+			if todoDDL.CommitTs < minPartitionResolvedTs {
+				log.Info("update minPartitionResolvedTs by DDL",
+					zap.Uint64("minPartitionResolvedTs", minPartitionResolvedTs),
+					zap.Any("DDL", todoDDL))
+			}
+			minPartitionResolvedTs = todoDDL.CommitTs
+		}
+
+		// update global resolved ts
+		if c.globalResolvedTs > minPartitionResolvedTs {
+			log.Panic("global ResolvedTs fallback",
+				zap.Uint64("globalResolvedTs", c.globalResolvedTs),
+				zap.Uint64("minPartitionResolvedTs", minPartitionResolvedTs))
+		}
+
+		if c.globalResolvedTs == minPartitionResolvedTs {
 			continue
 		}
 
-		if todoDDL != nil && todoDDL.CommitTs < globalResolvedTs {
-			globalResolvedTs = todoDDL.CommitTs
-		}
-		if lastGlobalResolvedTs > globalResolvedTs {
-			log.Panic("global ResolvedTs fallback",
-				zap.Any("lastGlobalResolvedTs", lastGlobalResolvedTs),
-				zap.Any("globalResolvedTs", globalResolvedTs))
-		}
+		c.globalResolvedTs = minPartitionResolvedTs
+		log.Info("update globalResolvedTs",
+			zap.Uint64("globalResolvedTs", c.globalResolvedTs))
 
-		if globalResolvedTs > lastGlobalResolvedTs {
-			lastGlobalResolvedTs = globalResolvedTs
-			atomic.StoreUint64(&c.globalResolvedTs, globalResolvedTs)
-			log.Info("update globalResolvedTs", zap.Uint64("ts", globalResolvedTs))
-
-			err = c.forEachSink(func(sink *partitionSink) error {
-				return syncFlushRowChangedEvents(ctx, sink, globalResolvedTs)
-			})
-			if err != nil {
-				return errors.Trace(err)
-			}
+		if err := c.forEachSink(func(sink *partitionSink) error {
+			return syncFlushRowChangedEvents(ctx, sink, c.globalResolvedTs)
+		}); err != nil {
+			return errors.Trace(err)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4731

### What is changed and how it works?

do not ignore ddl if it's commit ts equal to global resolved ts, and let global resolved ts update after ddl executed.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
