### PR TITLE
master/scheduler: support bound multi sources for dm-workers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ define run_dm_unit_test
 	mkdir -p $(DM_TEST_DIR)
 	$(FAILPOINT_ENABLE)
 	@export log_level=error; \
-	$(GOTEST) -timeout 5m -covermode=atomic -coverprofile="$(DM_TEST_DIR)/cov.unit_test.out" $(1) \
+	$(GOTEST) -timeout 8m -covermode=atomic -coverprofile="$(DM_TEST_DIR)/cov.unit_test.out" $(1) \
 	|| { $(FAILPOINT_DISABLE); exit 1; }
 	$(FAILPOINT_DISABLE)
 endef

--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ define run_dm_unit_test
 	mkdir -p $(DM_TEST_DIR)
 	$(FAILPOINT_ENABLE)
 	@export log_level=error; \
-	$(GOTEST) -timeout 10m -covermode=atomic -coverprofile="$(DM_TEST_DIR)/cov.unit_test.out" $(1) \
+	$(GOTEST) -timeout 5m -covermode=atomic -coverprofile="$(DM_TEST_DIR)/cov.unit_test.out" $(1) \
 	|| { $(FAILPOINT_DISABLE); exit 1; }
 	$(FAILPOINT_DISABLE)
 endef

--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ define run_dm_unit_test
 	mkdir -p $(DM_TEST_DIR)
 	$(FAILPOINT_ENABLE)
 	@export log_level=error; \
-	$(GOTEST) -timeout 5m -covermode=atomic -coverprofile="$(DM_TEST_DIR)/cov.unit_test.out" $(1) \
+	$(GOTEST) -timeout 10m -covermode=atomic -coverprofile="$(DM_TEST_DIR)/cov.unit_test.out" $(1) \
 	|| { $(FAILPOINT_DISABLE); exit 1; }
 	$(FAILPOINT_DISABLE)
 endef

--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ define run_dm_unit_test
 	mkdir -p $(DM_TEST_DIR)
 	$(FAILPOINT_ENABLE)
 	@export log_level=error; \
-	$(GOTEST) -timeout 8m -covermode=atomic -coverprofile="$(DM_TEST_DIR)/cov.unit_test.out" $(1) \
+	$(GOTEST) -timeout 5m -covermode=atomic -coverprofile="$(DM_TEST_DIR)/cov.unit_test.out" $(1) \
 	|| { $(FAILPOINT_DISABLE); exit 1; }
 	$(FAILPOINT_DISABLE)
 endef

