### PR TITLE
sink/mq(ticdc): make the topic manager use the correct number of partitions

### DIFF
--- a/cdc/sink/manager/kafka/manager.go
+++ b/cdc/sink/manager/kafka/manager.go
@@ -112,7 +112,8 @@ func (m *TopicManager) tryUpdatePartitionsAndLogging(topic string, partitions in
 	}
 }
 
-// CreateTopic creates a topic with the given name.
+// CreateTopic creates a topic with the given name
+// and returns the number of partitions.
 func (m *TopicManager) CreateTopic(topicName string) (int32, error) {
 	start := time.Now()
 	topics, err := m.admin.ListTopics()
@@ -138,7 +139,10 @@ func (m *TopicManager) CreateTopic(topicName string) (int32, error) {
 
 	// Maybe our cache has expired information, so we just return it.
 	if t, ok := topics[topicName]; ok {
-		log.Info("topic already exists and the cached information has expired", zap.String("topic", topicName))
+		log.Info(
+			"topic already exists and the cached information has expired",
+			zap.String("topic", topicName),
+		)
 		return t.NumPartitions, nil
 	}
 

--- a/cdc/sink/manager/kafka/manager.go
+++ b/cdc/sink/manager/kafka/manager.go
@@ -65,7 +65,7 @@ func (m *TopicManager) Partitions(topic string) (int32, error) {
 		return partitions.(int32), nil
 	}
 
-	return m.cfg.PartitionNum, m.CreateTopic(topic)
+	return m.CreateTopic(topic)
 }
 
 // tryRefreshMeta try to refresh the topics' information maintained by manager.
@@ -97,7 +97,7 @@ func (m *TopicManager) tryUpdatePartitionsAndLogging(topic string, partitions in
 			m.topics.Store(topic, partitions)
 			log.Info(
 				"update topic partition number",
-				zap.String("duration", topic),
+				zap.String("topic", topic),
 				zap.Int32("oldPartitionNumber", oldPartitions.(int32)),
 				zap.Int32("newPartitionNumber", partitions),
 			)
@@ -106,27 +106,27 @@ func (m *TopicManager) tryUpdatePartitionsAndLogging(topic string, partitions in
 		m.topics.Store(topic, partitions)
 		log.Info(
 			"store topic partition number",
-			zap.String("duration", topic),
+			zap.String("topic", topic),
 			zap.Int32("partitionNumber", partitions),
 		)
 	}
 }
 
 // CreateTopic creates a topic with the given name.
-func (m *TopicManager) CreateTopic(topicName string) error {
+func (m *TopicManager) CreateTopic(topicName string) (int32, error) {
 	start := time.Now()
 	topics, err := m.admin.ListTopics()
 	if err != nil {
 		log.Error(
 			"Kafka admin client list topics failed",
 			zap.Error(err),
-			zap.Duration("cost", time.Since(start)),
+			zap.Duration("duration", time.Since(start)),
 		)
-		return errors.Trace(err)
+		return 0, errors.Trace(err)
 	}
 	log.Info(
 		"Kafka admin client list topics success",
-		zap.Duration("cost", time.Since(start)),
+		zap.Duration("duration", time.Since(start)),
 	)
 
 	// Now that we have access to the latest topics' information,
@@ -137,12 +137,13 @@ func (m *TopicManager) CreateTopic(topicName string) error {
 	m.lastMetadataRefresh.Store(time.Now().Unix())
 
 	// Maybe our cache has expired information, so we just return it.
-	if _, ok := topics[topicName]; ok {
-		return nil
+	if t, ok := topics[topicName]; ok {
+		log.Info("topic already exists and the cached information has expired", zap.String("topic", topicName))
+		return t.NumPartitions, nil
 	}
 
 	if !m.cfg.AutoCreate {
-		return cerror.ErrKafkaInvalidConfig.GenWithStack(
+		return 0, cerror.ErrKafkaInvalidConfig.GenWithStack(
 			fmt.Sprintf("`auto-create-topic` is false, "+
 				"and %s not found", topicName))
 	}
@@ -162,7 +163,7 @@ func (m *TopicManager) CreateTopic(topicName string) error {
 			zap.Error(err),
 			zap.Duration("duration", time.Since(start)),
 		)
-		return cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
+		return 0, cerror.WrapError(cerror.ErrKafkaNewSaramaProducer, err)
 	}
 	log.Info(
 		"Kafka admin client create the topic success",
@@ -173,5 +174,5 @@ func (m *TopicManager) CreateTopic(topicName string) error {
 	)
 	m.tryUpdatePartitionsAndLogging(topicName, m.cfg.PartitionNum)
 
-	return nil
+	return m.cfg.PartitionNum, nil
 }

--- a/cdc/sink/manager/kafka/manager_test.go
+++ b/cdc/sink/manager/kafka/manager_test.go
@@ -91,11 +91,13 @@ func TestCreateTopic(t *testing.T) {
 	}
 
 	manager := NewTopicManager(client, adminClient, cfg)
-	err := manager.CreateTopic(kafkamock.DefaultMockTopicName)
+	partitionNum, err := manager.CreateTopic(kafkamock.DefaultMockTopicName)
 	require.Nil(t, err)
+	require.Equal(t, int32(3), partitionNum)
 
-	err = manager.CreateTopic("new-topic")
+	partitionNum, err = manager.CreateTopic("new-topic")
 	require.Nil(t, err)
+	require.Equal(t, int32(2), partitionNum)
 	partitionsNum, err := manager.Partitions("new-topic")
 	require.Nil(t, err)
 	require.Equal(t, int32(2), partitionsNum)
@@ -103,7 +105,7 @@ func TestCreateTopic(t *testing.T) {
 	// Try to create a topic without auto create.
 	cfg.AutoCreate = false
 	manager = NewTopicManager(client, adminClient, cfg)
-	err = manager.CreateTopic("new-topic2")
+	_, err = manager.CreateTopic("new-topic2")
 	require.Regexp(
 		t,
 		"`auto-create-topic` is false, and new-topic2 not found",

--- a/cdc/sink/manager/manager.go
+++ b/cdc/sink/manager/manager.go
@@ -20,5 +20,5 @@ type TopicManager interface {
 	// Partitions returns the partitions of the topic.
 	Partitions(topic string) (int32, error)
 	// CreateTopic creates the topic.
-	CreateTopic(topicName string) error
+	CreateTopic(topicName string) (int32, error)
 }

--- a/cdc/sink/manager/pulsar/manager.go
+++ b/cdc/sink/manager/pulsar/manager.go
@@ -35,6 +35,6 @@ func (m *TopicManager) Partitions(_ string) (int32, error) {
 }
 
 // CreateTopic do nothing.
-func (m *TopicManager) CreateTopic(_ string) error {
-	return nil
+func (m *TopicManager) CreateTopic(_ string) (int32, error) {
+	return m.partitionNum, nil
 }

--- a/cdc/sink/mq.go
+++ b/cdc/sink/mq.go
@@ -302,7 +302,7 @@ func (k *mqSink) EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error {
 	}
 	// Notice: We must call Partitions here,
 	// which will be responsible for automatically creating topics when they don't exist.
-	// If it is not called here and kafka has auto-creation of topic turned on,
+	// If it is not called here and kafka has `auto.create.topics.enable` turned on,
 	// then the auto-created topic will not be created as configured by ticdc.
 	_, err = k.topicManager.Partitions(topic)
 	if err != nil {

--- a/tests/integration_tests/multi_topics/run.sh
+++ b/tests/integration_tests/multi_topics/run.sh
@@ -9,8 +9,7 @@ CDC_BINARY=cdc.test
 SINK_TYPE=$1
 
 function run() {
-	# FIXME(hi-rustin): Now the kafka test is not very stable, so skip it for now.
-	if [[ "$SINK_TYPE" == "mysql" || "$SINK_TYPE" == "kafka" ]]; then
+	if [ "$SINK_TYPE" == "mysql" ]; then
 		return
 	fi
 
@@ -31,7 +30,7 @@ function run() {
 
 	run_sql_file $CUR/data/data.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	# NOTICE: we need to wait for the kafka topic to be created.
-	sleep 1m
+	sleep 2m
 
 	for i in $(seq 1 3); do
 		run_kafka_consumer $WORK_DIR "kafka://127.0.0.1:9092/test_test${i}?protocol=canal-json&version=${KAFKA_VERSION}&enable-tidb-extension=true" "" ${i}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/5076

### What is changed and how it works?

make the topic manager use the correct number of partitions.

It uses the wrong number of partitions when kafka turns on auto-create configuration.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change

Side effects

None

Related changes

None

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
