### PR TITLE
scheduler(cdc), tests: fix TestNoFinishOperationBeforeSyncIsReceived and TestClientSendAnomalies

### DIFF
--- a/pkg/p2p/client_test.go
+++ b/pkg/p2p/client_test.go
@@ -341,9 +341,11 @@ func TestClientSendAnomalies(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		closeClient()
 	}()
-	_, err = client.SendMessage(ctx, "test-topic", &testMessage{Value: 1})
-	require.Error(t, err)
-	require.Regexp(t, ".*ErrPeerMessageClientClosed.*", err.Error())
+	_, _ = client.SendMessage(ctx, "test-topic", &testMessage{Value: 1})
+	// There is no need to check for error here, because when a client is closing,
+	// message loss is expected because sending the message is fully asynchronous.
+	// The client implementation is considered correct if `SendMessage` does not
+	// block infinitely.
 
 	wg.Wait()
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4975 close #5012

### What is changed and how it works?
- Loosened TestClientSendAnomalies. We accept apparent successes of sending messages after the client is closed.
- Replaced `require.Never` in `TestNoFinishOperationBeforeSyncIsReceived`, as `require.Never` will cause data races.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