--- a/dm/_utils/terror_gen/errors_release.txt
+++ b/dm/_utils/terror_gen/errors_release.txt
@@ -549,7 +549,7 @@ ErrSchedulerStopRelayOnSpecified,[code=46029:class=scheduler:scope=internal:leve
 ErrSchedulerStartRelayOnBound,[code=46030:class=scheduler:scope=internal:level=low], "Message: the source has `start-relay` automatically for bound worker, so it can't `start-relay` with worker name now, Workaround: Please stop relay by `stop-relay` without worker name first."
 ErrSchedulerStopRelayOnBound,[code=46031:class=scheduler:scope=internal:level=low], "Message: the source has `start-relay` automatically for bound worker, so it can't `stop-relay` with worker name now, Workaround: Please use `stop-relay` without worker name."
 ErrSchedulerPauseTaskForTransferSource,[code=46032:class=scheduler:scope=internal:level=low], "Message: failed to auto pause tasks %s when transfer-source, Workaround: Please pause task by `dmctl pause-task`."
-ErrSchedulerWorkerNotFree,[code=46033:class=scheduler:scope=internal:level=low], "Message: dm-worker with name %s not free"
+ErrSchedulerWorkerOffline,[code=46033:class=scheduler:scope=internal:level=low], "Message: dm-worker with name %s not online"
 ErrCtlGRPCCreateConn,[code=48001:class=dmctl:scope=internal:level=high], "Message: can not create grpc connection, Workaround: Please check your network connection."
 ErrCtlInvalidTLSCfg,[code=48002:class=dmctl:scope=internal:level=medium], "Message: invalid TLS config, Workaround: Please check the `ssl-ca`, `ssl-cert` and `ssl-key` config in command line."
 ErrCtlLoadTLSCfg,[code=48003:class=dmctl:scope=internal:level=high], "Message: can not load tls config, Workaround: Please ensure that the tls certificate is accessible on the node currently running dmctl."

--- a/dm/dm/ctl/master/transfer_source.go
+++ b/dm/dm/ctl/master/transfer_source.go
@@ -28,7 +28,7 @@ import (
 func NewTransferSourceCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "transfer-source <source-id> <worker-id>",
-		Short: "Transfers a upstream MySQL/MariaDB source to a free worker",
+		Short: "Transfers a upstream MySQL/MariaDB source to an online worker",
 		RunE:  transferSourceFunc,
 	}
 	return cmd

--- a/dm/dm/master/openapi_view.go
+++ b/dm/dm/master/openapi_view.go
@@ -288,7 +288,7 @@ func (s *Server) DMAPIDisableSource(c *gin.Context, sourceName string) {
 	c.Status(http.StatusOK)
 }
 
-// DMAPITransferSource transfer source to another free worker url is: (POST /api/v1/sources/{source-name}/transfer).
+// DMAPITransferSource transfer source to another online worker url is: (POST /api/v1/sources/{source-name}/transfer).
 func (s *Server) DMAPITransferSource(c *gin.Context, sourceName string) {
 	var req openapi.WorkerNameRequest
 	if err := c.Bind(&req); err != nil {

--- a/dm/dm/master/scheduler/scheduler.go
+++ b/dm/dm/master/scheduler/scheduler.go
@@ -1297,7 +1297,7 @@ func (s *Scheduler) BoundSources() []string {
 }
 
 // UnboundSources returns all unbound source IDs in increasing order.
-// we don't lock this because all the situations that use this function has required lock
+// we don't lock this because all the situations that use this function has required lock.
 func (s *Scheduler) UnboundSources() []string {
 	capIDs := len(s.sourceCfgs) - len(s.bounds)
 	IDs := make([]string, 0, capIDs)

--- a/dm/dm/master/scheduler/scheduler.go
+++ b/dm/dm/master/scheduler/scheduler.go
@@ -136,7 +136,7 @@ type Scheduler struct {
 	// see `Cases trigger a source-to-worker binding try` above.
 	bounds map[string]*Worker
 
-	// a mirror of bounds whose element is not deleted when worker is unbound. source -> SourceBound
+	// sources last bound workers when worker is unbound. source -> SourceBound
 	lastBound map[string]ha.SourceBound
 
 	// expectant relay stages for sources, source ID -> stage.

--- a/dm/dm/master/scheduler/scheduler.go
+++ b/dm/dm/master/scheduler/scheduler.go
@@ -2250,19 +2250,19 @@ func (s *Scheduler) tryBoundForSource(source string) (bool, error) {
 	boundSourcesNum := sourceNum
 	if len(relayWorkers) > 0 {
 		for _, bound := range s.lastBound {
-			workerName := bound.Worker
+			boundWorker := bound.Worker
 			if bound.Source == source {
-				w, ok := s.workers[workerName]
+				w, ok := s.workers[boundWorker]
 				if !ok {
 					// a not found worker
 					continue
 				}
 				// the worker is not Offline
-				if _, ok2 := relayWorkers[workerName]; ok2 && w.Stage() != WorkerOffline && len(w.Bounds()) < boundSourcesNum {
+				if _, ok2 := relayWorkers[boundWorker]; ok2 && w.Stage() != WorkerOffline && len(w.Bounds()) < boundSourcesNum {
 					worker = w
 					boundSourcesNum = len(w.Bounds())
 					s.logger.Info("found history relay worker when source bound",
-						zap.String("worker", workerName),
+						zap.String("worker", boundWorker),
 						zap.String("source", source))
 				}
 			}

--- a/dm/dm/master/scheduler/scheduler_test.go
+++ b/dm/dm/master/scheduler/scheduler_test.go
@@ -75,6 +75,12 @@ func (t *testSchedulerSuite) TearDownSuite() {
 	t.mockCluster.Terminate(t.T())
 }
 
+func (t *testSchedulerSuite) TearDownTest() {
+	t.clearTestInfoOperation()
+}
+
+var stageEmpty ha.Stage
+
 func checkRelaySource(t *testing.T, relaySources map[string]struct{}, sources ...string) {
 	t.Helper()
 	require.Len(t, relaySources, len(sources))
@@ -82,12 +88,6 @@ func checkRelaySource(t *testing.T, relaySources map[string]struct{}, sources ..
 		require.Contains(t, relaySources, s)
 	}
 }
-
-func (t *testSchedulerSuite) TearDownTest() {
-	t.clearTestInfoOperation()
-}
-
-var stageEmpty ha.Stage
 
 func getUnboundedSourcesWithLock(s *Scheduler) []string {
 	s.mu.RLock()
@@ -1488,6 +1488,7 @@ func (t *testSchedulerSuite) TestStartStopRelay() {
 	require.NoError(t.T(), s.StartRelay(sourceID1, []string{workerName2}))
 	require.Equal(t.T(), WorkerBound, worker2.Stage())
 	checkRelaySource(t.T(), worker2.RelaySources(), sourceID1)
+
 	worker3.ToOffline()
 	worker4.ToOffline()
 
@@ -1961,6 +1962,7 @@ func (t *testSchedulerSuite) TestUpgradeCauseConflictRelayType() {
 	s.etcdCli = t.etcdTestCli
 	sourceCfg.EnableRelay = true
 	sourceCfg.SourceID = sourceID1
+
 	_, err = ha.PutSourceCfg(t.etcdTestCli, sourceCfg)
 	require.NoError(t.T(), err)
 	_, err = ha.PutRelayConfig(t.etcdTestCli, ha.NewSourceBound(sourceID1, workerName1))

--- a/dm/dm/master/scheduler/scheduler_test.go
+++ b/dm/dm/master/scheduler/scheduler_test.go
@@ -1452,7 +1452,7 @@ func (t *testSchedulerSuite) TestStartStopRelay() {
 	require.Equal(t.T(), []*Worker{worker2}, workers)
 
 	// failed on not-same-source worker and not exist worker
-	require.True(t.T(), terror.ErrSchedulerRelayWorkersWrongRelay.Equal(s.StopRelay(sourceID1, []string{workerName2})))
+	require.NoError(t.T(), s.StopRelay(sourceID1, []string{workerName2}))
 	require.True(t.T(), terror.ErrSchedulerWorkerNotExist.Equal(s.StopRelay(sourceID1, []string{"not-exist"})))
 
 	// nothing changed

--- a/dm/dm/master/scheduler/scheduler_test.go
+++ b/dm/dm/master/scheduler/scheduler_test.go
@@ -92,7 +92,7 @@ func checkRelaySource(t *testing.T, relaySources map[string]struct{}, sources ..
 func getUnboundedSourcesWithLock(s *Scheduler) []string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.UnboundSources()
+	return s.getUnboundSources()
 }
 
 func (t *testSchedulerSuite) TestScheduler() {

--- a/dm/dm/master/scheduler/scheduler_test.go
+++ b/dm/dm/master/scheduler/scheduler_test.go
@@ -500,7 +500,7 @@ func (t *testSchedulerSuite) testSchedulerProgress(restart int) {
 	// source2 not exist, worker1 is bound
 	t.sourceCfgNotExist(s, sourceID2)
 	t.workerBound(s, ha.NewSourceBound(sourceID1, workerName1))
-	require.True(t.T(), terror.ErrSchedulerWorkerNotFree.Equal(s.AddSourceCfgWithWorker(&sourceCfg2, workerName1)))
+	require.True(t.T(), terror.ErrSchedulerWorkerOffline.Equal(s.AddSourceCfgWithWorker(&sourceCfg2, workerName1)))
 	// source2 is not created because expected worker1 is already bound
 	t.sourceCfgNotExist(s, sourceID2)
 	rebuildScheduler(ctx)

--- a/dm/dm/master/scheduler/worker.go
+++ b/dm/dm/master/scheduler/worker.go
@@ -144,7 +144,7 @@ func (w *Worker) checkFree() {
 	}
 }
 
-// Unbound changes worker's stage from Bound to Free or Relay.
+// Unbound changes worker's stage from Bound to Free.
 func (w *Worker) Unbound(source string) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/dm/dm/master/scheduler/worker.go
+++ b/dm/dm/master/scheduler/worker.go
@@ -60,17 +60,13 @@ const (
 	WorkerOffline WorkerStage = "offline" // the worker is not online yet.
 	WorkerFree    WorkerStage = "free"    // the worker is online, but no upstream source assigned to it yet.
 	WorkerBound   WorkerStage = "bound"   // the worker is online, and one upstream source already assigned to it.
-	WorkerRelay   WorkerStage = "relay"   // the worker is online, pulling relay log but not responsible for migrating.
 )
 
 var (
-	nullBound ha.SourceBound
-
 	workerStage2Num = map[WorkerStage]float64{
 		WorkerOffline: 0.0,
 		WorkerFree:    1.0,
 		WorkerBound:   2.0,
-		WorkerRelay:   1.5,
 	}
 	unrecognizedState = -1.0
 )
@@ -81,12 +77,12 @@ type Worker struct {
 
 	cli workerrpc.Client // the gRPC client proxy.
 
-	baseInfo ha.WorkerInfo  // the base information of the DM-worker instance.
-	bound    ha.SourceBound // the source bound relationship, null value if not bounded.
-	stage    WorkerStage    // the current stage.
+	baseInfo ha.WorkerInfo             // the base information of the DM-worker instance.
+	bounds   map[string]ha.SourceBound // the source bounds relationship, source-id -> bound.
+	stage    WorkerStage               // the current stage.
 
-	// the source ID from which the worker is pulling relay log. should keep consistent with Scheduler.relayWorkers
-	relaySource string
+	// the sources from which the worker is pulling relay log. should keep consistent with Scheduler.relayWorkers
+	relaySources map[string]struct{}
 }
 
 // NewWorker creates a new Worker instance with Offline stage.
@@ -100,6 +96,7 @@ func NewWorker(baseInfo ha.WorkerInfo, securityCfg config.Security) (*Worker, er
 		cli:      cli,
 		baseInfo: baseInfo,
 		stage:    WorkerOffline,
+		bounds:   make(map[string]ha.SourceBound),
 	}
 	w.reportMetrics()
 	return w, nil
@@ -119,7 +116,7 @@ func (w *Worker) ToOffline() {
 	defer w.mu.Unlock()
 	w.stage = WorkerOffline
 	w.reportMetrics()
-	w.bound = nullBound
+	w.bounds = make(map[string]ha.SourceBound)
 }
 
 // ToFree transforms to Free and clears the bound and relay information.
@@ -129,8 +126,8 @@ func (w *Worker) ToFree() {
 	defer w.mu.Unlock()
 	w.stage = WorkerFree
 	w.reportMetrics()
-	w.bound = nullBound
-	w.relaySource = ""
+	w.bounds = make(map[string]ha.SourceBound)
+	w.relaySources = make(map[string]struct{})
 }
 
 // ToBound transforms to Bound.
@@ -141,74 +138,60 @@ func (w *Worker) ToBound(bound ha.SourceBound) error {
 	if w.stage == WorkerOffline {
 		return terror.ErrSchedulerWorkerInvalidTrans.Generate(w.BaseInfo(), WorkerOffline, WorkerBound)
 	}
-	if w.stage == WorkerRelay {
-		if w.relaySource != bound.Source {
-			return terror.ErrSchedulerBoundDiffWithStartedRelay.Generate(w.BaseInfo().Name, bound.Source, w.relaySource)
-		}
-	}
 
-	w.stage = WorkerBound
 	w.reportMetrics()
-	w.bound = bound
+	w.bounds[bound.Source] = bound
+	w.stage = WorkerBound
 	return nil
 }
 
-// Unbound changes worker's stage from Bound to Free or Relay.
-func (w *Worker) Unbound() error {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	if w.stage != WorkerBound {
-		// caller should not do this.
-		return terror.ErrSchedulerWorkerInvalidTrans.Generatef("can't unbound a worker that is not in bound stage.")
-	}
-
-	w.bound = nullBound
-	if w.relaySource != "" {
-		w.stage = WorkerRelay
-	} else {
+func (w *Worker) checkFree() {
+	if w.stage == WorkerBound && len(w.bounds) == 0 && len(w.relaySources) == 0 {
 		w.stage = WorkerFree
 	}
+}
+
+// Unbound changes worker's stage from Bound to Free or Relay.
+func (w *Worker) Unbound(source string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if _, ok := w.bounds[source]; !ok {
+		// caller should not do this.
+		return terror.ErrSchedulerWorkerInvalidTrans.Generatef("can't unbound a source %s that is not bound with worker %s.", source, w.baseInfo.Name)
+	}
+
+	delete(w.bounds, source)
+	w.checkFree()
 	w.reportMetrics()
 	return nil
 }
 
 // StartRelay adds relay source information to a bound worker and calculates the stage.
-func (w *Worker) StartRelay(sourceID string) error {
+func (w *Worker) StartRelay(sources ...string) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	switch w.stage {
-	case WorkerOffline, WorkerRelay:
-	case WorkerFree:
-		w.stage = WorkerRelay
-		w.reportMetrics()
-	case WorkerBound:
-		if w.bound.Source != sourceID {
-			return terror.ErrSchedulerRelayWorkersWrongBound.Generatef(
-				"can't turn on relay of source %s for worker %s, because the worker is bound to source %s",
-				sourceID, w.BaseInfo().Name, w.bound.Source)
-		}
+	for _, sourceID := range sources {
+		w.relaySources[sourceID] = struct{}{}
 	}
-	w.relaySource = sourceID
 
+	w.stage = WorkerBound
 	return nil
 }
 
 // StopRelay clears relay source information of a bound worker and calculates the stage.
-func (w *Worker) StopRelay() {
+func (w *Worker) StopRelay(source string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	w.relaySource = ""
-	switch w.stage {
-	case WorkerOffline, WorkerBound:
-	case WorkerFree:
+	if _, ok := w.relaySources[source]; !ok {
 		log.L().DPanic("StopRelay for a Free worker should not happen",
 			zap.String("worker name", w.baseInfo.Name))
-	case WorkerRelay:
-		w.stage = WorkerFree
-		w.reportMetrics()
 	}
+	delete(w.relaySources, source)
+
+	w.checkFree()
+	w.reportMetrics()
 }
 
 // BaseInfo returns the base info of the worker.
@@ -224,20 +207,19 @@ func (w *Worker) Stage() WorkerStage {
 	return w.stage
 }
 
-// Bound returns the current source ID bounded to,
-// returns null value if not bounded.
-func (w *Worker) Bound() ha.SourceBound {
+// Bounds returns the bounds info of the worker.
+func (w *Worker) Bounds() map[string]ha.SourceBound {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-	return w.bound
+	return w.bounds
 }
 
-// RelaySourceID returns the source ID from which this worker is pulling relay log,
+// RelaySources returns the sources from which this worker is pulling relay log,
 // returns empty string if not started relay.
-func (w *Worker) RelaySourceID() string {
+func (w *Worker) RelaySources() map[string]struct{} {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
-	return w.relaySource
+	return w.relaySources
 }
 
 // SendRequest sends request to the DM-worker instance.

--- a/dm/dm/master/scheduler/worker.go
+++ b/dm/dm/master/scheduler/worker.go
@@ -178,8 +178,10 @@ func (w *Worker) StopRelay(source string) {
 	defer w.mu.Unlock()
 
 	if _, ok := w.relaySources[source]; !ok {
-		log.L().DPanic("StopRelay for a Free worker should not happen",
-			zap.String("worker name", w.baseInfo.Name))
+		log.L().Debug("StopRelay on worker without this relay",
+			zap.String("worker name", w.baseInfo.Name),
+			zap.String("source", source))
+		return
 	}
 	delete(w.relaySources, source)
 

--- a/dm/dm/master/server.go
+++ b/dm/dm/master/server.go
@@ -2054,11 +2054,17 @@ func (s *Server) listMemberWorker(names []string) *pb.Members_Worker {
 			continue
 		}
 
+		bounds := workerAgent.Bounds()
+		sources := make([]string, 0, len(bounds))
+		for _, bound := range bounds {
+			sources = append(sources, bound.Source)
+		}
+
 		workers = append(workers, &pb.WorkerInfo{
 			Name:   workerAgent.BaseInfo().Name,
 			Addr:   workerAgent.BaseInfo().Addr,
 			Stage:  string(workerAgent.Stage()),
-			Source: workerAgent.Bound().Source,
+			Source: strings.Join(sources, ","),
 		})
 	}
 

--- a/dm/dm/master/server.go
+++ b/dm/dm/master/server.go
@@ -1504,7 +1504,7 @@ func (s *Server) OperateSource(ctx context.Context, req *pb.OperateSourceRequest
 	var noWorkerMsg string
 	switch req.Op {
 	case pb.SourceOp_StartSource, pb.SourceOp_ShowSource:
-		noWorkerMsg = "source is added but there is no free worker to bound"
+		noWorkerMsg = "source is added but there is no online worker to bound"
 	case pb.SourceOp_StopSource:
 		noWorkerMsg = "source is stopped and hasn't bound to worker before being stopped"
 	}
@@ -2061,9 +2061,10 @@ func (s *Server) listMemberWorker(names []string) *pb.Members_Worker {
 		}
 
 		workers = append(workers, &pb.WorkerInfo{
-			Name:   workerAgent.BaseInfo().Name,
-			Addr:   workerAgent.BaseInfo().Addr,
-			Stage:  string(workerAgent.Stage()),
+			Name:  workerAgent.BaseInfo().Name,
+			Addr:  workerAgent.BaseInfo().Addr,
+			Stage: string(workerAgent.Stage()),
+			// TODO: replace Source with Sources or other new fields
 			Source: strings.Join(sources, ","),
 		})
 	}

--- a/dm/dm/master/server_test.go
+++ b/dm/dm/master/server_test.go
@@ -377,7 +377,6 @@ func (t *testMaster) testMockScheduler(ctx context.Context, wg *sync.WaitGroup, 
 		cfg := config.NewSourceConfig()
 		cfg.SourceID = sources[i]
 		cfg.From.Password = password
-		c.Assert(scheduler2.AddSourceCfg(cfg), check.IsNil, check.Commentf("all sources: %v", sources))
 		wg.Add(1)
 		ctx1, cancel1 := context.WithCancel(ctx)
 		cancels = append(cancels, cancel1)
@@ -385,6 +384,13 @@ func (t *testMaster) testMockScheduler(ctx context.Context, wg *sync.WaitGroup, 
 			defer wg.Done()
 			c.Assert(ha.KeepAlive(ctx, t.etcdTestCli, workerName, keepAliveTTL), check.IsNil)
 		}(ctx1, name)
+		// wait the mock worker has alive
+		c.Assert(utils.WaitSomething(30, 100*time.Millisecond, func() bool {
+			resp, err2 := t.etcdTestCli.Get(ctx, common2.WorkerKeepAliveKeyAdapter.Encode(name))
+			c.Assert(err2, check.IsNil)
+			return resp.Count == 1
+		}), check.IsTrue)
+		c.Assert(scheduler2.AddSourceCfg(cfg), check.IsNil, check.Commentf("all sources: %v", sources))
 		idx := i
 		c.Assert(utils.WaitSomething(30, 100*time.Millisecond, func() bool {
 			w := scheduler2.GetWorkerBySource(sources[idx])
@@ -409,7 +415,6 @@ func (t *testMaster) testMockSchedulerForRelay(ctx context.Context, wg *sync.Wai
 		cfg := config.NewSourceConfig()
 		cfg.SourceID = sources[i]
 		cfg.From.Password = password
-		c.Assert(scheduler2.AddSourceCfg(cfg), check.IsNil, check.Commentf("all sources: %v", sources))
 		wg.Add(1)
 		ctx1, cancel1 := context.WithCancel(ctx)
 		cancels = append(cancels, cancel1)
@@ -424,6 +429,7 @@ func (t *testMaster) testMockSchedulerForRelay(ctx context.Context, wg *sync.Wai
 			c.Assert(err2, check.IsNil)
 			return resp.Count == 1
 		}), check.IsTrue)
+		c.Assert(scheduler2.AddSourceCfg(cfg), check.IsNil, check.Commentf("all sources: %v", sources))
 
 		c.Assert(scheduler2.StartRelay(sources[i], []string{workers[i]}), check.IsNil)
 		idx := i
@@ -1851,10 +1857,26 @@ func (t *testMaster) TestOperateSource(c *check.C) {
 		defer wg.Done()
 		c.Assert(ha.KeepAlive(ctx, s1.etcdClient, workerName, keepAliveTTL), check.IsNil)
 	}(ctx, workerName3)
+
 	c.Assert(utils.WaitSomething(30, 100*time.Millisecond, func() bool {
 		w := s1.scheduler.GetWorkerBySource(sourceID)
 		return w != nil
 	}), check.IsTrue)
+	// Transfer source two make sources evenly started on three workers
+	c.Assert(utils.WaitSomething(30, 100*time.Millisecond, func() bool {
+		w := s1.scheduler.GetWorkerByName(workerName2)
+		return w != nil && w.Stage() != scheduler.WorkerOffline
+	}), check.IsTrue)
+	c.Assert(s1.scheduler.TransferSource(ctx, sourceID2, workerName2), check.IsNil)
+	c.Assert(utils.WaitSomething(30, 100*time.Millisecond, func() bool {
+		w := s1.scheduler.GetWorkerByName(workerName3)
+		return w != nil && w.Stage() != scheduler.WorkerOffline
+	}), check.IsTrue)
+	c.Assert(s1.scheduler.TransferSource(ctx, sourceID3, workerName3), check.IsNil)
+	for _, sourceID := range []string{sourceID, sourceID2, sourceID3} {
+		w := s1.scheduler.GetWorkerBySource(sourceID)
+		c.Assert(w, check.NotNil)
+	}
 
 	// 6. stop sources
 	req.Config = []string{task, task2, task3}

--- a/dm/dm/master/server_test.go
+++ b/dm/dm/master/server_test.go
@@ -1778,9 +1778,10 @@ func (t *testMaster) TestOperateSource(c *check.C) {
 		Msg:    "source is added but there is no free worker to bound",
 		Source: sourceID,
 	}})
-	unBoundSources := s1.scheduler.UnboundSources()
-	c.Assert(unBoundSources, check.HasLen, 1)
-	c.Assert(unBoundSources[0], check.Equals, sourceID)
+	sourceCfgs := s1.scheduler.GetSourceCfgs()
+	c.Assert(sourceCfgs, check.HasLen, 1)
+	c.Assert(sourceCfgs, check.HasKey, sourceID)
+	c.Assert(s1.scheduler.BoundSources(), check.HasLen, 0)
 
 	// 3. try to add multiple source
 	// 3.1 duplicated source id
@@ -1814,11 +1815,12 @@ func (t *testMaster) TestOperateSource(c *check.C) {
 		Msg:    "source is added but there is no free worker to bound",
 		Source: sourceID3,
 	}})
-	unBoundSources = s1.scheduler.UnboundSources()
-	c.Assert(unBoundSources, check.HasLen, 3)
-	c.Assert(unBoundSources[0], check.Equals, sourceID)
-	c.Assert(unBoundSources[1], check.Equals, sourceID2)
-	c.Assert(unBoundSources[2], check.Equals, sourceID3)
+	sourceCfgs = s1.scheduler.GetSourceCfgs()
+	c.Assert(sourceCfgs, check.HasLen, 3)
+	c.Assert(sourceCfgs, check.HasKey, sourceID)
+	c.Assert(sourceCfgs, check.HasKey, sourceID2)
+	c.Assert(sourceCfgs, check.HasKey, sourceID3)
+	c.Assert(s1.scheduler.BoundSources(), check.HasLen, 0)
 
 	// 4. try to stop a non-exist-source
 	req.Op = pb.SourceOp_StopSource

--- a/dm/dm/master/server_test.go
+++ b/dm/dm/master/server_test.go
@@ -1758,7 +1758,10 @@ func (t *testMaster) TestOperateSource(c *check.C) {
 	s1 := NewServer(cfg1)
 	s1.leader.Store(oneselfLeader)
 	c.Assert(s1.Start(ctx), check.IsNil)
-	defer s1.Close()
+	defer func() {
+		cancel()
+		s1.Close()
+	}()
 	mysqlCfg, err := config.ParseYamlAndVerify(config.SampleSourceConfig)
 	c.Assert(err, check.IsNil)
 	mysqlCfg.From.Password = os.Getenv("MYSQL_PSWD")
@@ -1775,7 +1778,7 @@ func (t *testMaster) TestOperateSource(c *check.C) {
 	c.Assert(resp.Result, check.Equals, true)
 	c.Assert(resp.Sources, check.DeepEquals, []*pb.CommonWorkerResponse{{
 		Result: true,
-		Msg:    "source is added but there is no free worker to bound",
+		Msg:    "source is added but there is no online worker to bound",
 		Source: sourceID,
 	}})
 	sourceCfgs := s1.scheduler.GetSourceCfgs()
@@ -1808,11 +1811,11 @@ func (t *testMaster) TestOperateSource(c *check.C) {
 	})
 	c.Assert(resp.Sources, check.DeepEquals, []*pb.CommonWorkerResponse{{
 		Result: true,
-		Msg:    "source is added but there is no free worker to bound",
+		Msg:    "source is added but there is no online worker to bound",
 		Source: sourceID2,
 	}, {
 		Result: true,
-		Msg:    "source is added but there is no free worker to bound",
+		Msg:    "source is added but there is no online worker to bound",
 		Source: sourceID3,
 	}})
 	sourceCfgs = s1.scheduler.GetSourceCfgs()

--- a/dm/dm/master/shardddl/optimist_test.go
+++ b/dm/dm/master/shardddl/optimist_test.go
@@ -410,6 +410,10 @@ func (t *testOptimistSuite) testOptimist(cli *clientv3.Client, restart int) {
 	checkLocks(t.T(), o, nil, "", nil)
 
 	// no shard DDL info or lock operation exists.
+	c.Assert(utils.WaitSomething(backOff, waitTime, func() bool {
+		ifm, _, err := optimism.GetAllInfo(cli)
+		return err == nil && len(ifm) == 0
+	}), IsTrue)
 	ifm, _, err := optimism.GetAllInfo(cli)
 	require.NoError(t.T(), err)
 	require.Len(t.T(), ifm, 0)

--- a/dm/dm/master/shardddl/optimist_test.go
+++ b/dm/dm/master/shardddl/optimist_test.go
@@ -410,10 +410,10 @@ func (t *testOptimistSuite) testOptimist(cli *clientv3.Client, restart int) {
 	checkLocks(t.T(), o, nil, "", nil)
 
 	// no shard DDL info or lock operation exists.
-	c.Assert(utils.WaitSomething(backOff, waitTime, func() bool {
+	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
 		ifm, _, err := optimism.GetAllInfo(cli)
 		return err == nil && len(ifm) == 0
-	}), IsTrue)
+	}))
 	ifm, _, err := optimism.GetAllInfo(cli)
 	require.NoError(t.T(), err)
 	require.Len(t.T(), ifm, 0)

--- a/dm/dm/master/shardddl/optimist_test.go
+++ b/dm/dm/master/shardddl/optimist_test.go
@@ -411,8 +411,8 @@ func (t *testOptimistSuite) testOptimist(cli *clientv3.Client, restart int) {
 
 	// no shard DDL info or lock operation exists.
 	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
-		ifm, _, err := optimism.GetAllInfo(cli)
-		return err == nil && len(ifm) == 0
+		ifm, _, err2 := optimism.GetAllInfo(cli)
+		return err2 == nil && len(ifm) == 0
 	}))
 	ifm, _, err := optimism.GetAllInfo(cli)
 	require.NoError(t.T(), err)

--- a/dm/dm/master/shardddl/optimist_test.go
+++ b/dm/dm/master/shardddl/optimist_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/pingcap/tiflow/dm/dm/pb"
 	"github.com/pingcap/tiflow/dm/pkg/log"
 	"github.com/pingcap/tiflow/dm/pkg/shardddl/optimism"
-	"github.com/pingcap/tiflow/dm/pkg/utils"
 )
 
 func TestOptimistSuite(t *testing.T) {
@@ -153,6 +152,8 @@ func checkLocksByMap(t *testing.T, o *Optimist, expectedLocks map[string]*pb.DDL
 
 func (t *testOptimistSuite) TestOptimistSourceTables() {
 	var (
+		tick       = 100 * time.Millisecond
+		waitFor    = 30 * tick
 		logger     = log.L()
 		o          = NewOptimist(&logger, getDownstreamMeta)
 		task       = "task"
@@ -185,10 +186,10 @@ func (t *testOptimistSuite) TestOptimistSourceTables() {
 	// PUT st1, should find tables.
 	_, err := optimism.PutSourceTables(t.etcdTestCli, st1)
 	require.NoError(t.T(), err)
-	require.True(t.T(), utils.WaitSomething(30, 100*time.Millisecond, func() bool {
+	require.Eventually(t.T(), func() bool {
 		tts := o.tk.FindTables(task, downSchema, downTable)
 		return len(tts) == 1
-	}))
+	}, waitFor, tick)
 	tts := o.tk.FindTables(task, downSchema, downTable)
 	require.Len(t.T(), tts, 1)
 	require.Equal(t.T(), st1.TargetTable(downSchema, downTable), tts[0])
@@ -203,10 +204,10 @@ func (t *testOptimistSuite) TestOptimistSourceTables() {
 	// PUT st2, should find more tables.
 	_, err = optimism.PutSourceTables(t.etcdTestCli, st2)
 	require.NoError(t.T(), err)
-	require.True(t.T(), utils.WaitSomething(30, 100*time.Millisecond, func() bool {
+	require.Eventually(t.T(), func() bool {
 		tts = o.tk.FindTables(task, downSchema, downTable)
 		return len(tts) == 2
-	}))
+	}, waitFor, tick)
 	tts = o.tk.FindTables(task, downSchema, downTable)
 	require.Len(t.T(), tts, 2)
 	require.Equal(t.T(), st1.TargetTable(downSchema, downTable), tts[0])
@@ -224,10 +225,10 @@ func (t *testOptimistSuite) TestOptimistSourceTables() {
 	// DELETE st1, should find less tables.
 	_, err = optimism.DeleteSourceTables(t.etcdTestCli, st1)
 	require.NoError(t.T(), err)
-	require.True(t.T(), utils.WaitSomething(30, 100*time.Millisecond, func() bool {
+	require.Eventually(t.T(), func() bool {
 		tts = o.tk.FindTables(task, downSchema, downTable)
 		return len(tts) == 1
-	}))
+	}, waitFor, tick)
 	tts = o.tk.FindTables(task, downSchema, downTable)
 	require.Len(t.T(), tts, 1)
 	require.Equal(t.T(), st2.TargetTable(downSchema, downTable), tts[0])
@@ -247,10 +248,10 @@ func (t *testOptimistSuite) testOptimist(cli *clientv3.Client, restart int) {
 	}()
 
 	var (
-		backOff  = 30
-		waitTime = 100 * time.Millisecond
-		logger   = log.L()
-		o        = NewOptimist(&logger, getDownstreamMeta)
+		tick    = 100 * time.Millisecond
+		waitFor = 30 * tick
+		logger  = log.L()
+		o       = NewOptimist(&logger, getDownstreamMeta)
 
 		rebuildOptimist = func(ctx context.Context) {
 			switch restart {
@@ -316,9 +317,9 @@ func (t *testOptimistSuite) testOptimist(cli *clientv3.Client, restart int) {
 	// PUT i11, will create a lock but not synced.
 	rev1, err := optimism.PutInfo(cli, i11)
 	require.NoError(t.T(), err)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		return len(o.Locks()) == 1
-	}))
+	}, waitFor, tick)
 	require.Contains(t.T(), o.Locks(), lockID)
 	synced, remain := o.Locks()[lockID].IsSynced()
 	require.False(t.T(), synced)
@@ -355,23 +356,23 @@ func (t *testOptimistSuite) testOptimist(cli *clientv3.Client, restart int) {
 	_, putted, err := optimism.PutOperation(cli, false, op11c, 0)
 	require.NoError(t.T(), err)
 	require.True(t.T(), putted)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		lock := o.Locks()[lockID]
 		if lock == nil {
 			return false
 		}
 		return lock.IsDone(op11.Source, op11.UpSchema, op11.UpTable)
-	}))
+	}, waitFor, tick)
 	require.False(t.T(), o.Locks()[lockID].IsDone(i12.Source, i12.UpSchema, i12.UpTable))
 	checkLocks(t.T(), o, expectedLock, "", []string{})
 
 	// PUT i12, the lock will be synced.
 	rev2, err := optimism.PutInfo(cli, i12)
 	require.NoError(t.T(), err)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		synced, _ = o.Locks()[lockID].IsSynced()
 		return synced
-	}))
+	}, waitFor, tick)
 
 	expectedLock = []*pb.DDLLock{
 		{
@@ -402,18 +403,18 @@ func (t *testOptimistSuite) testOptimist(cli *clientv3.Client, restart int) {
 	_, putted, err = optimism.PutOperation(cli, false, op12c, 0)
 	require.NoError(t.T(), err)
 	require.True(t.T(), putted)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		_, ok := o.Locks()[lockID]
 		return !ok
-	}))
+	}, waitFor, tick)
 	require.Len(t.T(), o.Locks(), 0)
 	checkLocks(t.T(), o, nil, "", nil)
 
 	// no shard DDL info or lock operation exists.
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		ifm, _, err2 := optimism.GetAllInfo(cli)
 		return err2 == nil && len(ifm) == 0
-	}))
+	}, waitFor, tick)
 	ifm, _, err := optimism.GetAllInfo(cli)
 	require.NoError(t.T(), err)
 	require.Len(t.T(), ifm, 0)
@@ -424,9 +425,9 @@ func (t *testOptimistSuite) testOptimist(cli *clientv3.Client, restart int) {
 	// put another table info.
 	rev1, err = optimism.PutInfo(cli, i21)
 	require.NoError(t.T(), err)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		return len(o.Locks()) == 1
-	}))
+	}, waitFor, tick)
 	require.Contains(t.T(), o.Locks(), lockID)
 	synced, remain = o.Locks()[lockID].IsSynced()
 	require.False(t.T(), synced)
@@ -454,7 +455,7 @@ func (t *testOptimistSuite) testOptimist(cli *clientv3.Client, restart int) {
 	require.Eventually(t.T(), func() bool {
 		ready := o.Locks()[lockID].Ready()
 		return !ready[source2][i23.UpSchema][i23.UpTable]
-	}, time.Duration(backOff)*waitTime, waitTime)
+	}, waitFor, tick)
 	synced, remain = o.Locks()[lockID].IsSynced()
 	require.False(t.T(), synced)
 	require.Equal(t.T(), remain, 2)
@@ -516,7 +517,7 @@ func (t *testOptimistSuite) testOptimist(cli *clientv3.Client, restart int) {
 	require.Eventually(t.T(), func() bool {
 		synced, _ = o.Locks()[lockID].IsSynced()
 		return synced
-	}, time.Duration(backOff)*waitTime, waitTime)
+	}, waitFor, tick)
 	tts = o.tk.FindTables(task, downSchema, downTable)
 	require.Len(t.T(), tts, 2)
 	require.Equal(t.T(), source1, tts[0].Source)
@@ -545,9 +546,9 @@ func (t *testOptimistSuite) testOptimist(cli *clientv3.Client, restart int) {
 	_, putted, err = optimism.PutOperation(cli, false, op21c, 0)
 	require.NoError(t.T(), err)
 	require.True(t.T(), putted)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		return o.Locks()[lockID].IsDone(i21.Source, i21.UpSchema, i21.UpTable)
-	}))
+	}, waitFor, tick)
 
 	// CASE 5: start again with some previous shard DDL info and `done` operation.
 	rebuildOptimist(ctx)
