### PR TITLE
sink(ticdc): use slice in txnsWithTheSameCommitTs to support splitting transaction

### DIFF
--- a/cdc/model/mounter.go
+++ b/cdc/model/mounter.go
@@ -48,3 +48,25 @@ func NewResolvedPolymorphicEvent(regionID uint64, resolvedTs uint64) *Polymorphi
 func (e *PolymorphicEvent) RegionID() uint64 {
 	return e.RawKV.RegionID
 }
+
+// ComparePolymorphicEvents compares two events by CRTs, Resolved, StartTs, Put/Delete order.
+func ComparePolymorphicEvents(i, j *PolymorphicEvent) bool {
+	if i.CRTs == j.CRTs {
+		if j.RawKV.OpType == OpTypeResolved && i.RawKV.OpType != OpTypeResolved {
+			return true
+		} else if i.RawKV.OpType == OpTypeResolved {
+			return false
+		}
+
+		if i.StartTs < j.StartTs {
+			return true
+		} else if i.StartTs > j.StartTs {
+			return false
+		}
+
+		if i.RawKV.OpType == OpTypeDelete && j.RawKV.OpType != OpTypeDelete {
+			return true
+		}
+	}
+	return i.CRTs < j.CRTs
+}

--- a/cdc/model/mounter.go
+++ b/cdc/model/mounter.go
@@ -50,6 +50,7 @@ func (e *PolymorphicEvent) RegionID() uint64 {
 }
 
 // ComparePolymorphicEvents compares two events by CRTs, Resolved, StartTs, Delete/Put order.
