### PR TITLE
master, config(dm): fix case-sensitive compatibility for dmctl

### DIFF
--- a/dm/dm/config/source_config.go
+++ b/dm/dm/config/source_config.go
@@ -308,7 +308,7 @@ func (c *SourceConfig) Adjust(ctx context.Context, db *sql.DB) (err error) {
 		log.L().Warn("using an absolute relay path, relay log can't work when starting multiple relay worker")
 	}
 
-	return c.AdjustCaseSensitive(ctx2, db)
+	return nil
 }
 
 // AdjustCaseSensitive adjust CaseSensitive from DB.

--- a/dm/dm/master/bootstrap_test.go
+++ b/dm/dm/master/bootstrap_test.go
@@ -73,7 +73,7 @@ func (t *testMaster) TestCollectSourceConfigFilesV1Import(c *C) {
 	cfg1.From.User = user
 	cfg1.From.Password = password
 	cfg1.RelayDir = "relay-dir"
-	c.Assert(checkAndAdjustSourceConfigFunc(ctx, cfg1), IsNil) // adjust source config.
+	c.Assert(checkAndAdjustSourceConfigForDMCtlFunc(ctx, cfg1), IsNil) // adjust source config.
 	cfg2 := cfg1.Clone()
 	cfg2.SourceID = "mysql-replica-02"
 

--- a/dm/dm/master/server.go
+++ b/dm/dm/master/server.go
@@ -15,6 +15,7 @@ package master
 
 import (
 	"context"
+	"database/sql"
 	"encoding/binary"
 	"fmt"
 	"math/rand"
@@ -86,7 +87,11 @@ var (
 	registerOnce      sync.Once
 	runBackgroundOnce sync.Once
 
-	checkAndAdjustSourceConfigFunc = checkAndAdjustSourceConfig
+	// the difference of below functions is checkAndAdjustSourceConfigForDMCtlFunc will not AdjustCaseSensitive. It's a
+	// compatibility compromise.
+	// When we need to change the implementation of dmctl to OpenAPI, we should notice the user about this change.
+	checkAndAdjustSourceConfigFunc         = checkAndAdjustSourceConfig
+	checkAndAdjustSourceConfigForDMCtlFunc = checkAndAdjustSourceConfigForDMCtl
 )
 
 // Server handles RPC requests for dm-master.
@@ -1311,7 +1316,7 @@ func parseAndAdjustSourceConfig(ctx context.Context, contents []string) ([]*conf
 		if err != nil {
 			return cfgs, err
 		}
-		if err := checkAndAdjustSourceConfigFunc(ctx, cfg); err != nil {
+		if err := checkAndAdjustSourceConfigForDMCtlFunc(ctx, cfg); err != nil {
 			return cfgs, err
 		}
 		cfgs[i] = cfg
@@ -1319,7 +1324,11 @@ func parseAndAdjustSourceConfig(ctx context.Context, contents []string) ([]*conf
 	return cfgs, nil
 }
 
-func checkAndAdjustSourceConfig(ctx context.Context, cfg *config.SourceConfig) error {
+func innerCheckAndAdjustSourceConfig(
+	ctx context.Context,
+	cfg *config.SourceConfig,
+	hook func(sourceConfig *config.SourceConfig, ctx context.Context, db *sql.DB) error,
+) error {
 	dbConfig := cfg.GenerateDBConfig()
 	fromDB, err := conn.DefaultDBProvider.Apply(dbConfig)
 	if err != nil {
@@ -1329,10 +1338,23 @@ func checkAndAdjustSourceConfig(ctx context.Context, cfg *config.SourceConfig) e
 	if err = cfg.Adjust(ctx, fromDB.DB); err != nil {
 		return err
 	}
+	if hook != nil {
+		if err = hook(cfg, ctx, fromDB.DB); err != nil {
+			return err
+		}
+	}
 	if _, err = cfg.Yaml(); err != nil {
 		return err
 	}
 	return cfg.Verify()
+}
+
+func checkAndAdjustSourceConfig(ctx context.Context, cfg *config.SourceConfig) error {
+	return innerCheckAndAdjustSourceConfig(ctx, cfg, (*config.SourceConfig).AdjustCaseSensitive)
+}
+
+func checkAndAdjustSourceConfigForDMCtl(ctx context.Context, cfg *config.SourceConfig) error {
+	return innerCheckAndAdjustSourceConfig(ctx, cfg, nil)
 }
 
 func parseSourceConfig(contents []string) ([]*config.SourceConfig, error) {

--- a/dm/dm/master/server_test.go
+++ b/dm/dm/master/server_test.go
@@ -196,12 +196,12 @@ func (t *testMaster) SetUpSuite(c *check.C) {
 	t.workerClients = make(map[string]workerrpc.Client)
 	t.saveMaxRetryNum = maxRetryNum
 	maxRetryNum = 2
-	checkAndAdjustSourceConfigFunc = checkAndNoAdjustSourceConfigMock
+	checkAndAdjustSourceConfigForDMCtlFunc = checkAndNoAdjustSourceConfigMock
 }
 
 func (t *testMaster) TearDownSuite(c *check.C) {
 	maxRetryNum = t.saveMaxRetryNum
-	checkAndAdjustSourceConfigFunc = checkAndAdjustSourceConfig
+	checkAndAdjustSourceConfigForDMCtlFunc = checkAndAdjustSourceConfig
 }
 
 func (t *testMaster) SetUpTest(c *check.C) {

--- a/dm/pkg/utils/common.go
+++ b/dm/pkg/utils/common.go
@@ -184,12 +184,13 @@ func FetchLowerCaseTableNamesSetting(ctx context.Context, conn *sql.Conn) (Lower
 	return LowerCaseTableNamesFlavor(res), nil
 }
 
-// GetDBCaseSensitive returns the case sensitive setting of target db.
+// GetDBCaseSensitive returns the case-sensitive setting of target db.
 func GetDBCaseSensitive(ctx context.Context, db *sql.DB) (bool, error) {
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		return true, terror.DBErrorAdapt(err, terror.ErrDBDriverError)
 	}
+	defer conn.Close()
 	lcFlavor, err := FetchLowerCaseTableNamesSetting(ctx, conn)
 	if err != nil {
 		return true, err

--- a/dm/tests/all_mode/run.sh
+++ b/dm/tests/all_mode/run.sh
@@ -96,14 +96,13 @@ function test_query_timeout() {
 	# don't know why CI has turned on Event Scheduler
 	run_sql_both_source 'SET GLOBAL event_scheduler = OFF;'
 
-	# there's only 2 rows in result, one for dm-worker's source-level status, one for SHOW PROCESSLIST
+	# there's only 1 row in result, which is for SHOW PROCESSLIST
 	run_sql_source1 'SHOW PROCESSLIST;'
-	check_rows_equal 2
+	check_rows_equal 1
 
 	run_sql_source2 'SHOW PROCESSLIST;'
-	check_rows_equal 2
+	check_rows_equal 1
 
-	# there's only 1 row in result, which is for SHOW PROCESSLIST
 	run_sql_tidb 'SHOW PROCESSLIST;'
 	check_rows_equal 1
 

--- a/dm/tests/all_mode/run.sh
+++ b/dm/tests/all_mode/run.sh
@@ -130,14 +130,13 @@ function test_query_timeout() {
 		"stop-task $ILLEGAL_CHAR_NAME" \
 		"\"result\": true" 3
 
-	# there's only 2 rows in result, one for dm-worker's source-level status, one for SHOW PROCESSLIST
+	# there's only 1 row in result, which is for SHOW PROCESSLIST
 	run_sql_source1 'SHOW PROCESSLIST;'
-	check_rows_equal 2
+	check_rows_equal 1
 
 	run_sql_source2 'SHOW PROCESSLIST;'
-	check_rows_equal 2
+	check_rows_equal 1
 
-	# there's only 1 row in result, which is for SHOW PROCESSLIST
 	run_sql_tidb 'SHOW PROCESSLIST;'
 	check_rows_equal 1
 

--- a/dm/tests/case_sensitive/data/db2.prepare.sql
+++ b/dm/tests/case_sensitive/data/db2.prepare.sql
@@ -8,6 +8,7 @@ create table Upper_Table (
     PRIMARY KEY (id));
 insert into Upper_Table (name, ts) values ('Arya', now()), ('Bran', '2021-05-11 10:01:05'), ('Sansa', NULL);
 
+-- if case-insensitive, this should report conflict with Upper_Table
 create table upper_table(id int NOT NULL PRIMARY KEY);
 
 -- test block-allow-list


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5255

### What is changed and how it works?

OpenAPI needs automatically decides the case-sensitive from MySQL, but dmctl should keep the compatibility. So I split the two functions.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix DM can't replicate uppercase tables when the task has case-sensitive: false
```
