### PR TITLE
open (ticdc): fix openapi do not work on non-owner node

### DIFF
--- a/cdc/api/open.go
+++ b/cdc/api/open.go
@@ -841,7 +841,9 @@ func (h *openAPI) forwardToOwner(c *gin.Context) {
 	}
 
 	req.URL.Host = owner.AdvertiseAddr
-	if security != nil {
+	// we should check tls config instead of security here because
+	// security will never be nil
+	if tls, _ := security.ToTLSConfigWithVerify(); tls != nil {
 		req.URL.Scheme = "https"
 	} else {
 		req.URL.Scheme = "http"

--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -34,7 +34,7 @@ type Client struct {
 func NewClient(credential *security.Credential) (*Client, error) {
 	transport := http.DefaultTransport
 	if credential != nil {
-		tlsConf, err := credential.ToTLSConfig()
+		tlsConf, err := credential.ToTLSConfigWithVerify()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5482 

### What is changed and how it works?
Very simple in code.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
After this PR OpenAPI works normally.
<img width="985" alt="image" src="https://user-images.githubusercontent.com/20351731/169299793-784d5d3d-2821-411e-bfb2-fd86b0b1604e.png">

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`fix openapi do not work on non-owner node`.
```
