### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cdc/owner/changefeed_test.go
+++ b/cdc/owner/changefeed_test.go
@@ -16,7 +16,6 @@ package owner
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -479,9 +478,7 @@ func TestRemoveChangefeed(t *testing.T) {
 	baseCtx, cancel := context.WithCancel(context.Background())
 	ctx := cdcContext.NewContext4Test(baseCtx, true)
 	info := ctx.ChangefeedVars().Info
-	dir, err := ioutil.TempDir("", "remove-changefeed-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	info.Config.Consistent = &config.ConsistentConfig{
 		Level:   "eventual",
 		Storage: filepath.Join("nfs://", dir),
@@ -498,9 +495,7 @@ func TestRemovePausedChangefeed(t *testing.T) {
 	ctx := cdcContext.NewContext4Test(baseCtx, true)
 	info := ctx.ChangefeedVars().Info
 	info.State = model.StateStopped
-	dir, err := ioutil.TempDir("", "remove-paused-changefeed-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	info.Config.Consistent = &config.ConsistentConfig{
 		Level:   "eventual",
 		Storage: filepath.Join("nfs://", dir),

--- a/cdc/redo/reader/file_test.go
+++ b/cdc/redo/reader/file_test.go
@@ -17,7 +17,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,17 +39,13 @@ func TestReaderNewReader(t *testing.T) {
 	_, err := newReader(context.Background(), nil)
 	require.NotNil(t, err)
 
-	dir, err := ioutil.TempDir("", "redo-newReader")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	_, err = newReader(context.Background(), &readerConfig{dir: dir})
 	require.Nil(t, err)
 }
 
 func TestReaderRead(t *testing.T) {
-	dir, err := ioutil.TempDir("", "redo-reader")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	cfg := &writer.FileWriterConfig{
 		MaxLogSize:   100000,
@@ -104,9 +99,7 @@ func TestReaderRead(t *testing.T) {
 }
 
 func TestReaderOpenSelectedFiles(t *testing.T) {
-	dir, err := ioutil.TempDir("", "redo-openSelectedFiles")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -158,9 +151,7 @@ func TestReaderOpenSelectedFiles(t *testing.T) {
 	f1, err := os.Create(path)
 	require.Nil(t, err)
 
-	dir1, err := ioutil.TempDir("", "redo-openSelectedFiles1")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir1) //nolint:errcheck
+	dir1 := t.TempDir()
 	fileName = fmt.Sprintf(common.RedoLogFileFormatV2, "cp", "default", "test-cf",
 		common.DefaultDDLLogFileType, 11, uuidGen.NewString(), common.LogEXT+"test")
 	path = filepath.Join(dir1, fileName)

--- a/cdc/redo/reader/reader_test.go
+++ b/cdc/redo/reader/reader_test.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -44,9 +43,7 @@ func TestNewLogReader(t *testing.T) {
 	_, err = NewLogReader(context.Background(), &LogReaderConfig{})
 	require.Nil(t, err)
 
-	dir, err := ioutil.TempDir("", "redo-NewLogReader")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s3URI, err := url.Parse("s3://logbucket/test-changefeed?endpoint=http://111/")
 	require.Nil(t, err)
@@ -75,9 +72,7 @@ func TestNewLogReader(t *testing.T) {
 }
 
 func TestLogReaderResetReader(t *testing.T) {
-	dir, err := ioutil.TempDir("", "redo-ResetReader")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -237,9 +232,7 @@ func TestLogReaderResetReader(t *testing.T) {
 }
 
 func TestLogReaderReadMeta(t *testing.T) {
-	dir, err := ioutil.TempDir("", "redo-ReadMeta")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	fileName := fmt.Sprintf("%s_%s_%d_%s%s", "cp",
 		"test-changefeed",
@@ -271,9 +264,7 @@ func TestLogReaderReadMeta(t *testing.T) {
 	_, err = f.Write(data)
 	require.Nil(t, err)
 
-	dir1, err := ioutil.TempDir("", "redo-NoReadMeta")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir1)
+	dir1 := t.TempDir()
 
 	tests := []struct {
 		name                             string

--- a/cdc/redo/writer/file_test.go
+++ b/cdc/redo/writer/file_test.go
@@ -45,9 +45,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestWriterWrite(t *testing.T) {
-	dir, err := ioutil.TempDir("", "redo-writer")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	cfs := []model.ChangeFeedID{
 		model.DefaultChangeFeedID("test-cf"),
@@ -88,7 +86,7 @@ func TestWriterWrite(t *testing.T) {
 		}
 
 		w.eventCommitTS.Store(1)
-		_, err = w.Write([]byte("tes1t11111"))
+		_, err := w.Write([]byte("tes1t11111"))
 		require.Nil(t, err)
 		var fileName string
 		// create a .tmp file
@@ -207,9 +205,7 @@ func TestWriterWrite(t *testing.T) {
 }
 
 func TestWriterGC(t *testing.T) {
-	dir, err := ioutil.TempDir("", "redo-GC")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	uuidGen := uuid.NewConstGenerator("const-uuid")
 	controller := gomock.NewController(t)
@@ -265,7 +261,7 @@ func TestWriterGC(t *testing.T) {
 	}
 	w.running.Store(true)
 	w.eventCommitTS.Store(1)
-	_, err = w.Write([]byte("t1111"))
+	_, err := w.Write([]byte("t1111"))
 	require.Nil(t, err)
 	w.eventCommitTS.Store(2)
 	_, err = w.Write([]byte("t2222"))
@@ -318,9 +314,7 @@ func TestNewWriter(t *testing.T) {
 	s3URI, err := url.Parse("s3://logbucket/test-changefeed?endpoint=http://111/")
 	require.Nil(t, err)
 
-	dir, err := ioutil.TempDir("", "redo-NewWriter")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	uuidGen := uuid.NewConstGenerator("const-uuid")
 	w, err := NewWriter(context.Background(), &FileWriterConfig{

--- a/cdc/redo/writer/writer_test.go
+++ b/cdc/redo/writer/writer_test.go
@@ -16,7 +16,6 @@ package writer
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net/url"
 	"os"
@@ -303,9 +302,7 @@ func TestLogWriterFlushLog(t *testing.T) {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "redo-FlushLog")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	for _, tt := range tests {
 		controller := gomock.NewController(t)
@@ -394,9 +391,7 @@ func TestLogWriterEmitCheckpointTs(t *testing.T) {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "redo-EmitCheckpointTs")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	for _, tt := range tests {
 		controller := gomock.NewController(t)
@@ -486,9 +481,7 @@ func TestLogWriterEmitResolvedTs(t *testing.T) {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "redo-ResolvedTs")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	for _, tt := range tests {
 		controller := gomock.NewController(t)
@@ -568,9 +561,7 @@ func TestLogWriterGetCurrentResolvedTs(t *testing.T) {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "redo-GetCurrentResolvedTs")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	for _, tt := range tests {
 		mockWriter := &mockFileWriter{}
@@ -654,9 +645,7 @@ func TestNewLogWriter(t *testing.T) {
 	require.Nil(t, err)
 	require.NotSame(t, ll, ll2)
 
-	dir, err := ioutil.TempDir("", "redo-NewLogWriter")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	fileName := fmt.Sprintf("%s_%s_%d_%s%s", "cp", "test-changefeed", time.Now().Unix(), common.DefaultMetaFileType, common.MetaEXT)
 	path := filepath.Join(dir, fileName)
 	f, err := os.Create(path)
@@ -832,10 +821,9 @@ func TestDeleteAllLogs(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		dir, err := ioutil.TempDir("", "redo-DeleteAllLogs")
-		require.Nil(t, err)
+		dir := t.TempDir()
 		path := filepath.Join(dir, fileName)
-		_, err = os.Create(path)
+		_, err := os.Create(path)
 		require.Nil(t, err)
 		path = filepath.Join(dir, fileName1)
 		_, err = os.Create(path)
@@ -884,7 +872,6 @@ func TestDeleteAllLogs(t *testing.T) {
 				require.True(t, os.IsNotExist(err), tt.name)
 			}
 		}
-		os.RemoveAll(dir)
 		getAllFilesInS3 = origin
 	}
 }

--- a/dm/pkg/storage/utils_test.go
+++ b/dm/pkg/storage/utils_test.go
@@ -170,7 +170,6 @@ func TestCollectDirFilesAndRemove(t *testing.T) {
 
 	// test local
 	localDir := t.TempDir()
-	defer os.RemoveAll(localDir)
 	for _, fileName := range fileNames {
 		f, err := os.Create(path.Join(localDir, fileName))
 		require.NoError(t, err)

--- a/dm/relay/meta_test.go
+++ b/dm/relay/meta_test.go
@@ -37,9 +37,7 @@ type MetaTestCase struct {
 }
 
 func (r *testMetaSuite) TestLocalMeta(c *C) {
-	dir, err := os.MkdirTemp("", "test_local_meta")
-	c.Assert(err, IsNil)
-	defer os.RemoveAll(dir)
+	dir := c.MkDir()
 
 	gset0, _ := gtid.ParserGTID("mysql", "")
 	gset1, _ := gtid.ParserGTID("mysql", "85ab69d1-b21f-11e6-9c5e-64006a8978d2:1-12")
@@ -77,7 +75,7 @@ func (r *testMetaSuite) TestLocalMeta(c *C) {
 
 	// load, but empty
 	lm := NewLocalMeta("mysql", dir)
-	err = lm.Load()
+	err := lm.Load()
 	c.Assert(err, IsNil)
 
 	uuid, pos := lm.Pos()

--- a/dm/relay/purger_helper_test.go
+++ b/dm/relay/purger_helper_test.go
@@ -35,9 +35,7 @@ func (t *testPurgerSuite) TestPurgeRelayFilesBeforeFile(c *C) {
 	c.Assert(files, IsNil)
 
 	// create relay log dir
-	baseDir, err := os.MkdirTemp("", "test_get_relay_files_before_file")
-	c.Assert(err, IsNil)
-	defer os.RemoveAll(baseDir)
+	baseDir := c.MkDir()
 	// empty relay log dirs
 	safeRelay = &streamer.RelayLogInfo{
 		SubDir: t.uuids[len(t.uuids)-1],
@@ -120,9 +118,7 @@ func (t *testPurgerSuite) TestPurgeRelayFilesBeforeFile(c *C) {
 
 func (t *testPurgerSuite) TestPurgeRelayFilesBeforeFileAndTime(c *C) {
 	// create relay log dir
-	baseDir, err := os.MkdirTemp("", "test_get_relay_files_before_file_and_time")
-	c.Assert(err, IsNil)
-	defer os.RemoveAll(baseDir)
+	baseDir := c.MkDir()
 
 	// empty relay log dirs
 	safeRelay := &streamer.RelayLogInfo{

--- a/dm/relay/purger_test.go
+++ b/dm/relay/purger_test.go
@@ -60,9 +60,7 @@ func (t *testPurgerSuite) EarliestActiveRelayLog() *streamer.RelayLogInfo {
 
 func (t *testPurgerSuite) TestPurgeManuallyInactive(c *C) {
 	// create relay log dir
-	baseDir, err := os.MkdirTemp("", "test_purge_manually_inactive")
-	c.Assert(err, IsNil)
-	defer os.RemoveAll(baseDir)
+	baseDir := c.MkDir()
 
 	// prepare files and directories
 	relayDirsPath, relayFilesPath, _ := t.genRelayLogFiles(c, baseDir, -1, -1)
@@ -70,7 +68,7 @@ func (t *testPurgerSuite) TestPurgeManuallyInactive(c *C) {
 	c.Assert(len(relayFilesPath), Equals, 3)
 	c.Assert(len(relayFilesPath[2]), Equals, 3)
 
-	err = t.genUUIDIndexFile(baseDir)
+	err := t.genUUIDIndexFile(baseDir)
 	c.Assert(err, IsNil)
 
 	cfg := config.PurgeConfig{
@@ -99,9 +97,7 @@ func (t *testPurgerSuite) TestPurgeManuallyInactive(c *C) {
 
 func (t *testPurgerSuite) TestPurgeManuallyTime(c *C) {
 	// create relay log dir
-	baseDir, err := os.MkdirTemp("", "test_purge_manually_time")
-	c.Assert(err, IsNil)
-	defer os.RemoveAll(baseDir)
+	baseDir := c.MkDir()
 
 	// prepare files and directories
 	relayDirsPath, relayFilesPath, safeTime := t.genRelayLogFiles(c, baseDir, 1, 0)
@@ -109,7 +105,7 @@ func (t *testPurgerSuite) TestPurgeManuallyTime(c *C) {
 	c.Assert(len(relayFilesPath), Equals, 3)
 	c.Assert(len(relayFilesPath[2]), Equals, 3)
 
-	err = t.genUUIDIndexFile(baseDir)
+	err := t.genUUIDIndexFile(baseDir)
 	c.Assert(err, IsNil)
 
 	cfg := config.PurgeConfig{
@@ -138,9 +134,7 @@ func (t *testPurgerSuite) TestPurgeManuallyTime(c *C) {
 
 func (t *testPurgerSuite) TestPurgeManuallyFilename(c *C) {
 	// create relay log dir
-	baseDir, err := os.MkdirTemp("", "test_purge_manually_filename")
-	c.Assert(err, IsNil)
-	defer os.RemoveAll(baseDir)
+	baseDir := c.MkDir()
 
 	// prepare files and directories
 	relayDirsPath, relayFilesPath, _ := t.genRelayLogFiles(c, baseDir, -1, -1)
@@ -148,7 +142,7 @@ func (t *testPurgerSuite) TestPurgeManuallyFilename(c *C) {
 	c.Assert(len(relayFilesPath), Equals, 3)
 	c.Assert(len(relayFilesPath[2]), Equals, 3)
 
-	err = t.genUUIDIndexFile(baseDir)
+	err := t.genUUIDIndexFile(baseDir)
 	c.Assert(err, IsNil)
 
 	cfg := config.PurgeConfig{
@@ -181,9 +175,7 @@ func (t *testPurgerSuite) TestPurgeManuallyFilename(c *C) {
 
 func (t *testPurgerSuite) TestPurgeAutomaticallyTime(c *C) {
 	// create relay log dir
-	baseDir, err := os.MkdirTemp("", "test_purge_automatically_time")
-	c.Assert(err, IsNil)
-	defer os.RemoveAll(baseDir)
+	baseDir := c.MkDir()
 
 	// prepare files and directories
 	relayDirsPath, relayFilesPath, _ := t.genRelayLogFiles(c, baseDir, -1, -1)
@@ -191,7 +183,7 @@ func (t *testPurgerSuite) TestPurgeAutomaticallyTime(c *C) {
 	c.Assert(len(relayFilesPath), Equals, 3)
 	c.Assert(len(relayFilesPath[2]), Equals, 3)
 
-	err = t.genUUIDIndexFile(baseDir)
+	err := t.genUUIDIndexFile(baseDir)
 	c.Assert(err, IsNil)
 
 	cfg := config.PurgeConfig{
@@ -228,9 +220,7 @@ func (t *testPurgerSuite) TestPurgeAutomaticallyTime(c *C) {
 
 func (t *testPurgerSuite) TestPurgeAutomaticallySpace(c *C) {
 	// create relay log dir
-	baseDir, err := os.MkdirTemp("", "test_purge_automatically_space")
-	c.Assert(err, IsNil)
-	defer os.RemoveAll(baseDir)
+	baseDir := c.MkDir()
 
 	// prepare files and directories
 	relayDirsPath, relayFilesPath, _ := t.genRelayLogFiles(c, baseDir, -1, -1)
@@ -238,7 +228,7 @@ func (t *testPurgerSuite) TestPurgeAutomaticallySpace(c *C) {
 	c.Assert(len(relayFilesPath), Equals, 3)
 	c.Assert(len(relayFilesPath[2]), Equals, 3)
 
-	err = t.genUUIDIndexFile(baseDir)
+	err := t.genUUIDIndexFile(baseDir)
 	c.Assert(err, IsNil)
 
 	storageSize, err := utils.GetStorageSize(baseDir)

--- a/dm/syncer/checkpoint_test.go
+++ b/dm/syncer/checkpoint_test.go
@@ -263,9 +263,7 @@ func (s *testCheckpointSuite) testGlobalCheckPoint(c *C, cp CheckPoint) {
 	c.Assert(cp.FlushedGlobalPoint().Position, Equals, binlog.MinPosition)
 
 	// try load from mydumper's output
-	dir, err := os.MkdirTemp("", "test_global_checkpoint")
-	c.Assert(err, IsNil)
-	defer os.RemoveAll(dir)
+	dir := c.MkDir()
 
 	filename := filepath.Join(dir, "metadata")
 	err = os.WriteFile(filename, []byte(

--- a/engine/servermaster/etcd_test.go
+++ b/engine/servermaster/etcd_test.go
@@ -15,7 +15,6 @@ package servermaster
 
 import (
 	"fmt"
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -44,14 +43,12 @@ func TestStartEtcdTimeout(t *testing.T) {
 
 	name1 := "test-start-etcd-timeout-1"
 	name2 := "test-start-etcd-timeout-2"
-	dir, err := ioutil.TempDir("", name1)
-	require.Nil(t, err)
 
 	masterAddr := allocTempURL(t)
 	advertiseAddr := masterAddr
 	cfgCluster := &etcdutils.ConfigParams{}
 	cfgCluster.Name = name1
-	cfgCluster.DataDir = dir
+	cfgCluster.DataDir = t.TempDir()
 	peer1 := allocTempURL(t)
 	peer2 := peer1
 	require.Eventually(t, func() bool {
@@ -63,7 +60,7 @@ func TestStartEtcdTimeout(t *testing.T) {
 	cfgCluster.Adjust("", embed.ClusterStateFlagNew)
 
 	cfgClusterEtcd := etcdutils.GenEmbedEtcdConfigWithLogger("info")
-	cfgClusterEtcd, err = etcdutils.GenEmbedEtcdConfig(cfgClusterEtcd, masterAddr, advertiseAddr, cfgCluster)
+	cfgClusterEtcd, err := etcdutils.GenEmbedEtcdConfig(cfgClusterEtcd, masterAddr, advertiseAddr, cfgCluster)
 	require.Nil(t, err)
 
 	_, err = etcdutils.StartEtcd(cfgClusterEtcd, nil, nil, time.Millisecond*100)

--- a/engine/servermaster/server_test.go
+++ b/engine/servermaster/server_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -44,9 +43,8 @@ func init() {
 	}
 }
 
-func prepareServerEnv(t *testing.T, name string) (string, *Config, func()) {
-	dir, err := ioutil.TempDir("", name)
-	require.Nil(t, err)
+func prepareServerEnv(t *testing.T, name string) (string, *Config) {
+	dir := t.TempDir()
 
 	ports, err := freeport.GetFreePorts(2)
 	require.Nil(t, err)
@@ -73,19 +71,15 @@ initial-cluster = "%s=http://127.0.0.1:%d"`
 	err = cfg.adjust()
 	require.Nil(t, err)
 
-	cleanupFn := func() {
-		os.RemoveAll(dir)
-	}
 	masterAddr := fmt.Sprintf("127.0.0.1:%d", ports[0])
 
-	return masterAddr, cfg, cleanupFn
+	return masterAddr, cfg
 }
 
 // Disable parallel run for this case, because prometheus http handler will meet
 // data race if parallel run is enabled
 func TestStartGrpcSrv(t *testing.T) {
-	masterAddr, cfg, cleanup := prepareServerEnv(t, "test-start-grpc-srv")
-	defer cleanup()
+	masterAddr, cfg := prepareServerEnv(t, "test-start-grpc-srv")
 
 	s := &Server{cfg: cfg}
 	ctx := context.Background()
@@ -102,9 +96,7 @@ func TestStartGrpcSrv(t *testing.T) {
 func TestStartGrpcSrvCancelable(t *testing.T) {
 	t.Parallel()
 
-	dir, err := ioutil.TempDir("", "test-start-grpc-srv-cancelable")
-	require.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	ports, err := freeport.GetFreePorts(3)
 	require.Nil(t, err)
 	cfgTpl := `
@@ -188,8 +180,7 @@ func testPrometheusMetrics(t *testing.T, addr string) {
 // FIXME: disable this test temporary for no proper mock of frame metastore
 // nolint: deadcode
 func testRunLeaderService(t *testing.T) {
-	_, cfg, cleanup := prepareServerEnv(t, "test-run-leader-service")
-	defer cleanup()
+	_, cfg := prepareServerEnv(t, "test-run-leader-service")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -324,8 +315,7 @@ func (m *mockExecutorManager) ExecutorCount(status model.ExecutorStatus) int {
 }
 
 func TestCollectMetric(t *testing.T) {
-	masterAddr, cfg, cleanup := prepareServerEnv(t, "test-collect-metric")
-	defer cleanup()
+	masterAddr, cfg := prepareServerEnv(t, "test-collect-metric")
 
 	s := &Server{
 		cfg:     cfg,

--- a/pkg/cmd/util/helper_test.go
+++ b/pkg/cmd/util/helper_test.go
@@ -16,7 +16,6 @@ package util
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -100,12 +99,8 @@ func TestVerifyPdEndpoint(t *testing.T) {
 }
 
 func TestStrictDecodeValidFile(t *testing.T) {
-	dataDir, err := ioutil.TempDir("", "data")
-	require.NoError(t, err)
-	tmpDir, err := ioutil.TempDir("", "tmp")
-	require.NoError(t, err)
-	defer os.RemoveAll(dataDir)
-	defer os.RemoveAll(tmpDir)
+	dataDir := t.TempDir()
+	tmpDir := t.TempDir()
 
 	configPath := filepath.Join(tmpDir, "ticdc.toml")
 	configContent := fmt.Sprintf(`
@@ -142,7 +137,7 @@ cert-path = "bb"
 key-path = "cc"
 cert-allowed-cn = ["dd","ee"]
 `, dataDir)
-	err = os.WriteFile(configPath, []byte(configContent), 0o644)
+	err := os.WriteFile(configPath, []byte(configContent), 0o644)
 	require.Nil(t, err)
 
 	conf := config.GetDefaultServerConfig()
@@ -151,12 +146,8 @@ cert-allowed-cn = ["dd","ee"]
 }
 
 func TestStrictDecodeInvalidFile(t *testing.T) {
-	dataDir, err := ioutil.TempDir("", "data")
-	require.NoError(t, err)
-	tmpDir, err := ioutil.TempDir("", "tmp")
-	require.NoError(t, err)
-	defer os.RemoveAll(dataDir)
-	defer os.RemoveAll(tmpDir)
+	dataDir := t.TempDir()
+	tmpDir := t.TempDir()
 
 	configPath := filepath.Join(tmpDir, "ticdc.toml")
 	configContent := fmt.Sprintf(`
@@ -168,7 +159,7 @@ max-size = 200
 max-days = 1
 max-backups = 1
 `, dataDir)
-	err = os.WriteFile(configPath, []byte(configContent), 0o644)
+	err := os.WriteFile(configPath, []byte(configContent), 0o644)
 	require.Nil(t, err)
 
 	conf := config.GetDefaultServerConfig()
@@ -244,12 +235,8 @@ func TestJSONPrint(t *testing.T) {
 }
 
 func TestIgnoreStrictCheckItem(t *testing.T) {
-	dataDir, err := ioutil.TempDir("", "data")
-	require.NoError(t, err)
-	tmpDir, err := ioutil.TempDir("", "tmp")
-	require.NoError(t, err)
-	defer os.RemoveAll(dataDir)
-	defer os.RemoveAll(tmpDir)
+	dataDir := t.TempDir()
+	tmpDir := t.TempDir()
 
 	configPath := filepath.Join(tmpDir, "ticdc.toml")
 	configContent := fmt.Sprintf(`
@@ -259,7 +246,7 @@ max-size = 200
 max-days = 1
 max-backups = 1
 `, dataDir)
-	err = os.WriteFile(configPath, []byte(configContent), 0o644)
+	err := os.WriteFile(configPath, []byte(configContent), 0o644)
 	require.Nil(t, err)
 
 	conf := config.GetDefaultServerConfig()

--- a/pkg/etcd/client_test.go
+++ b/pkg/etcd/client_test.go
@@ -15,8 +15,6 @@ package etcd
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -119,12 +117,9 @@ func TestRetry(t *testing.T) {
 
 func TestDelegateLease(t *testing.T) {
 	ctx := context.Background()
-	dir, err := ioutil.TempDir("", "delegate-lease-test")
-	require.Nil(t, err)
-	url, server, err := SetupEmbedEtcd(dir)
+	url, server, err := SetupEmbedEtcd(t.TempDir())
 	defer func() {
 		server.Close()
-		os.RemoveAll(dir)
 	}()
 	require.Nil(t, err)
 	cli, err := clientv3.New(clientv3.Config{

--- a/pkg/etcd/etcd_test.go
+++ b/pkg/etcd/etcd_test.go
@@ -16,9 +16,7 @@ package etcd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
-	"os"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -58,8 +56,7 @@ type etcdTester struct {
 
 func (s *etcdTester) setUpTest(t *testing.T) {
 	var err error
-	s.dir, err = ioutil.TempDir("", "etcd-testing")
-	require.Nil(t, err)
+	s.dir = t.TempDir()
 	s.clientURL, s.etcd, err = SetupEmbedEtcd(s.dir)
 	require.Nil(t, err)
 	logConfig := logutil.DefaultZapLoggerConfig
@@ -91,7 +88,6 @@ logEtcdError:
 		}
 	}
 	s.client.Close() //nolint:errcheck
-	os.RemoveAll(s.dir)
 }
 
 func TestEmbedEtcd(t *testing.T) {

--- a/pkg/logutil/log_test.go
+++ b/pkg/logutil/log_test.go
@@ -88,9 +88,7 @@ func TestZapInternalErrorOutput(t *testing.T) {
 		{"test invalid error output path", filepath.Join(t.TempDir(), "/not-there/foo.log"), true},
 	}
 
-	dir, err := ioutil.TempDir("", "zap-error-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	for idx, tc := range testCases {
 		f := filepath.Join(dir, fmt.Sprintf("test-file%d", idx))
 		cfg := &Config{
@@ -98,7 +96,7 @@ func TestZapInternalErrorOutput(t *testing.T) {
 			File:                 f,
 			ZapInternalErrOutput: tc.errOutput,
 		}
-		err = InitLogger(cfg)
+		err := InitLogger(cfg)
 		if tc.error {
 			require.NotNil(t, err)
 		} else {

--- a/pkg/orchestrator/etcd_worker_test.go
+++ b/pkg/orchestrator/etcd_worker_test.go
@@ -16,8 +16,6 @@ package orchestrator
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -197,9 +195,7 @@ func (s *simpleReactorState) GetPatches() [][]DataPatch {
 }
 
 func setUpTest(t *testing.T) (func() *etcd.Client, func()) {
-	dir, err := ioutil.TempDir("", "etcd-test")
-	require.Nil(t, err)
-	url, server, err := etcd.SetupEmbedEtcd(dir)
+	url, server, err := etcd.SetupEmbedEtcd(t.TempDir())
 	require.Nil(t, err)
 	endpoints := []string{url.String()}
 	return func() *etcd.Client {
@@ -208,7 +204,6 @@ func setUpTest(t *testing.T) (func() *etcd.Client, func()) {
 			return etcd.Wrap(rawCli, map[string]prometheus.Counter{})
 		}, func() {
 			server.Close()
-			os.RemoveAll(dir)
 		}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5659

### What is changed and how it works?
This pull request replaces `ioutil.TempDir` and `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoErrror(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No

##### Do you need to update user documentation, design documentation or monitoring documentation?
No

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
