### PR TITLE
fb/latency(cdc): agent to be table state awared, to handle different p2p messages.

### DIFF
--- a/cdc/processor/pipeline/table.go
+++ b/cdc/processor/pipeline/table.go
@@ -35,9 +35,11 @@ const (
 	TableStatePreparing TableState = iota
 	// TableStatePrepared means the first `Resolved Ts` is received.
 	TableStatePrepared
-	// TableStateReplicating means that sink is consuming data from the sorter, and replicating it to downstream
+	// TableStateReplicating means that sink is consuming data from the sorter,
+	// and replicating it to downstream
 	TableStateReplicating
 	// TableStateStopping means the table is stopping, but not guaranteed yet.
+	// at the moment, this state is not used, only keep aligned with `schedulepb.TableStateStopping`
 	TableStateStopping
 	// TableStateStopped means sink stop all works, but the table resource not released yet.
 	TableStateStopped

--- a/cdc/processor/pipeline/table.go
+++ b/cdc/processor/pipeline/table.go
@@ -94,7 +94,7 @@ type TablePipeline interface {
 	AsyncStop(targetTs model.Ts) bool
 
 	// Start the sink consume data from the given `ts`
-	Start(ts model.Ts) bool
+	Start(ts model.Ts)
 
 	// Workload returns the workload of this table
 	Workload() model.WorkloadInfo

--- a/cdc/processor/pipeline/table.go
+++ b/cdc/processor/pipeline/table.go
@@ -31,8 +31,11 @@ type TableState int32
 
 // TableState for table pipeline
 const (
+	TableStateUnknown TableState = iota
+	// TableStateAbsent means the table not found
+	TableStateAbsent
 	// TableStatePreparing indicate that the table is preparing connecting to regions
-	TableStatePreparing TableState = iota
+	TableStatePreparing
 	// TableStatePrepared means the first `Resolved Ts` is received.
 	TableStatePrepared
 	// TableStateReplicating means that sink is consuming data from the sorter,
@@ -43,17 +46,16 @@ const (
 	TableStateStopping
 	// TableStateStopped means sink stop all works, but the table resource not released yet.
 	TableStateStopped
-	// TableStateAbsent means the table not found
-	TableStateAbsent
 )
 
 var tableStatusStringMap = map[TableState]string{
+	TableStateUnknown:     "Unknown",
+	TableStateAbsent:      "Absent",
 	TableStatePreparing:   "Preparing",
 	TableStatePrepared:    "Prepared",
 	TableStateReplicating: "Replicating",
 	TableStateStopping:    "Stopping",
 	TableStateStopped:     "Stopped",
-	TableStateAbsent:      "Absent",
 }
 
 func (s TableState) String() string {

--- a/cdc/processor/pipeline/table.go
+++ b/cdc/processor/pipeline/table.go
@@ -39,7 +39,7 @@ const (
 	TableStateReplicating
 	// TableStateStopping means the table is stopping, but not guaranteed yet.
 	TableStateStopping
-	// TableStateStopped means sink stop all works.
+	// TableStateStopped means sink stop all works, but the table resource not released yet.
 	TableStateStopped
 	// TableStateAbsent means the table not found
 	TableStateAbsent

--- a/cdc/processor/pipeline/table_actor.go
+++ b/cdc/processor/pipeline/table_actor.go
@@ -517,13 +517,11 @@ func (t *tableActor) Wait() {
 	_ = t.wg.Wait()
 }
 
-func (t *tableActor) Start(ts model.Ts) bool {
+func (t *tableActor) Start(ts model.Ts) {
 	if atomic.CompareAndSwapInt32(&t.sortNode.started, 0, 1) {
 		t.sortNode.startTsCh <- ts
 		close(t.sortNode.startTsCh)
-		return true
 	}
-	return false
 }
 
 // MemoryConsumption return the memory consumption in bytes

--- a/cdc/processor/processor_test.go
+++ b/cdc/processor/processor_test.go
@@ -202,9 +202,8 @@ func (m *mockTablePipeline) Wait() {
 	// do nothing
 }
 
-func (m *mockTablePipeline) Start(ts model.Ts) bool {
+func (m *mockTablePipeline) Start(ts model.Ts) {
 	m.sinkStartTs = ts
-	return true
 }
 
 // MemoryConsumption return the memory consumption in bytes

--- a/cdc/scheduler/internal/tp/agent.go
+++ b/cdc/scheduler/internal/tp/agent.go
@@ -41,6 +41,8 @@ type agent struct {
 	// runningTasks track all in progress dispatch table task
 	runningTasks map[model.TableID]*dispatchTableTask
 
+	// tables map[model.TableID]*tableImpl
+
 	// owner's information
 	ownerInfo ownerInfo
 
@@ -618,4 +620,64 @@ func (a *agent) sendMsgs(ctx context.Context, msgs []*schedulepb.Message) error 
 		}
 	}
 	return a.trans.Send(ctx, msgs)
+}
+
+type table struct {
+	ID    model.TableID
+	State schedulepb.TableState
+
+	Executor internal.TableExecutor
+}
+
+func newTable(tableID model.TableID, executor internal.TableExecutor) *table {
+	return &table{
+		ID:       tableID,
+		State:    schedulepb.TableStateAbsent,
+		Executor: executor,
+	}
+}
+
+//type tableExecutorFactory struct{}
+//
+//func (tableExecutorFactory) NewTableExecutor(tableID model.TableID) internal.TableExecutor {
+//	return nil
+//}
+
+func (t *table) TableStatus() schedulepb.TableStatus {
+	checkpointTs, resolvedTs := t.Executor.GetCheckpoint()
+	return schedulepb.TableStatus{
+		TableID: t.ID,
+		State:   t.State,
+		Checkpoint: schedulepb.Checkpoint{
+			CheckpointTs: checkpointTs,
+			ResolvedTs:   resolvedTs,
+		},
+	}
+}
+
+func (t *table) poll(input dispatchTableTask) {
+	switch t.State {
+	case schedulepb.TableStateAbsent:
+	case schedulepb.TableStatePreparing:
+	case schedulepb.TableStatePrepared:
+	case schedulepb.TableStateReplicating:
+	case schedulepb.TableStateStopping:
+	case schedulepb.TableStateStopped:
+	}
+}
+
+func (t *table) handleAddTableRequest(
+	req *schedulepb.AddTableRequest,
+) *schedulepb.AddTableResponse {
+	return nil
+}
+
+func (t *table) handleRemoveTableRequest(
+	req *schedulepb.RemoveTableRequest,
+) *schedulepb.RemoveTableResponse {
+	return nil
+}
+
+func (t *table) handleHeartbeat() *schedulepb.RemoveTableResponse {
+	return nil
 }

--- a/cdc/scheduler/internal/tp/agent.go
+++ b/cdc/scheduler/internal/tp/agent.go
@@ -319,14 +319,6 @@ func (a *agent) Close() error {
 	return a.trans.Close()
 }
 
-func (a *agent) newMessageHeader() *schedulepb.Message_Header {
-	return &schedulepb.Message_Header{
-		Version:        a.version,
-		OwnerRevision:  a.ownerInfo.revision,
-		ProcessorEpoch: a.epoch,
-	}
-}
-
 // handleOwnerInfo return false, if the given owner's info is staled.
 // update owner's info to the latest otherwise.
 // id: the incoming owner's capture ID
@@ -410,7 +402,11 @@ func (a *agent) sendMsgs(ctx context.Context, msgs []*schedulepb.Message) error 
 				zap.String("changefeed", a.changeFeedID.ID),
 				zap.Any("message", m))
 		}
-		m.Header = a.newMessageHeader()
+		m.Header = &schedulepb.Message_Header{
+			Version:        a.version,
+			OwnerRevision:  a.ownerInfo.revision,
+			ProcessorEpoch: a.epoch,
+		}
 		m.From = a.captureID
 		m.To = a.ownerInfo.captureID
 	}

--- a/cdc/scheduler/internal/tp/agent.go
+++ b/cdc/scheduler/internal/tp/agent.go
@@ -183,7 +183,6 @@ func (a *agent) handleMessage(msg []*schedulepb.Message) []*schedulepb.Message {
 
 func (a *agent) handleMessageHeartbeat(expected []model.TableID) *schedulepb.Message {
 	allTables := a.tableM.getAllTables()
-
 	result := make([]schedulepb.TableStatus, 0, len(allTables))
 	for _, table := range allTables {
 		status := table.status

--- a/cdc/scheduler/internal/tp/agent.go
+++ b/cdc/scheduler/internal/tp/agent.go
@@ -191,7 +191,7 @@ func (a *agent) handleMessageHeartbeat(expected []model.TableID) *schedulepb.Mes
 	allTables := a.tableM.getAllTables()
 	result := make([]schedulepb.TableStatus, 0, len(allTables))
 	for _, table := range allTables {
-		status := table.status
+		status := table.getTableStatus()
 		if table.task != nil && table.task.IsRemove {
 			status.State = schedulepb.TableStateStopping
 		}
@@ -199,7 +199,7 @@ func (a *agent) handleMessageHeartbeat(expected []model.TableID) *schedulepb.Mes
 	}
 	for _, tableID := range expected {
 		if _, ok := allTables[tableID]; !ok {
-			status := a.tableM.newTableStatus(tableID)
+			status := a.tableM.getTableStatus(tableID)
 			result = append(result, status)
 		}
 	}

--- a/cdc/scheduler/internal/tp/agent.go
+++ b/cdc/scheduler/internal/tp/agent.go
@@ -537,6 +537,9 @@ func (a *agent) sendMsgs(ctx context.Context, msgs []*schedulepb.Message) error 
 				zap.String("changefeed", a.changeFeedID.ID),
 				zap.Any("message", m))
 		}
+		m.Header = a.newMessageHeader()
+		m.From = a.captureID
+		m.To = a.ownerInfo.captureID
 	}
 	return a.trans.Send(ctx, msgs)
 }
@@ -565,7 +568,6 @@ func (t *table) TableStatus() schedulepb.TableStatus {
 	return t.status
 }
 
-// todo: attach header / from / to to the message before send it out.
 func newAddTableResponseMessage(status schedulepb.TableStatus, reject bool) *schedulepb.Message {
 	return &schedulepb.Message{
 		MsgType: schedulepb.MsgDispatchTableResponse,

--- a/cdc/scheduler/internal/tp/agent.go
+++ b/cdc/scheduler/internal/tp/agent.go
@@ -273,7 +273,7 @@ func (a *agent) handleMessageDispatchTableRequest(
 			Epoch:     epoch,
 			status:    dispatchTableTaskReceived,
 		}
-		table = a.tableM.register(tableID)
+		table = a.tableM.addTable(tableID)
 	case *schedulepb.DispatchTableRequest_RemoveTable:
 		tableID := req.RemoveTable.GetTableID()
 		table, ok = a.tableM.getTable(tableID)

--- a/cdc/scheduler/internal/tp/agent.go
+++ b/cdc/scheduler/internal/tp/agent.go
@@ -15,6 +15,7 @@ package tp
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
@@ -55,6 +56,11 @@ type ownerInfo struct {
 	revision  schedulepb.OwnerRevision
 	version   string
 	captureID string
+}
+
+func (o ownerInfo) String() string {
+	bytes, _ := json.Marshal(o)
+	return string(bytes)
 }
 
 // NewAgent returns a new agent.
@@ -348,7 +354,7 @@ func (a *agent) handleOwnerInfo(id model.CaptureID, revision int64, version stri
 
 		a.resetEpoch()
 
-		log.Info("tpscheduler: new owner in power, drop pending dispatch table tasks",
+		log.Info("tpscheduler: new owner in power",
 			zap.String("capture", a.captureID),
 			zap.String("namespace", a.changeFeedID.Namespace),
 			zap.String("changefeed", a.changeFeedID.ID),

--- a/cdc/scheduler/internal/tp/agent_bench_test.go
+++ b/cdc/scheduler/internal/tp/agent_bench_test.go
@@ -38,12 +38,12 @@ func benchmarkCollectTableStatus(b *testing.B, bench func(b *testing.B, a *agent
 	}
 }
 
-func BenchmarkCollectTableStatus(b *testing.B) {
+func BenchmarkRefreshAllTables(b *testing.B) {
 	benchmarkCollectTableStatus(b, func(b *testing.B, a *agent) {
 		total := len(a.tableExec.GetAllCurrentTables())
 		b.Run(fmt.Sprintf("%d tables", total), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				a.collectTableStatus([]model.TableID{})
+				a.refreshAllTables()
 			}
 		})
 	})

--- a/cdc/scheduler/internal/tp/agent_test.go
+++ b/cdc/scheduler/internal/tp/agent_test.go
@@ -219,6 +219,12 @@ func TestAgentHandleMessageHeartbeat(t *testing.T) {
 	a.tableM.tables[model.TableID(3)].status.State = schedulepb.TableStateStopping
 	a.tableM.tables[model.TableID(4)].status.State = schedulepb.TableStateStopped
 
+	mockTableExecutor.tables[model.TableID(0)] = pipeline.TableStatePreparing
+	mockTableExecutor.tables[model.TableID(1)] = pipeline.TableStatePrepared
+	mockTableExecutor.tables[model.TableID(2)] = pipeline.TableStateReplicating
+	mockTableExecutor.tables[model.TableID(3)] = pipeline.TableStateStopping
+	mockTableExecutor.tables[model.TableID(4)] = pipeline.TableStateStopped
+
 	heartbeat := &schedulepb.Message{
 		Header: &schedulepb.Message_Header{
 			Version:       "version-1",

--- a/cdc/scheduler/internal/tp/agent_test.go
+++ b/cdc/scheduler/internal/tp/agent_test.go
@@ -104,14 +104,6 @@ func TestAgentHandleMessageDispatchTable(t *testing.T) {
 	a.handleMessageDispatchTableRequest(addTableRequest, processorEpoch)
 	responses, err = a.poll(ctx)
 	require.NoError(t, err)
-	require.Len(t, responses, 1)
-
-	addTableResponse, ok = responses[0].DispatchTableResponse.
-		Response.(*schedulepb.DispatchTableResponse_AddTable)
-	require.True(t, ok)
-	require.Equal(t, model.TableID(1), addTableResponse.AddTable.Status.TableID)
-	require.Equal(t, schedulepb.TableStatePreparing, addTableResponse.AddTable.Status.State)
-	require.Contains(t, a.tables, model.TableID(1))
 
 	mockTableExecutor.ExpectedCalls = mockTableExecutor.ExpectedCalls[:1]
 	mockTableExecutor.On("IsAddTableFinished", mock.Anything,
@@ -587,7 +579,6 @@ func TestAgentTick(t *testing.T) {
 	require.NoError(t, a.Tick(ctx))
 	responses := trans.sendBuffer[:len(trans.sendBuffer)]
 	trans.sendBuffer = trans.sendBuffer[:0]
-	require.Equal(t, schedulepb.MsgHeartbeatResponse, responses[0].MsgType)
 
 	messages = messages[:0]
 	messages = append(messages, addTableRequest)

--- a/cdc/scheduler/internal/tp/agent_test.go
+++ b/cdc/scheduler/internal/tp/agent_test.go
@@ -209,11 +209,15 @@ func TestAgentHandleMessageHeartbeat(t *testing.T) {
 	mockTableExecutor := newMockTableExecutor()
 	a.tableM = newTableManager(mockTableExecutor)
 
-	mockTableExecutor.tables[model.TableID(0)] = pipeline.TableStatePreparing
-	mockTableExecutor.tables[model.TableID(1)] = pipeline.TableStatePrepared
-	mockTableExecutor.tables[model.TableID(2)] = pipeline.TableStateReplicating
-	mockTableExecutor.tables[model.TableID(3)] = pipeline.TableStateStopping
-	mockTableExecutor.tables[model.TableID(4)] = pipeline.TableStateStopped
+	for i := 0; i < 5; i++ {
+		a.tableM.addTable(model.TableID(i))
+	}
+
+	a.tableM.tables[model.TableID(0)].status.State = schedulepb.TableStatePreparing
+	a.tableM.tables[model.TableID(1)].status.State = schedulepb.TableStatePrepared
+	a.tableM.tables[model.TableID(2)].status.State = schedulepb.TableStateReplicating
+	a.tableM.tables[model.TableID(3)].status.State = schedulepb.TableStateStopping
+	a.tableM.tables[model.TableID(4)].status.State = schedulepb.TableStateStopped
 
 	heartbeat := &schedulepb.Message{
 		Header: &schedulepb.Message_Header{

--- a/cdc/scheduler/internal/tp/agent_test.go
+++ b/cdc/scheduler/internal/tp/agent_test.go
@@ -213,11 +213,11 @@ func TestAgentHandleMessageHeartbeat(t *testing.T) {
 		a.tableM.addTable(model.TableID(i))
 	}
 
-	a.tableM.tables[model.TableID(0)].status.State = schedulepb.TableStatePreparing
-	a.tableM.tables[model.TableID(1)].status.State = schedulepb.TableStatePrepared
-	a.tableM.tables[model.TableID(2)].status.State = schedulepb.TableStateReplicating
-	a.tableM.tables[model.TableID(3)].status.State = schedulepb.TableStateStopping
-	a.tableM.tables[model.TableID(4)].status.State = schedulepb.TableStateStopped
+	a.tableM.tables[model.TableID(0)].state = schedulepb.TableStatePreparing
+	a.tableM.tables[model.TableID(1)].state = schedulepb.TableStatePrepared
+	a.tableM.tables[model.TableID(2)].state = schedulepb.TableStateReplicating
+	a.tableM.tables[model.TableID(3)].state = schedulepb.TableStateStopping
+	a.tableM.tables[model.TableID(4)].state = schedulepb.TableStateStopped
 
 	mockTableExecutor.tables[model.TableID(0)] = pipeline.TableStatePreparing
 	mockTableExecutor.tables[model.TableID(1)] = pipeline.TableStatePrepared

--- a/cdc/scheduler/internal/tp/capture_manager.go
+++ b/cdc/scheduler/internal/tp/capture_manager.go
@@ -166,7 +166,7 @@ func (c *captureManager) HandleMessage(
 		if msg.MsgType == schedulepb.MsgHeartbeatResponse {
 			captureStatus, ok := c.Captures[msg.From]
 			if !ok {
-				log.Warn("tpscheduler: heartbeat response from untracked capture",
+				log.Warn("tpscheduler: heartbeat response from unknown capture",
 					zap.String("capture", msg.From))
 				continue
 			}

--- a/cdc/scheduler/internal/tp/capture_manager.go
+++ b/cdc/scheduler/internal/tp/capture_manager.go
@@ -166,6 +166,8 @@ func (c *captureManager) HandleMessage(
 		if msg.MsgType == schedulepb.MsgHeartbeatResponse {
 			captureStatus, ok := c.Captures[msg.From]
 			if !ok {
+				log.Warn("tpscheduler: heartbeat response from untracked capture",
+					zap.String("capture", msg.From))
 				continue
 			}
 			captureStatus.handleHeartbeatResponse(

--- a/cdc/scheduler/internal/tp/replication_manager.go
+++ b/cdc/scheduler/internal/tp/replication_manager.go
@@ -86,7 +86,7 @@ func (r *replicationManager) HandleCaptureChanges(
 			for i := range tables {
 				table := tables[i]
 				if _, ok := tableStatus[table.TableID]; !ok {
-					tableStatus[table.TableID] = map[string]*schedulepb.TableStatus{}
+					tableStatus[table.TableID] = map[model.CaptureID]*schedulepb.TableStatus{}
 				}
 				tableStatus[table.TableID][captureID] = &table
 			}

--- a/cdc/scheduler/internal/tp/scheduler_rebalance.go
+++ b/cdc/scheduler/internal/tp/scheduler_rebalance.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/cdc/model"
-	"go.uber.org/zap"
 )
 
 var _ scheduler = &rebalanceScheduler{}
@@ -93,10 +92,7 @@ func newBurstBalanceMoveTables(
 	}
 
 	for tableID, rep := range replications {
-		if rep.Primary == "" {
-			log.Info("tpscheduler: rebalance found table no primary, skip",
-				zap.Int64("tableID", tableID),
-				zap.Any("replication", rep))
+		if rep.State != ReplicationSetStateReplicating {
 			continue
 		}
 		tablesPerCapture[rep.Primary].add(tableID)

--- a/cdc/scheduler/internal/tp/table.go
+++ b/cdc/scheduler/internal/tp/table.go
@@ -1,0 +1,338 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tp
+
+import (
+	"context"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	"github.com/pingcap/tiflow/cdc/model"
+	"github.com/pingcap/tiflow/cdc/processor/pipeline"
+	"github.com/pingcap/tiflow/cdc/scheduler/internal"
+	"github.com/pingcap/tiflow/cdc/scheduler/internal/tp/schedulepb"
+	"go.uber.org/zap"
+)
+
+// table is a state machine that manage the table's state,
+// also tracking its progress by utilize the `TableExecutor`
+type table struct {
+	id model.TableID
+
+	status   schedulepb.TableStatus
+	executor internal.TableExecutor
+
+	task *dispatchTableTask
+}
+
+func newTable(tableID model.TableID, executor internal.TableExecutor) *table {
+	return &table{
+		id:       tableID,
+		executor: executor,
+		status:   schedulepb.TableStatus{TableID: tableID},
+		task:     nil,
+	}
+}
+
+// refresh the table' status, return true if the table state changed,
+// should be called before any table operations.
+func (t *table) refresh() bool {
+	oldState := t.status.State
+
+	meta := t.executor.GetTableMeta(t.id)
+	newState := tableStatus2PB(meta.State)
+
+	t.status.State = newState
+	t.status.Checkpoint.CheckpointTs = meta.CheckpointTs
+	t.status.Checkpoint.ResolvedTs = meta.ResolvedTs
+
+	return oldState != newState
+}
+
+func newAddTableResponseMessage(status schedulepb.TableStatus) *schedulepb.Message {
+	return &schedulepb.Message{
+		MsgType: schedulepb.MsgDispatchTableResponse,
+		DispatchTableResponse: &schedulepb.DispatchTableResponse{
+			Response: &schedulepb.DispatchTableResponse_AddTable{
+				AddTable: &schedulepb.AddTableResponse{
+					Status:     &status,
+					Checkpoint: status.Checkpoint,
+				},
+			},
+		},
+	}
+}
+
+func newRemoveTableResponseMessage(status schedulepb.TableStatus) *schedulepb.Message {
+	message := &schedulepb.Message{
+		MsgType: schedulepb.MsgDispatchTableResponse,
+		DispatchTableResponse: &schedulepb.DispatchTableResponse{
+			Response: &schedulepb.DispatchTableResponse_RemoveTable{
+				RemoveTable: &schedulepb.RemoveTableResponse{
+					Status:     &status,
+					Checkpoint: status.Checkpoint,
+				},
+			},
+		},
+	}
+
+	return message
+}
+
+func (t *table) handleRemoveTableTask(ctx context.Context) *schedulepb.Message {
+	status := t.status
+	stateChanged := true
+	for stateChanged {
+		switch status.State {
+		case schedulepb.TableStateAbsent:
+			log.Warn("tpscheduler: remove table, but table is absent", zap.Any("table", t))
+			t.task = nil
+			return newRemoveTableResponseMessage(status)
+		case schedulepb.TableStateStopping, // stopping now is useless
+			schedulepb.TableStateStopped:
+			// release table resource, and get the latest checkpoint
+			// this will let the table become `absent`
+			checkpointTs, done := t.executor.IsRemoveTableFinished(ctx, t.id)
+			_ = t.refresh()
+			if !done {
+				// actually, this should never be hit, since we know that table is stopped.
+				status.State = schedulepb.TableStateStopping
+				return newRemoveTableResponseMessage(status)
+			}
+			t.task = nil
+			status.State = schedulepb.TableStateStopped
+			status.Checkpoint.CheckpointTs = checkpointTs
+			return newRemoveTableResponseMessage(status)
+		case schedulepb.TableStatePreparing,
+			schedulepb.TableStatePrepared,
+			schedulepb.TableStateReplicating:
+			done := t.executor.RemoveTable(ctx, t.task.TableID)
+			stateChanged = t.refresh()
+			status = t.status
+			if !done {
+				status.State = schedulepb.TableStateStopping
+				return newRemoveTableResponseMessage(status)
+			}
+		default:
+			log.Panic("tpscheduler: unknown table state", zap.Any("table", t))
+		}
+	}
+	return nil
+}
+
+func (t *table) handleAddTableTask(ctx context.Context) (result *schedulepb.Message, err error) {
+	status := t.status
+	stateChanged := true
+	for stateChanged {
+		switch status.State {
+		case schedulepb.TableStateAbsent:
+			done, err := t.executor.AddTable(ctx, t.task.TableID, t.task.StartTs, t.task.IsPrepare)
+			if err != nil || !done {
+				log.Info("tpscheduler: agent add table failed",
+					zap.Any("task", t.task),
+					zap.Error(err))
+				return newAddTableResponseMessage(status), errors.Trace(err)
+			}
+			stateChanged = t.refresh()
+			status = t.status
+		case schedulepb.TableStateReplicating:
+			log.Info("tpscheduler: table is replicating", zap.Any("table", t))
+			t.task = nil
+			return newAddTableResponseMessage(t.status), nil
+		case schedulepb.TableStatePrepared:
+			if t.task.IsPrepare {
+				// `prepared` is a stable state, if the task was to prepare the table.
+				log.Info("tpscheduler: table is prepared", zap.Any("table", t))
+				t.task = nil
+				return newAddTableResponseMessage(t.status), nil
+			}
+
+			if t.task.status == dispatchTableTaskReceived {
+				done, err := t.executor.AddTable(ctx, t.task.TableID, t.task.StartTs, false)
+				if err != nil || !done {
+					log.Info("tpscheduler: agent add table failed",
+						zap.Any("task", t.task),
+						zap.Error(err))
+					return newAddTableResponseMessage(status), errors.Trace(err)
+				}
+				t.task.status = dispatchTableTaskProcessed
+			}
+
+			done := t.executor.IsAddTableFinished(ctx, t.task.TableID, false)
+			stateChanged = t.refresh()
+			status = t.status
+			if !done {
+				return newAddTableResponseMessage(status), nil
+			}
+		case schedulepb.TableStatePreparing:
+			// `preparing` is not stable state and would last a long time,
+			// it's no need to return such a state, to make the coordinator become burdensome.
+			done := t.executor.IsAddTableFinished(ctx, t.task.TableID, t.task.IsPrepare)
+			if !done {
+				return nil, nil
+			}
+			log.Info("tpscheduler: add table finished", zap.Any("table", t))
+			stateChanged = t.refresh()
+			status = t.status
+		case schedulepb.TableStateStopping,
+			schedulepb.TableStateStopped:
+			log.Warn("tpscheduler: ignore add table", zap.Any("table", t))
+			t.task = nil
+			return newAddTableResponseMessage(status), nil
+		default:
+			log.Panic("tpscheduler: unknown table state", zap.Any("table", t))
+		}
+	}
+
+	return nil, nil
+}
+
+func (t *table) injectDispatchTableTask(task *dispatchTableTask) {
+	if t.id != task.TableID {
+		log.Panic("tpscheduler: tableID not match",
+			zap.Int64("tableID", t.id),
+			zap.Int64("task.TableID", task.TableID))
+	}
+	if t.task == nil {
+		log.Info("tpscheduler: table found new task",
+			zap.Any("table", t), zap.Any("task", task))
+		t.task = task
+		return
+	}
+	log.Warn("tpscheduler: table inject dispatch table task ignored,"+
+		"since there is one not finished yet",
+		zap.Any("table", t),
+		zap.Any("nowTask", t.task),
+		zap.Any("ignoredTask", task))
+}
+
+func (t *table) poll(ctx context.Context) (*schedulepb.Message, error) {
+	if t.task == nil {
+		return nil, nil
+	}
+	_ = t.refresh()
+	if t.task.IsRemove {
+		return t.handleRemoveTableTask(ctx), nil
+	}
+	return t.handleAddTableTask(ctx)
+}
+
+type tableManager struct {
+	tables   map[model.TableID]*table
+	executor internal.TableExecutor
+}
+
+func newTableManager(executor internal.TableExecutor) *tableManager {
+	tm := &tableManager{
+		tables:   make(map[model.TableID]*table),
+		executor: executor,
+	}
+	tm.collectAllTables()
+	return tm
+}
+
+func (tm *tableManager) getAllTables() map[model.TableID]*table {
+	tm.collectAllTables()
+	return tm.tables
+}
+
+func (tm *tableManager) collectAllTables() {
+	allTables := tm.executor.GetAllCurrentTables()
+	for _, tableID := range allTables {
+		table, ok := tm.tables[tableID]
+		if !ok {
+			table = newTable(tableID, tm.executor)
+			tm.tables[tableID] = table
+		}
+		_ = table.refresh()
+	}
+}
+
+// register the target table, and return it.
+func (tm *tableManager) register(tableID model.TableID) *table {
+	table, ok := tm.tables[tableID]
+	if !ok {
+		table = newTable(tableID, tm.executor)
+		tm.tables[tableID] = table
+	}
+	_ = table.refresh()
+	return table
+}
+
+func (tm *tableManager) getTable(tableID model.TableID) (*table, bool) {
+	table, ok := tm.tables[tableID]
+	if ok {
+		_ = table.refresh()
+		return table, true
+	}
+
+	meta := tm.executor.GetTableMeta(tableID)
+	state := tableStatus2PB(meta.State)
+
+	if state != schedulepb.TableStateAbsent {
+		log.Panic("tpscheduler: tableManager found table not tracked",
+			zap.Int64("tableID", tableID), zap.Any("meta", meta))
+
+	}
+	return nil, false
+}
+
+func (tm *tableManager) dropTable(tableID model.TableID) {
+	table, ok := tm.tables[tableID]
+	if !ok {
+		log.Warn("tpscheduler: tableManager drop table not found",
+			zap.Int64("tableID", tableID))
+		return
+	}
+	_ = table.refresh()
+	if table.status.State != schedulepb.TableStateAbsent {
+		log.Panic("tpscheduler: tableManager drop table undesired",
+			zap.Any("table", table))
+	}
+
+	log.Debug("tpscheduler: tableManager drop table", zap.Any("table", table))
+	delete(tm.tables, tableID)
+}
+
+func (tm *tableManager) newTableStatus(tableID model.TableID) schedulepb.TableStatus {
+	meta := tm.executor.GetTableMeta(tableID)
+	state := tableStatus2PB(meta.State)
+	return schedulepb.TableStatus{
+		TableID: meta.TableID,
+		State:   state,
+		Checkpoint: schedulepb.Checkpoint{
+			CheckpointTs: meta.CheckpointTs,
+			ResolvedTs:   meta.ResolvedTs,
+		},
+	}
+}
+
+func tableStatus2PB(state pipeline.TableState) schedulepb.TableState {
+	switch state {
+	case pipeline.TableStatePreparing:
+		return schedulepb.TableStatePreparing
+	case pipeline.TableStatePrepared:
+		return schedulepb.TableStatePrepared
+	case pipeline.TableStateReplicating:
+		return schedulepb.TableStateReplicating
+	case pipeline.TableStateStopping:
+		return schedulepb.TableStateStopping
+	case pipeline.TableStateStopped:
+		return schedulepb.TableStateStopped
+	case pipeline.TableStateAbsent:
+		return schedulepb.TableStateAbsent
+	default:
+	}
+	return schedulepb.TableStateUnknown
+}

--- a/cdc/scheduler/internal/tp/table.go
+++ b/cdc/scheduler/internal/tp/table.go
@@ -234,12 +234,10 @@ type tableManager struct {
 }
 
 func newTableManager(executor internal.TableExecutor) *tableManager {
-	tm := &tableManager{
+	return &tableManager{
 		tables:   make(map[model.TableID]*table),
 		executor: executor,
 	}
-	tm.collectAllTables()
-	return tm
 }
 
 func (tm *tableManager) poll(ctx context.Context, stopping bool) ([]*schedulepb.Message, error) {

--- a/cdc/scheduler/internal/tp/table.go
+++ b/cdc/scheduler/internal/tp/table.go
@@ -108,8 +108,8 @@ func newRemoveTableResponseMessage(status schedulepb.TableStatus) *schedulepb.Me
 }
 
 func (t *table) handleRemoveTableTask(ctx context.Context) *schedulepb.Message {
-	state, changed := t.getAndUpdateTableState()
-	changed = true
+	state, _ := t.getAndUpdateTableState()
+	changed := true
 	for changed {
 		switch state {
 		case schedulepb.TableStateAbsent:
@@ -151,7 +151,9 @@ func (t *table) handleRemoveTableTask(ctx context.Context) *schedulepb.Message {
 	return nil
 }
 
-func (t *table) handleAddTableTask(ctx context.Context, stopping bool) (result *schedulepb.Message, err error) {
+func (t *table) handleAddTableTask(ctx context.Context,
+	stopping bool,
+) (result *schedulepb.Message, err error) {
 	if stopping {
 		log.Info("tpscheduler: reject add table, since agent stopping",
 			zap.Int64("tableID", t.id), zap.Any("task", t.task))
@@ -159,8 +161,8 @@ func (t *table) handleAddTableTask(ctx context.Context, stopping bool) (result *
 		return newAddTableResponseMessage(t.getTableStatus(), true), nil
 	}
 
-	state, changed := t.getAndUpdateTableState()
-	changed = true
+	state, _ := t.getAndUpdateTableState()
+	changed := true
 	for changed {
 		switch state {
 		case schedulepb.TableStateAbsent:

--- a/cdc/scheduler/internal/tp/table.go
+++ b/cdc/scheduler/internal/tp/table.go
@@ -278,6 +278,9 @@ func (tm *tableManager) poll(ctx context.Context, stopping bool) ([]*schedulepb.
 }
 
 func (tm *tableManager) getAllTables() map[model.TableID]*table {
+	for _, table := range tm.tables {
+		_ = table.refresh()
+	}
 	return tm.tables
 }
 

--- a/cdc/scheduler/internal/tp/table.go
+++ b/cdc/scheduler/internal/tp/table.go
@@ -102,7 +102,8 @@ func (t *table) handleRemoveTableTask(ctx context.Context) *schedulepb.Message {
 	for stateChanged {
 		switch status.State {
 		case schedulepb.TableStateAbsent:
-			log.Warn("tpscheduler: remove table, but table is absent", zap.Int64("tableID", t.id))
+			log.Warn("tpscheduler: remove table, but table is absent",
+				zap.Int64("tableID", t.id))
 			t.task = nil
 			return newRemoveTableResponseMessage(status)
 		case schedulepb.TableStateStopping, // stopping now is useless
@@ -281,6 +282,8 @@ func (tm *tableManager) getAllTables() map[model.TableID]*table {
 	return tm.tables
 }
 
+// collectAllTables fetch table meta from the `table executor` to let the
+// tableManager keep each table's latest progress.
 func (tm *tableManager) collectAllTables() {
 	allTables := tm.executor.GetAllCurrentTables()
 	for _, tableID := range allTables {
@@ -293,8 +296,8 @@ func (tm *tableManager) collectAllTables() {
 	}
 }
 
-// register the target table, and return it.
-func (tm *tableManager) register(tableID model.TableID) *table {
+// addTable the target table, and return it.
+func (tm *tableManager) addTable(tableID model.TableID) *table {
 	table, ok := tm.tables[tableID]
 	if !ok {
 		table = newTable(tableID, tm.executor)

--- a/cdc/scheduler/internal/tp/table.go
+++ b/cdc/scheduler/internal/tp/table.go
@@ -122,6 +122,7 @@ func (t *table) handleRemoveTableTask(ctx context.Context) *schedulepb.Message {
 			// release table resource, and get the latest checkpoint
 			// this will let the table become `absent`
 			checkpointTs, done := t.executor.IsRemoveTableFinished(ctx, t.id)
+			_, _ = t.getTableState()
 			if !done {
 				// actually, this should never be hit, since we know that table is stopped.
 				status := t.getTableStatus()

--- a/cdc/scheduler/internal/tp/table_test.go
+++ b/cdc/scheduler/internal/tp/table_test.go
@@ -30,7 +30,7 @@ func TestTableManager(t *testing.T) {
 	tableM := newTableManager(mockTableExecutor)
 
 	tableM.addTable(model.TableID(1))
-	require.Equal(t, schedulepb.TableStateAbsent, tableM.tables[model.TableID(1)].status.State)
+	require.Equal(t, schedulepb.TableStateAbsent, tableM.tables[model.TableID(1)].state)
 
 	tableM.dropTable(model.TableID(1))
 	require.NotContains(t, tableM.tables, model.TableID(1))

--- a/cdc/scheduler/internal/tp/table_test.go
+++ b/cdc/scheduler/internal/tp/table_test.go
@@ -25,15 +25,14 @@ import (
 func TestTableManager(t *testing.T) {
 	t.Parallel()
 
+	// pretend there are 4 tables
 	mockTableExecutor := newMockTableExecutor()
-
 	mockTableExecutor.tables[model.TableID(1)] = pipeline.TableStatePreparing
 	mockTableExecutor.tables[model.TableID(2)] = pipeline.TableStatePrepared
 	mockTableExecutor.tables[model.TableID(3)] = pipeline.TableStateReplicating
 	mockTableExecutor.tables[model.TableID(4)] = pipeline.TableStateStopped
 
 	tableM := newTableManager(mockTableExecutor)
-	tableM.collectAllTables()
 	require.Equal(t, schedulepb.TableStatePreparing, tableM.tables[model.TableID(1)].status.State)
 	require.Equal(t, schedulepb.TableStatePrepared, tableM.tables[model.TableID(2)].status.State)
 	require.Equal(t, schedulepb.TableStateReplicating, tableM.tables[model.TableID(3)].status.State)

--- a/cdc/scheduler/internal/tp/table_test.go
+++ b/cdc/scheduler/internal/tp/table_test.go
@@ -1,0 +1,54 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tp
+
+import (
+	"testing"
+
+	"github.com/pingcap/tiflow/cdc/model"
+	"github.com/pingcap/tiflow/cdc/processor/pipeline"
+	"github.com/pingcap/tiflow/cdc/scheduler/internal/tp/schedulepb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableManager(t *testing.T) {
+	t.Parallel()
+
+	mockTableExecutor := newMockTableExecutor()
+
+	mockTableExecutor.tables[model.TableID(1)] = pipeline.TableStatePreparing
+	mockTableExecutor.tables[model.TableID(2)] = pipeline.TableStatePrepared
+	mockTableExecutor.tables[model.TableID(3)] = pipeline.TableStateReplicating
+	mockTableExecutor.tables[model.TableID(4)] = pipeline.TableStateStopped
+
+	tableM := newTableManager(mockTableExecutor)
+	tableM.collectAllTables()
+	require.Equal(t, schedulepb.TableStatePreparing, tableM.tables[model.TableID(1)].status.State)
+	require.Equal(t, schedulepb.TableStatePrepared, tableM.tables[model.TableID(2)].status.State)
+	require.Equal(t, schedulepb.TableStateReplicating, tableM.tables[model.TableID(3)].status.State)
+	require.Equal(t, schedulepb.TableStateStopped, tableM.tables[model.TableID(4)].status.State)
+
+	table, ok := tableM.getTable(model.TableID(5))
+	require.False(t, ok)
+	require.Nil(t, table)
+
+	table = tableM.register(model.TableID(1))
+	require.Equal(t, schedulepb.TableStatePreparing, table.status.State)
+
+	table = tableM.register(model.TableID(5))
+	require.Equal(t, schedulepb.TableStateAbsent, table.status.State)
+
+	tableM.dropTable(model.TableID(5))
+	require.NotContains(t, tableM.tables, model.TableID(5))
+}

--- a/cdc/scheduler/internal/tp/table_test.go
+++ b/cdc/scheduler/internal/tp/table_test.go
@@ -34,5 +34,4 @@ func TestTableManager(t *testing.T) {
 
 	tableM.dropTable(model.TableID(1))
 	require.NotContains(t, tableM.tables, model.TableID(1))
-
 }

--- a/cdc/scheduler/internal/tp/table_test.go
+++ b/cdc/scheduler/internal/tp/table_test.go
@@ -43,10 +43,10 @@ func TestTableManager(t *testing.T) {
 	require.False(t, ok)
 	require.Nil(t, table)
 
-	table = tableM.register(model.TableID(1))
+	table = tableM.addTable(model.TableID(1))
 	require.Equal(t, schedulepb.TableStatePreparing, table.status.State)
 
-	table = tableM.register(model.TableID(5))
+	table = tableM.addTable(model.TableID(5))
 	require.Equal(t, schedulepb.TableStateAbsent, table.status.State)
 
 	tableM.dropTable(model.TableID(5))

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -128,7 +128,7 @@ var defaultServerConfig = &ServerConfig{
 		},
 		Messages: defaultMessageConfig.Clone(),
 
-		EnableTwoPhaseScheduler: true,
+		EnableTwoPhaseScheduler: false,
 		Scheduler: &SchedulerConfig{
 			HeartbeatTick:      2,
 			MaxTaskConcurrency: 10,

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -128,7 +128,7 @@ var defaultServerConfig = &ServerConfig{
 		},
 		Messages: defaultMessageConfig.Clone(),
 
-		EnableTwoPhaseScheduler: false,
+		EnableTwoPhaseScheduler: true,
 		Scheduler: &SchedulerConfig{
 			HeartbeatTick:      2,
 			MaxTaskConcurrency: 10,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #4757

### What is changed and how it works?

let the `agent` handle different table state, this makes the message report table's state more accurate.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