@@ -565,18 +566,18 @@ func (t *testOptimistSuite) testOptimist(cli *clientv3.Client, restart int) {
 	_, putted, err = optimism.PutOperation(cli, false, op23c, 0)
 	require.NoError(t.T(), err)
 	require.True(t.T(), putted)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		_, ok := o.Locks()[lockID]
 		return !ok
-	}))
+	}, waitFor, tick)
 	require.Len(t.T(), o.Locks(), 0)
 
 	// PUT i31, will create a lock but not synced (to test `DROP COLUMN`)
 	rev1, err = optimism.PutInfo(cli, i31)
 	require.NoError(t.T(), err)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		return len(o.Locks()) == 1
-	}))
+	}, waitFor, tick)
 	require.Contains(t.T(), o.Locks(), lockID)
 	synced, remain = o.Locks()[lockID].IsSynced()
 	require.False(t.T(), synced)
@@ -612,18 +613,18 @@ func (t *testOptimistSuite) testOptimist(cli *clientv3.Client, restart int) {
 	_, putted, err = optimism.PutOperation(cli, false, op31c, 0)
 	require.NoError(t.T(), err)
 	require.True(t.T(), putted)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		return o.Locks()[lockID].IsDone(op31c.Source, op31c.UpSchema, op31c.UpTable)
-	}))
+	}, waitFor, tick)
 	checkLocks(t.T(), o, expectedLock, "", []string{})
 
 	// PUT i33, the lock will be synced.
 	rev3, err = optimism.PutInfo(cli, i33)
 	require.NoError(t.T(), err)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		synced, _ = o.Locks()[lockID].IsSynced()
 		return synced
