### PR TITLE
lib/master(engine): fix PreDispatch failure handling

### DIFF
--- a/engine/client/task_dispatcher.go
+++ b/engine/client/task_dispatcher.go
@@ -85,6 +85,7 @@ func (d *TaskDispatcher) DispatchTask(
 ) error {
 	requestID, err := d.preDispatchTaskWithRetry(ctx, args)
 	if err != nil {
+		abortWorker(err)
 		return derrors.ErrExecutorPreDispatchFailed.Wrap(err)
 	}
 

--- a/engine/lib/master/worker_manager_test.go
+++ b/engine/lib/master/worker_manager_test.go
@@ -263,6 +263,22 @@ func TestCreateWorkerAndWorkerTimesOut(t *testing.T) {
 	suite.Close()
 }
 
+func TestCreateWorkerPredispatchFailed(t *testing.T) {
+	t.Parallel()
+
+	suite := NewWorkerManageTestSuite(true)
+	suite.manager.AbortCreatingWorker("worker-1", errors.New("injected error"))
+
+	event := suite.WaitForEvent(t, "worker-1")
+	require.Equal(t, workerDispatchFailedEvent, event.Tp)
+	require.NotNil(t, event.Handle.GetTombstone())
+	require.Error(t, event.Err)
+	require.Regexp(t, ".*injected error.*", event.Err)
+
+	suite.AssertNoEvents(t, "worker-1", 500*time.Millisecond)
+	suite.Close()
+}
+
 func TestCreateWorkerAndWorkerStatusUpdatedAndTimesOut(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5589 

### What is changed and how it works?
- Abort the dispatch appropriately if `PreDispatchTask` has failed.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

```release-note
None
```
