### PR TITLE
pkg/p2p: reduce workload of TestMessageClientBasicMultiTopics

### DIFF
--- a/pkg/p2p/server_client_integration_test.go
+++ b/pkg/p2p/server_client_integration_test.go
@@ -25,13 +25,12 @@ import (
 	"github.com/phayes/freeport"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"google.golang.org/grpc"
-
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/security"
 	"github.com/pingcap/tiflow/proto/p2p"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
 )
 
 // read only

--- a/pkg/p2p/server_client_integration_test.go
+++ b/pkg/p2p/server_client_integration_test.go
@@ -25,12 +25,13 @@ import (
 	"github.com/phayes/freeport"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
-	cerror "github.com/pingcap/tiflow/pkg/errors"
-	"github.com/pingcap/tiflow/pkg/security"
-	"github.com/pingcap/tiflow/proto/p2p"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+
+	cerror "github.com/pingcap/tiflow/pkg/errors"
+	"github.com/pingcap/tiflow/pkg/security"
+	"github.com/pingcap/tiflow/proto/p2p"
 )
 
 // read only
@@ -183,10 +184,10 @@ func TestMessageClientBasic(t *testing.T) {
 }
 
 func TestMessageClientBasicMultiTopics(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.TODO(), defaultTimeout)
+	ctx, cancel := context.WithTimeout(context.TODO(), defaultTimeout*2)
 	defer cancel()
 
-	runP2PIntegrationTest(ctx, t, defaultMessageBatchSizeLarge, 4, 16)
+	runP2PIntegrationTest(ctx, t, defaultMessageBatchSizeLarge, 4, 4)
 }
 
 func TestMessageClientServerRestart(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
Issue Number: close #5210 

### What is changed and how it works?
- The previous workload of this test case is for `64` goroutines to use the same `MessageClient` to send messages, which can be too much for the CI's machine. The workload concurrency is reduced to `16` and the timeout is doubled.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

```
> go test . -test.run TestMessageClientBasicMultiTopics -test.count 1000 
ok  	github.com/pingcap/tiflow/pkg/p2p	62.062s
```

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
