### PR TITLE
dm: parse start-time using upstream timezone

### DIFF
--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -44,8 +44,6 @@ import (
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
-	"github.com/pingcap/tiflow/dm/pkg/gtid"
-
 	"github.com/pingcap/tiflow/dm/dm/config"
 	"github.com/pingcap/tiflow/dm/dm/pb"
 	"github.com/pingcap/tiflow/dm/dm/unit"
@@ -55,6 +53,7 @@ import (
 	"github.com/pingcap/tiflow/dm/pkg/conn"
 	tcontext "github.com/pingcap/tiflow/dm/pkg/context"
 	fr "github.com/pingcap/tiflow/dm/pkg/func-rollback"
+	"github.com/pingcap/tiflow/dm/pkg/gtid"
 	"github.com/pingcap/tiflow/dm/pkg/ha"
 	"github.com/pingcap/tiflow/dm/pkg/log"
 	parserpkg "github.com/pingcap/tiflow/dm/pkg/parser"

--- a/dm/syncer/util.go
+++ b/dm/syncer/util.go
@@ -138,7 +138,8 @@ func str2TimezoneOrFromDB(tctx *tcontext.Context, tzStr string, dbCfg *config.DB
 	if err != nil {
 		return nil, err
 	}
-	tctx.L().Info("use timezone", zap.String("location", loc.String()))
+	tctx.L().Info("use timezone", zap.String("location", loc.String()),
+		zap.String("host", dbCfg.Host), zap.Int("port", dbCfg.Port))
 	return loc, nil
 }
 

--- a/dm/tests/openapi/run.sh
+++ b/dm/tests/openapi/run.sh
@@ -715,7 +715,7 @@ function test_start_task_with_condition() {
 		"query-status $task_name" \
 		"\"stage\": \"Stopped\"" 2
 	sleep 2
-	start_time=$(date '+%Y-%m-%d %T')
+	start_time=$(TZ='UTC' date '+%Y-%m-%d %T') # mysql 3306 and 3307 is in UTC
 	sleep 2
 	duration=""
 	is_success="success"
@@ -748,7 +748,7 @@ function test_start_task_with_condition() {
 		"query-status $task_name" \
 		"\"stage\": \"Stopped\"" 2
 	sleep 2
-	start_time=$(date '+%Y-%m-%d %T')
+	start_time=$(TZ='UTC' date '+%Y-%m-%d %T') # mysql 3306 and 3307 is in UTC
 	sleep 2
 	duration=""
 	is_success="success"
@@ -780,7 +780,7 @@ function test_start_task_with_condition() {
 	run_sql_source1 "CREATE TABLE openapi.t3(i TINYINT, j INT UNIQUE KEY);"
 	run_sql_source2 "CREATE TABLE openapi.t4(i TINYINT, j INT UNIQUE KEY);"
 	sleep 2
-	start_time=$(date '+%Y-%m-%d %T')
+	start_time=$(TZ='UTC' date '+%Y-%m-%d %T') # mysql 3306 and 3307 is in UTC
 	sleep 2
 	duration=""
 	is_success="success"
@@ -822,7 +822,7 @@ function test_start_task_with_condition() {
 	run_sql_source2 "CREATE TABLE openapi.t2(i TINYINT, j INT UNIQUE KEY);"
 
 	sleep 2
-	start_time=$(date '+%Y-%m-%d %T')
+	start_time=$(TZ='UTC' date '+%Y-%m-%d %T') # mysql 3306 and 3307 is in UTC
 	sleep 2
 	duration=""
 	is_success="success"


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5471

### What is changed and how it works?
as title

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
fix parsing task start-time using downstream timezone problem.
```
