### PR TITLE
metrics(ticdc): correct MySQL worker load legendFormat

### DIFF
--- a/metrics/grafana/ticdc.json
+++ b/metrics/grafana/ticdc.json
@@ -5599,7 +5599,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "0-2 row/s worker",
+              "legendFormat": "0-2 txn/m worker",
               "refId": "C"
             },
             {
@@ -5608,7 +5608,7 @@
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "2-10 row/s worker",
+              "legendFormat": "2-10 txn/m worker",
               "refId": "D"
             },
             {
@@ -5617,7 +5617,7 @@
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "10-100 row/s worker",
+              "legendFormat": "10-100 txn/m worker",
               "refId": "E"
             },
             {
@@ -5626,7 +5626,7 @@
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": ">100 row/s worker",
+              "legendFormat": ">100 txn/m worker",
               "refId": "F"
             }
           ],


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/5644

### What is changed and how it works?
correct MySQL worker load legendFormat.

row/s -> txn/m

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?

No

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
