### PR TITLE
sink/codc(ticdc): fix schema-registry options in cli & config file

### DIFF
--- a/cdc/sink/mq/codec/config.go
+++ b/cdc/sink/mq/codec/config.go
@@ -108,8 +108,8 @@ func (c *Config) Apply(sinkURI *url.URL, config *config.ReplicaConfig) error {
 		c.avroBigintUnsignedHandlingMode = s
 	}
 
-	if config.SchemaRegistry != "" {
-		c.avroSchemaRegistry = config.SchemaRegistry
+	if config.Sink != nil && config.Sink.SchemaRegistry != "" {
+		c.avroSchemaRegistry = config.Sink.SchemaRegistry
 	}
 
 	return nil

--- a/cdc/sink/mq/codec/config_test.go
+++ b/cdc/sink/mq/codec/config_test.go
@@ -52,7 +52,7 @@ func TestConfigApplyValidate(t *testing.T) {
 	c := NewConfig(p)
 	require.Equal(t, config.ProtocolCanalJSON, c.protocol)
 
-	replicaConfig := &config.ReplicaConfig{}
+	replicaConfig := config.GetDefaultReplicaConfig()
 	err = c.Apply(sinkURI, replicaConfig)
 	require.NoError(t, err)
 	require.True(t, c.enableTiDBExtension)
@@ -102,7 +102,7 @@ func TestConfigApplyValidate(t *testing.T) {
 	err = c.Validate()
 	require.ErrorContains(t, err, `Avro protocol requires parameter "schema-registry"`)
 
-	replicaConfig.SchemaRegistry = "this-is-a-uri"
+	replicaConfig.Sink.SchemaRegistry = "this-is-a-uri"
 	err = c.Apply(sinkURI, replicaConfig)
 	require.NoError(t, err)
 	require.Equal(t, "this-is-a-uri", c.avroSchemaRegistry)

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -758,6 +758,9 @@ var doc = `{
                 },
                 "protocol": {
                     "type": "string"
+                },
+                "schema-registry": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -739,6 +739,9 @@
                 },
                 "protocol": {
                     "type": "string"
+                },
+                "schema-registry": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -39,6 +39,8 @@ definitions:
         type: array
       protocol:
         type: string
+      schema-registry:
+        type: string
     type: object
   model.Capture:
     properties:

--- a/pkg/cmd/cli/cli_changefeed_update.go
+++ b/pkg/cmd/cli/cli_changefeed_update.go
@@ -162,6 +162,8 @@ func (o *updateChangefeedOptions) applyChanges(oldInfo *model.ChangeFeedInfo, cm
 			if err = o.commonChangefeedOptions.strictDecodeConfig("TiCDC changefeed", cfg); err != nil {
 				log.Error("decode config file error", zap.Error(err))
 			}
+		case "schema-registry":
+			newInfo.Config.Sink.SchemaRegistry = o.commonChangefeedOptions.schemaRegistry
 		case "opts":
 			for _, opt := range o.commonChangefeedOptions.opts {
 				s := strings.SplitN(opt, "=", 2)

--- a/pkg/config/config_test_data.go
+++ b/pkg/config/config_test_data.go
@@ -167,7 +167,8 @@ const (
           "b"
         ]
       }
-    ]
+    ],
+    "schema-registry": ""
   },
   "cyclic-replication": {
     "enable": false,
@@ -181,8 +182,7 @@ const (
     "max-log-size": 64,
     "flush-interval": 1000,
     "storage": ""
-  },
-  "schema-registry": ""
+  }
 }`
 
 	testCfgTestReplicaConfigMarshal2 = `{

--- a/pkg/config/replica_config.go
+++ b/pkg/config/replica_config.go
@@ -46,7 +46,6 @@ var defaultReplicaConfig = &ReplicaConfig{
 		FlushIntervalInMs: 1000,
 		Storage:           "",
 	},
-	SchemaRegistry: "",
 }
 
 // ReplicaConfig represents some addition replication config for a changefeed
@@ -62,7 +61,6 @@ type replicaConfig struct {
 	Sink             *SinkConfig       `toml:"sink" json:"sink"`
 	Cyclic           *CyclicConfig     `toml:"cyclic-replication" json:"cyclic-replication"`
 	Consistent       *ConsistentConfig `toml:"consistent" json:"consistent"`
-	SchemaRegistry   string            `toml:"schema-registry" json:"schema-registry"`
 }
 
 // Marshal returns the json marshal format of a ReplicationConfig

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -37,6 +37,7 @@ type SinkConfig struct {
 	DispatchRules   []*DispatchRule   `toml:"dispatchers" json:"dispatchers"`
 	Protocol        string            `toml:"protocol" json:"protocol"`
 	ColumnSelectors []*ColumnSelector `toml:"column-selectors" json:"column-selectors"`
+	SchemaRegistry  string            `toml:"schema-registry" json:"schema-registry"`
 }
 
 // DispatchRule represents partition rule for a table


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

Issue Number: ref #5338 

### What problem does this PR solve?

1. `schema-registry` option should accompany  the `protocol` option under `sink` section. Otherwise, it's really unnatural.
2. support update `schema-registry` from cli and file.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
