### PR TITLE
checker(dm): skip  check for mariadb some version

### DIFF
--- a/dm/pkg/checker/binlog.go
+++ b/dm/pkg/checker/binlog.go
@@ -105,8 +105,10 @@ func (pc *MySQLBinlogFormatChecker) Name() string {
 }
 
 /*****************************************************/
-
-var mysqlBinlogRowImageRequired MySQLVersion = [3]uint{5, 6, 2}
+var (
+	mysqlBinlogRowImageRequired   MySQLVersion = [3]uint{5, 6, 2}
+	mariaDBBinlogRowImageRequired MySQLVersion = [3]uint{10, 1, 6}
+)
 
 // MySQLBinlogRowImageChecker checks mysql binlog_row_image.
 type MySQLBinlogRowImageChecker struct {
@@ -140,6 +142,7 @@ func (pc *MySQLBinlogRowImageChecker) Check(ctx context.Context) *Result {
 		markCheckError(result, err)
 		return result
 	}
+
 	version, err := toMySQLVersion(value)
 	if err != nil {
 		markCheckError(result, err)
@@ -148,6 +151,12 @@ func (pc *MySQLBinlogRowImageChecker) Check(ctx context.Context) *Result {
 
 	// for mysql.version < 5.6.2,  we don't need to check binlog_row_image.
 	if !version.Ge(mysqlBinlogRowImageRequired) {
+		result.State = StateSuccess
+		return result
+	}
+
+	// for mariadb.version < 10.1.6.,  we don't need to check binlog_row_image.
+	if utils.IsMariaDB(value) && !version.Ge(mariaDBBinlogRowImageRequired) {
 		result.State = StateSuccess
 		return result
 	}

--- a/dm/pkg/checker/binlog.go
+++ b/dm/pkg/checker/binlog.go
@@ -105,6 +105,7 @@ func (pc *MySQLBinlogFormatChecker) Name() string {
 }
 
 /*****************************************************/
+
 var (
 	mysqlBinlogRowImageRequired   MySQLVersion = [3]uint{5, 6, 2}
 	mariaDBBinlogRowImageRequired MySQLVersion = [3]uint{10, 1, 6}

--- a/dm/pkg/checker/binlog_test.go
+++ b/dm/pkg/checker/binlog_test.go
@@ -127,3 +127,75 @@ func TestBinlogDB(t *testing.T) {
 		require.Equal(t, cs.state, r.State)
 	}
 }
+
+func TestMySQLBinlogRowImageChecker(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.Nil(t, err)
+	ctx := context.Background()
+
+	cases := []struct {
+		version   string
+		state     State
+		needCheck bool
+		rowImage  string
+	}{
+		// mysql < 5.6.2 don't need check
+		{
+			version:   "5.6.1-log",
+			state:     StateSuccess,
+			needCheck: false,
+			rowImage:  "full",
+		},
+
+		// mysql >= 5.6.2  need check - success
+		{
+			version:   "5.6.2-log",
+			state:     StateSuccess,
+			needCheck: true,
+			rowImage:  "full",
+		},
+		// mysql >= 5.6.2  need check - failed
+		{
+			version:   "5.6.2-log",
+			state:     StateFailure,
+			needCheck: true,
+			rowImage:  "NOBLOB",
+		},
+
+		// mariadb < 10.1.6 don't need check
+		{
+			version:   "10.1.5-MariaDB-1~wheezy",
+			state:     StateSuccess,
+			needCheck: false,
+			rowImage:  "full",
+		},
+
+		// mariadb >= 10.1.6  need check - success
+		{
+			version:   "10.1.6-MariaDB-1~wheezy",
+			state:     StateSuccess,
+			needCheck: true,
+			rowImage:  "full",
+		},
+		// mariadb >= 10.1.6  need check - failed
+		{
+			version:   "10.1.6-MariaDB-1~wheezy",
+			state:     StateFailure,
+			needCheck: true,
+			rowImage:  "NOBLOB",
+		},
+	}
+
+	for _, cs := range cases {
+		binlogDBChecker := NewMySQLBinlogRowImageChecker(db, &dbutil.DBConfig{})
+		versionRow := sqlmock.NewRows([]string{"Variable_name", "Value"}).AddRow("version", cs.version)
+		mock.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'version'").WillReturnRows(versionRow)
+		if cs.needCheck {
+			binlogRowImageRow := sqlmock.NewRows([]string{"Variable_name", "Value"}).AddRow("binlog_row_image", cs.rowImage)
+			mock.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'binlog_row_image'").WillReturnRows(binlogRowImageRow)
+		}
+		r := binlogDBChecker.Check(ctx)
+		require.Nil(t, mock.ExpectationsWereMet())
+		require.Equal(t, cs.state, r.State)
+	}
+}

--- a/dm/pkg/checker/binlog_test.go
+++ b/dm/pkg/checker/binlog_test.go
@@ -144,9 +144,8 @@ func TestMySQLBinlogRowImageChecker(t *testing.T) {
 			version:   "5.6.1-log",
 			state:     StateSuccess,
 			needCheck: false,
-			rowImage:  "full",
+			rowImage:  "",
 		},
-
 		// mysql >= 5.6.2  need check - success
 		{
 			version:   "5.6.2-log",
@@ -167,7 +166,7 @@ func TestMySQLBinlogRowImageChecker(t *testing.T) {
 			version:   "10.1.5-MariaDB-1~wheezy",
 			state:     StateSuccess,
 			needCheck: false,
-			rowImage:  "full",
+			rowImage:  "",
 		},
 
 		// mariadb >= 10.1.6  need check - success


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4959 

### What is changed and how it works?
as title

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

start task success with mariadb 10.1.2, there just one warning message

```
dmctl start-task tasks/task-from-mariadb.yaml
{
    "result": true,
    "msg": "",
    "sources": [
        {
            "result": true,
            "msg": "",
            "source": "mariadb",
            "worker": "worker1"
        }
    ],
    "checkResult": "fail to check synchronization configuration with type: no errors but some warnings
    	detail: {
		"results": [
			{
				"id": 0,
				"name": "mysql_version",
				"desc": "check whether mysql version is satisfied",
				"state": "warn",
				"errors": [
					{
						"severity": "warn",
						"short_error": "Migrating from MariaDB is experimentally supported. If you must use DM to migrate data from MariaDB, we suggest make your MariaDB \u003e= 10.1.2"
					}
				],
				"extra": "address of db instance xxxx:3308"
			}
		],
		"summary": {
			"passed": true,
			"total": 10,
			"successful": 9,
			"failed": 0,
			"warning": 1
		}
	}"
}

```

Code changes

 - Has exported function/method change


Side effects


Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`fix a but that can not start task when mariadb version < 10.1.6`.
```
