### PR TITLE
test(dm): fix unstable integration test

### DIFF
--- a/dm/tests/_utils/ha_cases_lib.sh
+++ b/dm/tests/_utils/ha_cases_lib.sh
@@ -163,7 +163,7 @@ function isolate_master() {
 		export GO_FAILPOINTS="github.com/pingcap/tiflow/dm/dm/master/FailToElect=return(\"master$1\")"
 	fi
 	echo "kill dm-master$1"
-	ps aux | grep dm-master$1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-master$1
 	check_master_port_offline $1
 	run_dm_master $WORK_DIR/master$1 $port $cur/conf/dm-master$1.toml
 	export GO_FAILPOINTS=''
@@ -175,7 +175,7 @@ function isolate_worker() {
 		export GO_FAILPOINTS="github.com/pingcap/tiflow/dm/dm/worker/FailToKeepAlive=return(\"worker$1\")"
 	fi
 	echo "kill dm-worker$1"
-	ps aux | grep dm-worker$1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker$1
 	check_port_offline $port 20
 	run_dm_worker $WORK_DIR/worker$1 $port $cur/conf/dm-worker$1.toml
 	export GO_FAILPOINTS=''
@@ -212,9 +212,9 @@ function kill_2_worker_ensure_unbound() {
 	worker_ports_2=(0 $WORKER1_PORT $WORKER2_PORT $WORKER3_PORT $WORKER4_PORT $WORKER5_PORT)
 
 	echo "kill dm-worker$1"
-	ps aux | grep dm-worker$1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker$1
 	echo "kill dm-worker$2"
-	ps aux | grep dm-worker$2 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker$2
 
 	check_port_offline ${worker_ports_2[$1]} 20
 	check_port_offline ${worker_ports_2[$2]} 20

--- a/dm/tests/_utils/shardddl_lib.sh
+++ b/dm/tests/_utils/shardddl_lib.sh
@@ -47,7 +47,7 @@ function clean_table() {
 
 function restart_master() {
 	echo "restart dm-master"
-	ps aux | grep dm-master | awk '{print $2}' | xargs kill || true
+	kill_process dm-master
 	check_master_port_offline 1
 	sleep 2
 
@@ -57,7 +57,7 @@ function restart_master() {
 
 function restart_worker1() {
 	echo "restart dm-worker1"
-	ps aux | grep worker1 | awk '{print $2}' | xargs kill || true
+	kill_process worker1
 	check_process_exit worker1 20
 	run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
 	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT
@@ -65,7 +65,7 @@ function restart_worker1() {
 
 function restart_worker2() {
 	echo "restart dm-worker2"
-	ps aux | grep worker2 | awk '{print $2}' | xargs kill || true
+	kill_process worker2
 	check_process_exit worker2 20
 	run_dm_worker $WORK_DIR/worker2 $WORKER2_PORT $cur/conf/dm-worker2.toml
 	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT

--- a/dm/tests/_utils/test_prepare
+++ b/dm/tests/_utils/test_prepare
@@ -43,6 +43,12 @@ function cleanup_tidb_server(){
     wait_process_exit tidb-server
 }
 
+function kill_process() {
+    keyword=$1
+    ps aux | grep $keyword | awk '{print $2}' | xargs kill || true
+    wait_process_exit $keyword
+}
+
 function wait_pattern_exit() {
     pattern=$1
     while true

--- a/dm/tests/checkpoint_transaction/run.sh
+++ b/dm/tests/checkpoint_transaction/run.sh
@@ -113,7 +113,7 @@ function run() {
 		"\"stage\": \"Running\"" 1
 
 	echo "kill dm-worker1"
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 	rm -rf $WORK_DIR/worker1
 	run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml

--- a/dm/tests/dmctl_basic/check_list/config.sh
+++ b/dm/tests/dmctl_basic/check_list/config.sh
@@ -118,15 +118,15 @@ function config_to_file() {
 		"\"result\": true" 3
 
 	# restart master with get config
-	ps aux | grep dm-master | awk '{print $2}' | xargs kill || true
+	kill_process dm-master
 	check_master_port_offline 1
 	run_dm_master $WORK_DIR/master $MASTER_PORT $dm_master_conf
 	check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT
 
 	# restart worker with get config
-	ps aux | grep worker1 | awk '{print $2}' | xargs kill || true
+	kill_process worker1
 	check_port_offline $WORKER1_PORT 20
-	ps aux | grep worker2 | awk '{print $2}' | xargs kill || true
+	kill_process worker2
 	check_port_offline $WORKER2_PORT 20
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"list-member --worker" \

--- a/dm/tests/dmctl_basic/run.sh
+++ b/dm/tests/dmctl_basic/run.sh
@@ -254,7 +254,7 @@ function run() {
 
 	# test for start relay
 	echo "kill worker2"
-	ps aux | grep worker2 | awk '{print $2}' | xargs kill || true
+	kill_process worker2
 	check_port_offline $WORKER2_PORT 20
 
 	stop_relay_on_offline_worker
@@ -332,9 +332,9 @@ function run() {
 	stop_relay_success
 
 	# stop worker to test query-status works well when no worker
-	ps aux | grep dmctl_basic/worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dmctl_basic/worker1
 	check_port_offline $WORKER1_PORT 20
-	ps aux | grep dmctl_basic/worker2 | awk '{print $2}' | xargs kill || true
+	kill_process dmctl_basic/worker2
 	check_port_offline $WORKER2_PORT 20
 
 	query_status_with_offline_worker

--- a/dm/tests/fake_rotate_event/run.sh
+++ b/dm/tests/fake_rotate_event/run.sh
@@ -32,7 +32,7 @@ function run() {
 	check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
 
 	echo "kill dm-worker"
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 
 	# make fake rotate event and rewrite binlog filename to mysql-bin.000001

--- a/dm/tests/ha/run.sh
+++ b/dm/tests/ha/run.sh
@@ -71,7 +71,7 @@ function run() {
 		"\"result\": true" 3
 
 	echo "start dm-worker3 and kill dm-worker2"
-	ps aux | grep dm-worker2 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker2
 	check_port_offline $WORKER2_PORT 20
 	rm -rf $WORK_DIR/worker2/relay_log
 
@@ -92,7 +92,7 @@ function run() {
 		"\"result\": true" 3
 
 	echo "start dm-worker2 and kill dm-worker3"
-	ps aux | grep dm-worker3 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker3
 	check_port_offline $WORKER3_PORT 20
 	rm -rf $WORK_DIR/worker3/relay_log
 
@@ -153,10 +153,10 @@ function run() {
 	sleep 5
 
 	echo "kill dm-master1"
-	ps aux | grep dm-master1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-master1
 	check_master_port_offline 1
 	echo "kill dm-master2"
-	ps aux | grep dm-master2 | awk '{print $2}' | xargs kill || true
+	kill_process dm-master2
 	check_master_port_offline 2
 
 	echo "initial cluster of dm-masters have been killed"

--- a/dm/tests/ha_cases/run.sh
+++ b/dm/tests/ha_cases/run.sh
@@ -72,7 +72,7 @@ function test_join_masters_and_worker {
 	run_dm_ctl_with_retry $WORK_DIR 127.0.0.1:$MASTER_PORT2 "list-member --worker --name=worker2" '"stage": "free",' 1
 
 	echo "kill dm-master-join1"
-	ps aux | grep dm-master-join1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-master-join1
 	check_master_port_offline 1
 	rm -rf $WORK_DIR/master1/default.master1
 
@@ -131,7 +131,7 @@ function test_standalone_running() {
 		"\"taskStatus\": \"Running\"" 2
 
 	echo "kill $worker_name"
-	ps aux | grep dm-worker${worker_idx} | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker${worker_idx}
 	check_port_offline ${worker_ports[$worker_idx]} 20
 	rm -rf $WORK_DIR/worker${worker_idx}/relay-dir
 
@@ -340,7 +340,7 @@ function test_exclusive_relay_2() {
 
 	# kill worker1, source1 should be bound to worker3
 	echo "kill dm-worker1"
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT1" \
 		"list-member --name worker3" \
@@ -358,7 +358,7 @@ function test_exclusive_relay_2() {
 
 	# kill worker2, source2 should not be bound
 	echo "kill dm-worker2"
-	ps aux | grep dm-worker2 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker2
 	check_port_offline $WORKER2_PORT 20
 
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \

--- a/dm/tests/ha_cases2/run.sh
+++ b/dm/tests/ha_cases2/run.sh
@@ -144,7 +144,7 @@ function test_multi_task_reduce_and_restart_worker() {
 			echo "restart unuse worker${idx}"
 
 			echo "try to kill worker port ${worker_ports[$(($idx - 1))]}"
-			ps aux | grep dm-worker${idx} | awk '{print $2}' | xargs kill || true
+			kill_process dm-worker${idx}
 			run_dm_ctl_with_retry $WORK_DIR 127.0.0.1:$MASTER_PORT2 "list-member --worker --name=worker$idx" '"stage": "offline"' 1
 
 			echo "start dm-worker${idx}"
@@ -156,7 +156,7 @@ function test_multi_task_reduce_and_restart_worker() {
 	for ((i = 0; i < ${#worker_inuse[@]}; i++)); do
 		wk=${worker_inuse[$i]:0-1:1}                                 # get worker id, such as ("1", "4")
 		echo "try to kill worker port ${worker_ports[$(($wk - 1))]}" # get relative worker port
-		ps aux | grep dm-${worker_inuse[$i]} | awk '{print $2}' | xargs kill || true
+		kill_process dm-${worker_inuse[$i]}
 		check_port_offline ${worker_ports[$(($wk - 1))]} 20
 		# just one worker was killed should be safe
 		echo "${worker_inuse[$i]} was killed"

--- a/dm/tests/ha_cases_1/run.sh
+++ b/dm/tests/ha_cases_1/run.sh
@@ -43,7 +43,7 @@ function test_kill_master() {
 	test_running
 
 	echo "kill dm-master1"
-	ps aux | grep dm-master1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-master1
 	check_master_port_offline 1
 	rm -rf $WORK_DIR/master1/default.master1
 
@@ -83,7 +83,7 @@ function test_kill_and_isolate_worker() {
 		"\"result\": true" 2
 
 	echo "kill dm-worker2"
-	ps aux | grep dm-worker2 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker2
 	check_port_offline $WORKER2_PORT 20
 	rm -rf $WORK_DIR/worker2/relay_log
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT1" \
@@ -104,7 +104,7 @@ function test_kill_and_isolate_worker() {
 		"\"result\": true" 3
 
 	echo "restart dm-worker3"
-	ps aux | grep dm-worker3 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker3
 	check_port_offline $WORKER3_PORT 20
 	rm -rf $WORK_DIR/worker3/relay_log
 
@@ -151,7 +151,7 @@ function test_kill_and_isolate_worker() {
 		"\"result\": true" 3
 
 	echo "restart worker4"
-	ps aux | grep dm-worker4 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker4
 	check_port_offline $WORKER4_PORT 20
 	rm -rf $WORK_DIR/worker4/relay_log
 	run_dm_worker $WORK_DIR/worker4 $WORKER4_PORT $cur/conf/dm-worker4.toml

--- a/dm/tests/ha_cases_2/run.sh
+++ b/dm/tests/ha_cases_2/run.sh
@@ -48,7 +48,7 @@ function test_kill_master_in_sync() {
 	load_data $MYSQL_PORT1 $MYSQL_PASSWORD1 "a" &
 	load_data $MYSQL_PORT2 $MYSQL_PASSWORD2 "b" &
 
-	ps aux | grep dm-master1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-master1
 	check_master_port_offline 1
 
 	echo "wait and check task running"
@@ -77,7 +77,7 @@ function test_kill_worker_in_sync() {
 	load_data $MYSQL_PORT2 $MYSQL_PASSWORD2 "b" &
 
 	echo "kill dm-worker1"
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	echo "start worker3"
 	run_dm_worker $WORK_DIR/worker3 $WORKER3_PORT $cur/conf/dm-worker3.toml
 	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER3_PORT
@@ -88,7 +88,7 @@ function test_kill_worker_in_sync() {
 		"\"result\": true" 2
 
 	echo "kill dm-worker2"
-	ps aux | grep dm-worker2 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker2
 	echo "start worker4"
 	run_dm_worker $WORK_DIR/worker4 $WORKER4_PORT $cur/conf/dm-worker4.toml
 	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER4_PORT

--- a/dm/tests/ha_master/run.sh
+++ b/dm/tests/ha_master/run.sh
@@ -139,7 +139,7 @@ function test_list_member() {
 
 		# kill leader
 		echo "kill leader" $leader
-		ps aux | grep $leader | awk '{print $2}' | xargs kill || true
+		kill_process $leader
 		check_master_port_offline $leader_idx
 	done
 
@@ -179,7 +179,7 @@ function test_list_member() {
 			continue
 		fi
 		echo "kill master$idx"
-		ps aux | grep dm-master$idx | awk '{print $2}' | xargs kill || true
+		kill_process dm-master$idx
 		check_master_port_offline $idx
 		sleep 5
 		run_dm_master $WORK_DIR/master${idx} ${master_ports[$idx]} $cur/conf/dm-master${idx}.toml
@@ -216,7 +216,7 @@ function test_list_member() {
 
 	# kill worker
 	echo "kill worker1"
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
@@ -226,7 +226,7 @@ function test_list_member() {
 
 	# kill worker
 	echo "kill worker2"
-	ps aux | grep dm-worker2 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker2
 	check_port_offline $WORKER2_PORT 20
 
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
@@ -283,9 +283,9 @@ function run() {
 
 	# kill dm-master1 and dm-master2 to simulate the first two dm-master addr in join config are invalid
 	echo "kill dm-master1 and kill dm-master2"
-	ps aux | grep dm-master1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-master1
 	check_master_port_offline 1
-	ps aux | grep dm-master2 | awk '{print $2}' | xargs kill || true
+	kill_process dm-master2
 	check_master_port_offline 2
 
 	# wait for master switch leader and re-setup
@@ -335,9 +335,9 @@ function run() {
 	run_sql "flush logs;" $MYSQL_PORT2 $MYSQL_PASSWORD2
 
 	echo "kill dm-master1 and kill dm-master2"
-	ps aux | grep dm-master1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-master1
 	check_master_port_offline 1
-	ps aux | grep dm-master2 | awk '{print $2}' | xargs kill || true
+	kill_process dm-master2
 	check_master_port_offline 2
 
 	echo "wait and check task running"
@@ -361,7 +361,7 @@ function run() {
 		"\"result\": true" 1
 
 	echo "kill dm-master3"
-	ps aux | grep dm-master3 | awk '{print $2}' | xargs kill || true
+	kill_process dm-master3
 	check_master_port_offline 3
 
 	sleep 2

--- a/dm/tests/http_apis/run.sh
+++ b/dm/tests/http_apis/run.sh
@@ -87,7 +87,7 @@ function run() {
 
 	sleep 1
 	echo "kill dm-worker1"
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"list-member --worker --name=worker1" \

--- a/dm/tests/import_goroutine_leak/run.sh
+++ b/dm/tests/import_goroutine_leak/run.sh
@@ -95,7 +95,7 @@ function run() {
 		"inject failpoint dispatchError" 1
 
 	echo "restart dm-workers block in sending to chan"
-	ps aux | grep dm-worker | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker
 	check_port_offline $WORKER1_PORT 20
 
 	# use a small job chan size to block the sender
@@ -119,7 +119,7 @@ function run() {
 	check_log_contains $WORK_DIR/goroutine.worker1 "chan send"
 
 	# try to kill, but can't kill (NOTE: the port will be shutdown, but the process still exists)
-	ps aux | grep dm-worker | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker
 	sleep 5
 	worker_cnt=$(ps aux | grep dm-worker | grep -v "grep" | wc -l)
 	if [ $worker_cnt -lt 1 ]; then

--- a/dm/tests/lightning_load_task/run.sh
+++ b/dm/tests/lightning_load_task/run.sh
@@ -15,7 +15,7 @@ WORKER3="worker3"
 function test_worker_restart() {
 	echo "test worker restart"
 	# worker1 offline
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 
 	# source1 bound to worker3
@@ -61,7 +61,7 @@ function test_worker_restart() {
 function test_transfer_two_sources() {
 	echo "test_transfer_two_sources"
 	# worker2 offline
-	ps aux | grep dm-worker2 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker2
 	check_port_offline $WORKER2_PORT 20
 
 	# source2 bound to worker3
@@ -92,7 +92,7 @@ function test_transfer_two_sources() {
 		"\"stage\": \"free\"" 1
 
 	# worker1 offline
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 
 	# source1 bound to worker2
@@ -121,7 +121,7 @@ function test_transfer_two_sources() {
 
 	# now, worker2 waiting worker3 finish load_task3, worker1 waiting worker2 finish load_task4
 	# worker3 offline
-	ps aux | grep dm-worker3 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker3
 	check_port_offline $WORKER3_PORT 20
 
 	# source2 bound to worker1

--- a/dm/tests/load_task/run.sh
+++ b/dm/tests/load_task/run.sh
@@ -13,7 +13,7 @@ WORKER3="worker3"
 function test_worker_restart() {
 	echo "test worker restart"
 	# worker1 offline
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 
 	# source1 bound to worker3
@@ -59,7 +59,7 @@ function test_worker_restart() {
 function test_transfer_two_sources() {
 	echo "test_transfer_two_sources"
 	# worker2 offline
-	ps aux | grep dm-worker2 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker2
 	check_port_offline $WORKER2_PORT 20
 
 	# source2 bound to worker3
@@ -90,7 +90,7 @@ function test_transfer_two_sources() {
 		"\"stage\": \"free\"" 1
 
 	# worker1 offline
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 
 	# source1 bound to worker2
@@ -119,7 +119,7 @@ function test_transfer_two_sources() {
 
 	# now, worker2 waiting worker3 finish load_task3, worker1 waiting worker2 finish load_task4
 	# worker3 offline
-	ps aux | grep dm-worker3 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker3
 	check_port_offline $WORKER3_PORT 20
 
 	# source2 bound to worker1
@@ -189,7 +189,7 @@ function stop_task_left_load() {
 	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER2_PORT
 
 	# kill worker1, load_task1 will be transferred to worker2, but lack local files
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"query-status load_task1" \
@@ -226,7 +226,7 @@ function stop_task_left_load() {
 	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"stop-task load_task1" \
 		"\"result\": true" 2
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \

--- a/dm/tests/new_relay/run.sh
+++ b/dm/tests/new_relay/run.sh
@@ -108,7 +108,7 @@ function test_cant_dail_upstream() {
 		"\"result\": true" 2
 
 	echo "kill dm-worker1"
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 
 	export GO_FAILPOINTS="github.com/pingcap/tiflow/dm/pkg/conn/failDBPing=return()"
@@ -141,7 +141,7 @@ function test_cant_dail_downstream() {
 	dmctl_start_task_standalone $cur/conf/dm-task.yaml "--remove-meta"
 
 	echo "kill dm-worker1"
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 	# kill tidb
 	pkill -hup tidb-server 2>/dev/null || true
@@ -254,7 +254,7 @@ function test_relay_operations() {
 
 	# subtask is preferred to scheduled to another relay worker
 	echo "kill dm-worker1"
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 	# worker1 is down, worker2 has running relay and sync unit
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
@@ -297,10 +297,10 @@ function test_relay_operations() {
 	[ "$new_relay_log_count_2" -eq 1 ]
 
 	echo "kill dm-worker1"
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 	echo "kill dm-worker2"
-	ps aux | grep dm-worker2 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker2
 	check_port_offline $WORKER1_PORT 20
 	# if all relay workers are offline, relay-not-enabled worker should continue to sync
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \

--- a/dm/tests/online_ddl/run.sh
+++ b/dm/tests/online_ddl/run.sh
@@ -118,7 +118,7 @@ function run() {
 	check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
 
 	echo "start dm-worker3 and kill dm-worker2"
-	ps aux | grep dm-worker2 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker2
 	check_port_offline $WORKER2_PORT 20
 
 	run_dm_worker $WORK_DIR/worker3 $WORKER3_PORT $cur/conf/dm-worker3.toml

--- a/dm/tests/sequence_sharding_optimistic/run.sh
+++ b/dm/tests/sequence_sharding_optimistic/run.sh
@@ -80,7 +80,7 @@ run() {
 	# in order to simply the check and resume flow, only enable the failpoint for one DM-worker.
 	export GO_FAILPOINTS="github.com/pingcap/tiflow/dm/syncer/FlushCheckpointStage=return(100)" # for all stages
 	echo "restart dm-worker1"
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 	run_dm_worker $WORK_DIR/worker1 $WORKER1_PORT $cur/conf/dm-worker1.toml
 	check_rpc_alive $cur/../bin/check_worker_online 127.0.0.1:$WORKER1_PORT

--- a/dm/tests/shardddl1/run.sh
+++ b/dm/tests/shardddl1/run.sh
@@ -206,7 +206,7 @@ function DM_RemoveLock_CASE() {
 }
 
 function DM_RemoveLock() {
-	ps aux | grep dm-master | awk '{print $2}' | xargs kill || true
+	kill_process dm-master
 	check_master_port_offline 1
 	export GO_FAILPOINTS="github.com/pingcap/tiflow/dm/dm/master/shardddl/SleepWhenRemoveLock=return(30)"
 	run_dm_master $WORK_DIR/master $MASTER_PORT $cur/conf/dm-master.toml
@@ -227,7 +227,7 @@ function DM_RemoveLock() {
 		"clean_table" "optimistic"
 
 	export GO_FAILPOINTS=""
-	ps aux | grep dm-master | awk '{print $2}' | xargs kill || true
+	kill_process dm-master
 	check_master_port_offline 1
 	run_dm_master $WORK_DIR/master $MASTER_PORT $cur/conf/dm-master.toml
 	check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT
@@ -558,7 +558,7 @@ function DM_COMPACT_CASE() {
 
 function DM_COMPACT() {
 	# mock downstream has a high latency and upstream has a high workload
-	ps aux | grep dm-worker | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker
 	check_process_exit worker1 20
 	check_process_exit worker2 20
 	export GO_FAILPOINTS='github.com/pingcap/tiflow/dm/syncer/BlockExecuteSQLs=return(1);github.com/pingcap/tiflow/dm/syncer/SafeModeInitPhaseSeconds=return(5)'
@@ -601,7 +601,7 @@ function DM_COMPACT_USE_DOWNSTREAM_SCHEMA_CASE() {
 
 function DM_COMPACT_USE_DOWNSTREAM_SCHEMA() {
 	# downstream pk/uk/column is diffrent with upstream, compact use downstream schema.
-	ps aux | grep dm-worker | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker
 	check_process_exit worker1 20
 	check_process_exit worker2 20
 	# DownstreamIdentifyKeyCheckInCompact=return(20) will check whether the key value in compact is less than 20, if false, it will be panic.
@@ -680,7 +680,7 @@ function DM_MULTIPLE_ROWS_CASE() {
 }
 
 function DM_MULTIPLE_ROWS() {
-	ps aux | grep dm-worker | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker
 	check_process_exit worker1 20
 	check_process_exit worker2 20
 	export GO_FAILPOINTS='github.com/pingcap/tiflow/dm/syncer/BlockExecuteSQLs=return(1);github.com/pingcap/tiflow/dm/syncer/SafeModeInitPhaseSeconds=return(5)'
@@ -693,7 +693,7 @@ function DM_MULTIPLE_ROWS() {
 		"run_sql_source1 \"create table ${shardddl1}.${tb1} (a int primary key, b int unique, c int);\"" \
 		"clean_table" ""
 
-	ps aux | grep dm-worker | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker
 	check_process_exit worker1 20
 	check_process_exit worker2 20
 	export GO_FAILPOINTS=''
@@ -760,7 +760,7 @@ function DM_DML_EXECUTE_ERROR_CASE() {
 }
 
 function DM_DML_EXECUTE_ERROR() {
-	ps aux | grep dm-worker | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker
 	check_process_exit worker1 20
 	check_process_exit worker2 20
 	export GO_FAILPOINTS='github.com/pingcap/tiflow/dm/syncer/ErrorOnLastDML=return()'

--- a/dm/tests/shardddl2/run.sh
+++ b/dm/tests/shardddl2/run.sh
@@ -226,10 +226,10 @@ function DM_INIT_SCHEMA() {
 function restart_worker() {
 	echo "restart dm-worker" $1
 	if [[ "$1" = "1" ]]; then
-		ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+		kill_process dm-worker1
 		check_port_offline $WORKER1_PORT 20
 	else
-		ps aux | grep dm-worker2 | awk '{print $2}' | xargs kill || true
+		kill_process dm-worker2
 		check_port_offline $WORKER2_PORT 20
 	fi
 	export GO_FAILPOINTS=$2

--- a/dm/tests/shardddl2_1/run.sh
+++ b/dm/tests/shardddl2_1/run.sh
@@ -536,10 +536,10 @@ function DM_068() {
 function restart_worker() {
 	echo "restart dm-worker" $1
 	if [[ "$1" = "1" ]]; then
-		ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+		kill_process dm-worker1
 		check_port_offline $WORKER1_PORT 20
 	else
-		ps aux | grep dm-worker2 | awk '{print $2}' | xargs kill || true
+		kill_process dm-worker2
 		check_port_offline $WORKER2_PORT 20
 	fi
 	export GO_FAILPOINTS=$2

--- a/dm/tests/shardddl3/run.sh
+++ b/dm/tests/shardddl3/run.sh
@@ -448,7 +448,7 @@ function DM_097_CASE() {
 	run_sql_source1 "alter table ${shardddl1}.${tb1} add column new_col1 int;"
 	run_sql_source2 "alter table ${shardddl1}.${tb1} add column new_col1 int;"
 
-	ps aux | grep dm-master | awk '{print $2}' | xargs kill || true
+	kill_process dm-master
 	check_master_port_offline 1
 
 	run_sql_source1 "alter table ${shardddl1}.${tb2} add column new_col1 int;"
@@ -484,7 +484,7 @@ function DM_098_CASE() {
 
 	run_sql_source1 "alter table ${shardddl1}.${tb1} add column new_col1 int;"
 
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 
 	run_sql_source2 "alter table ${shardddl1}.${tb1} add column new_col1 int;"

--- a/dm/tests/shardddl3_1/run.sh
+++ b/dm/tests/shardddl3_1/run.sh
@@ -24,7 +24,7 @@ function DM_099_CASE() {
 	run_sql_source1 "alter table ${shardddl1}.${tb1} add column new_col1 int;"
 	run_sql_source2 "alter table ${shardddl1}.${tb1} add column new_col1 int;"
 
-	ps aux | grep dm-worker2 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker2
 	check_port_offline $WORKER2_PORT 20
 
 	run_sql_source1 "alter table ${shardddl1}.${tb2} add column new_col1 int;"
@@ -57,7 +57,7 @@ function DM_100_CASE() {
 
 	run_sql_source1 "alter table ${shardddl1}.${tb1} add column new_col1 int;"
 
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 
 	run_sql_source2 "alter table ${shardddl1}.${tb1} add column new_col1 int;"
@@ -92,7 +92,7 @@ function DM_101_CASE() {
 	run_sql_source1 "alter table ${shardddl1}.${tb1} add column new_col1 int;"
 	run_sql_source2 "alter table ${shardddl1}.${tb1} add column new_col1 int;"
 
-	ps aux | grep dm-worker2 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker2
 	check_port_offline $WORKER2_PORT 20
 
 	run_sql_source1 "alter table ${shardddl1}.${tb2} add column new_col1 int;"

--- a/dm/tests/sharding2/run.sh
+++ b/dm/tests/sharding2/run.sh
@@ -54,9 +54,9 @@ function run() {
 	check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
 
 	echo "kill dm-worker1"
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	echo "kill dm-worker2"
-	ps aux | grep dm-worker2 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker2
 
 	check_port_offline $WORKER1_PORT 20
 	check_port_offline $WORKER2_PORT 20

--- a/dm/tests/tls/run.sh
+++ b/dm/tests/tls/run.sh
@@ -196,7 +196,7 @@ function test_worker_download_certs_from_master() {
 
 	# kill dm-worker 1 and clean the failpoint
 	export GO_FAILPOINTS=''
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 
 	rm -rf "$WORK_DIR/tidb_lightning_tls_config*"
@@ -269,7 +269,7 @@ function test_worker_ha_when_enable_source_tls() {
 		"\"result\": true" 2
 
 	echo "start dm-worker2 and kill dm-worker1"
-	ps aux | grep dm-worker1 | awk '{print $2}' | xargs kill || true
+	kill_process dm-worker1
 	check_port_offline $WORKER1_PORT 20
 
 	mysql_data_path=$(get_mysql_ssl_data_path)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #4159

### What is changed and how it works?
- when kill process, wait until it exist, else 2 process may run at same time, and cause
  - log is messed up
  - some case enable-relay, if we don't wait, there'll be 2 process r/w relay dir, may cause some case fail.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
