### PR TITLE
tracker(dm): add task name to unistore folder name

### DIFF
--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -245,7 +245,7 @@ func newTmpFolderForTracker(task string) (string, error) {
 	var buf strings.Builder
 	for _, c := range task {
 		if _, ok := specialChars[c]; ok {
-			buf.WriteByte('_')
+			fmt.Fprintf(&buf, "%%%02X", c)
 		} else {
 			buf.WriteRune(c)
 		}

--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -234,23 +235,8 @@ func NewTracker(ctx context.Context, task string, sessionCfg map[string]string, 
 	}, nil
 }
 
-var specialChars = map[rune]struct{}{
-	'`': {}, '~': {}, '!': {}, '@': {}, '#': {}, '$': {}, '%': {}, '^': {}, '&': {},
-	'*': {}, '(': {}, ')': {}, '-': {}, '_': {}, '=': {}, '+': {}, '\\': {}, '|': {},
-	'[': {}, '{': {}, ']': {}, '}': {}, ':': {}, ';': {}, '\'': {}, '"': {}, '<': {},
-	'>': {}, ',': {}, '.': {}, '?': {}, '/': {}, ' ': {},
-}
-
 func newTmpFolderForTracker(task string) (string, error) {
-	var buf strings.Builder
-	for _, c := range task {
-		if _, ok := specialChars[c]; ok {
-			fmt.Fprintf(&buf, "%%%02X", c)
-		} else {
-			buf.WriteRune(c)
-		}
-	}
-	return ioutil.TempDir("./", buf.String()+"-tracker")
+	return ioutil.TempDir("./", url.PathEscape(task)+"-tracker")
 }
 
 // Exec runs an SQL (DDL) statement.

--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -149,7 +149,7 @@ func NewTracker(ctx context.Context, task string, sessionCfg map[string]string, 
 		}
 	}
 
-	storePath, err = ioutil.TempDir("./", "schema-tracker")
+	storePath, err = ioutil.TempDir("./", task+"-schema-tracker")
 	if err != nil {
 		return nil, err
 	}

--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -149,7 +149,7 @@ func NewTracker(ctx context.Context, task string, sessionCfg map[string]string, 
 		}
 	}
 
-	storePath, err = ioutil.TempDir("./", task+"-schema-tracker")
+	storePath, err = newTmpFolderForTracker(task)
 	if err != nil {
 		return nil, err
 	}
@@ -232,6 +232,25 @@ func NewTracker(ctx context.Context, task string, sessionCfg map[string]string, 
 		se:        se,
 		dsTracker: dsTracker,
 	}, nil
+}
+
+var specialChars = map[rune]struct{}{
+	'`': {}, '~': {}, '!': {}, '@': {}, '#': {}, '$': {}, '%': {}, '^': {}, '&': {},
+	'*': {}, '(': {}, ')': {}, '-': {}, '_': {}, '=': {}, '+': {}, '\\': {}, '|': {},
+	'[': {}, '{': {}, ']': {}, '}': {}, ':': {}, ';': {}, '\'': {}, '"': {}, '<': {},
+	'>': {}, ',': {}, '.': {}, '?': {}, '/': {}, ' ': {},
+}
+
+func newTmpFolderForTracker(task string) (string, error) {
+	var buf strings.Builder
+	for _, c := range task {
+		if _, ok := specialChars[c]; ok {
+			buf.WriteByte('_')
+		} else {
+			buf.WriteRune(c)
+		}
+	}
+	return ioutil.TempDir("./", buf.String()+"-tracker")
 }
 
 // Exec runs an SQL (DDL) statement.

--- a/dm/pkg/schema/tracker_test.go
+++ b/dm/pkg/schema/tracker_test.go
@@ -18,6 +18,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"testing"
 	"time"
@@ -1026,4 +1027,13 @@ func TestTrackerRecreateTables(t *testing.T) {
 		clearVolatileInfo(cloneTi)
 		require.Equal(t, tiInfos[i], cloneTi)
 	}
+}
+
+func TestNewTmpFolderForTracker(t *testing.T) {
+	got, err := newTmpFolderForTracker("task`~!@#$%^&*()-=_+[]{}\\|;:'\"<>,./? task")
+	require.NoError(t, err)
+	t.Log(got)
+	require.DirExists(t, got)
+	err = os.RemoveAll(got)
+	require.NoError(t, err)
 }

