### PR TITLE
sink(ticdc): remove tableCheckpointTsMap from sink manager

### DIFF
--- a/cdc/sink/table_sink.go
+++ b/cdc/sink/table_sink.go
@@ -75,7 +75,7 @@ func (t *tableSink) FlushRowChangedEvents(ctx context.Context, tableID model.Tab
 
 	err := t.manager.bufSink.EmitRowChangedEvents(ctx, resolvedRows...)
 	if err != nil {
-		return t.manager.getCheckpointTs(tableID), errors.Trace(err)
+		return 0, errors.Trace(err)
 	}
 	return t.flushResolvedTs(ctx, resolvedTs)
 }
@@ -83,7 +83,7 @@ func (t *tableSink) FlushRowChangedEvents(ctx context.Context, tableID model.Tab
 func (t *tableSink) flushResolvedTs(ctx context.Context, resolvedTs uint64) (uint64, error) {
 	redoTs, err := t.flushRedoLogs(ctx, resolvedTs)
 	if err != nil {
-		return t.manager.getCheckpointTs(t.tableID), err
+		return 0, errors.Trace(err)
 	}
 	if redoTs < resolvedTs {
 		resolvedTs = redoTs


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5097

### What is changed and how it works?
 if flush failed, the returned checkpoint is not used by caller, so remove tableCheckpointTsMap from sink manager, it's useless.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported variable/fields change

Side effects

None

Related changes

None

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
