### PR TITLE
pkg/log(dm):support reading fields from Ctx

### DIFF
--- a/dm/pkg/log/ctx.go
+++ b/dm/pkg/log/ctx.go
@@ -1,0 +1,47 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+type logCtxKeyType string
+
+var logCtxKey = logCtxKeyType("zap-fields")
+
+func getZapFieldsFromCtx(ctx context.Context) []zap.Field {
+	// Use a pointer to key to save one allocation.
+	fields := ctx.Value(&logCtxKey)
+	if fields == nil {
+		return nil
+	}
+	// Note that the value is a pointer to slice, to save allocation.
+	return *fields.(*[]zap.Field)
+}
+
+// AppendZapFieldToCtx attaches new fields to the context, which can be then
+// used with log.WithCtx().
+func AppendZapFieldToCtx(ctx context.Context, newFields ...zap.Field) context.Context {
+	fields := getZapFieldsFromCtx(ctx)
+	if fields == nil {
+		// 8 fields should be enough for most situations.
+		fields = make([]zap.Field, 0, 8)
+	}
+	fields = append(fields, newFields...)
+
+	return context.WithValue(ctx, &logCtxKey, &fields)
+}

--- a/dm/pkg/log/ctx_test.go
+++ b/dm/pkg/log/ctx_test.go
@@ -1,0 +1,57 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestLogCtxBasics(t *testing.T) {
+	ctx := context.Background()
+	ctx1 := AppendZapFieldToCtx(ctx, zap.String("key1", "value1"))
+	ctx2 := AppendZapFieldToCtx(ctx1, zap.String("key2", "value2"))
+
+	require.Nil(t, getZapFieldsFromCtx(ctx))
+	require.Equal(t, []zap.Field{zap.String("key1", "value1")}, getZapFieldsFromCtx(ctx1))
+	require.Equal(t, []zap.Field{
+		zap.String("key1", "value1"),
+		zap.String("key2", "value2"),
+	}, getZapFieldsFromCtx(ctx2))
+}
+
+func TestLogCtxTooManyFields(t *testing.T) {
+	ctx := context.Background()
+	var (
+		ctxs   []context.Context
+		fields [][]zap.Field
+	)
+
+	ctxs = append(ctxs, ctx)
+	fields = append(fields, nil)
+	for i := 1; i < 100; i++ {
+		k := fmt.Sprintf("key%d", i)
+		v := fmt.Sprintf("value%d", i)
+		ctxs = append(ctxs, AppendZapFieldToCtx(ctxs[i-1], zap.String(k, v)))
+		fields = append(fields, append(fields[i-1], zap.String(k, v)))
+	}
+
+	for i := 0; i < 100; i++ {
+		require.Equal(t, fields[i], getZapFieldsFromCtx(ctxs[i]), "failed, index = %d", i)
+	}
+}

--- a/dm/pkg/log/log.go
+++ b/dm/pkg/log/log.go
@@ -183,3 +183,8 @@ func WrapStringerField(message string, object fmt.Stringer) zap.Field {
 
 	return zap.Stringer(message, object)
 }
+
+// WithCtx adds fields from ctx to the logger.
+func WithCtx(ctx context.Context) Logger {
+	return Logger{appLogger.With(getZapFieldsFromCtx(ctx)...)}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
Issue Number: close #5517

### What is changed and how it works?
- Put zap fields to contexts with `context.WithValue`.
- Add `WithCtx()` method to `log` package, so that in each function call, the fields can be logged easily.
- Added relevant benchmarks.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
- No regression for current production code, because no existing execution path is affected.
- Benchmark results are as follows
```
goos: linux
goarch: amd64
pkg: github.com/pingcap/tiflow/dm/pkg/log
cpu: AMD Ryzen 9 5900X 12-Core Processor            
BenchmarkBaseline
BenchmarkBaseline-24    	 9693552	       124.1 ns/op
BenchmarkWithCtx
BenchmarkWithCtx-24     	 6640200	       181.1 ns/op
PASS

Process finished with the exit code 0
```
Using `WithCtx` increases time cost by 50% compared to traditional, but more complex methods. But given the baseline high performance of `zap`, it should be fine as long as no logging is used in CPU intensive operations.


### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