+// It returns true if and only if i should precede j.
 func ComparePolymorphicEvents(i, j *PolymorphicEvent) bool {
 	if i.CRTs == j.CRTs {
 		if i.RawKV.OpType == OpTypeResolved {

--- a/cdc/model/mounter.go
+++ b/cdc/model/mounter.go
@@ -49,19 +49,19 @@ func (e *PolymorphicEvent) RegionID() uint64 {
 	return e.RawKV.RegionID
 }
 
-// ComparePolymorphicEvents compares two events by CRTs, Resolved, StartTs, Put/Delete order.
+// ComparePolymorphicEvents compares two events by CRTs, Resolved, StartTs, Delete/Put order.
 func ComparePolymorphicEvents(i, j *PolymorphicEvent) bool {
 	if i.CRTs == j.CRTs {
-		if j.RawKV.OpType == OpTypeResolved && i.RawKV.OpType != OpTypeResolved {
-			return true
-		} else if i.RawKV.OpType == OpTypeResolved {
+		if i.RawKV.OpType == OpTypeResolved {
 			return false
+		} else if j.RawKV.OpType == OpTypeResolved {
+			return true
 		}
 
-		if i.StartTs < j.StartTs {
-			return true
-		} else if i.StartTs > j.StartTs {
+		if i.StartTs > j.StartTs {
 			return false
+		} else if i.StartTs < j.StartTs {
+			return true
 		}
 
 		if i.RawKV.OpType == OpTypeDelete && j.RawKV.OpType != OpTypeDelete {

--- a/cdc/sink/mysql/txn_cache.go
+++ b/cdc/sink/mysql/txn_cache.go
@@ -34,9 +34,7 @@ func (t *txnsWithTheSameCommitTs) Append(row *model.RowChangedEvent) {
 			zap.Uint64("commitTs of txn", t.commitTs),
 			zap.Any("row", row))
 	}
-	if t.txns == nil {
-		t.txns = make([]*model.SingleTableTxn, 0)
-	}
+	
 	var txn *model.SingleTableTxn
 	if len(t.txns) == 0 || t.txns[len(t.txns)-1].StartTs < row.StartTs {
 		txn = &model.SingleTableTxn{

--- a/cdc/sink/mysql/txn_cache.go
+++ b/cdc/sink/mysql/txn_cache.go
@@ -34,7 +34,7 @@ func (t *txnsWithTheSameCommitTs) Append(row *model.RowChangedEvent) {
 			zap.Uint64("commitTs of txn", t.commitTs),
 			zap.Any("row", row))
 	}
-	
+
 	var txn *model.SingleTableTxn
 	if len(t.txns) == 0 || t.txns[len(t.txns)-1].StartTs < row.StartTs {
 		txn = &model.SingleTableTxn{

--- a/cdc/sorter/memory/entry_sorter.go
+++ b/cdc/sorter/memory/entry_sorter.go
@@ -159,16 +159,7 @@ func (es *EntrySorter) Output() <-chan *model.PolymorphicEvent {
 }
 
 func eventLess(i *model.PolymorphicEvent, j *model.PolymorphicEvent) bool {
-	if i.CRTs == j.CRTs {
-		if i.RawKV.OpType == model.OpTypeDelete {
-			return true
-		}
-
-		if j.RawKV.OpType == model.OpTypeResolved {
-			return true
-		}
-	}
-	return i.CRTs < j.CRTs
+	return model.ComparePolymorphicEvents(i, j)
 }
 
 func mergeEvents(kvsA []*model.PolymorphicEvent, kvsB []*model.PolymorphicEvent, output func(*model.PolymorphicEvent)) {

--- a/cdc/sorter/memory/entry_sorter_test.go
+++ b/cdc/sorter/memory/entry_sorter_test.go
@@ -289,20 +289,29 @@ func TestEntrySorterRandomly(t *testing.T) {
 func TestEventLess(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
+		order    int
 		i        *model.PolymorphicEvent
 		j        *model.PolymorphicEvent
 		expected bool
 	}{
 		{
+			0,
 			&model.PolymorphicEvent{
 				CRTs: 1,
+				RawKV: &model.RawKVEntry{
+					OpType: model.OpTypePut,
+				},
 			},
 			&model.PolymorphicEvent{
 				CRTs: 2,
+				RawKV: &model.RawKVEntry{
+					OpType: model.OpTypePut,
+				},
 			},
 			true,
 		},
 		{
+			1,
 			&model.PolymorphicEvent{
 				CRTs: 2,
 				RawKV: &model.RawKVEntry{
@@ -315,9 +324,10 @@ func TestEventLess(t *testing.T) {
 					OpType: model.OpTypeDelete,
 				},
 			},
-			true,
+			false,
 		},
 		{
+			2,
 			&model.PolymorphicEvent{
 				CRTs: 2,
 				RawKV: &model.RawKVEntry{
@@ -330,9 +340,10 @@ func TestEventLess(t *testing.T) {
 					OpType: model.OpTypeResolved,
 				},
 			},
-			true,
+			false,
 		},
 		{
+			3,
 			&model.PolymorphicEvent{
 				CRTs: 2,
 				RawKV: &model.RawKVEntry{
@@ -348,6 +359,7 @@ func TestEventLess(t *testing.T) {
 			false,
 		},
 		{
+			4,
 			&model.PolymorphicEvent{
 				CRTs: 3,
 				RawKV: &model.RawKVEntry{
@@ -364,8 +376,8 @@ func TestEventLess(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		require.Equal(t, tc.expected, eventLess(tc.i, tc.j))
+	for i, tc := range testCases {
+		require.Equal(t, tc.expected, eventLess(tc.i, tc.j), "case %d", i)
 	}
 }
 

--- a/cdc/sorter/unified/heap.go
+++ b/cdc/sorter/unified/heap.go
@@ -24,15 +24,7 @@ type sortHeap []*sortItem
 
 func (h sortHeap) Len() int { return len(h) }
 func (h sortHeap) Less(i, j int) bool {
-	if h[i].entry.CRTs == h[j].entry.CRTs {
-		if h[j].entry.RawKV.OpType == model.OpTypeResolved && h[i].entry.RawKV.OpType != model.OpTypeResolved {
-			return true
-		}
-		if h[i].entry.RawKV.OpType == model.OpTypeDelete && h[j].entry.RawKV.OpType != model.OpTypeDelete {
-			return true
-		}
-	}
-	return h[i].entry.CRTs < h[j].entry.CRTs
+	return model.ComparePolymorphicEvents(h[i].entry, h[j].entry)
 }
 func (h sortHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
 func (h *sortHeap) Push(x interface{}) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #5231

### What is changed and how it works?
1. Make memory and unified sorter modules have the same sorting rules as the leveldb sorter
2. Use slices instead of maps in txnsWithTheSameCommitTs to support splitting transaction.
3. Refactor test cases to match real data, which is sorted by commitTs and startTs.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
