### PR TITLE
kv(ticdc): fix data loss when upstream txn conflicts during scan

### DIFF
--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -127,6 +127,12 @@ func (m *mounterImpl) unmarshalAndMountRowChanged(ctx context.Context, raw *mode
 	if err != nil {
 		return nil, err
 	}
+	if len(raw.OldValue) == 0 && len(raw.Value) == 0 {
+		log.Warn("empty value and old value",
+			zap.String("namespace", m.changefeedID.Namespace),
+			zap.String("changefeed", m.changefeedID.ID),
+			zap.Any("row", raw))
+	}
 	baseInfo := baseKVEntry{
 		StartTs:         raw.StartTs,
 		CRTs:            raw.CRTs,

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -1176,7 +1176,7 @@ func (s *eventFeedSession) receiveFromStream(
 
 	// always create a new region worker, because `receiveFromStream` is ensured
 	// to call exactly once from outter code logic
-	worker := newRegionWorker(s, addr)
+	worker := newRegionWorker(changefeedID, s, addr)
 
 	defer worker.evictAllRegions()
 

--- a/cdc/kv/metrics.go
+++ b/cdc/kv/metrics.go
@@ -51,6 +51,13 @@ var (
 			Help:      "Size of KV events.",
 			Buckets:   prometheus.ExponentialBuckets(16, 2, 25),
 		}, []string{"type"})
+	cacheEventsSize = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "ticdc",
+			Subsystem: "kvclient",
+			Name:      "cache_event_size_bytes",
+			Help:      "Size of cached KV events.",
+		}, []string{"namespace", "changefeed"})
 	pullEventCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "ticdc",
@@ -109,6 +116,7 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(scanRegionsDuration)
 	registry.MustRegister(eventSize)
 	registry.MustRegister(eventFeedGauge)
+	registry.MustRegister(cacheEventsSize)
 	registry.MustRegister(pullEventCounter)
 	registry.MustRegister(sendEventCounter)
 	registry.MustRegister(clientChannelSize)