-	}))
+	}, waitFor, tick)
 
 	expectedLock = []*pb.DDLLock{
 		{
@@ -654,10 +655,10 @@ func (t *testOptimistSuite) testOptimist(cli *clientv3.Client, restart int) {
 	_, putted, err = optimism.PutOperation(cli, false, op33c, 0)
 	require.NoError(t.T(), err)
 	require.True(t.T(), putted)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		_, ok := o.Locks()[lockID]
 		return !ok
-	}))
+	}, waitFor, tick)
 	require.Len(t.T(), o.Locks(), 0)
 	checkLocks(t.T(), o, nil, "", nil)
 
@@ -777,8 +778,8 @@ func (t *testOptimistSuite) TestOptimistLockConflict() {
 
 func (t *testOptimistSuite) TestOptimistLockMultipleTarget() {
 	var (
-		backOff            = 30
-		waitTime           = 100 * time.Millisecond
+		tick               = 100 * time.Millisecond
+		waitFor            = 30 * tick
 		watchTimeout       = 5 * time.Second
 		logger             = log.L()
 		o                  = NewOptimist(&logger, getDownstreamMeta)
@@ -827,9 +828,9 @@ func (t *testOptimistSuite) TestOptimistLockMultipleTarget() {
 	require.NoError(t.T(), err)
 	_, err = optimism.PutInfo(t.etcdTestCli, i21)
 	require.NoError(t.T(), err)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		return len(o.Locks()) == 2
-	}))
+	}, waitFor, tick)
 	require.Contains(t.T(), o.Locks(), lockID1)
 	require.Contains(t.T(), o.Locks(), lockID2)
 
