### PR TITLE
sink(ticdc): make sink batch flush data 

### DIFF
--- a/cdc/model/mounter.go
+++ b/cdc/model/mounter.go
@@ -13,13 +13,13 @@
 
 package model
 
+import "math"
+
 // PolymorphicEvent describes an event can be in multiple states.
 type PolymorphicEvent struct {
-	StartTs uint64
-	// Commit or resolved TS
-	CRTs uint64
-	// Identify whether the resolved event is in batch mode.
-	Mode ResolvedMode
+	StartTs  uint64
+	CRTs     uint64
+	Resolved *ResolvedTs
 
 	RawKV *RawKVEntry
 	Row   *RowChangedEvent
@@ -66,11 +66,6 @@ func (e *PolymorphicEvent) IsResolved() bool {
 	return e.RawKV.OpType == OpTypeResolved
 }
 
-// IsBatchResolved returns true if the event is batch resolved event.
-func (e *PolymorphicEvent) IsBatchResolved() bool {
-	return e.IsResolved() && e.Mode == BatchResolvedMode
-}
-
 // ComparePolymorphicEvents compares two events by CRTs, Resolved, StartTs, Delete/Put order.
 // It returns true if and only if i should precede j.
 func ComparePolymorphicEvents(i, j *PolymorphicEvent) bool {
@@ -108,16 +103,42 @@ const (
 
 // ResolvedTs is the resolved timestamp of sink module.
 type ResolvedTs struct {
-	Ts   uint64
-	Mode ResolvedMode
+	Mode    ResolvedMode
+	Ts      uint64
+	BatchID uint64
 }
 
-// NewResolvedTs creates a new ResolvedTs.
+// NewResolvedTs creates a normal ResolvedTs.
 func NewResolvedTs(t uint64) ResolvedTs {
-	return ResolvedTs{Ts: t, Mode: NormalResolvedMode}
+	return ResolvedTs{Ts: t, Mode: NormalResolvedMode, BatchID: math.MaxUint64}
 }
 
-// NewResolvedTsWithMode creates a ResolvedTs with a given batch type.
-func NewResolvedTsWithMode(t uint64, m ResolvedMode) ResolvedTs {
-	return ResolvedTs{Ts: t, Mode: m}
+// IsBatchMode returns true if the resolved ts is BatchResolvedMode.
+func (r ResolvedTs) IsBatchMode() bool {
+	return r.Mode == BatchResolvedMode
+}
+
+// ParseTs parses a timestamp based on the r.mode.
+func (r ResolvedTs) ParseTs() uint64 {
+	switch r.Mode {
+	case NormalResolvedMode:
+		return r.Ts
+	case BatchResolvedMode:
+		return r.Ts - 1
+	default:
+		return 0
+	}
+}
+
+// EqualOrGreater judge whether the resolved ts is equal or greater than the given ts.
+func (r ResolvedTs) EqualOrGreater(r1 ResolvedTs) bool {
+	if r.Ts == r1.Ts {
+		return r.BatchID >= r1.BatchID
+	}
+	return r.Ts > r1.Ts
+}
+
+// Less judge whether the resolved ts is less than the given ts.
+func (r ResolvedTs) Less(r1 ResolvedTs) bool {
+	return !r.EqualOrGreater(r1)
 }

--- a/cdc/processor/pipeline/sorter.go
+++ b/cdc/processor/pipeline/sorter.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/redo"
 	"github.com/pingcap/tiflow/cdc/sorter"
-	"github.com/pingcap/tiflow/cdc/sorter/leveldb"
 	"github.com/pingcap/tiflow/cdc/sorter/memory"
 	"github.com/pingcap/tiflow/cdc/sorter/unified"
 	"github.com/pingcap/tiflow/pkg/actor"
@@ -90,21 +89,6 @@ func createSorter(ctx pipeline.NodeContext, tableName string, tableID model.Tabl
 				zap.String("tableName", tableName))
 		}
 
-		if config.GetGlobalServerConfig().Debug.EnableDBSorter {
-			startTs := ctx.ChangefeedVars().Info.StartTs
-			ssystem := ctx.GlobalVars().SorterSystem
-			dbActorID := ssystem.DBActorID(uint64(tableID))
-			compactScheduler := ctx.GlobalVars().SorterSystem.CompactScheduler()
-			levelSorter, err := leveldb.NewSorter(
-				ctx, tableID, startTs, ssystem.DBRouter, dbActorID,
-				ssystem.WriterSystem, ssystem.WriterRouter,
-				ssystem.ReaderSystem, ssystem.ReaderRouter,
-				compactScheduler, config.GetGlobalServerConfig().Debug.DB)
-			if err != nil {
-				return nil, err
-			}
-			return levelSorter, nil
-		}
 		// Sorter dir has been set and checked when server starts.
 		// See https://github.com/pingcap/tiflow/blob/9dad09/cdc/server.go#L275
 		sortDir := config.GetGlobalServerConfig().Sorter.SortDir

--- a/cdc/processor/pipeline/table.go
+++ b/cdc/processor/pipeline/table.go
@@ -54,8 +54,12 @@ type TablePipeline interface {
 // TODO find a better name or avoid using an interface
 // We use an interface here for ease in unit testing.
 type tableFlowController interface {
-	Consume(msg *model.PolymorphicEvent, size uint64, blockCallBack func(batch bool) error) error
-	Release(resolvedTs uint64)
+	Consume(
+		msg *model.PolymorphicEvent,
+		size uint64,
+		blockCallBack func(batchID uint64) error,
+	) error
+	Release(resolved model.ResolvedTs)
 	Abort()
 	GetConsumption() uint64
 }

--- a/cdc/processor/pipeline/table_actor.go
+++ b/cdc/processor/pipeline/table_actor.go
@@ -430,7 +430,7 @@ func (t *tableActor) ResolvedTs() model.Ts {
 	// another replication barrier for consistent replication instead of reusing
 	// the global resolved-ts.
 	if redo.IsConsistentEnabled(t.replicaConfig.Consistent.Level) {
-		return t.sinkNode.ResolvedTs().Ts
+		return t.sinkNode.ResolvedTs().ParseTs()
 	}
 	return t.sortNode.ResolvedTs()
 }

--- a/cdc/sink/black_hole.go
+++ b/cdc/sink/black_hole.go
@@ -55,7 +55,7 @@ func (b *blackHoleSink) EmitRowChangedEvents(ctx context.Context, rows ...*model
 
 func (b *blackHoleSink) FlushRowChangedEvents(
 	ctx context.Context, _ model.TableID, resolved model.ResolvedTs,
-) (uint64, error) {
+) (model.ResolvedTs, error) {
 	log.Debug("BlockHoleSink: FlushRowChangedEvents", zap.Uint64("resolvedTs", resolved.Ts))
 	err := b.statistics.RecordBatchExecution(func() (int, error) {
 		// TODO: add some random replication latency
@@ -65,7 +65,7 @@ func (b *blackHoleSink) FlushRowChangedEvents(
 		return int(batchSize), nil
 	})
 	b.statistics.PrintStatus(ctx)
-	return resolved.Ts, err
+	return resolved, err
 }
 
 func (b *blackHoleSink) EmitCheckpointTs(ctx context.Context, ts uint64, tables []model.TableName) error {

--- a/cdc/sink/flowcontrol/table_memory_quota.go
+++ b/cdc/sink/flowcontrol/table_memory_quota.go
@@ -54,9 +54,7 @@ func newTableMemoryQuota(quota uint64) *tableMemoryQuota {
 // block until enough memory has been freed up by release.
 // blockCallBack will be called if the function will block.
 // Should be used with care to prevent deadlock.
-func (c *tableMemoryQuota) consumeWithBlocking(
-	nBytes uint64, blockCallBack func(bool) error,
-) error {
+func (c *tableMemoryQuota) consumeWithBlocking(nBytes uint64, blockCallBack func() error) error {
 	if nBytes >= c.quota {
 		return cerrors.ErrFlowControllerEventLargerThanQuota.GenWithStackByArgs(nBytes, c.quota)
 	}
@@ -64,7 +62,7 @@ func (c *tableMemoryQuota) consumeWithBlocking(
 	c.consumed.Lock()
 	if c.consumed.bytes+nBytes >= c.quota {
 		c.consumed.Unlock()
-		err := blockCallBack(false)
+		err := blockCallBack()
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cdc/sink/mq/mq.go
+++ b/cdc/sink/mq/mq.go
@@ -125,10 +125,10 @@ func (k *mqSink) AddTable(tableID model.TableID) error {
 	// otherwise when the table is dispatched back again,
 	// it may read the old values.
 	// See: https://github.com/pingcap/tiflow/issues/4464#issuecomment-1085385382.
-	if checkpointTs, loaded := k.tableCheckpointTsMap.LoadAndDelete(tableID); loaded {
+	if checkpoint, loaded := k.tableCheckpointTsMap.LoadAndDelete(tableID); loaded {
 		log.Info("clean up table checkpoint ts in MQ sink",
 			zap.Int64("tableID", tableID),
-			zap.Uint64("checkpointTs", checkpointTs.(uint64)))
+			zap.Uint64("checkpointTs", checkpoint.(model.ResolvedTs).Ts))
 	}
 
 	return nil
@@ -174,25 +174,21 @@ func (k *mqSink) EmitRowChangedEvents(ctx context.Context, rows ...*model.RowCha
 // FlushRowChangedEvents is thread-safe.
 func (k *mqSink) FlushRowChangedEvents(
 	ctx context.Context, tableID model.TableID, resolved model.ResolvedTs,
-) (uint64, error) {
-	var checkpointTs uint64
-	v, ok := k.tableCheckpointTsMap.Load(tableID)
-	if ok {
-		checkpointTs = v.(uint64)
-	}
-	if resolved.Ts <= checkpointTs {
-		return checkpointTs, nil
+) (model.ResolvedTs, error) {
+	checkpoint := k.getTableCheckpointTs(tableID)
+	if checkpoint.EqualOrGreater(resolved) {
+		return checkpoint, nil
 	}
 	select {
 	case <-ctx.Done():
-		return 0, ctx.Err()
+		return model.NewResolvedTs(0), ctx.Err()
 	case k.resolvedBuffer.In() <- resolvedTsEvent{
 		tableID:  tableID,
-		resolved: model.NewResolvedTs(resolved.Ts),
+		resolved: resolved,
 	}:
 	}
 	k.statistics.PrintStatus(ctx)
-	return checkpointTs, nil
+	return checkpoint, nil
 }
 
 // bgFlushTs flush resolvedTs to workers and flush the mqProducer
@@ -217,7 +213,7 @@ func (k *mqSink) bgFlushTs(ctx context.Context) error {
 			// Since CDC does not guarantee exactly once semantic, it won't cause any problem
 			// here even if the table was moved or removed.
 			// ref: https://github.com/pingcap/tiflow/pull/4356#discussion_r787405134
-			k.tableCheckpointTsMap.Store(msg.tableID, resolved.Ts)
+			k.tableCheckpointTsMap.Store(msg.tableID, resolved)
 		}
 	}
 }
@@ -365,6 +361,14 @@ func (k *mqSink) RemoveTable(cxt context.Context, tableID model.TableID) error {
 	// RemoveTable does nothing because FlushRowChangedEvents in mq sink had flushed
 	// all buffered events by force.
 	return nil
+}
+
+func (k *mqSink) getTableCheckpointTs(tableID model.TableID) model.ResolvedTs {
+	v, ok := k.tableCheckpointTsMap.Load(tableID)
+	if ok {
+		return v.(model.ResolvedTs)
+	}
+	return model.NewResolvedTs(0)
 }
 
 func (k *mqSink) run(ctx context.Context) error {

--- a/cdc/sink/mysql/mysql.go
+++ b/cdc/sink/mysql/mysql.go
@@ -227,18 +227,18 @@ func (s *mysqlSink) EmitRowChangedEvents(ctx context.Context, rows ...*model.Row
 // Concurrency Note: FlushRowChangedEvents is thread-safe.
 func (s *mysqlSink) FlushRowChangedEvents(
 	ctx context.Context, tableID model.TableID, resolved model.ResolvedTs,
-) (uint64, error) {
+) (model.ResolvedTs, error) {
 	v, ok := s.getTableResolvedTs(tableID)
-	if !ok || v.Ts < resolved.Ts {
+	if !ok || v.Less(resolved) {
 		s.tableMaxResolvedTs.Store(tableID, resolved)
 	}
 
 	// check and throw error
 	select {
 	case <-ctx.Done():
-		return 0, ctx.Err()
+		return model.NewResolvedTs(0), ctx.Err()
 	case err := <-s.errCh:
-		return 0, err
+		return model.NewResolvedTs(0), err
 	case s.resolvedCh <- struct{}{}:
 		// Notify `flushRowChangedEvents` to asynchronously write data.
 	default:
@@ -273,8 +273,8 @@ func (s *mysqlSink) flushRowChangedEvents(ctx context.Context) {
 		if len(resolvedTxnsMap) != 0 {
 			s.dispatchAndExecTxns(ctx, resolvedTxnsMap)
 		}
-		for tableID, resolvedTs := range checkpointTsMap {
-			s.tableCheckpointTs.Store(tableID, resolvedTs)
+		for tableID, resolved := range checkpointTsMap {
+			s.tableCheckpointTs.Store(tableID, resolved)
 		}
 	}
 }
@@ -513,10 +513,10 @@ func (s *mysqlSink) cleanTableResource(tableID model.TableID) {
 			zap.Int64("tableID", tableID),
 			zap.Uint64("resolvedTs", resolved.(model.ResolvedTs).Ts))
 	}
-	if checkpointTs, loaded := s.tableCheckpointTs.LoadAndDelete(tableID); loaded {
+	if checkpoint, loaded := s.tableCheckpointTs.LoadAndDelete(tableID); loaded {
 		log.Info("clean up table checkpoint ts in MySQL sink",
 			zap.Int64("tableID", tableID),
-			zap.Uint64("checkpointTs", checkpointTs.(uint64)))
+			zap.Uint64("checkpointTs", checkpoint.(model.ResolvedTs).Ts))
 	}
 	// try to remove table txn cache
 	s.txnCache.RemoveTableTxn(tableID)
@@ -541,25 +541,26 @@ func (s *mysqlSink) RemoveTable(ctx context.Context, tableID model.TableID) erro
 			return errors.Trace(ctx.Err())
 		case <-ticker.C:
 			maxResolved, ok := s.getTableResolvedTs(tableID)
-			log.Warn("Barrier doesn't return in time, may be stuck",
+			log.Warn("RemoveTable doesn't return in time, may be stuck",
 				zap.Int64("tableID", tableID),
 				zap.Bool("hasResolvedTs", ok),
 				zap.Any("resolvedTs", maxResolved.Ts),
-				zap.Uint64("checkpointTs", s.getTableCheckpointTs(tableID)))
+				zap.Uint64("checkpointTs", s.getTableCheckpointTs(tableID).Ts))
 		default:
 			maxResolved, ok := s.getTableResolvedTs(tableID)
 			if !ok {
 				log.Info("No table resolvedTs is found", zap.Int64("tableID", tableID))
 				return nil
 			}
-			if s.getTableCheckpointTs(tableID) >= maxResolved.Ts {
+			checkpoint := s.getTableCheckpointTs(tableID)
+			if checkpoint.EqualOrGreater(maxResolved) {
 				return nil
 			}
-			checkpointTs, err := s.FlushRowChangedEvents(ctx, tableID, maxResolved)
+			checkpoint, err := s.FlushRowChangedEvents(ctx, tableID, maxResolved)
 			if err != nil {
 				return err
 			}
-			if checkpointTs >= maxResolved.Ts {
+			if checkpoint.Ts >= maxResolved.Ts {
 				return nil
 			}
 			// short sleep to avoid cpu spin
@@ -568,12 +569,12 @@ func (s *mysqlSink) RemoveTable(ctx context.Context, tableID model.TableID) erro
 	}
 }
 
-func (s *mysqlSink) getTableCheckpointTs(tableID model.TableID) uint64 {
+func (s *mysqlSink) getTableCheckpointTs(tableID model.TableID) model.ResolvedTs {
 	v, ok := s.tableCheckpointTs.Load(tableID)
 	if ok {
-		return v.(uint64)
+		return v.(model.ResolvedTs)
 	}
-	return uint64(0)
+	return model.NewResolvedTs(0)
 }
 
 func (s *mysqlSink) getTableResolvedTs(tableID model.TableID) (model.ResolvedTs, bool) {

--- a/cdc/sink/mysql/mysql_test.go
+++ b/cdc/sink/mysql/mysql_test.go
@@ -1250,8 +1250,8 @@ func TestNewMySQLSinkExecDML(t *testing.T) {
 	err = retry.Do(context.Background(), func() error {
 		ts, err := sink.FlushRowChangedEvents(ctx, 1, model.NewResolvedTs(uint64(2)))
 		require.Nil(t, err)
-		if ts < uint64(2) {
-			return errors.Errorf("checkpoint ts %d less than resolved ts %d", ts, 2)
+		if ts.Ts < uint64(2) {
+			return errors.Errorf("checkpoint ts %d less than resolved ts %d", ts.Ts, 2)
 		}
 		return nil
 	}, retry.WithBackoffBaseDelay(20), retry.WithMaxTries(10), retry.WithIsRetryableErr(cerror.IsRetryableError))
@@ -1261,8 +1261,8 @@ func TestNewMySQLSinkExecDML(t *testing.T) {
 	err = retry.Do(context.Background(), func() error {
 		ts, err := sink.FlushRowChangedEvents(ctx, 2, model.NewResolvedTs(uint64(4)))
 		require.Nil(t, err)
-		if ts < uint64(4) {
-			return errors.Errorf("checkpoint ts %d less than resolved ts %d", ts, 4)
+		if ts.Ts < uint64(4) {
+			return errors.Errorf("checkpoint ts %d less than resolved ts %d", ts.Ts, 4)
 		}
 		return nil
 	}, retry.WithBackoffBaseDelay(20), retry.WithMaxTries(10), retry.WithIsRetryableErr(cerror.IsRetryableError))
@@ -1789,7 +1789,7 @@ func TestMySQLSinkFlushResolvedTs(t *testing.T) {
 	require.Nil(t, err)
 	checkpoint, err := sink.FlushRowChangedEvents(ctx, model.TableID(1), model.NewResolvedTs(1))
 	require.Nil(t, err)
-	require.True(t, checkpoint <= 1)
+	require.True(t, checkpoint.Ts <= 1)
 	rows := []*model.RowChangedEvent{
 		{
 			Table:    &model.TableName{Schema: "s1", Table: "t1", TableID: 1},
@@ -1807,9 +1807,9 @@ func TestMySQLSinkFlushResolvedTs(t *testing.T) {
 	err = sink.EmitRowChangedEvents(ctx, rows...)
 	require.Nil(t, err)
 	checkpoint, err = sink.FlushRowChangedEvents(ctx, model.TableID(1), model.NewResolvedTs(6))
-	require.True(t, checkpoint <= 6)
+	require.True(t, checkpoint.Ts <= 6)
 	require.Nil(t, err)
-	require.True(t, sink.getTableCheckpointTs(model.TableID(1)) <= 6)
+	require.True(t, sink.getTableCheckpointTs(model.TableID(1)).Ts <= 6)
 	rows = []*model.RowChangedEvent{
 		{
 			Table:    &model.TableName{Schema: "s1", Table: "t2", TableID: 2},
@@ -1827,9 +1827,9 @@ func TestMySQLSinkFlushResolvedTs(t *testing.T) {
 	err = sink.EmitRowChangedEvents(ctx, rows...)
 	require.Nil(t, err)
 	checkpoint, err = sink.FlushRowChangedEvents(ctx, model.TableID(2), model.NewResolvedTs(5))
-	require.True(t, checkpoint <= 5)
+	require.True(t, checkpoint.Ts <= 5)
 	require.Nil(t, err)
-	require.True(t, sink.getTableCheckpointTs(model.TableID(2)) <= 5)
+	require.True(t, sink.getTableCheckpointTs(model.TableID(2)).Ts <= 5)
 	_ = sink.Close(ctx)
 	_, err = sink.FlushRowChangedEvents(ctx, model.TableID(2), model.NewResolvedTs(6))
 	require.Nil(t, err)
@@ -1905,7 +1905,7 @@ func TestCleanTableResource(t *testing.T) {
 	require.Nil(t, s.EmitRowChangedEvents(ctx, &model.RowChangedEvent{
 		Table: &model.TableName{TableID: tblID, Schema: "test", Table: "t1"},
 	}))
-	s.tableCheckpointTs.Store(tblID, uint64(1))
+	s.tableCheckpointTs.Store(tblID, model.NewResolvedTs(uint64(1)))
 	s.tableMaxResolvedTs.Store(tblID, model.NewResolvedTs(uint64(2)))
 	_, ok := s.txnCache.unresolvedTxns[tblID]
 	require.True(t, ok)

--- a/cdc/sink/mysql/txn_cache_test.go
+++ b/cdc/sink/mysql/txn_cache_test.go
@@ -266,7 +266,9 @@ func TestSplitResolvedTxn(test *testing.T) {
 		for _, t := range tc {
 			cache.Append(nil, t.input...)
 			resolvedTsMap := sync.Map{}
+			expectedCheckpointTsMap := make(map[model.TableID]model.ResolvedTs)
 			for tableID, ts := range t.resolvedTsMap {
+				expectedCheckpointTsMap[tableID] = model.NewResolvedTs(ts)
 				resolvedTsMap.Store(tableID, model.NewResolvedTs(ts))
 			}
 			checkpointTsMap, resolvedTxn := cache.Resolved(&resolvedTsMap)
@@ -280,7 +282,7 @@ func TestSplitResolvedTxn(test *testing.T) {
 				resolvedTxn[tableID] = txns
 			}
 			require.Equal(test, t.expected, resolvedTxn, cmp.Diff(resolvedTxn, t.expected))
-			require.Equal(test, t.resolvedTsMap, checkpointTsMap)
+			require.Equal(test, expectedCheckpointTsMap, checkpointTsMap)
 		}
 	}
 }

--- a/cdc/sink/sink.go
+++ b/cdc/sink/sink.go
@@ -62,7 +62,7 @@ type Sink interface {
 	// FlushRowChangedEvents is thread-safe.
 	FlushRowChangedEvents(
 		ctx context.Context, tableID model.TableID, resolved model.ResolvedTs,
-	) (uint64, error)
+	) (model.ResolvedTs, error)
 
 	// EmitCheckpointTs sends CheckpointTs to Sink.
 	// TiCDC guarantees that all Events **in the cluster** which of commitTs

--- a/cmd/kafka-consumer/main.go
+++ b/cmd/kafka-consumer/main.go
@@ -784,18 +784,18 @@ func syncFlushRowChangedEvents(ctx context.Context, sink *partitionSink, resolve
 		}
 		// tables are flushed
 		var (
-			err          error
-			checkpointTs uint64
+			err        error
+			checkpoint model.ResolvedTs
 		)
 		flushedResolvedTs := true
 		sink.tablesMap.Range(func(key, value interface{}) bool {
 			tableID := key.(int64)
-			checkpointTs, err = sink.FlushRowChangedEvents(ctx,
+			checkpoint, err = sink.FlushRowChangedEvents(ctx,
 				tableID, model.NewResolvedTs(resolvedTs))
 			if err != nil {
 				return false
 			}
-			if checkpointTs < resolvedTs {
+			if checkpoint.Ts < resolvedTs {
 				flushedResolvedTs = false
 			}
 			return true


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5453, close #1683

### What is changed and how it works?
1. In flowcontrol module, allocate and release based on resolvedTs and batchID.
2. In sink module, replace model.Ts with model.ResolvedTs to support batch-based memory release.
3. Note OOM also occurs when there is a large gap between upstream and downstream throughput.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
> down stream: TiDB
total row of txn: 20 million
txn size: ~3.7 GB
downstream: tidb cluster
memory of cdc node: 32 GB

![image](https://user-images.githubusercontent.com/61726649/169859847-d73c3743-7496-45e7-bf8c-678541e9e130.png)
![image](https://user-images.githubusercontent.com/61726649/169860261-a485b19f-54d1-447d-89f7-1acc68b3249c.png)


> down stream: TiDB
total row of txn: 30 million
txn size: ~5.4 GB
downstream: tidb cluster
memory of cdc node: 32 GB
![image](https://user-images.githubusercontent.com/61726649/169861284-08d866b5-85f8-4cb1-a86e-081656a6fb68.png)
![image](https://user-images.githubusercontent.com/61726649/169862047-fbd0c9e7-5f32-4bd2-b9e2-da1bf47bd49f.png)


> down stream: Kafka / canal-json
total row of txn: 30 million
txn size: ~5.4 GB
downstream: tidb cluster
memory of cdc node: 32 GB
<img width="553" alt="image" src="https://user-images.githubusercontent.com/61726649/170935191-248ac48e-3b1a-47bf-86da-55307c5c7090.png">
<img width="937" alt="image" src="https://user-images.githubusercontent.com/61726649/170935329-5dfdbb1b-4843-49fa-89b4-9b10a5cf1eff.png">



#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`Optimize the memory consumption required for TiCDC to process large transactions`.
```
