### PR TITLE
sink(ticdc): add batch field to resolveTs

### DIFF
--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -101,7 +101,7 @@ func NewMounter(schemaStorage SchemaStorage,
 // this method could block indefinitely if the DDL puller is lagging.
 func (m *mounterImpl) DecodeEvent(ctx context.Context, pEvent *model.PolymorphicEvent) error {
 	m.metricTotalRows.Inc()
-	if pEvent.RawKV.OpType == model.OpTypeResolved {
+	if pEvent.IsResolved() {
 		return nil
 	}
 	start := time.Now()

--- a/cdc/processor/pipeline/cyclic_mark.go
+++ b/cdc/processor/pipeline/cyclic_mark.go
@@ -95,7 +95,7 @@ func (n *cyclicMarkNode) TryHandleDataMessage(
 	case pmessage.MessageTypePolymorphicEvent:
 		event := msg.PolymorphicEvent
 		n.flush(ctx, event.CRTs)
-		if event.RawKV.OpType == model.OpTypeResolved {
+		if event.IsResolved() {
 			ctx.SendToNextNode(msg)
 			return true, nil
 		}

--- a/cdc/processor/pipeline/cyclic_mark_test.go
+++ b/cdc/processor/pipeline/cyclic_mark_test.go
@@ -171,7 +171,7 @@ func TestCyclicMarkNode(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for row := range outputCh {
-				if row.PolymorphicEvent.RawKV.OpType == model.OpTypeResolved {
+				if row.PolymorphicEvent.IsResolved() {
 					continue
 				}
 				output = append(output, row.PolymorphicEvent.Row)
@@ -213,7 +213,7 @@ func TestCyclicMarkNode(t *testing.T) {
 		require.Nil(t, err)
 		output := []*model.RowChangedEvent{}
 		putToOutput := func(row *pmessage.Message) {
-			if row == nil || row.PolymorphicEvent.RawKV.OpType == model.OpTypeResolved {
+			if row == nil || row.PolymorphicEvent.IsResolved() {
 				return
 			}
 			output = append(output, row.PolymorphicEvent.Row)

--- a/cdc/processor/pipeline/sink_test.go
+++ b/cdc/processor/pipeline/sink_test.go
@@ -76,12 +76,14 @@ func (s *mockSink) EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error 
 	panic("unreachable")
 }
 
-func (s *mockSink) FlushRowChangedEvents(ctx context.Context, _ model.TableID, resolvedTs uint64) (uint64, error) {
+func (s *mockSink) FlushRowChangedEvents(
+	ctx context.Context, _ model.TableID, resolved model.ResolvedTs,
+) (uint64, error) {
 	s.received = append(s.received, struct {
 		resolvedTs model.Ts
 		row        *model.RowChangedEvent
-	}{resolvedTs: resolvedTs})
-	return resolvedTs, nil
+	}{resolvedTs: resolved.Ts})
+	return resolved.Ts, nil
 }
 
 func (s *mockSink) EmitCheckpointTs(_ context.Context, _ uint64, _ []model.TableName) error {
@@ -420,7 +422,7 @@ func TestManyTs(t *testing.T) {
 		{resolvedTs: 1},
 	})
 	sink.Reset()
-	require.Equal(t, uint64(2), node.ResolvedTs())
+	require.Equal(t, model.NewResolvedTs(uint64(2)), node.ResolvedTs())
 	require.Equal(t, uint64(1), node.CheckpointTs())
 
 	require.Nil(t, node.Receive(
@@ -433,7 +435,7 @@ func TestManyTs(t *testing.T) {
 		{resolvedTs: 2},
 	})
 	sink.Reset()
-	require.Equal(t, uint64(2), node.ResolvedTs())
+	require.Equal(t, model.NewResolvedTs(uint64(2)), node.ResolvedTs())
 	require.Equal(t, uint64(2), node.CheckpointTs())
 }
 
@@ -646,11 +648,13 @@ type flushSink struct {
 // fall back
 var fallBackResolvedTs = uint64(10)
 
-func (s *flushSink) FlushRowChangedEvents(ctx context.Context, _ model.TableID, resolvedTs uint64) (uint64, error) {
-	if resolvedTs == fallBackResolvedTs {
+func (s *flushSink) FlushRowChangedEvents(
+	ctx context.Context, _ model.TableID, resolved model.ResolvedTs,
+) (uint64, error) {
+	if resolved.Ts == fallBackResolvedTs {
 		return 0, nil
 	}
-	return resolvedTs, nil
+	return resolved.Ts, nil
 }
 
 // TestFlushSinkReleaseFlowController tests sinkNode.flushSink method will always
@@ -674,12 +678,12 @@ func TestFlushSinkReleaseFlowController(t *testing.T) {
 	require.Nil(t, sNode.Init(pipeline.MockNodeContext4Test(ctx, pmessage.Message{}, nil)))
 	sNode.barrierTs = 10
 
-	err := sNode.flushSink(context.Background(), uint64(8))
+	err := sNode.flushSink(context.Background(), model.NewResolvedTs(uint64(8)))
 	require.Nil(t, err)
 	require.Equal(t, uint64(8), sNode.checkpointTs)
 	require.Equal(t, 1, flowController.releaseCounter)
 	// resolvedTs will fall back in this call
-	err = sNode.flushSink(context.Background(), uint64(10))
+	err = sNode.flushSink(context.Background(), model.NewResolvedTs(uint64(10)))
 	require.Nil(t, err)
 	require.Equal(t, uint64(8), sNode.checkpointTs)
 	require.Equal(t, 2, flowController.releaseCounter)

--- a/cdc/processor/pipeline/table.go
+++ b/cdc/processor/pipeline/table.go
@@ -91,7 +91,7 @@ func (t *tablePipelineImpl) ResolvedTs() model.Ts {
 	// another replication barrier for consistent replication instead of reusing
 	// the global resolved-ts.
 	if redo.IsConsistentEnabled(t.replConfig.Consistent.Level) {
-		return t.sinkNode.ResolvedTs()
+		return t.sinkNode.ResolvedTs().Ts
 	}
 	return t.sorterNode.ResolvedTs()
 }

--- a/cdc/processor/pipeline/table_actor.go
+++ b/cdc/processor/pipeline/table_actor.go
@@ -429,7 +429,7 @@ func (t *tableActor) ResolvedTs() model.Ts {
 	// another replication barrier for consistent replication instead of reusing
 	// the global resolved-ts.
 	if redo.IsConsistentEnabled(t.replicaConfig.Consistent.Level) {
-		return t.sinkNode.ResolvedTs()
+		return t.sinkNode.ResolvedTs().Ts
 	}
 	return t.sortNode.ResolvedTs()
 }

--- a/cdc/processor/pipeline/table_actor_test.go
+++ b/cdc/processor/pipeline/table_actor_test.go
@@ -91,7 +91,7 @@ func TestTableActorInterface(t *testing.T) {
 
 	require.Equal(t, model.Ts(5), tbl.ResolvedTs())
 	tbl.replicaConfig.Consistent.Level = string(redo.ConsistentLevelEventual)
-	atomic.StoreUint64(&sink.resolvedTs, 6)
+	sink.resolvedTs.Store(model.NewResolvedTs(6))
 	require.Equal(t, model.Ts(6), tbl.ResolvedTs())
 }
 
@@ -184,15 +184,18 @@ func TestPollStoppedActor(t *testing.T) {
 
 func TestPollTickMessage(t *testing.T) {
 	startTime := time.Now().Add(-sinkFlushInterval)
+
+	sn := &sinkNode{
+		status:         TableStatusInitializing,
+		sink:           &mockSink{},
+		flowController: &mockFlowController{},
+		checkpointTs:   10,
+		targetTs:       11,
+	}
+	sn.resolvedTs.Store(model.NewResolvedTs(10))
+
 	tbl := tableActor{
-		sinkNode: &sinkNode{
-			status:         TableStatusInitializing,
-			sink:           &mockSink{},
-			flowController: &mockFlowController{},
-			resolvedTs:     10,
-			checkpointTs:   10,
-			targetTs:       11,
-		},
+		sinkNode:          sn,
 		lastFlushSinkTime: time.Now().Add(-2 * sinkFlushInterval),
 		cancel:            func() {},
 		reportErr:         func(err error) {},
@@ -235,13 +238,15 @@ func TestPollStopMessage(t *testing.T) {
 }
 
 func TestPollBarrierTsMessage(t *testing.T) {
+	sn := &sinkNode{
+		targetTs:     10,
+		checkpointTs: 5,
+		barrierTs:    8,
+	}
+	sn.resolvedTs.Store(model.NewResolvedTs(5))
+
 	tbl := tableActor{
-		sinkNode: &sinkNode{
-			targetTs:     10,
-			checkpointTs: 5,
-			resolvedTs:   5,
-			barrierTs:    8,
-		},
+		sinkNode: sn,
 		sortNode: &sorterNode{
 			barrierTs: 8,
 		},

--- a/cdc/sink/black_hole.go
+++ b/cdc/sink/black_hole.go
@@ -37,6 +37,8 @@ type blackHoleSink struct {
 	lastAccumulated uint64
 }
 
+var _ Sink = (*blackHoleSink)(nil)
+
 func (b *blackHoleSink) AddTable(tableID model.TableID) error {
 	return nil
 }
@@ -51,8 +53,10 @@ func (b *blackHoleSink) EmitRowChangedEvents(ctx context.Context, rows ...*model
 	return nil
 }
 
-func (b *blackHoleSink) FlushRowChangedEvents(ctx context.Context, _ model.TableID, resolvedTs uint64) (uint64, error) {
-	log.Debug("BlockHoleSink: FlushRowChangedEvents", zap.Uint64("resolvedTs", resolvedTs))
+func (b *blackHoleSink) FlushRowChangedEvents(
+	ctx context.Context, _ model.TableID, resolved model.ResolvedTs,
+) (uint64, error) {
+	log.Debug("BlockHoleSink: FlushRowChangedEvents", zap.Uint64("resolvedTs", resolved.Ts))
 	err := b.statistics.RecordBatchExecution(func() (int, error) {
 		// TODO: add some random replication latency
 		accumulated := atomic.LoadUint64(&b.accumulated)
@@ -61,7 +65,7 @@ func (b *blackHoleSink) FlushRowChangedEvents(ctx context.Context, _ model.Table
 		return int(batchSize), nil
 	})
 	b.statistics.PrintStatus(ctx)
-	return resolvedTs, err
+	return resolved.Ts, err
 }
 
 func (b *blackHoleSink) EmitCheckpointTs(ctx context.Context, ts uint64, tables []model.TableName) error {

--- a/cdc/sink/mq/mq.go
+++ b/cdc/sink/mq/mq.go
@@ -42,8 +42,8 @@ import (
 )
 
 type resolvedTsEvent struct {
-	tableID    model.TableID
-	resolvedTs model.Ts
+	tableID  model.TableID
+	resolved model.ResolvedTs
 }
 
 const (
@@ -179,21 +179,23 @@ func (k *mqSink) EmitRowChangedEvents(ctx context.Context, rows ...*model.RowCha
 // that the data before the resolvedTs has been
 // successfully written downstream.
 // FlushRowChangedEvents is thread-safe.
-func (k *mqSink) FlushRowChangedEvents(ctx context.Context, tableID model.TableID, resolvedTs uint64) (uint64, error) {
+func (k *mqSink) FlushRowChangedEvents(
+	ctx context.Context, tableID model.TableID, resolved model.ResolvedTs,
+) (uint64, error) {
 	var checkpointTs uint64
 	v, ok := k.tableCheckpointTsMap.Load(tableID)
 	if ok {
 		checkpointTs = v.(uint64)
 	}
-	if resolvedTs <= checkpointTs {
+	if resolved.Ts <= checkpointTs {
 		return checkpointTs, nil
 	}
 	select {
 	case <-ctx.Done():
 		return 0, ctx.Err()
 	case k.resolvedBuffer <- resolvedTsEvent{
-		tableID:    tableID,
-		resolvedTs: resolvedTs,
+		tableID:  tableID,
+		resolved: model.NewResolvedTs(resolved.Ts),
 	}:
 	}
 	k.statistics.PrintStatus(ctx)
@@ -207,21 +209,21 @@ func (k *mqSink) bgFlushTs(ctx context.Context) error {
 		case <-ctx.Done():
 			return errors.Trace(ctx.Err())
 		case msg := <-k.resolvedBuffer:
-			resolvedTs := msg.resolvedTs
-			err := k.flushTsToWorker(ctx, resolvedTs)
+			resolved := msg.resolved
+			err := k.flushTsToWorker(ctx, resolved)
 			if err != nil {
 				return errors.Trace(err)
 			}
 			// Since CDC does not guarantee exactly once semantic, it won't cause any problem
 			// here even if the table was moved or removed.
 			// ref: https://github.com/pingcap/tiflow/pull/4356#discussion_r787405134
-			k.tableCheckpointTsMap.Store(msg.tableID, resolvedTs)
+			k.tableCheckpointTsMap.Store(msg.tableID, resolved.Ts)
 		}
 	}
 }
 
-func (k *mqSink) flushTsToWorker(ctx context.Context, resolvedTs model.Ts) error {
-	if err := k.flushWorker.addEvent(ctx, mqEvent{resolvedTs: resolvedTs}); err != nil {
+func (k *mqSink) flushTsToWorker(ctx context.Context, resolved model.ResolvedTs) error {
+	if err := k.flushWorker.addEvent(ctx, mqEvent{resolved: resolved}); err != nil {
 		if errors.Cause(err) != context.Canceled {
 			log.Warn("failed to flush TS to worker", zap.Error(err))
 		} else {

--- a/cdc/sink/mq/mq_flush_worker.go
+++ b/cdc/sink/mq/mq_flush_worker.go
@@ -43,9 +43,9 @@ type topicPartitionKey struct {
 // It carries the partition information of the message,
 // and it is also used as resolved ts messaging.
 type mqEvent struct {
-	key        topicPartitionKey
-	row        *model.RowChangedEvent
-	resolvedTs model.Ts
+	key      topicPartitionKey
+	row      *model.RowChangedEvent
+	resolved model.ResolvedTs
 }
 
 // flushWorker is responsible for sending messages to the Kafka producer on a batch basis.
@@ -98,7 +98,7 @@ func (w *flushWorker) batch(
 	case msg := <-w.msgChan:
 		// When the resolved ts is received,
 		// we need to write the previous data to the producer as soon as possible.
-		if msg.resolvedTs != 0 {
+		if msg.resolved.Ts != 0 {
 			w.needSyncFlush = true
 			return index, nil
 		}
@@ -116,7 +116,7 @@ func (w *flushWorker) batch(
 		case <-ctx.Done():
 			return index, ctx.Err()
 		case msg := <-w.msgChan:
-			if msg.resolvedTs != 0 {
+			if msg.resolved.Ts != 0 {
 				w.needSyncFlush = true
 				return index, nil
 			}

--- a/cdc/sink/mq/mq_flush_worker_test.go
+++ b/cdc/sink/mq/mq_flush_worker_test.go
@@ -114,7 +114,7 @@ func TestBatch(t *testing.T) {
 			name: "Normal batching",
 			events: []mqEvent{
 				{
-					resolvedTs: 0,
+					resolved: model.NewResolvedTs(0),
 				},
 				{
 					row: &model.RowChangedEvent{
@@ -139,7 +139,7 @@ func TestBatch(t *testing.T) {
 			name: "No row change events",
 			events: []mqEvent{
 				{
-					resolvedTs: 1,
+					resolved: model.NewResolvedTs(1),
 				},
 			},
 			expectedN: 0,
@@ -156,7 +156,7 @@ func TestBatch(t *testing.T) {
 					key: key,
 				},
 				{
-					resolvedTs: 1,
+					resolved: model.NewResolvedTs(1),
 				},
 				{
 					row: &model.RowChangedEvent{
@@ -384,7 +384,7 @@ func TestFlush(t *testing.T) {
 			key: key1,
 		},
 		{
-			resolvedTs: 1,
+			resolved: model.NewResolvedTs(1),
 		},
 	}
 
@@ -461,15 +461,15 @@ func TestProducerError(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	err = worker.addEvent(ctx, mqEvent{resolvedTs: 100})
+	err = worker.addEvent(ctx, mqEvent{resolved: model.NewResolvedTs(100)})
 	require.NoError(t, err)
 	wg.Wait()
 
-	err = worker.addEvent(ctx, mqEvent{resolvedTs: 200})
+	err = worker.addEvent(ctx, mqEvent{resolved: model.NewResolvedTs(200)})
 	require.Error(t, err)
 	require.Regexp(t, ".*fake.*", err.Error())
 
-	err = worker.addEvent(ctx, mqEvent{resolvedTs: 300})
+	err = worker.addEvent(ctx, mqEvent{resolved: model.NewResolvedTs(300)})
 	require.Error(t, err)
 	require.Regexp(t, ".*ErrMQWorkerClosed.*", err.Error())
 }

--- a/cdc/sink/mq/mq_test.go
+++ b/cdc/sink/mq/mq_test.go
@@ -93,11 +93,11 @@ func (s mqSinkSuite) TestKafkaSink(c *check.C) {
 	}
 	err = sink.EmitRowChangedEvents(ctx, row)
 	c.Assert(err, check.IsNil)
-	checkpointTs, err := sink.FlushRowChangedEvents(ctx, tableID, uint64(120))
+	checkpointTs, err := sink.FlushRowChangedEvents(ctx, tableID, model.NewResolvedTs(uint64(120)))
 	c.Assert(err, check.IsNil)
 	c.Assert(checkpointTs, check.Equals, uint64(120))
 	// flush older resolved ts
-	checkpointTs, err = sink.FlushRowChangedEvents(ctx, tableID, uint64(110))
+	checkpointTs, err = sink.FlushRowChangedEvents(ctx, tableID, model.NewResolvedTs(uint64(110)))
 	c.Assert(err, check.IsNil)
 	c.Assert(checkpointTs, check.Equals, uint64(120))
 
@@ -324,20 +324,24 @@ func (s mqSinkSuite) TestFlushRowChangedEvents(c *check.C) {
 
 	// mock kafka broker processes 1 row resolvedTs event
 	leader.Returns(prodSuccess)
-	checkpointTs1, err := sink.FlushRowChangedEvents(ctx, tableID1, row1.CommitTs)
+	checkpointTs1, err := sink.FlushRowChangedEvents(ctx,
+		tableID1, model.NewResolvedTs(row1.CommitTs))
 	c.Assert(err, check.IsNil)
 	c.Assert(checkpointTs1, check.Equals, row1.CommitTs)
 
-	checkpointTs2, err := sink.FlushRowChangedEvents(ctx, tableID2, row2.CommitTs)
+	checkpointTs2, err := sink.FlushRowChangedEvents(ctx,
+		tableID2, model.NewResolvedTs(row2.CommitTs))
 	c.Assert(err, check.IsNil)
 	c.Assert(checkpointTs2, check.Equals, row2.CommitTs)
 
-	checkpointTs3, err := sink.FlushRowChangedEvents(ctx, tableID3, row3.CommitTs)
+	checkpointTs3, err := sink.FlushRowChangedEvents(ctx,
+		tableID3, model.NewResolvedTs(row3.CommitTs))
 	c.Assert(err, check.IsNil)
 	c.Assert(checkpointTs3, check.Equals, row3.CommitTs)
 
 	// flush older resolved ts
-	checkpointTsOld, err := sink.FlushRowChangedEvents(ctx, tableID1, uint64(110))
+	checkpointTsOld, err := sink.FlushRowChangedEvents(ctx, tableID1,
+		model.NewResolvedTs(uint64(110)))
 	c.Assert(err, check.IsNil)
 	c.Assert(checkpointTsOld, check.Equals, row1.CommitTs)
 

--- a/cdc/sink/mysql/mysql_test.go
+++ b/cdc/sink/mysql/mysql_test.go
@@ -1248,7 +1248,7 @@ func TestNewMySQLSinkExecDML(t *testing.T) {
 
 	// retry to make sure event is flushed
 	err = retry.Do(context.Background(), func() error {
-		ts, err := sink.FlushRowChangedEvents(ctx, 1, uint64(2))
+		ts, err := sink.FlushRowChangedEvents(ctx, 1, model.NewResolvedTs(uint64(2)))
 		require.Nil(t, err)
 		if ts < uint64(2) {
 			return errors.Errorf("checkpoint ts %d less than resolved ts %d", ts, 2)
@@ -1259,7 +1259,7 @@ func TestNewMySQLSinkExecDML(t *testing.T) {
 	require.Nil(t, err)
 
 	err = retry.Do(context.Background(), func() error {
-		ts, err := sink.FlushRowChangedEvents(ctx, 2, uint64(4))
+		ts, err := sink.FlushRowChangedEvents(ctx, 2, model.NewResolvedTs(uint64(4)))
 		require.Nil(t, err)
 		if ts < uint64(4) {
 			return errors.Errorf("checkpoint ts %d less than resolved ts %d", ts, 4)
@@ -1787,7 +1787,7 @@ func TestMySQLSinkFlushResolvedTs(t *testing.T) {
 		model.DefaultChangeFeedID(changefeed),
 		sinkURI, f, rc, map[string]string{})
 	require.Nil(t, err)
-	checkpoint, err := sink.FlushRowChangedEvents(ctx, model.TableID(1), 1)
+	checkpoint, err := sink.FlushRowChangedEvents(ctx, model.TableID(1), model.NewResolvedTs(1))
 	require.Nil(t, err)
 	require.True(t, checkpoint <= 1)
 	rows := []*model.RowChangedEvent{
@@ -1806,7 +1806,7 @@ func TestMySQLSinkFlushResolvedTs(t *testing.T) {
 	}
 	err = sink.EmitRowChangedEvents(ctx, rows...)
 	require.Nil(t, err)
-	checkpoint, err = sink.FlushRowChangedEvents(ctx, model.TableID(1), 6)
+	checkpoint, err = sink.FlushRowChangedEvents(ctx, model.TableID(1), model.NewResolvedTs(6))
 	require.True(t, checkpoint <= 6)
 	require.Nil(t, err)
 	require.True(t, sink.getTableCheckpointTs(model.TableID(1)) <= 6)
@@ -1826,16 +1826,16 @@ func TestMySQLSinkFlushResolvedTs(t *testing.T) {
 	}
 	err = sink.EmitRowChangedEvents(ctx, rows...)
 	require.Nil(t, err)
-	checkpoint, err = sink.FlushRowChangedEvents(ctx, model.TableID(2), 5)
+	checkpoint, err = sink.FlushRowChangedEvents(ctx, model.TableID(2), model.NewResolvedTs(5))
 	require.True(t, checkpoint <= 5)
 	require.Nil(t, err)
 	require.True(t, sink.getTableCheckpointTs(model.TableID(2)) <= 5)
 	_ = sink.Close(ctx)
-	_, err = sink.FlushRowChangedEvents(ctx, model.TableID(2), 6)
+	_, err = sink.FlushRowChangedEvents(ctx, model.TableID(2), model.NewResolvedTs(6))
 	require.Nil(t, err)
 
 	cancel()
-	_, err = sink.FlushRowChangedEvents(ctx, model.TableID(2), 6)
+	_, err = sink.FlushRowChangedEvents(ctx, model.TableID(2), model.NewResolvedTs(6))
 	require.Regexp(t, ".*context canceled.*", err)
 }
 
@@ -1906,7 +1906,7 @@ func TestCleanTableResource(t *testing.T) {
 		Table: &model.TableName{TableID: tblID, Schema: "test", Table: "t1"},
 	}))
 	s.tableCheckpointTs.Store(tblID, uint64(1))
-	s.tableMaxResolvedTs.Store(tblID, uint64(2))
+	s.tableMaxResolvedTs.Store(tblID, model.NewResolvedTs(uint64(2)))
 	_, ok := s.txnCache.unresolvedTxns[tblID]
 	require.True(t, ok)
 	require.Nil(t, s.AddTable(tblID))

--- a/cdc/sink/mysql/txn_cache.go
+++ b/cdc/sink/mysql/txn_cache.go
@@ -134,8 +134,8 @@ func splitResolvedTxn(
 	checkpointTsMap = make(map[model.TableID]uint64, len(unresolvedTxns))
 	resolvedTsMap.Range(func(k, v any) bool {
 		tableID := k.(model.TableID)
-		resolvedTs := v.(model.Ts)
-		checkpointTsMap[tableID] = resolvedTs
+		resolved := v.(model.ResolvedTs)
+		checkpointTsMap[tableID] = resolved.Ts
 		return true
 	})
 

--- a/cdc/sink/mysql/txn_cache_test.go
+++ b/cdc/sink/mysql/txn_cache_test.go
@@ -267,19 +267,19 @@ func TestSplitResolvedTxn(test *testing.T) {
 			cache.Append(nil, t.input...)
 			resolvedTsMap := sync.Map{}
 			for tableID, ts := range t.resolvedTsMap {
-				resolvedTsMap.Store(tableID, ts)
+				resolvedTsMap.Store(tableID, model.NewResolvedTs(ts))
 			}
-			checkpointTsMap, resolved := cache.Resolved(&resolvedTsMap)
-			for tableID, txns := range resolved {
+			checkpointTsMap, resolvedTxn := cache.Resolved(&resolvedTsMap)
+			for tableID, txns := range resolvedTxn {
 				sort.Slice(txns, func(i, j int) bool {
 					if txns[i].CommitTs != txns[j].CommitTs {
 						return txns[i].CommitTs < txns[j].CommitTs
 					}
 					return txns[i].StartTs < txns[j].StartTs
 				})
-				resolved[tableID] = txns
+				resolvedTxn[tableID] = txns
 			}
-			require.Equal(test, t.expected, resolved, cmp.Diff(resolved, t.expected))
+			require.Equal(test, t.expected, resolvedTxn, cmp.Diff(resolvedTxn, t.expected))
 			require.Equal(test, t.resolvedTsMap, checkpointTsMap)
 		}
 	}

--- a/cdc/sink/sink.go
+++ b/cdc/sink/sink.go
@@ -53,12 +53,16 @@ type Sink interface {
 	EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error
 
 	// FlushRowChangedEvents flushes each row which of commitTs less than or
-	// equal to `resolvedTs` into downstream.
-	// TiCDC guarantees that all the Events whose commitTs is less than or
-	// equal to `resolvedTs` are sent to Sink through `EmitRowChangedEvents`
+	// equal to `resolved.Ts` into downstream.
+	// With `resolved.Mode == NormalResolvedMode`, TiCDC guarantees that all events whose commitTs
+	// is less than or equal to `resolved.Ts` are sent to Sink.
+	// With `resolved.Mode == BatchResolvedMode`, TiCDC guarantees that all events whose commitTs
+	// is less than 'resolved.Ts' are sent to Sink.
 	//
 	// FlushRowChangedEvents is thread-safe.
-	FlushRowChangedEvents(ctx context.Context, tableID model.TableID, resolvedTs uint64) (uint64, error)
+	FlushRowChangedEvents(
+		ctx context.Context, tableID model.TableID, resolved model.ResolvedTs,
+	) (uint64, error)
 
 	// EmitCheckpointTs sends CheckpointTs to Sink.
 	// TiCDC guarantees that all Events **in the cluster** which of commitTs

--- a/cdc/sorter/leveldb/writer.go
+++ b/cdc/sorter/leveldb/writer.go
@@ -17,7 +17,6 @@ import (
 	"context"
 
 	"github.com/pingcap/log"
-	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/sorter/encoding"
 	"github.com/pingcap/tiflow/cdc/sorter/leveldb/message"
 	"github.com/pingcap/tiflow/pkg/actor"
@@ -57,7 +56,7 @@ func (w *writer) Poll(ctx context.Context, msgs []actormsg.Message[message.Task]
 		}
 
 		ev := msgs[i].Value.InputEvent
-		if ev.RawKV.OpType == model.OpTypeResolved {
+		if ev.IsResolved() {
 			if w.maxResolvedTs < ev.CRTs {
 				w.maxResolvedTs = ev.CRTs
 			}

--- a/cdc/sorter/memory/entry_sorter.go
+++ b/cdc/sorter/memory/entry_sorter.go
@@ -141,7 +141,7 @@ func (es *EntrySorter) AddEntry(_ context.Context, entry *model.PolymorphicEvent
 	}
 	es.lock.Lock()
 	defer es.lock.Unlock()
-	if entry.RawKV.OpType == model.OpTypeResolved {
+	if entry.IsResolved() {
 		es.resolvedTsGroup = append(es.resolvedTsGroup, entry.CRTs)
 		es.resolvedNotifier.Notify()
 	} else {

--- a/cdc/sorter/memory/entry_sorter_test.go
+++ b/cdc/sorter/memory/entry_sorter_test.go
@@ -275,7 +275,7 @@ func TestEntrySorterRandomly(t *testing.T) {
 		}
 		lastTs = entry.CRTs
 		lastOpType = entry.RawKV.OpType
-		if entry.RawKV.OpType == model.OpTypeResolved {
+		if entry.IsResolved() {
 			resolvedTs = entry.CRTs
 		}
 		if resolvedTs == maxTs {
@@ -509,7 +509,7 @@ func BenchmarkSorter(b *testing.B) {
 	}()
 	var resolvedTs uint64
 	for entry := range es.Output() {
-		if entry.RawKV.OpType == model.OpTypeResolved {
+		if entry.IsResolved() {
 			resolvedTs = entry.CRTs
 		}
 		if resolvedTs == maxTs {

--- a/cdc/sorter/unified/heap_sorter.go
+++ b/cdc/sorter/unified/heap_sorter.go
@@ -118,7 +118,7 @@ func (h *heapSorter) flush(ctx context.Context, maxResolvedTs uint64) error {
 	// Since when a table is mostly idle or near-idle, most flushes would contain one ResolvedEvent alone,
 	// this optimization will greatly improve performance when (1) total number of table is large,
 	// and (2) most tables do not have many events.
-	if h.heap.Len() == 1 && h.heap[0].entry.RawKV.OpType == model.OpTypeResolved {
+	if h.heap.Len() == 1 && h.heap[0].entry.IsResolved() {
 		h.heap.Pop()
 	}
 
@@ -303,7 +303,7 @@ func (h *heapSorter) init(ctx context.Context, onError func(err error)) {
 	poolHandle := heapSorterPool.RegisterEvent(func(ctx context.Context, eventI interface{}) error {
 		event := eventI.(*model.PolymorphicEvent)
 		heap.Push(&h.heap, &sortItem{entry: event})
-		isResolvedEvent := event.RawKV != nil && event.RawKV.OpType == model.OpTypeResolved
+		isResolvedEvent := event.RawKV != nil && event.IsResolved()
 
 		if isResolvedEvent {
 			if event.RawKV.CRTs < state.maxResolved {

--- a/cdc/sorter/unified/merger.go
+++ b/cdc/sorter/unified/merger.go
@@ -352,7 +352,7 @@ func runMerger(ctx context.Context, numSorters int, in <-chan *flushTask, out ch
 				continue
 			}
 
-			if event.CRTs > minResolvedTs || (event.CRTs == minResolvedTs && event.RawKV.OpType == model.OpTypeResolved) {
+			if event.CRTs > minResolvedTs || (event.CRTs == minResolvedTs && event.IsResolved()) {
 				// we have processed all events from this task that need to be processed in this merge
 				if event.CRTs > minResolvedTs || event.RawKV.OpType != model.OpTypeResolved {
 					pendingSet.Store(task, event)

--- a/cdc/sorter/unified/unified_sorter.go
+++ b/cdc/sorter/unified/unified_sorter.go
@@ -183,7 +183,7 @@ func (s *Sorter) Run(ctx context.Context) error {
 			case <-subctx.Done():
 				return subctx.Err()
 			case event := <-s.inputCh:
-				if event.RawKV != nil && event.RawKV.OpType == model.OpTypeResolved {
+				if event.RawKV != nil && event.IsResolved() {
 					// broadcast resolved events
 					for _, sorter := range heapSorters {
 						select {

--- a/cmd/kafka-consumer/main.go
+++ b/cmd/kafka-consumer/main.go
@@ -790,7 +790,8 @@ func syncFlushRowChangedEvents(ctx context.Context, sink *partitionSink, resolve
 		flushedResolvedTs := true
 		sink.tablesMap.Range(func(key, value interface{}) bool {
 			tableID := key.(int64)
-			checkpointTs, err = sink.FlushRowChangedEvents(ctx, tableID, resolvedTs)
+			checkpointTs, err = sink.FlushRowChangedEvents(ctx,
+				tableID, model.NewResolvedTs(resolvedTs))
 			if err != nil {
 				return false
 			}

--- a/pkg/applier/redo.go
+++ b/pkg/applier/redo.go
@@ -165,7 +165,7 @@ func (ra *RedoApplier) consumeLogs(ctx context.Context) error {
 		}
 
 		for tableID, tableLastResolvedTs := range tableResolvedTsMap {
-			_, err = s.FlushRowChangedEvents(ctx, tableID, tableLastResolvedTs)
+			_, err = s.FlushRowChangedEvents(ctx, tableID, model.NewResolvedTs(tableLastResolvedTs))
 			if err != nil {
 				return err
 			}
@@ -177,7 +177,7 @@ func (ra *RedoApplier) consumeLogs(ctx context.Context) error {
 	}
 
 	for tableID := range tableResolvedTsMap {
-		_, err = s.FlushRowChangedEvents(ctx, tableID, resolvedTs)
+		_, err = s.FlushRowChangedEvents(ctx, tableID, model.NewResolvedTs(resolvedTs))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5398

### What is changed and how it works?
1. Add batch field to resolveTs
2. Added batch Resolved semantics support to Sink's `FlushRowChangedEvents` interface:

      -  With `resolved.Batch == false`, TiCDC guarantees that all the Events whose commitTs is less than or equal to `resolved.Ts` are sent to Sink through `EmitRowChangedEvents`.
      -  With `resolved.Batch == true`, TiCDC guarantees that all events whose commitTs is less than 'resolved.Ts' are sent to Sink.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change

Side effects

 - Possible performance regression
 - Increased code complexity

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