--- a/dm/pkg/schema/tracker_test.go
+++ b/dm/pkg/schema/tracker_test.go
@@ -1030,9 +1030,9 @@ func TestTrackerRecreateTables(t *testing.T) {
 }
 
 func TestNewTmpFolderForTracker(t *testing.T) {
-	got, err := newTmpFolderForTracker("task`~!@#$%^&*()-=_+[]{}\\|;:'\"<>,./? task")
+	got, err := newTmpFolderForTracker("task/db01")
 	require.NoError(t, err)
-	t.Log(got)
+	require.Contains(t, got, "task%2Fdb01")
 	require.DirExists(t, got)
 	err = os.RemoveAll(got)
 	require.NoError(t, err)

--- a/dm/syncer/syncer_test.go
+++ b/dm/syncer/syncer_test.go
@@ -1261,9 +1261,10 @@ func (s *testSyncerSuite) TestTrackDDL(c *C) {
 	syncer.ddlDBConn = dbconn.NewDBConn(s.cfg, conn.NewBaseConn(dbConn, &retry.FiniteRetryStrategy{}))
 	syncer.checkpoint.(*RemoteCheckPoint).dbConn = dbconn.NewDBConn(s.cfg, conn.NewBaseConn(checkPointDBConn, &retry.FiniteRetryStrategy{}))
 	syncer.schemaTracker, err = schema.NewTracker(context.Background(), s.cfg.Name, defaultTestSessionCfg, syncer.ddlDBConn)
+	c.Assert(err, IsNil)
+	defer syncer.schemaTracker.Close()
 	syncer.exprFilterGroup = NewExprFilterGroup(utils.NewSessionCtx(nil), nil)
 	c.Assert(syncer.genRouter(), IsNil)
-	c.Assert(err, IsNil)
 
 	cases := []struct {
 		sql      string
@@ -1579,6 +1580,7 @@ func (s *testSyncerSuite) TestTrackDownstreamTableWontOverwrite(c *C) {
 	syncer.downstreamTrackConn = dbconn.NewDBConn(s.cfg, conn.NewBaseConn(dbConn, &retry.FiniteRetryStrategy{}))
 	syncer.schemaTracker, err = schema.NewTracker(ctx, s.cfg.Name, defaultTestSessionCfg, syncer.downstreamTrackConn)
 	c.Assert(err, IsNil)
+	defer syncer.schemaTracker.Close()
 
 	upTable := &filter.Table{
 		Schema: "test",
@@ -1660,8 +1662,10 @@ func (s *testSyncerSuite) TestDownstreamTableHasAutoRandom(c *C) {
 		"tidb_skip_utf8_check":    "0",
 		schema.TiDBClusteredIndex: "ON",
 	}
+	c.Assert(syncer.schemaTracker.Close(), IsNil)
 	syncer.schemaTracker, err = schema.NewTracker(ctx, s.cfg.Name, sessionCfg, syncer.downstreamTrackConn)
 	c.Assert(err, IsNil)
+	defer syncer.schemaTracker.Close()
 	v, ok := syncer.schemaTracker.GetSystemVar(schema.TiDBClusteredIndex)
 	c.Assert(v, Equals, "ON")
 	c.Assert(ok, IsTrue)
@@ -1839,8 +1843,8 @@ func TestSyncerGetTableInfo(t *testing.T) {
 	syncer.ddlDBConn = dbconn.NewDBConn(cfg, baseConn)
 	syncer.downstreamTrackConn = dbconn.NewDBConn(cfg, conn.NewBaseConn(dbConn, &retry.FiniteRetryStrategy{}))
 	syncer.schemaTracker, err = schema.NewTracker(ctx, cfg.Name, defaultTestSessionCfg, syncer.downstreamTrackConn)
-	defer syncer.schemaTracker.Close()
 	require.NoError(t, err)
+	defer syncer.schemaTracker.Close()
 
 	upTable := &filter.Table{
 		Schema: "test",


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #5334

### What is changed and how it works?

sometimes unistore folder is abnormally big, we add task name to the folder name to know which task it belongs.

Also, clean that folder for unit tests by `Close()` 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
 `None`.
```
