### PR TITLE
sink: remove useless error check

### DIFF
--- a/cdc/sink/mq.go
+++ b/cdc/sink/mq.go
@@ -93,9 +93,6 @@ func newMqSink(
 	role := util.RoleFromCtx(ctx)
 
 	encoder := encoderBuilder.Build()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	statistics := NewStatistics(ctx, sinkTypeMQ)
 	flushWorker := newFlushWorker(encoder, mqProducer, statistics)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #4623

### What is changed and how it works?

#4609 removed error returned from `encoderBuilder.Build()`, so remove useless error check.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
