### PR TITLE
scripts: fix un-catched pattern in check log style

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -1227,7 +1227,7 @@ func (s *eventFeedSession) receiveFromStream(
 			log.Warn("change data event size too large",
 				zap.String("changefeed", s.client.changefeed),
 				zap.Int("size", size), zap.Int("eventLen", len(cevent.Events)),
-				zap.Int("resolved region count", regionCount))
+				zap.Int("resolvedRegionCount", regionCount))
 		}
 
 		for _, event := range cevent.Events {

--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -335,7 +335,7 @@ func (w *regionWorker) resolveLock(ctx context.Context) error {
 					sinceLastEvent := time.Since(rts.ts.eventTime)
 					if sinceLastResolvedTs > reconnectInterval && sinceLastEvent > reconnectInterval {
 						log.Warn("kv client reconnect triggered", zap.String("changefeed", w.session.client.changefeed),
-							zap.Duration("duration", sinceLastResolvedTs), zap.Duration("since last event", sinceLastResolvedTs))
+							zap.Duration("duration", sinceLastResolvedTs), zap.Duration("sinceLastEvent", sinceLastResolvedTs))
 						return errReconnect
 					}
 					// Only resolve lock if the resolved-ts keeps unchanged for

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -346,8 +346,8 @@ func (info *ChangeFeedInfo) fixSinkProtocol() {
 			sinkURIParsed.RawQuery = newRawQuery
 			fixedSinkURI := sinkURIParsed.String()
 			log.Info("handle incompatible protocol from sink URI",
-				zap.String("old URI query", oldRawQuery),
-				zap.String("fixed URI query", newRawQuery))
+				zap.String("oldUriQuery", oldRawQuery),
+				zap.String("fixedUriQuery", newRawQuery))
 			info.SinkURI = fixedSinkURI
 		}
 	} else {

--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -546,9 +546,9 @@ type SingleTableTxn struct {
 func (t *SingleTableTxn) Append(row *RowChangedEvent) {
 	if row.StartTs != t.StartTs || row.CommitTs != t.CommitTs || row.Table.TableID != t.Table.TableID {
 		log.Panic("unexpected row change event",
-			zap.Uint64("startTs of txn", t.StartTs),
-			zap.Uint64("commitTs of txn", t.CommitTs),
-			zap.Any("table of txn", t.Table),
+			zap.Uint64("startTs", t.StartTs),
+			zap.Uint64("commitTs", t.CommitTs),
+			zap.Any("table", t.Table),
 			zap.Any("row", row))
 	}
 	t.Rows = append(t.Rows, row)

--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -269,7 +269,7 @@ LOOP:
 	checkpointTs := c.state.Info.GetCheckpointTs(c.state.Status)
 	log.Info("initialize changefeed", zap.String("changefeed", c.state.ID),
 		zap.Stringer("info", c.state.Info),
-		zap.Uint64("checkpoint ts", checkpointTs))
+		zap.Uint64("checkpointTs", checkpointTs))
 	failpoint.Inject("NewChangefeedNoRetryError", func() {
 		failpoint.Return(cerror.ErrStartTsBeforeGC.GenWithStackByArgs(checkpointTs-300, checkpointTs))
 	})

--- a/cdc/sink/mq/mq.go
+++ b/cdc/sink/mq/mq.go
@@ -147,7 +147,7 @@ func (k *mqSink) EmitRowChangedEvents(ctx context.Context, rows ...*model.RowCha
 	for _, row := range rows {
 		if k.filter.ShouldIgnoreDMLEvent(row.StartTs, row.Table.Schema, row.Table.Table) {
 			log.Info("Row changed event ignored",
-				zap.Uint64("start-ts", row.StartTs),
+				zap.Uint64("startTs", row.StartTs),
 				zap.String("changefeed", k.id),
 				zap.Any("role", k.role))
 			continue

--- a/cdc/sink/mq/producer/kafka/config.go
+++ b/cdc/sink/mq/producer/kafka/config.go
@@ -81,8 +81,8 @@ func (c *Config) setPartitionNum(realPartitionCount int32) error {
 	if c.PartitionNum < realPartitionCount {
 		log.Warn("number of partition specified in sink-uri is less than that of the actual topic. "+
 			"Some partitions will not have messages dispatched to",
-			zap.Int32("sink-uri partitions", c.PartitionNum),
-			zap.Int32("topic partitions", realPartitionCount))
+			zap.Int32("sinkUriPartitions", c.PartitionNum),
+			zap.Int32("topicPartitions", realPartitionCount))
 		return nil
 	}
 

--- a/cdc/sink/mysql/mysql.go
+++ b/cdc/sink/mysql/mysql.go
@@ -664,7 +664,7 @@ func (s *mysqlSink) execDMLWithMaxRetries(ctx context.Context, dmls *preparedDML
 		}
 		log.Debug("Exec Rows succeeded",
 			zap.String("changefeed", s.params.changefeedID),
-			zap.Int("num of Rows", dmls.rowCount),
+			zap.Int("numOfRows", dmls.rowCount),
 			zap.Int("bucket", bucket))
 		return nil
 	}, retry.WithBackoffBaseDelay(backoffBaseDelayInMs),

--- a/cdc/sink/mysql/txn_cache.go
+++ b/cdc/sink/mysql/txn_cache.go
@@ -31,7 +31,7 @@ type txnsWithTheSameCommitTs struct {
 func (t *txnsWithTheSameCommitTs) Append(row *model.RowChangedEvent) {
 	if row.CommitTs != t.commitTs {
 		log.Panic("unexpected row change event",
-			zap.Uint64("commitTs of txn", t.commitTs),
+			zap.Uint64("commitTs", t.commitTs),
 			zap.Any("row", row))
 	}
 
@@ -86,7 +86,7 @@ func (c *unresolvedTxnCache) Append(filter *filter.Filter, rows ...*model.RowCha
 	appendRows := 0
 	for _, row := range rows {
 		if filter != nil && filter.ShouldIgnoreDMLEvent(row.StartTs, row.Table.Schema, row.Table.Table) {
-			log.Info("Row changed event ignored", zap.Uint64("start-ts", row.StartTs))
+			log.Info("Row changed event ignored", zap.Uint64("startTs", row.StartTs))
 			continue
 		}
 		txns := c.unresolvedTxns[row.Table.TableID]

--- a/cdc/sorter/unified/file_backend.go
+++ b/cdc/sorter/unified/file_backend.go
@@ -219,8 +219,8 @@ func (r *fileBackEndReader) readNext() (*model.PolymorphicEvent, error) {
 			if r.totalEvents != r.readEvents {
 				log.Panic("unexpected EOF",
 					zap.String("file", r.backEnd.fileName),
-					zap.Uint64("expected-num-events", r.totalEvents),
-					zap.Uint64("actual-num-events", r.readEvents))
+					zap.Uint64("expectedNumEvents", r.totalEvents),
+					zap.Uint64("actualNumEvents", r.readEvents))
 			}
 			return nil, nil
 		}

--- a/cdc/sorter/unified/heap_sorter.go
+++ b/cdc/sorter/unified/heap_sorter.go
@@ -259,7 +259,7 @@ func (h *heapSorter) flush(ctx context.Context, maxResolvedTs uint64) error {
 					zap.Int64("tableID", tableID),
 					zap.String("tableName", tableName),
 					zap.Uint64("resolvedTs", task.maxResolvedTs),
-					zap.Uint64("data-size", dataSize),
+					zap.Uint64("dataSize", dataSize),
 					zap.Int("size", eventCount))
 			})
 
@@ -305,14 +305,14 @@ func (h *heapSorter) init(ctx context.Context, onError func(err error)) {
 
 		if isResolvedEvent {
 			if event.RawKV.CRTs < state.maxResolved {
-				log.Panic("ResolvedTs regression, bug?", zap.Uint64("event-resolvedTs", event.RawKV.CRTs),
-					zap.Uint64("max-resolvedTs", state.maxResolved))
+				log.Panic("ResolvedTs regression, bug?", zap.Uint64("resolvedTs", event.RawKV.CRTs),
+					zap.Uint64("maxResolvedTs", state.maxResolved))
 			}
 			state.maxResolved = event.RawKV.CRTs
 		}
 
 		if event.RawKV.CRTs < state.maxResolved {
-			log.Panic("Bad input to sorter", zap.Uint64("cur-ts", event.RawKV.CRTs), zap.Uint64("maxResolved", state.maxResolved))
+			log.Panic("Bad input to sorter", zap.Uint64("curTs", event.RawKV.CRTs), zap.Uint64("maxResolved", state.maxResolved))
 		}
 
 		// 5 * 8 is for the 5 fields in PolymorphicEvent

--- a/cdc/sorter/unified/memory_backend.go
+++ b/cdc/sorter/unified/memory_backend.go
@@ -115,8 +115,8 @@ func (w *memoryBackEndWriter) writeNext(event *model.PolymorphicEvent) error {
 	failpoint.Inject("sorterDebug", func() {
 		if event.CRTs < w.maxTs {
 			log.Panic("memoryBackEnd: ts regressed, bug?",
-				zap.Uint64("prev-ts", w.maxTs),
-				zap.Uint64("cur-ts", event.CRTs))
+				zap.Uint64("prevTs", w.maxTs),
+				zap.Uint64("curTs", event.CRTs))
 		}
 		w.maxTs = event.CRTs
 	})

--- a/cdc/sorter/unified/merger.go
+++ b/cdc/sorter/unified/merger.go
@@ -245,7 +245,7 @@ func runMerger(ctx context.Context, numSorters int, in <-chan *flushTask, out ch
 				pendingSet.Store(task, nextEvent)
 				if nextEvent.CRTs < minResolvedTs {
 					log.Panic("remaining event CRTs too small",
-						zap.Uint64("next-ts", nextEvent.CRTs),
+						zap.Uint64("nextTs", nextEvent.CRTs),
 						zap.Uint64("minResolvedTs", minResolvedTs))
 				}
 			}
@@ -293,7 +293,7 @@ func runMerger(ctx context.Context, numSorters int, in <-chan *flushTask, out ch
 						zap.Uint64("curTs", event.CRTs),
 						zap.Int("lastHeapID", lastTask.heapSorterID),
 						zap.Int("lastTaskID", lastTask.taskID),
-						zap.Uint64("lastTask-resolved", task.maxResolvedTs),
+						zap.Uint64("lastTaskResolved", task.maxResolvedTs),
 						zap.Reflect("lastEvent", lastEvent),
 						zap.Uint64("lastTs", lastOutputTs),
 						zap.Int("sortHeapLen", sortHeap.Len()))
@@ -301,7 +301,7 @@ func runMerger(ctx context.Context, numSorters int, in <-chan *flushTask, out ch
 
 				if event.CRTs <= lastOutputResolvedTs {
 					log.Panic("unified sorter: output ts smaller than resolved ts, bug?", zap.Uint64("minResolvedTs", minResolvedTs),
-						zap.Uint64("lastOutputResolvedTs", lastOutputResolvedTs), zap.Uint64("event-crts", event.CRTs))
+						zap.Uint64("lastOutputResolvedTs", lastOutputResolvedTs), zap.Uint64("eventCrts", event.CRTs))
 				}
 				lastOutputTs = event.CRTs
 				lastEvent = event

--- a/pkg/cyclic/filter.go
+++ b/pkg/cyclic/filter.go
@@ -80,7 +80,7 @@ func FilterAndReduceTxns(
 						event.RowID != first.RowID {
 						log.Panic(
 							"there should be at most one mark row for each txn",
-							zap.Uint64("start-ts", event.StartTs),
+							zap.Uint64("startTs", event.StartTs),
 							zap.Any("first", first),
 							zap.Any("second", event))
 					}

--- a/pkg/orchestrator/etcd_worker.go
+++ b/pkg/orchestrator/etcd_worker.go
@@ -186,8 +186,8 @@ func (worker *EtcdWorker) Run(ctx context.Context, session *concurrency.Session,
 			// Check whether the response is stale.
 			if worker.revision >= response.Header.GetRevision() {
 				log.Info("Stale Etcd event dropped",
-					zap.Int64("event-revision", response.Header.GetRevision()),
-					zap.Int64("previous-revision", worker.revision),
+					zap.Int64("eventRevision", response.Header.GetRevision()),
+					zap.Int64("previousRevision", worker.revision),
 					zap.Any("events", response.Events),
 					zap.String("role", role))
 				continue

--- a/pkg/p2p/client.go
+++ b/pkg/p2p/client.go
@@ -296,7 +296,7 @@ func (c *MessageClient) retrySending(ctx context.Context, stream clientStream) e
 			retryFromSeq := tpk.sentMessages.Front().(*p2p.MessageEntry).Sequence
 			log.Info("peer-to-peer client retrying",
 				zap.String("topic", topic),
-				zap.Int64("from-seq", retryFromSeq))
+				zap.Int64("fromSeq", retryFromSeq))
 		}
 
 		for i := 0; i < tpk.sentMessages.Len(); i++ {

--- a/scripts/check-log-style.sh
+++ b/scripts/check-log-style.sh
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 # zap field name should be camelCase, excepts for idioms and special terms.
-grep -RnE "zap.[A-Z][a-z]+\(\"[0-9A-Za-z]*[-_ ][0-9A-Za-z]*\"(,|\))" cdc tests pkg |
+grep -RnE "zap.[A-Z][a-zA-Z0-9]+\(\"[0-9A-Za-z]*[-_ ][^\"]*\"(,|\))" cdc tests pkg |
 	grep -vE "user-agent" |
 	grep -vE "https_proxy|http_proxy|no_proxy" |
 	grep -vE "max-message-bytes|max-message-size" |


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5324

related to https://github.com/pingcap/tiflow/pull/5296#discussion_r862283378

### What is changed and how it works?

Change the zap filed regex pattern to fix some un cached log style

```diff
-grep -RnE "zap.[A-Z][a-z]+
+grep -RnE "zap.[A-Z][a-zA-Z0-9]+
```
- This change catches `zap.Int64`, `zap.ByteStrings` etc.

```diff
-(\"[0-9A-Za-z]*[-_ ][0-9A-Za-z]*\"(,|\))"
+(\"[0-9A-Za-z]*[-_ ][^\"]*\"(,|\))"
```

- This change catches `zap.Int("num of Rows", dmls.rowCount),`, `zap.Uint64("expected-num-events", r.totalEvents),` etc.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects

 -  **Has several zap fields change in log, but user should not relay on log contents, so it is all right to break the complexity**

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Change all variable names to camelCase in logs
```
