### PR TITLE
tests: use python3 to run http_api test to fix failed integration_tests

### DIFF
--- a/tests/integration_tests/http_api/run.sh
+++ b/tests/integration_tests/http_api/run.sh
@@ -16,7 +16,7 @@ function run() {
 		return
 	fi
 
-	sudo pip install -U requests==2.26.0
+	sudo python3 -m pip install -U requests==2.26.0
 
 	rm -rf $WORK_DIR && mkdir -p $WORK_DIR
 
@@ -60,10 +60,10 @@ function run() {
 
 	SINK_URI="mysql://normal:123456@127.0.0.1:3306/"
 
-	python $CUR/util/test_case.py check_health $TLS_DIR
-	python $CUR/util/test_case.py get_status $TLS_DIR
+	python3 $CUR/util/test_case.py check_health $TLS_DIR
+	python3 $CUR/util/test_case.py get_status $TLS_DIR
 
-	python $CUR/util/test_case.py create_changefeed $TLS_DIR "$SINK_URI"
+	python3 $CUR/util/test_case.py create_changefeed $TLS_DIR "$SINK_URI"
 	# wait for all changefeed created
 	ensure $MAX_RETRIES check_changefeed_state "https://${TLS_PD_HOST}:${TLS_PD_PORT}" "changefeed-test1" "normal" "null" ${TLS_DIR}
 	ensure $MAX_RETRIES check_changefeed_state "https://${TLS_PD_HOST}:${TLS_PD_PORT}" "changefeed-test2" "normal" "null" ${TLS_DIR}
@@ -112,7 +112,7 @@ function run() {
 	)
 
 	for case in ${sequential_cases[@]}; do
-		python $CUR/util/test_case.py "$case" $TLS_DIR
+		python3 $CUR/util/test_case.py "$case" $TLS_DIR
 	done
 
 	cleanup_process $CDC_BINARY


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5474 

### What is changed and how it works?

Our CI envs still default to python2 to run tests. `http_api` requires using `requests` which brings `certifi`. Actually `certifi`'s recent releases doesn't support python2 any more.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
