### PR TITLE
sink(ticdc): store checkpointTs by flushedResolvedTsMap in mysql sink

### DIFF
--- a/cdc/sink/mysql/mysql.go
+++ b/cdc/sink/mysql/mysql.go
@@ -258,7 +258,7 @@ func (s *mysqlSink) FlushRowChangedEvents(ctx context.Context, tableID model.Tab
 func (s *mysqlSink) flushRowChangedEvents(ctx context.Context, receiver *notify.Receiver) {
 	defer func() {
 		for _, worker := range s.workers {
-			worker.closedCh <- struct{}{}
+			worker.close()
 		}
 	}()
 	for {
@@ -276,7 +276,7 @@ func (s *mysqlSink) flushRowChangedEvents(ctx context.Context, receiver *notify.
 			s.statistics.SubRowsCount(skippedRowCount)
 		}
 
-		if len(resolvedTxnsMap) == 0 {
+		if len(resolvedTxnsMap) != 0 {
 			s.dispatchAndExecTxns(ctx, resolvedTxnsMap)
 		}
 		for tableID, resolvedTs := range flushedResolvedTsMap {

--- a/cdc/sink/mysql/mysql.go
+++ b/cdc/sink/mysql/mysql.go
@@ -239,6 +239,8 @@ func (s *mysqlSink) FlushRowChangedEvents(ctx context.Context, tableID model.Tab
 
 	// check and throw error
 	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
 	case err := <-s.errCh:
 		return 0, err
 	case s.resolvedCh <- struct{}{}:
@@ -524,7 +526,6 @@ func (s *mysqlSink) cleanTableResource(tableID model.TableID) {
 
 func (s *mysqlSink) Close(ctx context.Context) error {
 	s.execWaitNotifier.Close()
-	close(s.resolvedCh)
 	err := s.db.Close()
 	s.cancel()
 	return cerror.WrapError(cerror.ErrMySQLConnectionError, err)

--- a/cdc/sink/mysql/mysql.go
+++ b/cdc/sink/mysql/mysql.go
@@ -197,13 +197,12 @@ func NewMySQLSink(
 		statistics:                      metrics.NewStatistics(ctx, metrics.SinkTypeDB),
 		metricConflictDetectDurationHis: metricConflictDetectDurationHis,
 		metricBucketSizeCounters:        metricBucketSizeCounters,
+		execWaitNotifier:                new(notify.Notifier),
+		resolvedCh:                      make(chan struct{}, 1),
 		errCh:                           make(chan error, 1),
 		forceReplicate:                  replicaConfig.ForceReplicate,
 		cancel:                          cancel,
 	}
-
-	sink.execWaitNotifier = new(notify.Notifier)
-	sink.resolvedCh = make(chan struct{})
 
 	err = sink.createSinkWorkers(ctx)
 	if err != nil {

--- a/cdc/sink/mysql/mysql.go
+++ b/cdc/sink/mysql/mysql.go
@@ -263,7 +263,7 @@ func (s *mysqlSink) flushRowChangedEvents(ctx context.Context) {
 			return
 		case <-s.resolvedCh:
 		}
-		flushedResolvedTsMap, resolvedTxnsMap := s.txnCache.Resolved(&s.tableMaxResolvedTs)
+		checkpointTsMap, resolvedTxnsMap := s.txnCache.Resolved(&s.tableMaxResolvedTs)
 
 		if s.cyclic != nil {
 			// Filter rows if it is origin from downstream.
@@ -275,7 +275,7 @@ func (s *mysqlSink) flushRowChangedEvents(ctx context.Context) {
 		if len(resolvedTxnsMap) != 0 {
 			s.dispatchAndExecTxns(ctx, resolvedTxnsMap)
 		}
-		for tableID, resolvedTs := range flushedResolvedTsMap {
+		for tableID, resolvedTs := range checkpointTsMap {
 			s.tableCheckpointTs.Store(tableID, resolvedTs)
 		}
 	}

--- a/cdc/sink/mysql/mysql_worker.go
+++ b/cdc/sink/mysql/mysql_worker.go
@@ -170,3 +170,7 @@ func (w *mysqlSinkWorker) cleanup() {
 		}
 	}
 }
+
+func (w *mysqlSinkWorker) close() {
+	w.closedCh <- struct{}{}
+}

--- a/cdc/sink/mysql/txn_cache.go
+++ b/cdc/sink/mysql/txn_cache.go
@@ -121,7 +121,7 @@ func (c *unresolvedTxnCache) Resolved(
 
 func splitResolvedTxn(
 	resolvedTsMap *sync.Map, unresolvedTxns map[model.TableID][]*txnsWithTheSameCommitTs,
-) (flushedResolvedTsMap map[model.TableID]uint64, resolvedRowsMap map[model.TableID][]*model.SingleTableTxn) {
+) (checkpointTsMap map[model.TableID]uint64, resolvedRowsMap map[model.TableID][]*model.SingleTableTxn) {
 	var (
 		ok                              bool
 		txnsLength                      int
@@ -129,16 +129,16 @@ func splitResolvedTxn(
 		resolvedTxnsWithTheSameCommitTs []*txnsWithTheSameCommitTs
 	)
 
-	flushedResolvedTsMap = make(map[model.TableID]uint64, len(unresolvedTxns))
+	checkpointTsMap = make(map[model.TableID]uint64, len(unresolvedTxns))
 	resolvedTsMap.Range(func(k, v any) bool {
 		tableID := k.(model.TableID)
 		resolvedTs := v.(model.Ts)
-		flushedResolvedTsMap[tableID] = resolvedTs
+		checkpointTsMap[tableID] = resolvedTs
 		return true
 	})
 
 	resolvedRowsMap = make(map[model.TableID][]*model.SingleTableTxn, len(unresolvedTxns))
-	for tableID, resolvedTs := range flushedResolvedTsMap {
+	for tableID, resolvedTs := range checkpointTsMap {
 		if txns, ok = unresolvedTxns[tableID]; !ok {
 			continue
 		}

--- a/cdc/sink/mysql/txn_cache.go
+++ b/cdc/sink/mysql/txn_cache.go
@@ -133,6 +133,7 @@ func splitResolvedTxn(
 			continue
 		}
 		resolvedTs := v.(uint64)
+		flushedResolvedTsMap[tableID] = resolvedTs
 		i := sort.Search(len(txns), func(i int) bool {
 			return txns[i].commitTs > resolvedTs
 		})
@@ -156,7 +157,6 @@ func splitResolvedTxn(
 			resolvedTxns = append(resolvedTxns, txns.txns...)
 		}
 		resolvedRowsMap[tableID] = resolvedTxns
-		flushedResolvedTsMap[tableID] = resolvedTs
 	}
 	return
 }

--- a/cdc/sink/mysql/txn_cache.go
+++ b/cdc/sink/mysql/txn_cache.go
@@ -122,6 +122,13 @@ func (c *unresolvedTxnCache) Resolved(
 func splitResolvedTxn(
 	resolvedTsMap *sync.Map, unresolvedTxns map[model.TableID][]*txnsWithTheSameCommitTs,
 ) (flushedResolvedTsMap map[model.TableID]uint64, resolvedRowsMap map[model.TableID][]*model.SingleTableTxn) {
+	var (
+		ok                              bool
+		txnsLength                      int
+		txns                            []*txnsWithTheSameCommitTs
+		resolvedTxnsWithTheSameCommitTs []*txnsWithTheSameCommitTs
+	)
+
 	flushedResolvedTsMap = make(map[model.TableID]uint64, len(unresolvedTxns))
 	resolvedTsMap.Range(func(k, v any) bool {
 		tableID := k.(model.TableID)
@@ -131,12 +138,6 @@ func splitResolvedTxn(
 	})
 
 	resolvedRowsMap = make(map[model.TableID][]*model.SingleTableTxn, len(unresolvedTxns))
-	var (
-		txns                            []*txnsWithTheSameCommitTs
-		ok                              bool
-		resolvedTxnsWithTheSameCommitTs []*txnsWithTheSameCommitTs
-		txnsLength                      int
-	)
 	for tableID, resolvedTs := range flushedResolvedTsMap {
 		if txns, ok = unresolvedTxns[tableID]; !ok {
 			continue

--- a/cdc/sink/mysql/txn_cache.go
+++ b/cdc/sink/mysql/txn_cache.go
@@ -115,9 +115,6 @@ func (c *unresolvedTxnCache) Resolved(
 ) (map[model.TableID]uint64, map[model.TableID][]*model.SingleTableTxn) {
 	c.unresolvedTxnsMu.Lock()
 	defer c.unresolvedTxnsMu.Unlock()
-	if len(c.unresolvedTxns) == 0 {
-		return nil, nil
-	}
 
 	return splitResolvedTxn(resolvedTsMap, c.unresolvedTxns)
 }

--- a/cdc/sink/mysql/txn_cache_test.go
+++ b/cdc/sink/mysql/txn_cache_test.go
@@ -269,7 +269,7 @@ func TestSplitResolvedTxn(test *testing.T) {
 			for tableID, ts := range t.resolvedTsMap {
 				resolvedTsMap.Store(tableID, ts)
 			}
-			flushedResolvedTsMap, resolved := cache.Resolved(&resolvedTsMap)
+			checkpointTsMap, resolved := cache.Resolved(&resolvedTsMap)
 			for tableID, txns := range resolved {
 				sort.Slice(txns, func(i, j int) bool {
 					if txns[i].CommitTs != txns[j].CommitTs {
@@ -280,7 +280,7 @@ func TestSplitResolvedTxn(test *testing.T) {
 				resolved[tableID] = txns
 			}
 			require.Equal(test, t.expected, resolved, cmp.Diff(resolved, t.expected))
-			require.Equal(test, t.resolvedTsMap, flushedResolvedTsMap)
+			require.Equal(test, t.resolvedTsMap, checkpointTsMap)
 		}
 	}
 }

--- a/cdc/sink/mysql/txn_cache_test.go
+++ b/cdc/sink/mysql/txn_cache_test.go
@@ -128,7 +128,7 @@ func TestSplitResolvedTxn(test *testing.T) {
 					2: uint64(13),
 					3: uint64(13),
 				},
-				expected: nil,
+				expected: map[model.TableID][]*model.SingleTableTxn{},
 			},
 			{
 				input: []*model.RowChangedEvent{
@@ -264,7 +264,7 @@ func TestSplitResolvedTxn(test *testing.T) {
 			for tableID, ts := range t.resolvedTsMap {
 				resolvedTsMap.Store(tableID, ts)
 			}
-			_, resolved := cache.Resolved(&resolvedTsMap)
+			flushedResolvedTsMap, resolved := cache.Resolved(&resolvedTsMap)
 			for tableID, txns := range resolved {
 				sort.Slice(txns, func(i, j int) bool {
 					if txns[i].CommitTs != txns[j].CommitTs {
@@ -275,6 +275,7 @@ func TestSplitResolvedTxn(test *testing.T) {
 				resolved[tableID] = txns
 			}
 			require.Equal(test, t.expected, resolved, cmp.Diff(resolved, t.expected))
+			require.Equal(test, t.resolvedTsMap, flushedResolvedTsMap)
 		}
 	}
 }

--- a/cdc/sink/mysql/txn_cache_test.go
+++ b/cdc/sink/mysql/txn_cache_test.go
@@ -44,6 +44,7 @@ func TestSplitResolvedTxn(test *testing.T) {
 				resolvedTsMap: map[model.TableID]uint64{
 					1: uint64(6),
 					2: uint64(6),
+					3: uint64(6),
 				},
 				expected: map[model.TableID][]*model.SingleTableTxn{
 					1: {{
@@ -70,6 +71,7 @@ func TestSplitResolvedTxn(test *testing.T) {
 					1: uint64(13),
 					2: uint64(13),
 					3: uint64(13),
+					4: uint64(6),
 				},
 				expected: map[model.TableID][]*model.SingleTableTxn{
 					1: {
@@ -139,6 +141,7 @@ func TestSplitResolvedTxn(test *testing.T) {
 				resolvedTsMap: map[model.TableID]uint64{
 					1: uint64(6),
 					2: uint64(6),
+					3: uint64(13),
 				},
 				expected: map[model.TableID][]*model.SingleTableTxn{},
 			},
@@ -159,6 +162,7 @@ func TestSplitResolvedTxn(test *testing.T) {
 				resolvedTsMap: map[model.TableID]uint64{
 					1: uint64(6),
 					2: uint64(6),
+					3: uint64(13),
 				},
 				expected: map[model.TableID][]*model.SingleTableTxn{
 					1: {
@@ -202,6 +206,7 @@ func TestSplitResolvedTxn(test *testing.T) {
 				resolvedTsMap: map[model.TableID]uint64{
 					1: uint64(13),
 					2: uint64(13),
+					3: uint64(13),
 				},
 				expected: map[model.TableID][]*model.SingleTableTxn{
 					1: {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-CDC! Please read MD's [CONTRIBUTING](https://github.com/pingcap/tidb-cdc/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5107

### What is changed and how it works?
- When mysql Sink traverses the`tableMaxResolvedTs ` at this [line](https://github.com/pingcap/tiflow/blob/f3bf091a656301a59f2c98fff0ed5e49355d49e8/cdc/sink/mysql/mysql.go#L272), the map may have been concurrently modified, [which will result in an incorrect value being saved to`tableCheckpointTs `](https://github.com/pingcap/tiflow/blob/f3bf091a656301a59f2c98fff0ed5e49355d49e8/cdc/sink/mysql/mysql.go#L273).
To solve this problem, we need to: 
    1. Save the resolvedTs, which are used to [search data](https://github.com/pingcap/tiflow/pull/5418/files#diff-ab73e67a0b47a3a9537743cf306c53bbf2247b8b53e8a1998ac3529e4c2d41b9R145) from txnCache, into the [flushedResolvedTsMap](https://github.com/pingcap/tiflow/pull/5418/files#diff-ab73e67a0b47a3a9537743cf306c53bbf2247b8b53e8a1998ac3529e4c2d41b9R130)
    2. In mysql sink, always store checkpointTs based on [flushedResolvedTsMap](https://github.com/pingcap/tiflow/pull/5418/files#diff-ba27cb35a4f83fcd923c1403ff1fb7c1ad29659e7eadd87dd505700bf82f92b9R282)

- Replace `resolvedNotifier` with `resolvedCh` to simplify the code



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`Fix a bug that mysql sink may save a wrong checkpointTs`.
```