@@ -869,11 +870,11 @@ func (t *testOptimistSuite) TestOptimistLockMultipleTarget() {
 	require.NoError(t.T(), err)
 	rev2, err := optimism.PutInfo(t.etcdTestCli, i22)
 	require.NoError(t.T(), err)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		synced1, _ := o.Locks()[lockID1].IsSynced()
 		synced2, _ := o.Locks()[lockID2].IsSynced()
 		return synced1 && synced2
-	}))
+	}, waitFor, tick)
 
 	expectedLock[lockID1].Synced = []string{
 		fmt.Sprintf("%s-%s", i11.Source, dbutil.TableName(i11.UpSchema, i11.UpTable)),
@@ -918,10 +919,10 @@ func (t *testOptimistSuite) TestOptimistLockMultipleTarget() {
 	_, putted, err = optimism.PutOperation(t.etcdTestCli, false, op12c, 0)
 	require.NoError(t.T(), err)
 	require.True(t.T(), putted)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		_, ok := o.Locks()[lockID1]
 		return !ok
-	}))
+	}, waitFor, tick)
 	require.Len(t.T(), o.Locks(), 1)
 	checkLocksByMap(t.T(), o, expectedLock, nil, lockID2)
 
@@ -956,18 +957,18 @@ func (t *testOptimistSuite) TestOptimistLockMultipleTarget() {
 	_, putted, err = optimism.PutOperation(t.etcdTestCli, false, op22c, 0)
 	require.NoError(t.T(), err)
 	require.True(t.T(), putted)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		_, ok := o.Locks()[lockID2]
 		return !ok
-	}))
+	}, waitFor, tick)
 	require.Len(t.T(), o.Locks(), 0)
 	checkLocksByMap(t.T(), o, expectedLock, nil)
 }
 
 func (t *testOptimistSuite) TestOptimistInitSchema() {
 	var (
-		backOff      = 30
-		waitTime     = 100 * time.Millisecond
+		tick         = 100 * time.Millisecond
+		waitFor      = 30 * tick
 		watchTimeout = 5 * time.Second
 		logger       = log.L()
 		o            = NewOptimist(&logger, getDownstreamMeta)
@@ -1011,10 +1012,10 @@ func (t *testOptimistSuite) TestOptimistInitSchema() {
 	// PUT i11, will creat a lock.
 	_, err = optimism.PutInfo(t.etcdTestCli, i11)
 	require.NoError(t.T(), err)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		return len(o.Locks()) == 1
-	}))
-	time.Sleep(waitTime) // sleep one more time to wait for update of init schema.
+	}, waitFor, tick)
+	time.Sleep(tick) // sleep one more time to wait for update of init schema.
 
 	// PUT i12, the lock will be synced.
 	rev1, err := optimism.PutInfo(t.etcdTestCli, i12)