--- a/cdc/kv/region_worker_test.go
+++ b/cdc/kv/region_worker_test.go
@@ -14,13 +14,18 @@
 package kv
 
 import (
+	"context"
 	"math/rand"
 	"runtime"
 	"sync"
 	"testing"
 
+	"github.com/pingcap/kvproto/pkg/cdcpb"
+	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/pkg/config"
+	"github.com/pingcap/tiflow/pkg/regionspan"
 	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/tikv"
 )
 
 func TestRegionStateManager(t *testing.T) {
@@ -125,4 +130,130 @@ func TestRegionWorkerPoolSize(t *testing.T) {
 	conf.KVClient.WorkerPoolSize = maxWorkerPoolSize + 1
 	size = getWorkerPoolSize()
 	require.Equal(t, maxWorkerPoolSize, size)
+}
+
+func TestRegionWokerHandleEventEntryEventOutOfOrder(t *testing.T) {
+	// For UPDATE SQL, its prewrite event has both value and old value.
+	// It is possible that TiDB prewrites multiple times for the same row when
+	// there are other transcations it conflicts with. For this case,
+	// if the value is not "short", only the first prewrite contains the value.
+	//
+	// TiKV may output events for the UPDATE SQL as following:
+	//
+	// TiDB: [Prwrite1]    [Prewrite2]      [Commit]
+	//       v             v                v                                   Time
+	// ---------------------------------------------------------------------------->
+	//         ^            ^    ^           ^     ^       ^     ^          ^     ^
+	// TiKV:   [Scan Start] [Send Prewrite2] [Send Commit] [Send Prewrite1] [Send Init]
+	// TiCDC:                    [Recv Prewrite2]  [Recv Commit] [Recv Prewrite1] [Recv Init]
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	eventCh := make(chan model.RegionFeedEvent, 2)
+	s := createFakeEventFeedSession(ctx)
+	s.eventCh = eventCh
+	span := regionspan.Span{}.Hack()
+	state := newRegionFeedState(newSingleRegionInfo(
+		tikv.RegionVerID{},
+		regionspan.ToComparableSpan(span),
+		0, &tikv.RPCContext{}), 0)
+	state.start()
+	worker := newRegionWorker(s, "")
+	worker.initMetrics(ctx)
+	require.Equal(t, 2, cap(worker.outputCh))
+
+	// Receive prewrite2 with empty value.
+	events := &cdcpb.Event_Entries_{
+		Entries: &cdcpb.Event_Entries{
+			Entries: []*cdcpb.Event_Row{{
+				StartTs:  1,
+				Type:     cdcpb.Event_PREWRITE,
+				OpType:   cdcpb.Event_Row_PUT,
+				Key:      []byte("key"),
+				Value:    nil,
+				OldValue: []byte("oldvalue"),
+			}},
+		},
+	}
+	err := worker.handleEventEntry(ctx, events, state)
+	require.Nil(t, err)
+
+	// Receive commit.
+	events = &cdcpb.Event_Entries_{
+		Entries: &cdcpb.Event_Entries{
+			Entries: []*cdcpb.Event_Row{{
+				StartTs:  1,
+				CommitTs: 2,
+				Type:     cdcpb.Event_COMMIT,
+				OpType:   cdcpb.Event_Row_PUT,
+				Key:      []byte("key"),
+			}},
+		},
+	}
+	err = worker.handleEventEntry(context.Background(), events, state)
+	require.Nil(t, err)
+
+	// Must not output event.
+	var event model.RegionFeedEvent
+	var ok bool
+	select {
+	case event, ok = <-eventCh:
+	default:
+	}
+	require.Falsef(t, ok, "%v", event)
+	require.EqualValuesf(t, model.RegionFeedEvent{}, event, "%v", event)
+
+	// Receive prewrite1 with actual value.
+	events = &cdcpb.Event_Entries_{
+		Entries: &cdcpb.Event_Entries{
+			Entries: []*cdcpb.Event_Row{{
+				StartTs:  1,
+				Type:     cdcpb.Event_PREWRITE,
+				OpType:   cdcpb.Event_Row_PUT,
+				Key:      []byte("key"),
+				Value:    []byte("value"),
+				OldValue: []byte("oldvalue"),
+			}},
+		},
+	}
+	err = worker.handleEventEntry(ctx, events, state)
+	require.Nil(t, err)
+
+	// Must not output event.
+	select {
+	case event, ok = <-eventCh:
+	default:
+	}
+	require.Falsef(t, ok, "%v", event)
+	require.EqualValuesf(t, model.RegionFeedEvent{}, event, "%v", event)
+
+	// Receive prewrite1 with actual value.
+	events = &cdcpb.Event_Entries_{
+		Entries: &cdcpb.Event_Entries{
+			Entries: []*cdcpb.Event_Row{
+				{
+					Type: cdcpb.Event_INITIALIZED,
+				}},
+		},
+	}
+	err = worker.handleEventEntry(ctx, events, state)
+	require.Nil(t, err)
+
+	// Must output event.
+	select {
+	case event, ok = <-eventCh:
+	default:
+	}
+	require.Truef(t, ok, "%v", event)
+	require.EqualValuesf(t, model.RegionFeedEvent{
+		RegionID: 0,
+		Val: &model.RawKVEntry{
+			OpType:   model.OpTypePut,
+			Key:      []byte("key"),
+			Value:    []byte("value"),
+			StartTs:  1,
+			CRTs:     2,
+			RegionID: 0,
+			OldValue: []byte("oldvalue"),
+		}}, event, "%v", event)
 }

--- a/cdc/kv/region_worker_test.go
+++ b/cdc/kv/region_worker_test.go
@@ -135,7 +135,7 @@ func TestRegionWorkerPoolSize(t *testing.T) {
 func TestRegionWokerHandleEventEntryEventOutOfOrder(t *testing.T) {
 	// For UPDATE SQL, its prewrite event has both value and old value.
 	// It is possible that TiDB prewrites multiple times for the same row when
-	// there are other transcations it conflicts with. For this case,
+	// there are other transactions it conflicts with. For this case,
 	// if the value is not "short", only the first prewrite contains the value.
 	//
 	// TiKV may output events for the UPDATE SQL as following:
@@ -158,8 +158,7 @@ func TestRegionWokerHandleEventEntryEventOutOfOrder(t *testing.T) {
 		regionspan.ToComparableSpan(span),
 		0, &tikv.RPCContext{}), 0)
 	state.start()
-	worker := newRegionWorker(s, "")
-	worker.initMetrics(ctx)
+	worker := newRegionWorker(model.ChangeFeedID{}, s, "")
 	require.Equal(t, 2, cap(worker.outputCh))
 
 	// Receive prewrite2 with empty value.
@@ -233,7 +232,8 @@ func TestRegionWokerHandleEventEntryEventOutOfOrder(t *testing.T) {
 			Entries: []*cdcpb.Event_Row{
 				{
 					Type: cdcpb.Event_INITIALIZED,
-				}},
+				},
+			},
 		},
 	}
 	err = worker.handleEventEntry(ctx, events, state)
@@ -255,5 +255,6 @@ func TestRegionWokerHandleEventEntryEventOutOfOrder(t *testing.T) {
 			CRTs:     2,
 			RegionID: 0,
 			OldValue: []byte("oldvalue"),
-		}}, event, "%v", event)
+		},
+	}, event, "%v", event)
 }

--- a/cdc/model/kv.go
+++ b/cdc/model/kv.go
@@ -84,8 +84,10 @@ type RawKVEntry struct {
 }
 
 func (v *RawKVEntry) String() string {
-	return fmt.Sprintf("OpType: %v, Key: %s, Value: %s, StartTs: %d, CRTs: %d, RegionID: %d",
-		v.OpType, string(v.Key), string(v.Value), v.StartTs, v.CRTs, v.RegionID)
+	// TODO: redact values.
+	return fmt.Sprintf(
+		"OpType: %v, Key: %s, Value: %s, OldValue: %s StartTs: %d, CRTs: %d, RegionID: %d",
+		v.OpType, string(v.Key), string(v.Value), string(v.OldValue), v.StartTs, v.CRTs, v.RegionID)
 }
 
 // ApproximateDataSize calculate the approximate size of protobuf binary


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #5468 

### What is changed and how it works?

Do not match prewrite and commit util it receives init event.
See more in #5468 

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

##### Will it cause performance regression or break compatibility?

It caches more events in memory during incremental scan, it cause OOM when upstream workload is write-heavy.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix data loss when upstream transaction conflicts during cdc reconnection 
```
