### PR TITLE
sink/producer(ticdc): migrate test-infra to testify for kafka producer

### DIFF
--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -20,23 +20,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/Shopify/sarama"
 	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiflow/cdc/sink/codec"
 	"github.com/pingcap/tiflow/pkg/kafka"
 	"github.com/pingcap/tiflow/pkg/util"
-	"github.com/pingcap/tiflow/pkg/util/testleak"
 )
 
 type kafkaSuite struct{}
 
 var _ = check.Suite(&kafkaSuite{})
 
-func Test(t *testing.T) { check.TestingT(t) }
-
-func (s *kafkaSuite) TestClientID(c *check.C) {
-	defer testleak.AfterTest(c)()
+func TestClientID(t *testing.T) {
 	testCases := []struct {
 		role         string
 		addr         string
@@ -54,20 +52,19 @@ func (s *kafkaSuite) TestClientID(c *check.C) {
 	for _, tc := range testCases {
 		id, err := kafkaClientID(tc.role, tc.addr, tc.changefeedID, tc.configuredID)
 		if tc.hasError {
-			c.Assert(err, check.NotNil)
+			require.Error(t, err)
 		} else {
-			c.Assert(err, check.IsNil)
-			c.Assert(id, check.Equals, tc.expected)
+			require.Nil(t, err)
+			require.Equal(t, tc.expected, id)
 		}
 	}
 }
 
-func (s *kafkaSuite) TestNewSaramaProducer(c *check.C) {
-	defer testleak.AfterTest(c)()
+func TestNewSaramaProducer(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	topic := kafka.DefaultMockTopicName
-	leader := sarama.NewMockBroker(c, 2)
+	leader := sarama.NewMockBroker(t, 2)
 	defer leader.Close()
 	metadataResponse := new(sarama.MetadataResponse)
 	metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
@@ -102,12 +99,12 @@ func (s *kafkaSuite) TestNewSaramaProducer(c *check.C) {
 
 	ctx = util.PutRoleInCtx(ctx, util.RoleTester)
 	saramaConfig, err := NewSaramaConfig(ctx, config)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	saramaConfig.Producer.Flush.MaxMessages = 1
 	client, err := sarama.NewClient(config.BrokerEndpoints, saramaConfig)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	adminClient, err := NewAdminClientImpl(config.BrokerEndpoints, saramaConfig)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	producer, err := NewKafkaSaramaProducer(
 		ctx,
 		client,
@@ -116,49 +113,49 @@ func (s *kafkaSuite) TestNewSaramaProducer(c *check.C) {
 		saramaConfig,
 		errCh,
 	)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	for i := 0; i < 100; i++ {
 		err = producer.AsyncSendMessage(ctx, topic, int32(0), &codec.MQMessage{
 			Key:   []byte("test-key-1"),
 			Value: []byte("test-value"),
 		})
-		c.Assert(err, check.IsNil)
+		require.Nil(t, err)
 		err = producer.AsyncSendMessage(ctx, topic, int32(1), &codec.MQMessage{
 			Key:   []byte("test-key-1"),
 			Value: []byte("test-value"),
 		})
-		c.Assert(err, check.IsNil)
+		require.Nil(t, err)
 	}
 
 	err = producer.Flush(ctx)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	select {
 	case err := <-errCh:
-		c.Fatalf("unexpected err: %s", err)
+		t.Fatalf("unexpected err: %s", err)
 	default:
 	}
 	producer.mu.Lock()
-	c.Assert(producer.mu.inflight, check.Equals, int64(0))
+	require.Equal(t, int64(0), producer.mu.inflight)
 	producer.mu.Unlock()
 	// check no events to flush
 	err = producer.Flush(ctx)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	producer.mu.Lock()
-	c.Assert(producer.mu.inflight, check.Equals, int64(0))
+	require.Equal(t, int64(0), producer.mu.inflight)
 	producer.mu.Unlock()
 
 	err = producer.SyncBroadcastMessage(ctx, topic, 2, &codec.MQMessage{
 		Key:   []byte("test-broadcast"),
 		Value: nil,
 	})
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	err = producer.Close()
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	// check reentrant close
 	err = producer.Close()
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	cancel()
 
 	// check send messages when context is canceled or producer closed
@@ -167,20 +164,18 @@ func (s *kafkaSuite) TestNewSaramaProducer(c *check.C) {
 		Value: nil,
 	})
 	if err != nil {
-		c.Assert(err, check.Equals, context.Canceled)
+		require.Equal(t, context.Canceled, err)
 	}
 	err = producer.SyncBroadcastMessage(ctx, topic, 2, &codec.MQMessage{
 		Key:   []byte("cancel"),
 		Value: nil,
 	})
 	if err != nil {
-		c.Assert(err, check.Equals, context.Canceled)
+		require.Equal(t, context.Canceled, err)
 	}
 }
 
-func (s *kafkaSuite) TestAdjustConfigTopicNotExist(c *check.C) {
-	defer testleak.AfterTest(c)()
-
+func TestAdjustConfigTopicNotExist(t *testing.T) {
 	adminClient := kafka.NewClusterAdminClientMockImpl()
 	defer func() {
 		_ = adminClient.Close()
@@ -193,35 +188,33 @@ func (s *kafkaSuite) TestAdjustConfigTopicNotExist(c *check.C) {
 	// topic not exist, `max-message-bytes` = `message.max.bytes`
 	config.MaxMessageBytes = adminClient.GetBrokerMessageMaxBytes()
 	saramaConfig, err := NewSaramaConfig(context.Background(), config)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	err = AdjustConfig(adminClient, config, saramaConfig, "create-random1")
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	expectedSaramaMaxMessageBytes := config.MaxMessageBytes
-	c.Assert(saramaConfig.Producer.MaxMessageBytes, check.Equals, expectedSaramaMaxMessageBytes)
+	require.Equal(t, expectedSaramaMaxMessageBytes, saramaConfig.Producer.MaxMessageBytes)
 
 	// topic not exist, `max-message-bytes` > `message.max.bytes`
 	config.MaxMessageBytes = adminClient.GetBrokerMessageMaxBytes() + 1
 	saramaConfig, err = NewSaramaConfig(context.Background(), config)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	err = AdjustConfig(adminClient, config, saramaConfig, "create-random2")
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	expectedSaramaMaxMessageBytes = adminClient.GetBrokerMessageMaxBytes()
-	c.Assert(saramaConfig.Producer.MaxMessageBytes, check.Equals, expectedSaramaMaxMessageBytes)
+	require.Equal(t, expectedSaramaMaxMessageBytes, saramaConfig.Producer.MaxMessageBytes)
 
 	// topic not exist, `max-message-bytes` < `message.max.bytes`
 	config.MaxMessageBytes = adminClient.GetBrokerMessageMaxBytes() - 1
 	saramaConfig, err = NewSaramaConfig(context.Background(), config)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	err = AdjustConfig(adminClient, config, saramaConfig, "create-random3")
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	expectedSaramaMaxMessageBytes = config.MaxMessageBytes
-	c.Assert(saramaConfig.Producer.MaxMessageBytes, check.Equals, expectedSaramaMaxMessageBytes)
+	require.Equal(t, expectedSaramaMaxMessageBytes, saramaConfig.Producer.MaxMessageBytes)
 }
 
-func (s *kafkaSuite) TestAdjustConfigTopicExist(c *check.C) {
-	defer testleak.AfterTest(c)()
-
+func TestAdjustConfigTopicExist(t *testing.T) {
 	adminClient := kafka.NewClusterAdminClientMockImpl()
 	defer func() {
 		_ = adminClient.Close()
@@ -233,35 +226,35 @@ func (s *kafkaSuite) TestAdjustConfigTopicExist(c *check.C) {
 	// topic exists, `max-message-bytes` = `max.message.bytes`.
 	config.MaxMessageBytes = adminClient.GetTopicMaxMessageBytes()
 	saramaConfig, err := NewSaramaConfig(context.Background(), config)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	err = AdjustConfig(adminClient, config, saramaConfig, adminClient.GetDefaultMockTopicName())
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	expectedSaramaMaxMessageBytes := config.MaxMessageBytes
-	c.Assert(saramaConfig.Producer.MaxMessageBytes, check.Equals, expectedSaramaMaxMessageBytes)
+	require.Equal(t, expectedSaramaMaxMessageBytes, saramaConfig.Producer.MaxMessageBytes)
 
 	// topic exists, `max-message-bytes` > `max.message.bytes`
 	config.MaxMessageBytes = adminClient.GetTopicMaxMessageBytes() + 1
 	saramaConfig, err = NewSaramaConfig(context.Background(), config)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	err = AdjustConfig(adminClient, config, saramaConfig, adminClient.GetDefaultMockTopicName())
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	expectedSaramaMaxMessageBytes = adminClient.GetTopicMaxMessageBytes()
-	c.Assert(saramaConfig.Producer.MaxMessageBytes, check.Equals, expectedSaramaMaxMessageBytes)
+	require.Equal(t, expectedSaramaMaxMessageBytes, saramaConfig.Producer.MaxMessageBytes)
 
 	// topic exists, `max-message-bytes` < `max.message.bytes`
 	config.MaxMessageBytes = adminClient.GetTopicMaxMessageBytes() - 1
 	saramaConfig, err = NewSaramaConfig(context.Background(), config)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	err = AdjustConfig(adminClient, config, saramaConfig, adminClient.GetDefaultMockTopicName())
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	expectedSaramaMaxMessageBytes = config.MaxMessageBytes
-	c.Assert(saramaConfig.Producer.MaxMessageBytes, check.Equals, expectedSaramaMaxMessageBytes)
+	require.Equal(t, expectedSaramaMaxMessageBytes, saramaConfig.Producer.MaxMessageBytes)
 
 	// When the topic exists, but the topic does not have `max.message.bytes`
 	// create a topic without `max.message.bytes`
@@ -272,34 +265,32 @@ func (s *kafkaSuite) TestAdjustConfigTopicExist(c *check.C) {
 		ConfigEntries: make(map[string]*string),
 	}
 	err = adminClient.CreateTopic(topicName, detail, false)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	config.MaxMessageBytes = adminClient.GetBrokerMessageMaxBytes() - 1
 	saramaConfig, err = NewSaramaConfig(context.Background(), config)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	err = AdjustConfig(adminClient, config, saramaConfig, topicName)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	// since `max.message.bytes` cannot found, use broker's `message.max.bytes` instead.
 	expectedSaramaMaxMessageBytes = config.MaxMessageBytes
-	c.Assert(saramaConfig.Producer.MaxMessageBytes, check.Equals, expectedSaramaMaxMessageBytes)
+	require.Equal(t, expectedSaramaMaxMessageBytes, saramaConfig.Producer.MaxMessageBytes)
 
 	// When the topic exists, but the topic doesn't have `max.message.bytes`
 	// `max-message-bytes` > `message.max.bytes`
 	config.MaxMessageBytes = adminClient.GetBrokerMessageMaxBytes() + 1
 	saramaConfig, err = NewSaramaConfig(context.Background(), config)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	err = AdjustConfig(adminClient, config, saramaConfig, topicName)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	expectedSaramaMaxMessageBytes = adminClient.GetBrokerMessageMaxBytes()
-	c.Assert(saramaConfig.Producer.MaxMessageBytes, check.Equals, expectedSaramaMaxMessageBytes)
+	require.Equal(t, expectedSaramaMaxMessageBytes, saramaConfig.Producer.MaxMessageBytes)
 }
 
-func (s *kafkaSuite) TestAdjustConfigMinInsyncReplicas(c *check.C) {
-	defer testleak.AfterTest(c)()
-
+func TestAdjustConfigMinInsyncReplicas(t *testing.T) {
 	adminClient := kafka.NewClusterAdminClientMockImpl()
 	defer func() {
 		_ = adminClient.Close()
@@ -311,44 +302,41 @@ func (s *kafkaSuite) TestAdjustConfigMinInsyncReplicas(c *check.C) {
 	// Report an error if the replication-factor is less than min.insync.replicas
 	// when the topic does not exist.
 	saramaConfig, err := NewSaramaConfig(context.Background(), config)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	adminClient.SetMinInsyncReplicas("2")
 	err = AdjustConfig(adminClient, config, saramaConfig, "create-new-fail-invalid-min-insync-replicas")
-	c.Assert(
-		errors.Cause(err),
-		check.ErrorMatches,
+	require.Regexp(
+		t,
 		".*`replication-factor` cannot be smaller than the `min.insync.replicas` of broker.*",
+		errors.Cause(err),
 	)
 
 	// Report an error if the replication-factor is less than min.insync.replicas
 	// when the topic does exist.
 	saramaConfig, err = NewSaramaConfig(context.Background(), config)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	adminClient.SetMinInsyncReplicas("2")
 	err = AdjustConfig(adminClient, config, saramaConfig, adminClient.GetDefaultMockTopicName())
-	c.Assert(
-		errors.Cause(err),
-		check.ErrorMatches,
+	require.Regexp(t,
 		".*`replication-factor` cannot be smaller than the `min.insync.replicas` of topic.*",
+		errors.Cause(err),
 	)
 }
 
-func (s *kafkaSuite) TestCreateProducerFailed(c *check.C) {
-	defer testleak.AfterTest(c)()
+func TestCreateProducerFailed(t *testing.T) {
 	config := NewConfig()
 	config.Version = "invalid"
 	saramaConfig, err := NewSaramaConfig(context.Background(), config)
-	c.Assert(errors.Cause(err), check.ErrorMatches, "invalid version.*")
-	c.Assert(saramaConfig, check.IsNil)
+	require.Regexp(t, "invalid version.*", errors.Cause(err))
+	require.Nil(t, saramaConfig)
 }
 
-func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
-	defer testleak.AfterTest(c)()
+func TestProducerSendMessageFailed(t *testing.T) {
 	topic := kafka.DefaultMockTopicName
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
-	leader := sarama.NewMockBroker(c, 2)
+	leader := sarama.NewMockBroker(t, 2)
 	defer leader.Close()
 	metadataResponse := new(sarama.MetadataResponse)
 	metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
@@ -374,15 +362,15 @@ func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
 	errCh := make(chan error, 1)
 	ctx = util.PutRoleInCtx(ctx, util.RoleTester)
 	saramaConfig, err := NewSaramaConfig(context.Background(), config)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	saramaConfig.Producer.Flush.MaxMessages = 1
 	saramaConfig.Producer.Retry.Max = 2
 	saramaConfig.Producer.MaxMessageBytes = 8
 
 	client, err := sarama.NewClient(config.BrokerEndpoints, saramaConfig)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	adminClient, err := NewAdminClientImpl(config.BrokerEndpoints, saramaConfig)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	producer, err := NewKafkaSaramaProducer(
 		ctx,
 		client,
@@ -393,47 +381,46 @@ func (s *kafkaSuite) TestProducerSendMessageFailed(c *check.C) {
 	)
 	defer func() {
 		err := producer.Close()
-		c.Assert(err, check.IsNil)
+		require.Nil(t, err)
 	}()
 
-	c.Assert(err, check.IsNil)
-	c.Assert(producer, check.NotNil)
+	require.Nil(t, err)
+	require.NotNil(t, producer)
 
 	var wg sync.WaitGroup
 
 	wg.Add(1)
-	go func() {
+	go func(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < 20; i++ {
 			err = producer.AsyncSendMessage(ctx, topic, int32(0), &codec.MQMessage{
 				Key:   []byte("test-key-1"),
 				Value: []byte("test-value"),
 			})
-			c.Assert(err, check.IsNil)
+			require.Nil(t, err)
 		}
-	}()
+	}(t)
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		select {
 		case <-ctx.Done():
-			c.Fatal("TestProducerSendMessageFailed timed out")
+			t.Errorf("TestProducerSendMessageFailed timed out")
 		case err := <-errCh:
-			c.Assert(err, check.ErrorMatches, ".*too large.*")
+			require.Regexp(t, ".*too large.*", err)
 		}
 	}()
 
 	wg.Wait()
 }
 
-func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
-	defer testleak.AfterTest(c)()
+func TestProducerDoubleClose(t *testing.T) {
 	topic := kafka.DefaultMockTopicName
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
-	leader := sarama.NewMockBroker(c, 2)
+	leader := sarama.NewMockBroker(t, 2)
 	defer leader.Close()
 	metadataResponse := new(sarama.MetadataResponse)
 	metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
@@ -459,11 +446,11 @@ func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
 	errCh := make(chan error, 1)
 	ctx = util.PutRoleInCtx(ctx, util.RoleTester)
 	saramaConfig, err := NewSaramaConfig(context.Background(), config)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	client, err := sarama.NewClient(config.BrokerEndpoints, saramaConfig)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	adminClient, err := NewAdminClientImpl(config.BrokerEndpoints, saramaConfig)
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 	producer, err := NewKafkaSaramaProducer(
 		ctx,
 		client,
@@ -474,15 +461,15 @@ func (s *kafkaSuite) TestProducerDoubleClose(c *check.C) {
 	)
 	defer func() {
 		err := producer.Close()
-		c.Assert(err, check.IsNil)
+		require.Nil(t, err)
 	}()
 
-	c.Assert(err, check.IsNil)
-	c.Assert(producer, check.NotNil)
+	require.Nil(t, err)
+	require.NotNil(t, producer)
 
 	err = producer.Close()
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 
 	err = producer.Close()
-	c.Assert(err, check.IsNil)
+	require.Nil(t, err)
 }

--- a/cdc/sink/producer/kafka/kafka_test.go
+++ b/cdc/sink/producer/kafka/kafka_test.go
@@ -20,14 +20,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/Shopify/sarama"
 	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiflow/cdc/sink/codec"
 	"github.com/pingcap/tiflow/pkg/kafka"
 	"github.com/pingcap/tiflow/pkg/util"
+	"github.com/stretchr/testify/require"
 )
 
 type kafkaSuite struct{}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref https://github.com/pingcap/tiflow/issues/2164

### What is changed and how it works?

migrate test-infra to testify for kafka producer.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

None

Related changes

None

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