@@ -1051,17 +1052,17 @@ func (t *testOptimistSuite) TestOptimistInitSchema() {
 	_, putted, err = optimism.PutOperation(t.etcdTestCli, false, op12c, 0)
 	require.NoError(t.T(), err)
 	require.True(t.T(), putted)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		return len(o.Locks()) == 0
-	}))
+	}, waitFor, tick)
 
 	// PUT i21 to create the lock again.
 	_, err = optimism.PutInfo(t.etcdTestCli, i21)
 	require.NoError(t.T(), err)
-	require.True(t.T(), utils.WaitSomething(backOff, waitTime, func() bool {
+	require.Eventually(t.T(), func() bool {
 		return len(o.Locks()) == 1
-	}))
-	time.Sleep(waitTime) // sleep one more time to wait for update of init schema.
+	}, waitFor, tick)
+	time.Sleep(tick) // sleep one more time to wait for update of init schema.
 }
 
 func (t *testOptimistSuite) testSortInfos(cli *clientv3.Client) {

--- a/dm/dm/worker/server_test.go
+++ b/dm/dm/worker/server_test.go
@@ -361,7 +361,7 @@ func (t *testServer) TestHandleSourceBoundAfterError(c *C) {
 		return s.getSourceWorker(true) != nil
 	}), IsTrue)
 
