### PR TITLE
metrics(*): fix for promtheus_client breaking change

### DIFF
--- a/cdc/metrics.go
+++ b/cdc/metrics.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tiflow/pkg/orchestrator"
 	"github.com/pingcap/tiflow/pkg/p2p"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	tikvmetrics "github.com/tikv/client-go/v2/metrics"
 )
 
@@ -39,7 +40,8 @@ var registry = prometheus.NewRegistry()
 
 func init() {
 	registry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
-	registry.MustRegister(prometheus.NewGoCollector())
+	registry.MustRegister(prometheus.NewGoCollector(
+		collectors.WithGoCollections(collectors.GoRuntimeMemStatsCollection | collectors.GoRuntimeMetricsCollection)))
 
 	kv.InitMetrics(registry)
 	puller.InitMetrics(registry)

--- a/dm/dm/worker/metrics.go
+++ b/dm/dm/worker/metrics.go
@@ -22,6 +22,7 @@ import (
 
 	cpu "github.com/pingcap/tidb-tools/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/pingcap/tiflow/dm/dm/common"
@@ -104,7 +105,8 @@ func (s *Server) runBackgroundJob(ctx context.Context) {
 func RegistryMetrics() {
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
-	registry.MustRegister(prometheus.NewGoCollector())
+	registry.MustRegister(prometheus.NewGoCollector(
+		collectors.WithGoCollections(collectors.GoRuntimeMemStatsCollection | collectors.GoRuntimeMetricsCollection)))
 
 	registry.MustRegister(cpuUsageGauge)
 

--- a/engine/pkg/promutil/registry.go
+++ b/engine/pkg/promutil/registry.go
@@ -33,7 +33,8 @@ var (
 
 func init() {
 	globalMetricRegistry.MustRegister(systemID, collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
-	globalMetricRegistry.MustRegister(systemID, collectors.NewGoCollector())
+	globalMetricRegistry.MustRegister(systemID, collectors.NewGoCollector(
+		collectors.WithGoCollections(collectors.GoRuntimeMemStatsCollection|collectors.GoRuntimeMetricsCollection)))
 }
 
 // Registry is used for registering metric


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5494

### What is changed and how it works?

add flag for smooth transition, see more in  https://github.com/prometheus/client_golang/releases/tag/v1.12.2

and https://github.com/pingcap/tiflow/pull/5393#discussion_r884428789
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

the breaking changed metrics are not used in our code

* go_gc_heap_allocs_by_size_bytes_total -> go_gc_heap_allocs_by_size_bytes,
* go_gc_heap_frees_by_size_bytes_total -> go_gc_heap_allocs_by_size_bytes
* go_gc_pauses_seconds_total -> go_gc_pauses_seconds.


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
