### PR TITLE
worker[engine]: fix bug that worker impl call 'Exit', but may not return

### DIFF
--- a/engine/lib/worker.go
+++ b/engine/lib/worker.go
@@ -429,11 +429,11 @@ func (w *DefaultBaseWorker) Exit(ctx context.Context, status libModel.WorkerStat
 	w.workerStatus.ErrorMessage = status.ErrorMessage
 	w.workerStatus.ExtBytes = status.ExtBytes
 	if errRet = w.statusSender.UpdateStatus(ctx, w.workerStatus); errRet != nil {
-		return errRet
+		return
 	}
 
 	errRet = derror.ErrWorkerFinish.FastGenByArgs()
-	return errRet
+	return
 }
 
 func (w *DefaultBaseWorker) startBackgroundTasks() {

--- a/engine/lib/worker_test.go
+++ b/engine/lib/worker_test.go
@@ -36,14 +36,7 @@ var (
 )
 
 func putMasterMeta(ctx context.Context, t *testing.T, metaclient pkgOrm.Client, metaData *libModel.MasterMetaKVData) {
-	// FIXME: current backend mock db is not support unique index
-	if _, err := metaclient.GetJobByID(ctx, metaData.ID); err != nil {
-		err := metaclient.UpsertJob(ctx, metaData)
-		require.NoError(t, err)
-		return
-	}
-
-	err := metaclient.UpdateJob(ctx, metaData)
+	err := metaclient.UpsertJob(ctx, metaData)
 	require.NoError(t, err)
 }
 
@@ -498,6 +491,8 @@ func TestWorkerGracefulExitWhileTimeout(t *testing.T) {
 }
 
 func TestCloseBeforeInit(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -506,6 +501,73 @@ func TestCloseBeforeInit(t *testing.T) {
 	worker.On("CloseImpl").Return(nil)
 	err := worker.Close(ctx)
 	require.NoError(t, err)
+}
+
+func TestExitWithoutReturn(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	worker := newMockWorkerImpl(workerID1, masterName)
+	worker.clock = clock.NewMock()
+	worker.clock.(*clock.Mock).Set(time.Now())
+	putMasterMeta(ctx, t, worker.metaClient, &libModel.MasterMetaKVData{
+		ID:         masterName,
+		NodeID:     masterNodeName,
+		Epoch:      1,
+		StatusCode: libModel.MasterStatusInit,
+	})
+
+	worker.On("InitImpl", mock.Anything).Return(nil)
+	worker.On("Status").Return(libModel.WorkerStatus{
+		Code: libModel.WorkerStatusNormal,
+	}, nil)
+
+	err := worker.Init(ctx)
+	require.NoError(t, err)
+
+	worker.On("Tick", mock.Anything).Return(nil)
+
+	worker.DefaultBaseWorker.Exit(ctx, libModel.WorkerStatus{
+		Code: libModel.WorkerStatusFinished,
+	}, errors.New("Exit error"))
+
+	for {
+		err := worker.Poll(ctx)
+		require.NoError(t, err)
+
+		// Make the heartbeat worker tick.
+		worker.clock.(*clock.Mock).Add(time.Second)
+
+		rawMsg, ok := worker.messageSender.TryPop(masterNodeName, libModel.HeartbeatPingTopic(masterName))
+		if !ok {
+			continue
+		}
+		msg := rawMsg.(*libModel.HeartbeatPingMessage)
+		if msg.IsFinished {
+			pongMsg := &libModel.HeartbeatPongMessage{
+				SendTime:   msg.SendTime,
+				ReplyTime:  time.Now(),
+				ToWorkerID: workerID1,
+				Epoch:      1,
+				IsFinished: true,
+			}
+
+			err := worker.messageHandlerManager.InvokeHandler(
+				t,
+				libModel.HeartbeatPongTopic(masterName, workerID1),
+				masterNodeName,
+				pongMsg,
+			)
+			require.NoError(t, err)
+			break
+		}
+	}
+
+	err = worker.Poll(ctx)
+	require.Error(t, err)
+	require.Regexp(t, ".*worker finished.*", err)
 }
 
 func checkWorkerStatusMsg(t *testing.T, expect, msg *statusutil.WorkerStatusMessage) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5523 

### What is changed and how it works?
Set the error on errCenter when call 'Exit'


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
