### PR TITLE
test(dm): fix unstable TestFailToStartLeader

### DIFF
--- a/dm/dm/master/election_test.go
+++ b/dm/dm/master/election_test.go
@@ -17,21 +17,20 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"testing"
 	"time"
 
-	"github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tiflow/dm/pkg/log"
+	"github.com/stretchr/testify/require"
 	"github.com/tikv/pd/pkg/tempurl"
 
 	"github.com/pingcap/tiflow/dm/pkg/etcdutil"
-	"github.com/pingcap/tiflow/dm/pkg/utils"
 )
 
-var _ = check.Suite(&testElectionSuite{})
-
-type testElectionSuite struct{}
-
-func (t *testElectionSuite) TestFailToStartLeader(c *check.C) {
+func TestFailToStartLeader(t *testing.T) {
+	err := log.InitLogger(&log.Config{Level: "info"})
+	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	var s1, s2 *Server
@@ -47,9 +46,9 @@ func (t *testElectionSuite) TestFailToStartLeader(c *check.C) {
 
 	// create a new cluster
 	cfg1 := NewConfig()
-	c.Assert(cfg1.FromContent(SampleConfig), check.IsNil)
+	require.NoError(t, cfg1.FromContent(SampleConfig))
 	cfg1.Name = "dm-master-1"
-	cfg1.DataDir = c.MkDir()
+	cfg1.DataDir = t.TempDir()
 	cfg1.MasterAddr = tempurl.Alloc()[len("http://"):]
 	cfg1.AdvertiseAddr = cfg1.MasterAddr
 	cfg1.PeerUrls = tempurl.Alloc()
@@ -57,17 +56,17 @@ func (t *testElectionSuite) TestFailToStartLeader(c *check.C) {
 	cfg1.InitialCluster = fmt.Sprintf("%s=%s", cfg1.Name, cfg1.AdvertisePeerUrls)
 
 	s1 = NewServer(cfg1)
-	c.Assert(s1.Start(ctx), check.IsNil)
+	require.NoError(t, s1.Start(ctx))
 	// wait the first one become the leader
-	c.Assert(utils.WaitSomething(30, 100*time.Millisecond, func() bool {
+	require.Eventually(t, func() bool {
 		return s1.election.IsLeader() && s1.scheduler.Started()
-	}), check.IsTrue)
+	}, 3*time.Second, 100*time.Millisecond)
 
 	// join to an existing cluster
 	cfg2 := NewConfig()
-	c.Assert(cfg2.FromContent(SampleConfig), check.IsNil)
+	require.NoError(t, cfg2.FromContent(SampleConfig))
 	cfg2.Name = "dm-master-2"
-	cfg2.DataDir = c.MkDir()
+	cfg2.DataDir = t.TempDir()
 	cfg2.MasterAddr = tempurl.Alloc()[len("http://"):]
 	cfg2.AdvertiseAddr = cfg2.MasterAddr
 	cfg2.PeerUrls = tempurl.Alloc()
@@ -75,35 +74,36 @@ func (t *testElectionSuite) TestFailToStartLeader(c *check.C) {
 	cfg2.Join = cfg1.MasterAddr // join to an existing cluster
 
 	// imitate fail to start scheduler/pessimism/optimism
-	c.Assert(failpoint.Enable("github.com/pingcap/tiflow/dm/dm/master/FailToStartLeader", `return("dm-master-2")`), check.IsNil)
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tiflow/dm/dm/master/FailToStartLeader", `return("dm-master-2")`))
 	//nolint:errcheck
 	defer failpoint.Disable("github.com/pingcap/tiflow/dm/dm/master/FailToStartLeader")
 
 	s2 = NewServer(cfg2)
-	c.Assert(s2.Start(ctx), check.IsNil)
+	require.NoError(t, s2.Start(ctx))
 	// wait the second master ready
-	c.Assert(utils.WaitSomething(30, 100*time.Millisecond, func() bool {
-		return s2.election.IsLeader()
-	}), check.IsFalse)
+	time.Sleep(time.Second)
+	require.False(t, s2.election.IsLeader())
 
 	client, err := etcdutil.CreateClient(strings.Split(cfg1.AdvertisePeerUrls, ","), nil)
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	defer client.Close()
 
 	// s1 is still the leader
 	_, leaderID, _, err := s2.election.LeaderInfo(ctx)
-	c.Assert(err, check.IsNil)
-	c.Assert(leaderID, check.Equals, cfg1.Name)
-	c.Assert(s1.ClusterID(), check.Greater, uint64(0))
-	c.Assert(s2.ClusterID(), check.Equals, uint64(0))
+	require.NoError(t, err)
+	require.Equal(t, cfg1.Name, leaderID)
+	require.Greater(t, s1.ClusterID(), uint64(0))
+	require.Equal(t, uint64(0), s2.ClusterID())
 
 	s1.election.Resign()
 	time.Sleep(1 * time.Second)
 
 	// s1 is still the leader
-	_, leaderID, _, err = s2.election.LeaderInfo(ctx)
-	c.Assert(err, check.IsNil)
-	c.Assert(leaderID, check.Equals, cfg1.Name)
+	require.Eventually(t, func() bool {
+		_, leaderID, _, err = s2.election.LeaderInfo(ctx)
+		require.NoError(t, err)
+		return leaderID == cfg1.Name
+	}, 3*time.Second, 100*time.Millisecond)
 	clusterID := s1.ClusterID()
 
 	//nolint:errcheck
@@ -113,7 +113,7 @@ func (t *testElectionSuite) TestFailToStartLeader(c *check.C) {
 
 	// s2 now become leader
 	_, leaderID, _, err = s2.election.LeaderInfo(ctx)
-	c.Assert(err, check.IsNil)
-	c.Assert(leaderID, check.Equals, cfg2.Name)
-	c.Assert(clusterID, check.Equals, s2.ClusterID())
+	require.NoError(t, err)
+	require.Equal(t, cfg2.Name, leaderID)
+	require.Equal(t, clusterID, s2.ClusterID())
 }


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/4875

### What is changed and how it works?

even we inject FailToStartLeader, master may still write the election key to etcd. So we should retry the check

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note 
 `None`.
```
