### PR TITLE
http&migration(ticdc): Return http error if server is not ready

### DIFF
--- a/cdc/api/v1/api.go
+++ b/cdc/api/v1/api.go
@@ -70,6 +70,7 @@ func (h *OpenAPI) statusProvider() owner.StatusProvider {
 func RegisterOpenAPIRoutes(router *gin.Engine, api OpenAPI) {
 	v1 := router.Group("/api/v1")
 
+	v1.Use(middleware.CheckServerReadyMiddleware(api.capture))
 	v1.Use(middleware.LogMiddleware())
 	v1.Use(middleware.ErrorHandleMiddleware())
 

--- a/cdc/api/v2/api.go
+++ b/cdc/api/v2/api.go
@@ -33,6 +33,7 @@ func NewOpenAPIV2(c *capture.Capture) OpenAPIV2 {
 func RegisterOpenAPIV2Routes(router *gin.Engine, api OpenAPIV2) {
 	v2 := router.Group("/api/v2")
 
+	v2.Use(middleware.CheckServerReadyMiddleware(api.capture))
 	v2.Use(middleware.LogMiddleware())
 	v2.Use(middleware.ErrorHandleMiddleware())
 

--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
+	"github.com/pingcap/tiflow/pkg/migrate"
 	"github.com/pingcap/tiflow/pkg/util"
 	"go.etcd.io/etcd/client/v3/concurrency"
 	"go.etcd.io/etcd/server/v3/mvcc"
@@ -81,6 +82,8 @@ type Capture struct {
 
 	cancel context.CancelFunc
 
+	migrator migrate.Migrator
+
 	newProcessorManager func(upstreamManager *upstream.Manager) *processor.Manager
 	newOwner            func(upstreamManager *upstream.Manager) owner.Owner
 }
@@ -90,6 +93,7 @@ func NewCapture(pdEndpoints []string,
 	etcdClient *etcd.CDCEtcdClient,
 	grpcService *p2p.ServerWrapper,
 ) *Capture {
+	conf := config.GetGlobalServerConfig()
 	return &Capture{
 		EtcdClient:          etcdClient,
 		grpcService:         grpcService,
@@ -97,6 +101,10 @@ func NewCapture(pdEndpoints []string,
 		pdEndpoints:         pdEndpoints,
 		newProcessorManager: processor.NewManager,
 		newOwner:            owner.NewOwner,
+
+		migrator: migrate.NewMigrator(etcdClient.ClusterID,
+			etcdClient.Client,
+			pdEndpoints, conf.Security),
 	}
 }
 
@@ -441,7 +449,7 @@ func (c *Capture) runEtcdWorker(
 	role string,
 ) error {
 	etcdWorker, err := orchestrator.NewEtcdWorker(ctx.GlobalVars().EtcdClient,
-		etcd.BaseKey(c.EtcdClient.ClusterID), reactor, reactorState)
+		etcd.BaseKey(c.EtcdClient.ClusterID), reactor, reactorState, c.migrator)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -627,4 +635,9 @@ func (c *Capture) StatusProvider() owner.StatusProvider {
 		return nil
 	}
 	return owner.NewStatusProvider(c.owner)
+}
+
+// IsReady returns if the cdc server is ready
+func (c *Capture) IsReady() bool {
+	return c.migrator.IsMigrateDone()
 }

--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -102,9 +102,9 @@ func NewCapture(pdEndpoints []string,
 		newProcessorManager: processor.NewManager,
 		newOwner:            owner.NewOwner,
 
-		migrator: migrate.NewMigrator(etcdClient.ClusterID,
-			etcdClient.Client,
-			pdEndpoints, conf.Security),
+		migrator: migrate.NewMigrator(
+			etcdClient,
+			pdEndpoints, conf),
 	}
 }
 

--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -111,7 +111,9 @@ func NewCapture(pdEndpoints []string,
 // NewCapture4Test returns a new Capture instance for test.
 func NewCapture4Test(o owner.Owner) *Capture {
 	res := &Capture{
-		info: &model.CaptureInfo{ID: "capture-for-test", AdvertiseAddr: "127.0.0.1", Version: "test"},
+		info: &model.CaptureInfo{ID: "capture-for-test",
+			AdvertiseAddr: "127.0.0.1", Version: "test"},
+		migrator: &migrate.NoOpMigrator{},
 	}
 	res.owner = o
 	return res
@@ -121,6 +123,7 @@ func NewCapture4Test(o owner.Owner) *Capture {
 func NewCaptureWithManager4Test(o owner.Owner, m *upstream.Manager) *Capture {
 	res := &Capture{
 		UpstreamManager: m,
+		migrator:        &migrate.NoOpMigrator{},
 	}
 	res.owner = o
 	return res

--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -111,8 +111,10 @@ func NewCapture(pdEndpoints []string,
 // NewCapture4Test returns a new Capture instance for test.
 func NewCapture4Test(o owner.Owner) *Capture {
 	res := &Capture{
-		info: &model.CaptureInfo{ID: "capture-for-test",
-			AdvertiseAddr: "127.0.0.1", Version: "test"},
+		info: &model.CaptureInfo{
+			ID:            "capture-for-test",
+			AdvertiseAddr: "127.0.0.1", Version: "test",
+		},
 		migrator: &migrate.NoOpMigrator{},
 	}
 	res.owner = o

--- a/errors.toml
+++ b/errors.toml
@@ -906,6 +906,11 @@ error = '''
 serve http error
 '''
 
+["CDC:ErrServerIsNotReady"]
+error = '''
+cdc server is not ready
+'''
+
 ["CDC:ErrServerNewPDClient"]
 error = '''
 server creates pd client failed

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -995,4 +995,9 @@ var (
 		"upStram not found, cluster-id: %d",
 		errors.RFCCodeText("CDC:ErrUpStreamNotFound"),
 	)
+
+	ErrServerIsNotReady = errors.Normalize(
+		"cdc server is not ready",
+		errors.RFCCodeText("CDC:ErrServerIsNotReady"),
+	)
 )

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -56,7 +56,7 @@ func TaskPositionKeyPrefix(clusterID, namespace string) string {
 
 // ChangefeedStatusKeyPrefix is the prefix of changefeed status keys
 func ChangefeedStatusKeyPrefix(clusterID, namespace string) string {
-	return NamespacedPrefix(clusterID, namespace) + changefeedStatusKey
+	return NamespacedPrefix(clusterID, namespace) + ChangefeedStatusKey
 }
 
 // GetEtcdKeyChangeFeedList returns the prefix key of all changefeed config

--- a/pkg/etcd/etcdkey.go
+++ b/pkg/etcd/etcdkey.go
@@ -30,10 +30,13 @@ const (
 	captureKey      = "/capture"
 	taskPositionKey = "/task/position"
 
-	changefeedInfoKey   = "/changefeed/info"
-	changefeedStatusKey = "/changefeed/status"
-	metaVersionKey      = "/meta/meta-version"
-	upstreamKey         = "/upstream"
+	// ChangefeedInfoKey is the key path for changefeed info
+	ChangefeedInfoKey = "/changefeed/info"
+	// ChangefeedStatusKey is the key path for changefeed status
+	ChangefeedStatusKey = "/changefeed/status"
+	// MetaVersionKey is the key path for metadata version
+	MetaVersionKey = "/meta/meta-version"
+	upstreamKey    = "/upstream"
 
 	// DeletionCounterKey is the key path for the counter of deleted keys
 	DeletionCounterKey = metaPrefix + "/meta/ticdc-delete-etcd-key-count"
@@ -127,7 +130,7 @@ func (k *CDCKey) Parse(clusterID, key string) error {
 			k.Tp = CDCKeyTypeCapture
 			k.CaptureID = key[len(captureKey)+1:]
 			k.OwnerLeaseID = ""
-		case strings.HasPrefix(key, metaVersionKey):
+		case strings.HasPrefix(key, MetaVersionKey):
 			k.Tp = CDCKeyTypeMetaVersion
 		default:
 			return cerror.ErrInvalidEtcdKey.GenWithStackByArgs(key)
@@ -137,12 +140,12 @@ func (k *CDCKey) Parse(clusterID, key string) error {
 		key = key[len(namespace)+1:]
 		k.Namespace = namespace
 		switch {
-		case strings.HasPrefix(key, changefeedInfoKey):
+		case strings.HasPrefix(key, ChangefeedInfoKey):
 			k.Tp = CDCKeyTypeChangefeedInfo
 			k.CaptureID = ""
 			k.ChangefeedID = model.ChangeFeedID{
 				Namespace: namespace,
-				ID:        key[len(changefeedInfoKey)+1:],
+				ID:        key[len(ChangefeedInfoKey)+1:],
 			}
 			k.OwnerLeaseID = ""
 		case strings.HasPrefix(key, upstreamKey):
@@ -153,12 +156,12 @@ func (k *CDCKey) Parse(clusterID, key string) error {
 				return err
 			}
 			k.UpstreamID = id
-		case strings.HasPrefix(key, changefeedStatusKey):
+		case strings.HasPrefix(key, ChangefeedStatusKey):
 			k.Tp = CDCKeyTypeChangeFeedStatus
 			k.CaptureID = ""
 			k.ChangefeedID = model.ChangeFeedID{
 				Namespace: namespace,
-				ID:        key[len(changefeedStatusKey)+1:],
+				ID:        key[len(ChangefeedStatusKey)+1:],
 			}
 			k.OwnerLeaseID = ""
 		case strings.HasPrefix(key, taskPositionKey):
@@ -190,16 +193,16 @@ func (k *CDCKey) String() string {
 	case CDCKeyTypeCapture:
 		return BaseKey(k.ClusterID) + metaPrefix + captureKey + "/" + k.CaptureID
 	case CDCKeyTypeChangefeedInfo:
-		return NamespacedPrefix(k.ClusterID, k.ChangefeedID.Namespace) + changefeedInfoKey +
+		return NamespacedPrefix(k.ClusterID, k.ChangefeedID.Namespace) + ChangefeedInfoKey +
 			"/" + k.ChangefeedID.ID
 	case CDCKeyTypeChangeFeedStatus:
-		return NamespacedPrefix(k.ClusterID, k.ChangefeedID.Namespace) + changefeedStatusKey +
+		return NamespacedPrefix(k.ClusterID, k.ChangefeedID.Namespace) + ChangefeedStatusKey +
 			"/" + k.ChangefeedID.ID
 	case CDCKeyTypeTaskPosition:
 		return NamespacedPrefix(k.ClusterID, k.ChangefeedID.Namespace) + taskPositionKey +
 			"/" + k.CaptureID + "/" + k.ChangefeedID.ID
 	case CDCKeyTypeMetaVersion:
-		return BaseKey(k.ClusterID) + metaPrefix + metaVersionKey
+		return BaseKey(k.ClusterID) + metaPrefix + MetaVersionKey
 	case CDCKeyTypeUpStream:
 		return fmt.Sprintf("%s%s/%d",
 			NamespacedPrefix(k.ClusterID, k.Namespace),

--- a/pkg/etcd/testing.go
+++ b/pkg/etcd/testing.go
@@ -1,0 +1,81 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiflow/pkg/util"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/client/pkg/v3/logutil"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/server/v3/embed"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"golang.org/x/sync/errgroup"
+)
+
+// Tester is for ut tests
+type Tester struct {
+	dir       string
+	etcd      *embed.Etcd
+	ClientURL *url.URL
+	client    CDCEtcdClient
+	ctx       context.Context
+	cancel    context.CancelFunc
+	errg      *errgroup.Group
+}
+
+// SetUpTest setup etcd tester
+func (s *Tester) SetUpTest(t *testing.T) {
+	var err error
+	s.dir = t.TempDir()
+	s.ClientURL, s.etcd, err = SetupEmbedEtcd(s.dir)
+	require.Nil(t, err)
+	logConfig := logutil.DefaultZapLoggerConfig
+	logConfig.Level = zap.NewAtomicLevelAt(zapcore.ErrorLevel)
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{s.ClientURL.String()},
+		DialTimeout: 3 * time.Second,
+		LogConfig:   &logConfig,
+	})
+	require.NoError(t, err)
+
+	s.client, err = NewCDCEtcdClient(context.TODO(), client, DefaultCDCClusterID)
+	require.Nil(t, err)
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	s.errg = util.HandleErrWithErrGroup(s.ctx, s.etcd.Err(), func(e error) { t.Log(e) })
+}
+
+// TearDownTest teardown etcd
+func (s *Tester) TearDownTest(t *testing.T) {
+	s.etcd.Close()
+	s.cancel()
+logEtcdError:
+	for {
+		select {
+		case err, ok := <-s.etcd.Err():
+			if !ok {
+				break logEtcdError
+			}
+			t.Logf("etcd server error: %v", err)
+		default:
+			break logEtcdError
+		}
+	}
+	_ = s.client.Close() //nolint:errcheck
+}

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -26,7 +26,6 @@ import (
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/etcd"
 	"github.com/pingcap/tiflow/pkg/security"
-	"github.com/pingcap/tiflow/pkg/txnutil/gc"
 	pd "github.com/tikv/pd/client"
 	clientV3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
@@ -249,12 +248,6 @@ func (m *migrator) migrate(ctx context.Context, etcdNoMetaVersion bool, oldVersi
 	if err != nil {
 		log.Error("update meta version failed, etcd meta data migration failed", zap.Error(err))
 		return cerror.WrapError(cerror.ErrEtcdMigrateFailed, err)
-	}
-	err = gc.RemoveServiceGCSafepoint(ctx, pdClient, "ticdc")
-	if err != nil {
-		log.Warn("remove old ticdc gc service failed", zap.Error(err))
-	} else {
-		log.Info("remove gc service safe point successful")
 	}
 	log.Info("etcd data migration successful")
 	return nil

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -161,7 +161,7 @@ func (m *migrator) migrate(ctx context.Context, etcdNoMetaVersion bool, oldVersi
 
 	upstreamID := pdClient.GetClusterID(ctx)
 	// 1.1 check metaVersion, if the metaVersion in etcd does not match
-	// m.oldMetaVersion, it means that someone has migrated the meta data
+	// m.oldMetaVersion, it means that someone has migrated the metadata
 	metaVersion, err := getMetaVersion(ctx, m.cli, m.clusterID)
 	if err != nil {
 		log.Error("get meta version failed, etcd meta data migration failed", zap.Error(err))
@@ -253,8 +253,9 @@ func (m *migrator) migrate(ctx context.Context, etcdNoMetaVersion bool, oldVersi
 	err = gc.RemoveServiceGCSafepoint(ctx, pdClient, "ticdc")
 	if err != nil {
 		log.Warn("remove old ticdc gc service failed", zap.Error(err))
+	} else {
+		log.Info("remove gc service safe point successful")
 	}
-	log.Info("remove gc service safe point successful")
 	log.Info("etcd data migration successful")
 	return nil
 }

--- a/pkg/orchestrator/etcd_worker.go
+++ b/pkg/orchestrator/etcd_worker.go
@@ -547,10 +547,6 @@ func (worker *EtcdWorker) checkAndMigrateMetaData(
 
 	if role != pkgutil.RoleOwner.String() {
 		err := worker.migrator.WaitMetaVersionMatched(ctx)
-		if err != nil {
-			// processor
-			worker.migrator.MarkMigrateDone()
-		}
 		return errors.Trace(err)
 	}
 

--- a/pkg/orchestrator/etcd_worker_bank_test.go
+++ b/pkg/orchestrator/etcd_worker_bank_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/log"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/etcd"
+	"github.com/pingcap/tiflow/pkg/migrate"
 	"github.com/pingcap/tiflow/pkg/orchestrator/util"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -157,7 +158,8 @@ func TestEtcdBank(t *testing.T) {
 			for {
 				worker, err := NewEtcdWorker(&cdcCli, bankTestPrefix, &bankReactor{
 					accountNumber: totalAccountNumber,
-				}, &bankReactorState{t: t, index: i, account: make([]int, totalAccountNumber)})
+				}, &bankReactorState{t: t, index: i, account: make([]int, totalAccountNumber)},
+					&migrate.NoOpMigrator{})
 				require.Nil(t, err)
 				err = worker.Run(ctx, nil, 100*time.Millisecond, "owner")
 				if err == nil || err.Error() == "etcdserver: request timed out" {

--- a/pkg/orchestrator/etcd_worker_test.go
+++ b/pkg/orchestrator/etcd_worker_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
+	"github.com/pingcap/tiflow/pkg/migrate"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
@@ -258,7 +259,8 @@ func TestEtcdSum(t *testing.T) {
 				_ = cli.Unwrap().Close()
 			}()
 
-			etcdWorker, err := NewEtcdWorker(&cdcCli, testEtcdKeyPrefix, reactor, initState)
+			etcdWorker, err := NewEtcdWorker(&cdcCli, testEtcdKeyPrefix, reactor, initState,
+				&migrate.NoOpMigrator{})
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -344,7 +346,7 @@ func TestLinearizability(t *testing.T) {
 	}, &intReactorState{
 		val:       0,
 		isUpdated: false,
-	})
+	}, &migrate.NoOpMigrator{})
 	require.Nil(t, err)
 	errg := &errgroup.Group{}
 	errg.Go(func() error {
@@ -432,7 +434,7 @@ func TestFinished(t *testing.T) {
 		prefix: prefix,
 	}, &commonReactorState{
 		state: make(map[string]string),
-	})
+	}, &migrate.NoOpMigrator{})
 	require.Nil(t, err)
 	err = reactor.Run(ctx, nil, 10*time.Millisecond, "owner")
 	require.Nil(t, err)
@@ -502,7 +504,7 @@ func TestCover(t *testing.T) {
 		prefix: prefix,
 	}, &commonReactorState{
 		state: make(map[string]string),
-	})
+	}, &migrate.NoOpMigrator{})
 	require.Nil(t, err)
 	err = reactor.Run(ctx, nil, 10*time.Millisecond, "owner")
 	require.Nil(t, err)
@@ -582,7 +584,7 @@ func TestEmptyTxn(t *testing.T) {
 		cli:    cli,
 	}, &commonReactorState{
 		state: make(map[string]string),
-	})
+	}, &migrate.NoOpMigrator{})
 	require.Nil(t, err)
 	err = reactor.Run(ctx, nil, 10*time.Millisecond, "owner")
 	require.Nil(t, err)
@@ -650,7 +652,7 @@ func TestEmptyOrNil(t *testing.T) {
 		prefix: prefix,
 	}, &commonReactorState{
 		state: make(map[string]string),
-	})
+	}, &migrate.NoOpMigrator{})
 	require.Nil(t, err)
 	err = reactor.Run(ctx, nil, 10*time.Millisecond, "owner")
 	require.Nil(t, err)
@@ -729,7 +731,7 @@ func TestModifyAfterDelete(t *testing.T) {
 	}
 	worker1, err := NewEtcdWorker(&cdcCli1, "/test", modifyReactor, &commonReactorState{
 		state: make(map[string]string),
-	})
+	}, &migrate.NoOpMigrator{})
 	require.Nil(t, err)
 
 	var wg sync.WaitGroup
@@ -748,7 +750,7 @@ func TestModifyAfterDelete(t *testing.T) {
 	}
 	worker2, err := NewEtcdWorker(&cdcCli2, "/test", deleteReactor, &commonReactorState{
 		state: make(map[string]string),
-	})
+	}, &migrate.NoOpMigrator{})
 	require.Nil(t, err)
 
 	err = worker2.Run(ctx, nil, time.Millisecond*100, "owner")

--- a/pkg/txnutil/gc/gc_manager.go
+++ b/pkg/txnutil/gc/gc_manager.go
@@ -51,8 +51,6 @@ type gcManager struct {
 	lastSucceededTime time.Time
 	lastSafePointTs   uint64
 	isTiCDCBlockGC    bool
-
-	isOldGCServicePointIsRemoved bool
 }
 
 // NewManager creates a new Manager.
@@ -78,7 +76,7 @@ func (m *gcManager) TryUpdateGCSafePoint(
 	}
 	m.lastUpdatedTime = time.Now()
 
-	actual, err := setServiceGCSafepoint(
+	actual, err := SetServiceGCSafepoint(
 		ctx, m.pdClient, m.gcServiceID, m.gcTTL, checkpointTs)
 	if err != nil {
 		log.Warn("updateGCSafePoint failed",
@@ -104,15 +102,6 @@ func (m *gcManager) TryUpdateGCSafePoint(
 	m.isTiCDCBlockGC = actual == checkpointTs
 	m.lastSafePointTs = actual
 	m.lastSucceededTime = time.Now()
-	if !m.isOldGCServicePointIsRemoved {
-		err = RemoveServiceGCSafepoint(ctx, m.pdClient, "ticdc")
-		if err == nil {
-			m.isOldGCServicePointIsRemoved = true
-		} else {
-			log.Warn("remove old gc service safepoint failed",
-				zap.Error(err))
-		}
-	}
 	return nil
 }
 

--- a/pkg/txnutil/gc/gc_service.go
+++ b/pkg/txnutil/gc/gc_service.go
@@ -34,7 +34,7 @@ func EnsureChangefeedStartTsSafety(
 	changefeedID model.ChangeFeedID,
 	TTL int64, startTs uint64,
 ) error {
-	minServiceGCTs, err := setServiceGCSafepoint(
+	minServiceGCTs, err := SetServiceGCSafepoint(
 		ctx, pdCli,
 		gcServiceIDPrefix+changefeedID.Namespace+"_"+changefeedID.ID,
 		TTL, startTs)
@@ -55,8 +55,8 @@ const (
 	gcServiceMaxRetries   = 9
 )
 
-// setServiceGCSafepoint set a service safepoint to PD.
-func setServiceGCSafepoint(
+// SetServiceGCSafepoint set a service safepoint to PD.
+func SetServiceGCSafepoint(
 	ctx context.Context, pdCli pd.Client, serviceID string, TTL int64, safePoint uint64,
 ) (minServiceGCTs uint64, err error) {
 	err = retry.Do(ctx,

--- a/pkg/txnutil/gc/testing.go
+++ b/pkg/txnutil/gc/testing.go
@@ -25,6 +25,7 @@ import (
 type MockPDClient struct {
 	pd.Client
 	UpdateServiceGCSafePointFunc func(ctx context.Context, serviceID string, ttl int64, safePoint uint64) (uint64, error)
+	ClusterID                    uint64
 }
 
 // UpdateServiceGCSafePoint implements pd.Client.UpdateServiceGCSafePoint.
@@ -40,3 +41,8 @@ func (m *MockPDClient) GetTS(ctx context.Context) (int64, int64, error) {
 // Close implements pd.Client.Close()
 // This method is used in some unit test cases.
 func (m *MockPDClient) Close() {}
+
+// GetClusterID gets the cluster ID from PD.
+func (m *MockPDClient) GetClusterID(ctx context.Context) uint64 {
+	return m.ClusterID
+}

--- a/pkg/upstream/manager.go
+++ b/pkg/upstream/manager.go
@@ -111,13 +111,16 @@ func (m *Manager) add(upstreamID uint64,
 		up.hold()
 		return up
 	}
-	up := newUpstream(pdEndpoints,
-		&security.Credential{
+	securityConf := &security.Credential{}
+	if conf != nil {
+		securityConf = &security.Credential{
 			CAPath:        conf.CAPath,
 			CertPath:      conf.CertPath,
 			KeyPath:       conf.KeyPath,
 			CertAllowedCN: conf.CertAllowedCN,
-		})
+		}
+	}
+	up := newUpstream(pdEndpoints, securityConf)
 	m.ups.Store(upstreamID, up)
 	go func() {
 		up.err = up.init(m.ctx, m.gcServiceID)

--- a/pkg/upstream/manager_test.go
+++ b/pkg/upstream/manager_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/benbjohnson/clock"
-	"github.com/pingcap/tiflow/pkg/config"
 	"github.com/pingcap/tiflow/pkg/txnutil/gc"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +30,7 @@ func TestUpstream(t *testing.T) {
 	require.NotNil(t, up1)
 
 	// test Add
-	manager.add(DefaultUpstreamID, []string{}, config.GetGlobalServerConfig().Security)
+	manager.add(DefaultUpstreamID, []string{}, nil)
 
 	// test Get
 	testID := uint64(1)

--- a/pkg/upstream/upstream.go
+++ b/pkg/upstream/upstream.go
@@ -169,7 +169,7 @@ func (up *Upstream) init(ctx context.Context, gcServiceID string) error {
 	log.Info("upstream's GCManager created", zap.Uint64("upstreamID", up.ID))
 
 	// Update meta-region label to ensure that meta region isolated from data regions.
-	err = pdutil.UpdateMetaLabel(ctx, up.PDClient)
+	err = pdutil.UpdateMetaLabel(ctx, up.PDClient, up.SecurityConfig)
 	if err != nil {
 		log.Warn("Fail to verify region label rule",
 			zap.Error(err),

--- a/tests/integration_tests/availability/capture.sh
+++ b/tests/integration_tests/availability/capture.sh
@@ -120,7 +120,7 @@ function test_hang_up_capture() {
 function test_expire_capture() {
 	echo "run test case test_expire_capture"
 	# start one server
-	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix test_expire_capture.server1
 
 	# ensure the server become the owner
 	ensure $MAX_RETRIES "$CDC_BINARY cli capture list --disable-version-check 2>&1 | grep '\"is-owner\": true'"
@@ -134,7 +134,7 @@ function test_expire_capture() {
 	echo "process status:" $(ps -h -p $owner_pid -o "s")
 
 	# ensure the session has expired
-	ensure $MAX_RETRIES "$CDC_BINARY cli capture list --disable-version-check 2>&1 | grep '\[\]'"
+	ensure $MAX_RETRIES "ETCDCTL_API=3 etcdctl get /tidb/cdc/default/__cdc_meta__/owner --prefix | grep -v '$owner_id'"
 
 	# resume the owner
 	kill -SIGCONT $owner_pid

--- a/tests/integration_tests/availability/owner.sh
+++ b/tests/integration_tests/availability/owner.sh
@@ -44,14 +44,14 @@ function test_kill_owner() {
 	# run another server
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8301" --logsuffix test_kill_owner.server2
 	ensure $MAX_RETRIES "$CDC_BINARY cli capture list --disable-version-check 2>&1 | grep -v \"$owner_id\" | grep id"
-	capture_id=$($CDC_BINARY cli capture list --disable-version-check 2>&1 | awk -F '"' '/id/{print $4}' | grep -v "$owner_id")
+	capture_id=$($CDC_BINARY cli capture list --server-addr --server-addr 'http://127.0.0.1:8301' --disable-version-check 2>&1 | awk -F '"' '/id/{print $4}' | grep -v "$owner_id")
 	echo "capture_id:" $capture_id
 
 	# kill the server
 	kill $owner_pid
 
 	# check that the new owner is elected
-	ensure $MAX_RETRIES "$CDC_BINARY cli capture list --disable-version-check 2>&1 |grep $capture_id -A1 | grep '\"is-owner\": true'"
+	ensure $MAX_RETRIES "$CDC_BINARY cli capture list --server-addr 'http://127.0.0.1:8301' --disable-version-check 2>&1 |grep $capture_id -A1 | grep '\"is-owner\": true'"
 	echo "test_kill_owner: pass"
 
 	cleanup_process $CDC_BINARY
@@ -74,7 +74,7 @@ function test_hang_up_owner() {
 
 	# run another server
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8301" --logsuffix test_hang_up_owner.server2
-	ensure $MAX_RETRIES "$CDC_BINARY cli capture list --disable-version-check 2>&1 | grep -v \"$owner_id\" | grep id"
+	ensure $MAX_RETRIES "$CDC_BINARY cli capture list --server-addr 'http://127.0.0.1:8301'  --disable-version-check 2>&1 | grep -v \"$owner_id\" | grep id"
 	capture_id=$($CDC_BINARY cli capture list --disable-version-check 2>&1 | awk -F '"' '/id/{print $4}' | grep -v "$owner_id")
 	echo "capture_id:" $capture_id
 
@@ -82,7 +82,7 @@ function test_hang_up_owner() {
 	kill -SIGSTOP $owner_pid
 
 	# check that the new owner is elected
-	ensure $MAX_RETRIES "$CDC_BINARY cli capture list --disable-version-check 2>&1 |grep $capture_id -A1 | grep '\"is-owner\": true'"
+	ensure $MAX_RETRIES "$CDC_BINARY cli capture list --server-addr 'http://127.0.0.1:8301'  --disable-version-check 2>&1 |grep $capture_id -A1 | grep '\"is-owner\": true'"
 	# resume the original process
 	kill -SIGCONT $owner_pid
 
@@ -139,9 +139,9 @@ function test_owner_cleanup_stale_tasks() {
 
 	# run another server
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --addr "127.0.0.1:8301" --logsuffix test_owner_cleanup_stale_tasks.server2
-	ensure $MAX_RETRIES "$CDC_BINARY cli capture list --disable-version-check 2>&1 | grep -v \"$owner_id\" | grep id"
+	ensure $MAX_RETRIES "$CDC_BINARY cli capture list --server-addr 'http://127.0.0.1:8301' --disable-version-check 2>&1 | grep -v \"$owner_id\" | grep id"
 	capture_pid=$(ps -C $CDC_BINARY -o pid= | awk '{print $1}' | grep -v "$owner_pid")
-	capture_id=$($CDC_BINARY cli capture list --disable-version-check 2>&1 | awk -F '"' '/id/{print $4}' | grep -v "$owner_id")
+	capture_id=$($CDC_BINARY cli capture list --server-addr 'http://127.0.0.1:8301' --disable-version-check 2>&1 | awk -F '"' '/id/{print $4}' | grep -v "$owner_id")
 	echo "capture_id:" $capture_id
 
 	kill -SIGKILL $owner_pid

--- a/tests/integration_tests/changefeed_error/run.sh
+++ b/tests/integration_tests/changefeed_error/run.sh
@@ -64,7 +64,7 @@ function run() {
 
 	export GO_FAILPOINTS='github.com/pingcap/tiflow/cdc/owner/NewChangefeedRetryError=return(true)'
 	kill $capture_pid
-	ensure $MAX_RETRIES check_no_capture http://${UP_PD_HOST_1}:${UP_PD_PORT_1}
+	ensure $MAX_RETRIES "ETCDCTL_API=3 etcdctl get /tidb/cdc/default/__cdc_meta__/capture --prefix | grep -v 'capture'"
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
 	ensure $MAX_RETRIES check_changefeed_state http://${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid} "error" "failpoint injected retriable error" ""
 

--- a/tests/integration_tests/processor_resolved_ts_fallback/run.sh
+++ b/tests/integration_tests/processor_resolved_ts_fallback/run.sh
@@ -34,7 +34,7 @@ function run() {
 	run_sql "CREATE database processor_resolved_ts_fallback;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "CREATE table processor_resolved_ts_fallback.t1(id int primary key auto_increment, val int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	# wait table t1 is processed by cdc server
-	ensure 10 "cdc cli processor list|jq '.|length'|grep -E '^1$'"
+	ensure 10 "cdc cli processor list --server-addr http://127.0.0.1:8301 |jq '.|length'|grep -E '^1$'"
 	# check the t1 is replicated to downstream to make sure the t1 is dispatched to cdc1
 	check_table_exists "processor_resolved_ts_fallback.t1" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 
@@ -44,11 +44,11 @@ function run() {
 	run_sql "CREATE table processor_resolved_ts_fallback.t3(id int primary key auto_increment, val int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	check_table_exists "processor_resolved_ts_fallback.t2" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	check_table_exists "processor_resolved_ts_fallback.t3" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
-	ensure 10 "cdc cli processor list|jq '.|length'|grep -E '^2$'"
+	ensure 10 "cdc cli processor list --server-addr http://127.0.0.1:8301 |jq '.|length'|grep -E '^2$'"
 
 	run_sql "INSERT INTO processor_resolved_ts_fallback.t1 values (),(),();" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	# wait cdc server 1 is panic
-	ensure 10 "cdc cli capture list|jq '.|length'|grep -E '^1$'"
+	ensure 10 "cdc cli capture list --server-addr http://127.0.0.1:8302 |jq '.|length'|grep -E '^1$'"
 	run_sql "INSERT INTO processor_resolved_ts_fallback.t1 values (),(),();" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "INSERT INTO processor_resolved_ts_fallback.t2 values (),(),();" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #5663 

### What is changed and how it works?
1. remove /tidb/cdc gc service safe point after the migration is done
2. add upstream info
3. if server is not ready, return error


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
