### PR TITLE
tests(ticdc): fix unstable TestResolvedTs

### DIFF
--- a/cdc/model/mounter_test.go
+++ b/cdc/model/mounter_test.go
@@ -52,8 +52,8 @@ func TestResolvedTs(t *testing.T) {
 	invalidResolvedTs := ResolvedTs{Mode: -1, Ts: 1}
 	require.Equal(t, uint64(0), invalidResolvedTs.ResolvedMark())
 
-	ts := rand.Uint64()
-	batchID := rand.Uint64()
+	ts := rand.Uint64()%10 + 1
+	batchID := rand.Uint64()%10 + 1
 	normalResolvedTs := NewResolvedTs(ts)
 	batchResolvedTs1 := ResolvedTs{Mode: BatchResolvedMode, Ts: ts, BatchID: batchID}
 	require.True(t, normalResolvedTs.EqualOrGreater(batchResolvedTs1))
@@ -67,14 +67,16 @@ func TestResolvedTs(t *testing.T) {
 	require.True(t, batchResolvedTs2.Less(normalResolvedTs))
 	require.True(t, batchResolvedTs1.Less(batchResolvedTs2))
 
-	largerResolvedTs := NewResolvedTs(ts + rand.Uint64()%10)
+	largerTs := ts + rand.Uint64()%10 + 1
+	largerResolvedTs := NewResolvedTs(largerTs)
 	require.True(t, largerResolvedTs.EqualOrGreater(normalResolvedTs))
 	largerBatchResolvedTs := ResolvedTs{
 		Mode:    BatchResolvedMode,
-		Ts:      ts + rand.Uint64()%10,
+		Ts:      largerTs,
 		BatchID: batchID,
 	}
-	require.True(t, largerBatchResolvedTs.EqualOrGreater(normalResolvedTs))
+	require.True(t, largerBatchResolvedTs.EqualOrGreater(normalResolvedTs),
+		"largerBatchResolvedTs:%+v\nnormalResolvedTs:%+v", largerBatchResolvedTs, normalResolvedTs)
 
 	smallerResolvedTs := NewResolvedTs(0)
 	require.True(t, normalResolvedTs.EqualOrGreater(smallerResolvedTs))


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5854

### What is changed and how it works?
Make sure that `ts` of largerBatchResolvedTs is greater than that of normalResolvedTs.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
