### PR TITLE
fix(worker): fix worker error if not return after calling 'Exit'

### DIFF
--- a/engine/lib/worker_test.go
+++ b/engine/lib/worker_test.go
@@ -36,14 +36,7 @@ var (
 )
 
 func putMasterMeta(ctx context.Context, t *testing.T, metaclient pkgOrm.Client, metaData *libModel.MasterMetaKVData) {
-	// FIXME: current backend mock db is not support unique index
-	if _, err := metaclient.GetJobByID(ctx, metaData.ID); err != nil {
-		err := metaclient.UpsertJob(ctx, metaData)
-		require.NoError(t, err)
-		return
-	}
-
-	err := metaclient.UpdateJob(ctx, metaData)
+	err := metaclient.UpsertJob(ctx, metaData)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
close  #5523

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5523 

### What is changed and how it works?
Set errCenter if user call 'Exit' to prevent user from forgetting return directly.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
