### PR TITLE
tests: fix wrong dump path in mq_protocol_tests

### DIFF
--- a/tests/mq_protocol_tests/framework/docker_compose_op.go
+++ b/tests/mq_protocol_tests/framework/docker_compose_op.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/integralist/go-findroot/find"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	cerrors "github.com/pingcap/tiflow/pkg/errors"
@@ -142,7 +143,11 @@ func execInController(controller, shellCmd string) ([]byte, error) {
 func (d *DockerComposeOperator) DumpStdout() error {
 	log.Info("Dumping container logs")
 	cmd := exec.Command("docker-compose", "-f", d.FileName, "logs", "-t")
-	f, err := os.Create("../deployments/ticdc/docker-compose/logs/stdout.log")
+	st, err := find.Repo()
+	if err != nil {
+		log.Fatal("Could not find git repo root", zap.Error(err))
+	}
+	f, err := os.Create(st.Path + "/deployments/ticdc/docker-compose/logs/stdout.log")
 	if err != nil {
 		return errors.AddStack(err)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5622 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Nonr
```