-	_, err = ha.DeleteSourceBound(etcdCli, s.cfg.Name)
+	_, err = ha.DeleteSourceBoundByWorker(etcdCli, s.cfg.Name)
 	c.Assert(err, IsNil)
 	c.Assert(utils.WaitSomething(30, 100*time.Millisecond, func() bool {
 		return s.getSourceWorker(true) == nil
@@ -406,7 +406,7 @@ func (t *testServer) TestWatchSourceBoundEtcdCompact(c *C) {
 	sourceBound := ha.NewSourceBound(sourceCfg.SourceID, cfg.Name)
 	_, err = ha.PutSourceBound(etcdCli, sourceBound)
 	c.Assert(err, IsNil)
-	rev, err := ha.DeleteSourceBound(etcdCli, cfg.Name)
+	rev, err := ha.DeleteSourceBoundByWorker(etcdCli, cfg.Name)
 	c.Assert(err, IsNil)
 	// step 2: start source at this worker
 	w, err := s.getOrStartWorker(sourceCfg, true)
@@ -510,7 +510,7 @@ func (t *testServer) testOperateWorker(c *C, s *Server, dir string, start bool) 
 		w := s.getSourceWorker(true)
 		c.Assert(w, NotNil)
 		c.Assert(w.closed.Load(), IsFalse)
-		_, err := ha.DeleteRelayConfig(s.etcdClient, w.name)
+		_, err := ha.DeleteRelayConfig(s.etcdClient, sourceCfg.SourceID, w.name)
 		c.Assert(err, IsNil)
 		_, err = ha.DeleteSourceCfgRelayStageSourceBound(s.etcdClient, sourceCfg.SourceID, s.cfg.Name)
 		c.Assert(err, IsNil)

--- a/dm/errors.toml
+++ b/dm/errors.toml
@@ -3293,7 +3293,7 @@ workaround = "Please pause task by `dmctl pause-task`."
 tags = ["internal", "low"]
 
 [error.DM-scheduler-46033]
-message = "dm-worker with name %s not free"
+message = "dm-worker with name %s not online"
 description = ""
 workaround = ""
 tags = ["internal", "low"]

--- a/dm/pkg/ha/bound.go
+++ b/dm/pkg/ha/bound.go
@@ -101,11 +101,21 @@ func PutSourceBound(cli *clientv3.Client, bounds ...SourceBound) (int64, error) 
 	return rev, err
 }
 
-// DeleteSourceBound deletes the bound relationship in etcd for the specified worker.
-func DeleteSourceBound(cli *clientv3.Client, workers ...string) (int64, error) {
+// DeleteSourceBoundByWorker deletes the bound relationship in etcd for the specified worker.
+func DeleteSourceBoundByWorker(cli *clientv3.Client, workers ...string) (int64, error) {
 	ops := make([]clientv3.Op, 0, len(workers))
 	for _, worker := range workers {
-		ops = append(ops, deleteSourceBoundOp(worker)...)
+		ops = append(ops, deleteSourceBoundByWorkerOp(worker)...)
+	}
+	_, rev, err := etcdutil.DoOpsInOneTxnWithRetry(cli, ops...)
+	return rev, err
+}
+
+// DeleteSourceBoundByBound deletes the bound relationship in etcd for the specified bound.
+func DeleteSourceBoundByBound(cli *clientv3.Client, bounds ...SourceBound) (int64, error) {
+	ops := make([]clientv3.Op, 0, len(bounds))
+	for _, bound := range bounds {
+		ops = append(ops, deleteSourceBoundByBoundOp(bound)...)
 	}
 	_, rev, err := etcdutil.DoOpsInOneTxnWithRetry(cli, ops...)
 	return rev, err
@@ -114,7 +124,7 @@ func DeleteSourceBound(cli *clientv3.Client, workers ...string) (int64, error) {
 // ReplaceSourceBound deletes an old bound and puts a new bound in one transaction, so a bound source will not become
 // unbound because of failing halfway.
 func ReplaceSourceBound(cli *clientv3.Client, source, oldWorker, newWorker string) (int64, error) {
-	deleteOps := deleteSourceBoundOp(oldWorker)
+	deleteOps := deleteSourceBoundByBoundOp(NewSourceBound(source, oldWorker))
 	putOps, err := putSourceBoundOp(NewSourceBound(source, newWorker))
 	if err != nil {
 		return 0, err
@@ -374,16 +384,23 @@ func lastSourceBoundFromResp(resp *clientv3.GetResponse) (map[string]SourceBound
 	return sbm, nil
 }
 
-// deleteSourceBoundOp returns a DELETE etcd operation for the bound relationship of the specified DM-worker.
-func deleteSourceBoundOp(worker string) []clientv3.Op {
+// deleteSourceBoundByWorkerOp returns a DELETE etcd operation for the bound relationship of the specified DM-worker.
+func deleteSourceBoundByWorkerOp(worker string) []clientv3.Op {
 	return []clientv3.Op{
 		clientv3.OpDelete(common.UpstreamBoundWorkerKeyAdapter.Encode(worker), clientv3.WithPrefix()),
 	}
 }
 
-// deleteLastSourceBoundOp returns a DELETE etcd operation for the last bound relationship of the specified DM-worker.
-func deleteLastSourceBoundOp(worker string) clientv3.Op {
-	return clientv3.OpDelete(common.UpstreamLastBoundWorkerKeyAdapter.Encode(worker), clientv3.WithPrefix())
+// deleteSourceBoundByBoundOp returns a DELETE etcd operation for the bound relationship of the specified DM-worker.
+func deleteSourceBoundByBoundOp(bound SourceBound) []clientv3.Op {
+	return []clientv3.Op{
+		clientv3.OpDelete(common.UpstreamBoundWorkerKeyAdapter.Encode(bound.Worker, bound.Source)),
+	}
+}
+
+// deleteLastSourceBoundOp returns a DELETE etcd operation for the last bound relationship of the specified source.
+func deleteLastSourceBoundOp(source string) clientv3.Op {
+	return clientv3.OpDelete(common.UpstreamLastBoundWorkerKeyAdapter.Encode(source))
 }
 
 // putSourceBoundOp returns PUT etcd operations for the bound relationship.
@@ -395,7 +412,7 @@ func putSourceBoundOp(bound SourceBound) ([]clientv3.Op, error) {
 	}
 	key1 := common.UpstreamBoundWorkerKeyAdapter.Encode(bound.Worker, bound.Source)
 	op1 := clientv3.OpPut(key1, value)
-	key2 := common.UpstreamLastBoundWorkerKeyAdapter.Encode(bound.Worker, bound.Source)
+	key2 := common.UpstreamLastBoundWorkerKeyAdapter.Encode(bound.Source)
 	op2 := clientv3.OpPut(key2, value)
 
 	return []clientv3.Op{op1, op2}, nil

--- a/dm/pkg/ha/bound_test.go
+++ b/dm/pkg/ha/bound_test.go
@@ -102,12 +102,12 @@ func (t *testForEtcd) TestSourceBoundEtcd(c *C) {
 	c.Assert(sbm2[worker2][bound2.Source], DeepEquals, bound2)
 
 	// delete bound1.
-	rev5, err := DeleteSourceBound(etcdTestCli, worker1)
+	rev5, err := DeleteSourceBoundByWorker(etcdTestCli, worker1)
 	c.Assert(err, IsNil)
 	c.Assert(rev5, Greater, rev4)
 
 	// delete bound2.
-	rev6, err := DeleteSourceBound(etcdTestCli, worker2)
+	rev6, err := DeleteSourceBoundByWorker(etcdTestCli, worker2)
 	c.Assert(err, IsNil)
 	c.Assert(rev6, Greater, rev5)
 

--- a/dm/pkg/ha/doc.go
+++ b/dm/pkg/ha/doc.go
@@ -87,7 +87,7 @@ package ha
 // 2. DM-master GET the information of the DM-worker instance, and mark it as `free` status.
 // 3. the user adds an upstream config.
 //   - PUT the config of the upstream into etcd.
-// 4. DM-master schedules the upstream relevant operations to the free DM-worker.
+// 4. DM-master schedules the upstream relevant operations to the online DM-worker.
 //   - PUT the bound relationship.
 //   - PUT the expectant stage of the relay if not exists.
 // 5. DM-worker GET the bound relationship, the config of the upstream and the expectant stage of the relay.

--- a/dm/pkg/ha/ops.go
+++ b/dm/pkg/ha/ops.go
@@ -53,7 +53,7 @@ func PutRelayStageRelayConfigSourceBound(cli *clientv3.Client, stage Stage, boun
 	if err != nil {
 		return 0, err
 	}
-	op3 := putRelayConfigOp(bound.Worker, bound.Source)
+	op3 := putRelayConfigOp(bound)
 	ops := make([]clientv3.Op, 0, len(ops1)+len(op2)+1)
 	ops = append(ops, ops1...)
 	ops = append(ops, op2...)
@@ -69,8 +69,8 @@ func PutRelayStageRelayConfigSourceBound(cli *clientv3.Client, stage Stage, boun
 func DeleteSourceCfgRelayStageSourceBound(cli *clientv3.Client, source, worker string) (int64, error) {
 	sourceCfgOp := deleteSourceCfgOp(source)
 	relayStageOp := deleteRelayStageOp(source)
-	sourceBoundOp := deleteSourceBoundOp(worker)
-	lastBoundOp := deleteLastSourceBoundOp(worker)
+	sourceBoundOp := deleteSourceBoundByBoundOp(NewSourceBound(source, worker))
+	lastBoundOp := deleteLastSourceBoundOp(source)
 	ops := make([]clientv3.Op, 0, 3+len(sourceBoundOp))
 	ops = append(ops, sourceCfgOp)
 	ops = append(ops, relayStageOp)

--- a/dm/pkg/ha/relay.go
+++ b/dm/pkg/ha/relay.go
@@ -41,20 +41,20 @@ type RelaySource struct {
 // PutRelayConfig puts the relay config for given workers.
 // k/v: worker-name -> source-id.
 // TODO: let caller wait until worker has enabled relay.
-func PutRelayConfig(cli *clientv3.Client, source string, workers ...string) (int64, error) {
-	ops := make([]clientv3.Op, 0, len(workers))
-	for _, worker := range workers {
-		ops = append(ops, putRelayConfigOp(worker, source))
+func PutRelayConfig(cli *clientv3.Client, bounds ...SourceBound) (int64, error) {
+	ops := make([]clientv3.Op, 0, len(bounds))
+	for _, bound := range bounds {
+		ops = append(ops, putRelayConfigOp(bound))
 	}
 	_, rev, err := etcdutil.DoOpsInOneTxnWithRetry(cli, ops...)
 	return rev, err
 }
 
 // DeleteRelayConfig deletes the relay config for given workers.
-func DeleteRelayConfig(cli *clientv3.Client, workers ...string) (int64, error) {
+func DeleteRelayConfig(cli *clientv3.Client, source string, workers ...string) (int64, error) {
 	ops := make([]clientv3.Op, 0, len(workers))
 	for _, worker := range workers {
-		ops = append(ops, deleteRelayConfigOp(worker))
+		ops = append(ops, deleteRelayConfigOp(NewSourceBound(source, worker)))
 	}
 	_, rev, err := etcdutil.DoOpsInOneTxnWithRetry(cli, ops...)
 	return rev, err
@@ -189,14 +189,14 @@ func GetRelayConfig(cli *clientv3.Client, worker string) (*config.SourceConfig, 
 }
 
 // putRelayConfigOp returns PUT etcd operations for the relay relationship of the specified DM-worker.
-// k/v: worker-name -> source-id.
-func putRelayConfigOp(worker, source string) clientv3.Op {
-	return clientv3.OpPut(common.UpstreamRelayWorkerKeyAdapter.Encode(worker, source), source)
+// k/v: (worker-name, source-id) -> source-id.
+func putRelayConfigOp(bound SourceBound) clientv3.Op {
+	return clientv3.OpPut(common.UpstreamRelayWorkerKeyAdapter.Encode(bound.Worker, bound.Source), bound.Source)
 }
 
 // deleteRelayConfigOp returns a DELETE etcd operation for the relay relationship of the specified DM-worker.
-func deleteRelayConfigOp(worker string) clientv3.Op {
-	return clientv3.OpDelete(common.UpstreamRelayWorkerKeyAdapter.Encode(worker), clientv3.WithPrefix())
+func deleteRelayConfigOp(bound SourceBound) clientv3.Op {
+	return clientv3.OpDelete(common.UpstreamRelayWorkerKeyAdapter.Encode(bound.Worker, bound.Source))
 }
 
 // WatchRelayConfig watches PUT & DELETE operations for the relay relationship of the specified DM-worker.

--- a/dm/pkg/ha/relay_test.go
+++ b/dm/pkg/ha/relay_test.go
@@ -35,7 +35,7 @@ func (t *testForEtcd) TestGetRelayConfigEtcd(c *C) {
 	c.Assert(rev1, Greater, int64(0))
 	c.Assert(cfg1, IsNil)
 
-	rev2, err := PutRelayConfig(etcdTestCli, source, worker)
+	rev2, err := PutRelayConfig(etcdTestCli, NewSourceBound(source, worker))
 	c.Assert(err, IsNil)
 	c.Assert(rev2, Greater, rev1)
 
@@ -52,7 +52,7 @@ func (t *testForEtcd) TestGetRelayConfigEtcd(c *C) {
 	c.Assert(rev4, Equals, rev3)
 	c.Assert(cfg2, DeepEquals, cfg)
 
-	rev5, err := DeleteRelayConfig(etcdTestCli, worker)
+	rev5, err := DeleteRelayConfig(etcdTestCli, source, worker)
 	c.Assert(err, IsNil)
 	c.Assert(rev5, Greater, rev4)
 

--- a/dm/pkg/terror/error_list.go
+++ b/dm/pkg/terror/error_list.go
@@ -666,7 +666,7 @@ const (
 	codeSchedulerStartRelayOnBound
 	codeSchedulerStopRelayOnBound
 	codeSchedulerPauseTaskForTransferSource
-	codeSchedulerWorkerNotFree
+	codeSchedulerWorkerOffline
 	codeSchedulerSubTaskNotExist
 	codeSchedulerSubTaskCfgUpdate
 )
@@ -1335,7 +1335,7 @@ var (
 	ErrSchedulerStartRelayOnBound            = New(codeSchedulerStartRelayOnBound, ClassScheduler, ScopeInternal, LevelLow, "the source has `start-relay` automatically for bound worker, so it can't `start-relay` with worker name now", "Please stop relay by `stop-relay` without worker name first.")
 	ErrSchedulerStopRelayOnBound             = New(codeSchedulerStopRelayOnBound, ClassScheduler, ScopeInternal, LevelLow, "the source has `start-relay` automatically for bound worker, so it can't `stop-relay` with worker name now", "Please use `stop-relay` without worker name.")
 	ErrSchedulerPauseTaskForTransferSource   = New(codeSchedulerPauseTaskForTransferSource, ClassScheduler, ScopeInternal, LevelLow, "failed to auto pause tasks %s when transfer-source", "Please pause task by `dmctl pause-task`.")
-	ErrSchedulerWorkerNotFree                = New(codeSchedulerWorkerNotFree, ClassScheduler, ScopeInternal, LevelLow, "dm-worker with name %s not free", "")
+	ErrSchedulerWorkerOffline                = New(codeSchedulerWorkerOffline, ClassScheduler, ScopeInternal, LevelLow, "dm-worker with name %s not online", "")
 
 	// dmctl.
 	ErrCtlGRPCCreateConn = New(codeCtlGRPCCreateConn, ClassDMCtl, ScopeInternal, LevelHigh, "can not create grpc connection", "Please check your network connection.")

--- a/dm/tests/dmctl_basic/run.sh
+++ b/dm/tests/dmctl_basic/run.sh
@@ -230,7 +230,7 @@ function run() {
 	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"operate-source show" \
 		"\"result\": true" 3 \
-		'msg": "source is added but there is no free worker to bound"' 1 \
+		'msg": "source is added but there is no online worker to bound"' 1 \
 		'"worker": "worker1"' 1
 
 	run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $dm_worker2_conf

--- a/dm/tests/ha_cases/run.sh
+++ b/dm/tests/ha_cases/run.sh
@@ -302,7 +302,7 @@ function test_exclusive_relay() {
 
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"operate-source show -s $SOURCE_ID2" \
-		"\"msg\": \"source is added but there is no free worker to bound\"" 1
+		"\"msg\": \"source is added but there is no online worker to bound\"" 1
 
 	cleanup
 	echo "[$(date)] <<<<<< finish test_exclusive_relay >>>>>>"
@@ -363,7 +363,7 @@ function test_exclusive_relay_2() {
 
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"operate-source show -s $SOURCE_ID2" \
-		"\"msg\": \"source is added but there is no free worker to bound\"" 1
+		"\"msg\": \"source is added but there is no online worker to bound\"" 1
 
 	# worker2 online, bound to source2
 	run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/4842

### What is changed and how it works?
1. Support bind multi-sources for one worker
2. Support starting several relay sources on one worker.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
support scheduler bound multi-sources for dm-workers
```
