### PR TITLE
dm/ha: rolling update support to new etcd keys

### DIFF
--- a/dm/dm/common/common.go
+++ b/dm/dm/common/common.go
@@ -125,7 +125,8 @@ func keyAdapterKeysLen(s KeyAdapter) int {
 	case ShardDDLOptimismDroppedColumnsKeyAdapter:
 		return 5
 	// used in upgrading
-	case UpstreamConfigKeyAdapterV1, StageRelayKeyAdapterV1:
+	case UpstreamConfigKeyAdapterV1, StageRelayKeyAdapterV1, UpstreamBoundWorkerKeyAdapterV1,
+		UpstreamLastBoundWorkerKeyAdapterV1, UpstreamRelayWorkerKeyAdapterV1:
 		return 1
 	}
 	return -1

--- a/dm/dm/ctl/master/config.go
+++ b/dm/dm/ctl/master/config.go
@@ -337,9 +337,9 @@ func getRelayCfgs(cli *clientv3.Client) (map[string]map[string]struct{}, error) 
 	if err != nil {
 		return nil, err
 	}
-	// try to get all source cfgs before v6.1.0
+	// try to get all source cfgs before v6.2.0
 	if len(relayCfgsMap) == 0 {
-		relayCfgsMap, _, err = ha.GetAllRelayConfigBeforeV610(cli)
+		relayCfgsMap, _, err = ha.GetAllRelayConfigBeforeV620(cli)
 		if err != nil {
 			return nil, err
 		}

--- a/dm/pkg/ha/relay.go
+++ b/dm/pkg/ha/relay.go
@@ -95,9 +95,9 @@ func GetAllRelayConfig(cli *clientv3.Client) (map[string]map[string]struct{}, in
 	return ret, resp.Header.Revision, nil
 }
 
-// GetAllRelayConfigBeforeV610 gets all upstream relay configs before v6.1.0.
+// GetAllRelayConfigBeforeV620 gets all upstream relay configs before v6.2.0.
 // This func only use for config export command.
-func GetAllRelayConfigBeforeV610(cli *clientv3.Client) (map[string]map[string]struct{}, int64, error) {
+func GetAllRelayConfigBeforeV620(cli *clientv3.Client) (map[string]map[string]struct{}, int64, error) {
 	ctx, cancel := context.WithTimeout(cli.Ctx(), etcdutil.DefaultRequestTimeout)
 	defer cancel()
 

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/pingcap/tidb v1.1.0-beta.0.20220318092833-a30449081049
 	github.com/pingcap/tidb-tools v6.0.0-alpha.0.20220317013353-dfc5146f4746+incompatible
 	github.com/pingcap/tidb/parser v0.0.0-20220318092833-a30449081049
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/r3labs/diff v1.1.0
@@ -203,7 +204,6 @@ require (
 	github.com/pingcap/sysutil v0.0.0-20220114020952-ea68d2dbf5b4 // indirect
 	github.com/pingcap/tipb v0.0.0-20220215045658-d12dec7a7609 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/common v0.32.1 // indirect


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/5099

### What is changed and how it works?
Support rolling upgrade in dm. We didn't keep old dm etcd keys to avoid users deploy both old/new versions of dm-workers.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


Code changes

 - Has persistent data change

Side effects

 - Breaking backward compatibility

Related changes

- None

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
