### PR TITLE
promutil(engine): avoid embedding Mutex and prometheus.Registry in Registry

### DIFF
--- a/engine/pkg/promutil/registry_test.go
+++ b/engine/pkg/promutil/registry_test.go
@@ -24,7 +24,7 @@ func TestNewRegistry(t *testing.T) {
 	t.Parallel()
 
 	reg := NewRegistry()
-	require.NotNil(t, reg.Registry)
+	require.NotNil(t, reg.registry)
 	require.Len(t, reg.collectorByWorker, 0)
 }
 
@@ -42,7 +42,7 @@ func TestMustRegister(t *testing.T) {
 	t.Parallel()
 
 	reg := NewRegistry()
-	require.NotNil(t, reg.Registry)
+	require.NotNil(t, reg.registry)
 
 	// normal case, register successfully
 	reg.MustRegister("worker0", prometheus.NewCounter(prometheus.CounterOpts{
@@ -112,7 +112,7 @@ func TestMustRegisterNotValidName(t *testing.T) {
 	}()
 
 	reg := NewRegistry()
-	require.NotNil(t, reg.Registry)
+	require.NotNil(t, reg.registry)
 
 	// not a valid metric name
 	reg.MustRegister("worker", prometheus.NewCounter(prometheus.CounterOpts{
@@ -130,7 +130,7 @@ func TestMustRegisterNotValidLableName(t *testing.T) {
 	}()
 
 	reg := NewRegistry()
-	require.NotNil(t, reg.Registry)
+	require.NotNil(t, reg.registry)
 
 	// not a valid metric name
 	reg.MustRegister("worker", prometheus.NewCounter(prometheus.CounterOpts{
@@ -152,7 +152,7 @@ func TestMustRegisterFailDuplicateNameLabels(t *testing.T) {
 	}()
 
 	reg := NewRegistry()
-	require.NotNil(t, reg.Registry)
+	require.NotNil(t, reg.registry)
 
 	reg.MustRegister("worker", prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "counter5",
@@ -179,7 +179,7 @@ func TestMustRegisterFailInconsistent(t *testing.T) {
 	}()
 
 	reg := NewRegistry()
-	require.NotNil(t, reg.Registry)
+	require.NotNil(t, reg.registry)
 
 	reg.MustRegister("worker", prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "counter5",
@@ -199,7 +199,7 @@ func TestUnregister(t *testing.T) {
 	t.Parallel()
 
 	reg := NewRegistry()
-	require.NotNil(t, reg.Registry)
+	require.NotNil(t, reg.registry)
 	reg.MustRegister("worker0", prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "counter5",
 		ConstLabels: prometheus.Labels{


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref https://github.com/pingcap/tiflow/issues/5673

Problem Summary:

Avoid embedding `Mutex` and `prometheus.Registry` in `Registry`. 

Refer to uber go style:
* https://github.com/uber-go/guide/blob/master/style.md#avoid-embedding-types-in-public-structs
* https://github.com/uber-go/guide/blob/master/style.md#zero-value-mutexes-are-valid

### What is changed and how it works?

Make `Mutex` and `prometheus.Registry` become private normal members.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
