### PR TITLE
sink/mq,sink/mysql(ticdc): remove useless opts for MQ and MySQL sink

### DIFF
--- a/cdc/api/validator/validator.go
+++ b/cdc/api/validator/validator.go
@@ -130,7 +130,6 @@ func VerifyCreateChangefeedConfig(
 	// init ChangefeedInfo
 	info := &model.ChangeFeedInfo{
 		SinkURI:           changefeedConfig.SinkURI,
-		Opts:              make(map[string]string),
 		CreateTime:        time.Now(),
 		StartTs:           changefeedConfig.StartTS,
 		TargetTs:          changefeedConfig.TargetTS,
@@ -157,7 +156,7 @@ func VerifyCreateChangefeedConfig(
 		return nil, cerror.ErrAPIInvalidParam.Wrap(errors.Annotatef(err, "invalid timezone:%s", changefeedConfig.TimeZone))
 	}
 	ctx = contextutil.PutTimezoneInCtx(ctx, tz)
-	if err := sink.Validate(ctx, info.SinkURI, info.Config, info.Opts); err != nil {
+	if err := sink.Validate(ctx, info.SinkURI, info.Config); err != nil {
 		return nil, err
 	}
 
@@ -205,7 +204,7 @@ func VerifyUpdateChangefeedConfig(ctx context.Context,
 	// verify sink_uri
 	if changefeedConfig.SinkURI != "" {
 		newInfo.SinkURI = changefeedConfig.SinkURI
-		if err := sink.Validate(ctx, changefeedConfig.SinkURI, newInfo.Config, newInfo.Opts); err != nil {
+		if err := sink.Validate(ctx, changefeedConfig.SinkURI, newInfo.Config); err != nil {
 			return nil, cerror.ErrChangefeedUpdateRefused.GenWithStackByCause(err)
 		}
 	}

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -113,10 +113,9 @@ func (s FeedState) IsNeeded(need string) bool {
 
 // ChangeFeedInfo describes the detail of a ChangeFeed
 type ChangeFeedInfo struct {
-	UpstreamID uint64            `json:"upstream-id"`
-	SinkURI    string            `json:"sink-uri"`
-	Opts       map[string]string `json:"opts"`
-	CreateTime time.Time         `json:"create-time"`
+	UpstreamID uint64    `json:"upstream-id"`
+	SinkURI    string    `json:"sink-uri"`
+	CreateTime time.Time `json:"create-time"`
 	// Start sync at this commit ts if `StartTs` is specify or using the CreateTime of changefeed.
 	StartTs uint64 `json:"start-ts"`
 	// The ChangeFeed will exits until sync to timestamp TargetTs

--- a/cdc/model/changefeed_test.go
+++ b/cdc/model/changefeed_test.go
@@ -104,7 +104,6 @@ func TestFillV1(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, &ChangeFeedInfo{
 		SinkURI: "blackhole://",
-		Opts:    map[string]string{},
 		StartTs: 417136892416622595,
 		Engine:  "memory",
 		SortDir: ".",
@@ -150,7 +149,6 @@ func TestVerifyAndComplete(t *testing.T) {
 
 	info := &ChangeFeedInfo{
 		SinkURI: "blackhole://",
-		Opts:    map[string]string{},
 		StartTs: 417257993615179777,
 		Config: &config.ReplicaConfig{
 			CaseSensitive:    true,
@@ -602,7 +600,6 @@ func TestChangeFeedInfoClone(t *testing.T) {
 
 	info := &ChangeFeedInfo{
 		SinkURI: "blackhole://",
-		Opts:    map[string]string{},
 		StartTs: 417257993615179777,
 		Config: &config.ReplicaConfig{
 			CaseSensitive:    true,

--- a/cdc/model/changefeed_test.go
+++ b/cdc/model/changefeed_test.go
@@ -34,9 +34,6 @@ func TestFillV1(t *testing.T) {
 	v1Config := `
 {
     "sink-uri":"blackhole://",
-    "opts":{
-
-    },
     "start-ts":417136892416622595,
     "target-ts":0,
     "admin-job-type":0,

--- a/cdc/owner/ddl_sink.go
+++ b/cdc/owner/ddl_sink.go
@@ -101,7 +101,7 @@ func ddlSinkInitializer(ctx cdcContext.Context, a *ddlSinkImpl, id model.ChangeF
 
 	stdCtx := contextutil.PutChangefeedIDInCtx(ctx, id)
 	stdCtx = contextutil.PutRoleInCtx(stdCtx, util.RoleOwner)
-	s, err := sink.New(stdCtx, id, info.SinkURI, filter, info.Config, info.Opts, a.errCh)
+	s, err := sink.New(stdCtx, id, info.SinkURI, filter, info.Config, a.errCh)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cdc/owner/feed_state_manager_test.go
+++ b/cdc/owner/feed_state_manager_test.go
@@ -258,7 +258,6 @@ func TestChangefeedStatusNotExist(t *testing.T) {
 	changefeedInfo := `
 {
     "sink-uri": "blackhole:///",
-    "opts": {},
     "create-time": "2021-06-05T00:44:15.065939487+08:00",
     "start-ts": 425381670108266496,
     "target-ts": 0,

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -34,7 +34,6 @@ import (
 	"github.com/pingcap/tiflow/cdc/redo"
 	"github.com/pingcap/tiflow/cdc/scheduler"
 	"github.com/pingcap/tiflow/cdc/sink"
-	"github.com/pingcap/tiflow/cdc/sink/metrics"
 	sinkmetric "github.com/pingcap/tiflow/cdc/sink/metrics"
 	"github.com/pingcap/tiflow/cdc/sorter/memory"
 	"github.com/pingcap/tiflow/pkg/config"
@@ -482,18 +481,19 @@ func (p *processor) lazyInitImpl(ctx cdcContext.Context) error {
 		contextutil.TimezoneFromCtx(ctx),
 		p.changefeed.Info.Config.EnableOldValue)
 
-	opts := make(map[string]string, len(p.changefeed.Info.Opts)+2)
-	for k, v := range p.changefeed.Info.Opts {
-		opts[k] = v
-	}
-
-	opts[metrics.OptCaptureAddr] = ctx.GlobalVars().CaptureInfo.AdvertiseAddr
 	log.Info("processor try new sink",
 		zap.String("namespace", p.changefeedID.Namespace),
 		zap.String("changefeed", p.changefeed.ID.ID))
 
 	start := time.Now()
-	p.sink, err = sink.New(stdCtx, p.changefeed.ID, p.changefeed.Info.SinkURI, p.filter, p.changefeed.Info.Config, opts, errCh)
+	p.sink, err = sink.New(
+		stdCtx,
+		p.changefeed.ID,
+		p.changefeed.Info.SinkURI,
+		p.filter,
+		p.changefeed.Info.Config,
+		errCh,
+	)
 	if err != nil {
 		log.Info("processor new sink failed",
 			zap.String("namespace", p.changefeedID.Namespace),

--- a/cdc/processor/processor_test.go
+++ b/cdc/processor/processor_test.go
@@ -60,7 +60,6 @@ func initProcessor4Test(ctx cdcContext.Context, t *testing.T) (*processor, *orch
 	changefeedInfo := `
 {
     "sink-uri": "blackhole://",
-    "opts": {},
     "create-time": "2020-02-02T00:00:00.000000+00:00",
     "start-ts": 0,
     "target-ts": 0,

--- a/cdc/sink/metrics/statistics.go
+++ b/cdc/sink/metrics/statistics.go
@@ -26,9 +26,6 @@ import (
 )
 
 const (
-	// OptCaptureAddr is the key for capture address.
-	OptCaptureAddr = "_capture_addr"
-
 	printStatusInterval  = 10 * time.Minute
 	flushMetricsInterval = 5 * time.Second
 )

--- a/cdc/sink/mq/mq.go
+++ b/cdc/sink/mq/mq.go
@@ -396,8 +396,7 @@ func (k *mqSink) asyncFlushToPartitionZero(
 
 // NewKafkaSaramaSink creates a new Kafka mqSink.
 func NewKafkaSaramaSink(ctx context.Context, sinkURI *url.URL,
-	filter *filter.Filter, replicaConfig *config.ReplicaConfig,
-	opts map[string]string, errCh chan error,
+	filter *filter.Filter, replicaConfig *config.ReplicaConfig, errCh chan error,
 ) (*mqSink, error) {
 	topic := strings.TrimFunc(sinkURI.Path, func(r rune) bool {
 		return r == '/'
@@ -502,7 +501,7 @@ func NewKafkaSaramaSink(ctx context.Context, sinkURI *url.URL,
 
 // NewPulsarSink creates a new Pulsar mqSink.
 func NewPulsarSink(ctx context.Context, sinkURI *url.URL, filter *filter.Filter,
-	replicaConfig *config.ReplicaConfig, opts map[string]string, errCh chan error,
+	replicaConfig *config.ReplicaConfig, errCh chan error,
 ) (*mqSink, error) {
 	s := sinkURI.Query().Get(config.ProtocolKey)
 	if s != "" {

--- a/cdc/sink/mq/mq_test.go
+++ b/cdc/sink/mq/mq_test.go
@@ -83,7 +83,6 @@ func TestKafkaSink(t *testing.T) {
 	replicaConfig := config.GetDefaultReplicaConfig()
 	fr, err := filter.NewFilter(replicaConfig)
 	require.Nil(t, err)
-	opts := map[string]string{}
 	errCh := make(chan error, 1)
 
 	kafkap.NewAdminClientImpl = kafka.NewMockAdminClient
@@ -91,7 +90,7 @@ func TestKafkaSink(t *testing.T) {
 		kafkap.NewAdminClientImpl = kafka.NewSaramaAdminClient
 	}()
 
-	sink, err := NewKafkaSaramaSink(ctx, sinkURI, fr, replicaConfig, opts, errCh)
+	sink, err := NewKafkaSaramaSink(ctx, sinkURI, fr, replicaConfig, errCh)
 	require.Nil(t, err)
 
 	encoder := sink.encoderBuilder.Build()
@@ -179,7 +178,6 @@ func TestKafkaSinkFilter(t *testing.T) {
 	}
 	fr, err := filter.NewFilter(replicaConfig)
 	require.Nil(t, err)
-	opts := map[string]string{}
 	errCh := make(chan error, 1)
 
 	kafkap.NewAdminClientImpl = kafka.NewMockAdminClient
@@ -187,7 +185,7 @@ func TestKafkaSinkFilter(t *testing.T) {
 		kafkap.NewAdminClientImpl = kafka.NewSaramaAdminClient
 	}()
 
-	sink, err := NewKafkaSaramaSink(ctx, sinkURI, fr, replicaConfig, opts, errCh)
+	sink, err := NewKafkaSaramaSink(ctx, sinkURI, fr, replicaConfig, errCh)
 	require.Nil(t, err)
 
 	row := &model.RowChangedEvent{
@@ -236,10 +234,9 @@ func TestPulsarSinkEncoderConfig(t *testing.T) {
 	replicaConfig := config.GetDefaultReplicaConfig()
 	fr, err := filter.NewFilter(replicaConfig)
 	require.Nil(t, err)
-	opts := map[string]string{}
 	errCh := make(chan error, 1)
 
-	sink, err := NewPulsarSink(ctx, sinkURI, fr, replicaConfig, opts, errCh)
+	sink, err := NewPulsarSink(ctx, sinkURI, fr, replicaConfig, errCh)
 	require.Nil(t, err)
 
 	encoder := sink.encoderBuilder.Build()
@@ -270,7 +267,6 @@ func TestFlushRowChangedEvents(t *testing.T) {
 	replicaConfig := config.GetDefaultReplicaConfig()
 	fr, err := filter.NewFilter(replicaConfig)
 	require.Nil(t, err)
-	opts := map[string]string{}
 	errCh := make(chan error, 1)
 
 	kafkap.NewAdminClientImpl = kafka.NewMockAdminClient
@@ -278,7 +274,7 @@ func TestFlushRowChangedEvents(t *testing.T) {
 		kafkap.NewAdminClientImpl = kafka.NewSaramaAdminClient
 	}()
 
-	sink, err := NewKafkaSaramaSink(ctx, sinkURI, fr, replicaConfig, opts, errCh)
+	sink, err := NewKafkaSaramaSink(ctx, sinkURI, fr, replicaConfig, errCh)
 	require.Nil(t, err)
 
 	// mock kafka broker processes 1 row changed event

--- a/cdc/sink/mysql/mysql.go
+++ b/cdc/sink/mysql/mysql.go
@@ -83,9 +83,8 @@ func NewMySQLSink(
 	sinkURI *url.URL,
 	filter *tifilter.Filter,
 	replicaConfig *config.ReplicaConfig,
-	opts map[string]string,
 ) (*mysqlSink, error) {
-	params, err := parseSinkURIToParams(ctx, changefeedID, sinkURI, opts)
+	params, err := parseSinkURIToParams(ctx, changefeedID, sinkURI)
 	if err != nil {
 		return nil, err
 	}

--- a/cdc/sink/mysql/mysql_params.go
+++ b/cdc/sink/mysql/mysql_params.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/cdc/contextutil"
 	"github.com/pingcap/tiflow/cdc/model"
-	"github.com/pingcap/tiflow/cdc/sink/metrics"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/security"
 	"go.uber.org/zap"
@@ -84,7 +83,6 @@ type sinkParams struct {
 	maxTxnRow           int
 	tidbTxnMode         string
 	changefeedID        model.ChangeFeedID
-	captureAddr         string
 	batchReplaceEnabled bool
 	batchReplaceSize    int
 	readTimeout         string
@@ -103,14 +101,11 @@ func (s *sinkParams) Clone() *sinkParams {
 
 func parseSinkURIToParams(ctx context.Context,
 	changefeedID model.ChangeFeedID,
-	sinkURI *url.URL, opts map[string]string,
+	sinkURI *url.URL,
 ) (*sinkParams, error) {
 	params := defaultParams.Clone()
 
 	params.changefeedID = changefeedID
-	if caddr, ok := opts[metrics.OptCaptureAddr]; ok {
-		params.captureAddr = caddr
-	}
 
 	if sinkURI == nil {
 		return nil, cerror.ErrMySQLConnectionError.GenWithStack("fail to open MySQL sink, empty URL")

--- a/cdc/sink/mysql/mysql_test.go
+++ b/cdc/sink/mysql/mysql_test.go
@@ -1965,7 +1965,7 @@ func TestMySQLSinkExecDMLError(t *testing.T) {
 	require.Nil(t, err)
 	sink, err := NewMySQLSink(ctx,
 		model.DefaultChangeFeedID(changefeed),
-		sinkURI, f, rc, map[string]string{})
+		sinkURI, f, rc)
 	require.Nil(t, err)
 
 	rows := []*model.RowChangedEvent{

--- a/cdc/sink/mysql/mysql_test.go
+++ b/cdc/sink/mysql/mysql_test.go
@@ -1013,10 +1013,9 @@ func TestAdjustSQLMode(t *testing.T) {
 	f, err := filter.NewFilter(rc)
 	require.Nil(t, err)
 	require.Nil(t, err)
-	opts := map[string]string{}
 	sink, err := NewMySQLSink(ctx,
 		model.DefaultChangeFeedID(changefeed),
-		sinkURI, f, rc, opts)
+		sinkURI, f, rc)
 	require.Nil(t, err)
 
 	err = sink.Close(ctx)
@@ -1085,7 +1084,7 @@ func TestNewMySQLTimeout(t *testing.T) {
 	f, err := filter.NewFilter(rc)
 	require.Nil(t, err)
 	_, err = NewMySQLSink(ctx, model.DefaultChangeFeedID(changefeed),
-		sinkURI, f, rc, map[string]string{})
+		sinkURI, f, rc)
 	require.Equal(t, driver.ErrBadConn, errors.Cause(err))
 }
 
@@ -1133,7 +1132,7 @@ func TestNewMySQLSinkExecDML(t *testing.T) {
 	require.Nil(t, err)
 	sink, err := NewMySQLSink(ctx,
 		model.DefaultChangeFeedID(changefeed),
-		sinkURI, f, rc, map[string]string{})
+		sinkURI, f, rc)
 	require.Nil(t, err)
 
 	rows := []*model.RowChangedEvent{
@@ -1340,7 +1339,7 @@ func TestExecDMLRollbackErrDatabaseNotExists(t *testing.T) {
 	require.Nil(t, err)
 	sink, err := NewMySQLSink(ctx,
 		model.DefaultChangeFeedID(changefeed),
-		sinkURI, f, rc, map[string]string{})
+		sinkURI, f, rc)
 	require.Nil(t, err)
 
 	err = sink.execDMLs(ctx, rows, 1 /* replicaID */, 1 /* bucket */)
@@ -1418,7 +1417,7 @@ func TestExecDMLRollbackErrTableNotExists(t *testing.T) {
 	require.Nil(t, err)
 	sink, err := NewMySQLSink(ctx,
 		model.DefaultChangeFeedID(changefeed),
-		sinkURI, f, rc, map[string]string{})
+		sinkURI, f, rc)
 	require.Nil(t, err)
 
 	err = sink.execDMLs(ctx, rows, 1 /* replicaID */, 1 /* bucket */)
@@ -1501,7 +1500,7 @@ func TestExecDMLRollbackErrRetryable(t *testing.T) {
 	require.Nil(t, err)
 	sink, err := NewMySQLSink(ctx,
 		model.DefaultChangeFeedID(changefeed),
-		sinkURI, f, rc, map[string]string{})
+		sinkURI, f, rc)
 	require.Nil(t, err)
 
 	err = sink.execDMLs(ctx, rows, 1 /* replicaID */, 1 /* bucket */)
@@ -1559,7 +1558,7 @@ func TestNewMySQLSinkExecDDL(t *testing.T) {
 	require.Nil(t, err)
 	sink, err := NewMySQLSink(ctx,
 		model.DefaultChangeFeedID(changefeed),
-		sinkURI, f, rc, map[string]string{})
+		sinkURI, f, rc)
 	require.Nil(t, err)
 
 	ddl1 := &model.DDLEvent{
@@ -1679,7 +1678,7 @@ func TestNewMySQLSink(t *testing.T) {
 	require.Nil(t, err)
 	sink, err := NewMySQLSink(ctx,
 		model.DefaultChangeFeedID(changefeed),
-		sinkURI, f, rc, map[string]string{})
+		sinkURI, f, rc)
 	require.Nil(t, err)
 	err = sink.Close(ctx)
 	require.Nil(t, err)
@@ -1724,7 +1723,7 @@ func TestMySQLSinkClose(t *testing.T) {
 	// test sink.Close will work correctly even if the ctx pass in has not been cancel
 	sink, err := NewMySQLSink(ctx,
 		model.DefaultChangeFeedID(changefeed),
-		sinkURI, f, rc, map[string]string{})
+		sinkURI, f, rc)
 	require.Nil(t, err)
 	err = sink.Close(ctx)
 	require.Nil(t, err)
@@ -1776,7 +1775,7 @@ func TestMySQLSinkFlushResolvedTs(t *testing.T) {
 	// test sink.Close will work correctly even if the ctx pass in has not been cancel
 	sink, err := NewMySQLSink(ctx,
 		model.DefaultChangeFeedID(changefeed),
-		sinkURI, f, rc, map[string]string{})
+		sinkURI, f, rc)
 	require.Nil(t, err)
 	checkpoint, err := sink.FlushRowChangedEvents(ctx, model.TableID(1), model.NewResolvedTs(1))
 	require.Nil(t, err)
@@ -1870,7 +1869,7 @@ func TestGBKSupported(t *testing.T) {
 	require.Nil(t, err)
 	sink, err := NewMySQLSink(ctx,
 		model.DefaultChangeFeedID(changefeed),
-		sinkURI, f, rc, map[string]string{})
+		sinkURI, f, rc)
 	require.Nil(t, err)
 
 	// no gbk-related warning log will be output because GBK charset is supported

--- a/cdc/sink/sink.go
+++ b/cdc/sink/sink.go
@@ -122,7 +122,7 @@ func init() {
 		filter *filter.Filter, config *config.ReplicaConfig, opts map[string]string,
 		errCh chan error,
 	) (Sink, error) {
-		return mq.NewKafkaSaramaSink(ctx, sinkURI, filter, config, opts, errCh)
+		return mq.NewKafkaSaramaSink(ctx, sinkURI, filter, config, errCh)
 	}
 	sinkIniterMap["kafka+ssl"] = sinkIniterMap["kafka"]
 
@@ -132,7 +132,7 @@ func init() {
 		filter *filter.Filter, config *config.ReplicaConfig, opts map[string]string,
 		errCh chan error,
 	) (Sink, error) {
-		return mq.NewPulsarSink(ctx, sinkURI, filter, config, opts, errCh)
+		return mq.NewPulsarSink(ctx, sinkURI, filter, config, errCh)
 	}
 	sinkIniterMap["pulsar+ssl"] = sinkIniterMap["pulsar"]
 

--- a/cdc/sink/sink_test.go
+++ b/cdc/sink/sink_test.go
@@ -27,16 +27,15 @@ func TestValidateSink(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	replicateConfig := config.GetDefaultReplicaConfig()
-	opts := make(map[string]string)
 
 	// test sink uri error
 	sinkURI := "mysql://root:111@127.0.0.1:3306/"
-	err := Validate(ctx, sinkURI, replicateConfig, opts)
+	err := Validate(ctx, sinkURI, replicateConfig)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "fail to open MySQL connection")
 
 	// test sink uri right
 	sinkURI = "blackhole://"
-	err = Validate(ctx, sinkURI, replicateConfig, opts)
+	err = Validate(ctx, sinkURI, replicateConfig)
 	require.Nil(t, err)
 }

--- a/cmd/kafka-consumer/main.go
+++ b/cmd/kafka-consumer/main.go
@@ -416,11 +416,10 @@ func NewConsumer(ctx context.Context) (*Consumer, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	ctx = contextutil.PutRoleInCtx(ctx, util.RoleKafkaConsumer)
 	errCh := make(chan error, 1)
-	opts := map[string]string{}
 	for i := 0; i < int(kafkaPartitionNum); i++ {
 		s, err := sink.New(ctx,
 			model.DefaultChangeFeedID("kafka-consumer"),
-			downstreamURIStr, filter, config.GetDefaultReplicaConfig(), opts, errCh)
+			downstreamURIStr, filter, config.GetDefaultReplicaConfig(), errCh)
 		if err != nil {
 			cancel()
 			return nil, errors.Trace(err)
@@ -429,7 +428,7 @@ func NewConsumer(ctx context.Context) (*Consumer, error) {
 	}
 	sink, err := sink.New(ctx,
 		model.DefaultChangeFeedID("kafka-consumer"),
-		downstreamURIStr, filter, config.GetDefaultReplicaConfig(), opts, errCh)
+		downstreamURIStr, filter, config.GetDefaultReplicaConfig(), errCh)
 	if err != nil {
 		cancel()
 		return nil, errors.Trace(err)

--- a/pkg/applier/redo.go
+++ b/pkg/applier/redo.go
@@ -113,11 +113,10 @@ func (ra *RedoApplier) consumeLogs(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	opts := map[string]string{}
 	ctx = contextutil.PutRoleInCtx(ctx, util.RoleRedoLogApplier)
 	s, err := sink.New(ctx,
 		model.DefaultChangeFeedID(applierChangefeed),
-		ra.cfg.SinkURI, ft, replicaConfig, opts, ra.errCh)
+		ra.cfg.SinkURI, ft, replicaConfig, ra.errCh)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/cli/cli_changefeed_update.go
+++ b/pkg/cmd/cli/cli_changefeed_update.go
@@ -164,23 +164,6 @@ func (o *updateChangefeedOptions) applyChanges(oldInfo *model.ChangeFeedInfo, cm
 			}
 		case "schema-registry":
 			newInfo.Config.Sink.SchemaRegistry = o.commonChangefeedOptions.schemaRegistry
-		case "opts":
-			for _, opt := range o.commonChangefeedOptions.opts {
-				s := strings.SplitN(opt, "=", 2)
-				if len(s) <= 0 {
-					cmd.Printf("omit opt: %s", opt)
-					continue
-				}
-
-				var key string
-				var value string
-				key = s[0]
-				if len(s) > 1 {
-					value = s[1]
-				}
-				newInfo.Opts[key] = value
-			}
-
 		case "sort-engine":
 			newInfo.Engine = o.commonChangefeedOptions.sortEngine
 		case "sync-point":

--- a/pkg/orchestrator/reactor_state_test.go
+++ b/pkg/orchestrator/reactor_state_test.go
@@ -111,7 +111,6 @@ func TestChangefeedStateUpdate(t *testing.T) {
 				ID: model.DefaultChangeFeedID("test1"),
 				Info: &model.ChangeFeedInfo{
 					SinkURI:           "blackhole://",
-					Opts:              map[string]string{},
 					CreateTime:        createTime,
 					StartTs:           421980685886554116,
 					Engine:            model.SortInMemory,
@@ -170,7 +169,6 @@ func TestChangefeedStateUpdate(t *testing.T) {
 				ID: model.DefaultChangeFeedID("test1"),
 				Info: &model.ChangeFeedInfo{
 					SinkURI:           "blackhole://",
-					Opts:              map[string]string{},
 					CreateTime:        createTime,
 					StartTs:           421980685886554116,
 					Engine:            model.SortInMemory,
@@ -236,7 +234,6 @@ func TestChangefeedStateUpdate(t *testing.T) {
 				ID: model.DefaultChangeFeedID("test1"),
 				Info: &model.ChangeFeedInfo{
 					SinkURI:           "blackhole://",
-					Opts:              map[string]string{},
 					CreateTime:        createTime,
 					StartTs:           421980685886554116,
 					Engine:            model.SortInMemory,

--- a/scripts/avro-local-test.sh
+++ b/scripts/avro-local-test.sh
@@ -38,7 +38,7 @@ sub_help() {
 
 sub_init() {
 	sudo docker exec -it ticdc_controller_1 sh -c "
-  /cdc cli changefeed create --pd=\"http://upstream-pd:2379\" --sink-uri=\"kafka://kafka:9092/testdb_test?protocol=avro\" --opts \"registry=http://schema-registry:8081\"
+  /cdc cli changefeed create --pd=\"http://upstream-pd:2379\" --sink-uri=\"kafka://kafka:9092/testdb_test?protocol=avro\"
   curl -X POST -H \"Content-Type: application/json\" -d @/config/jdbc-sink-connector.json http://kafka-connect-01:8083/connectors
   "
 }

--- a/scripts/canal/canal-local-test.sh
+++ b/scripts/canal/canal-local-test.sh
@@ -74,7 +74,7 @@ sub_help() {
 sub_init() {
 	prepare_db
 	sudo docker exec -it ticdc_controller_1 sh -c "
-  /cdc cli changefeed create --pd=\"http://upstream-pd:2379\" --sink-uri=\"kafka://kafka:9092/testdb\" --config=\"/config/canal-test-config.toml\" --opts \"force-handle-key-pkey=true, support-txn=true\"
+  /cdc cli changefeed create --pd=\"http://upstream-pd:2379\" --sink-uri=\"kafka://kafka:9092/testdb\" --config=\"/config/canal-test-config.toml\"
   "
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref https://github.com/pingcap/tiflow/issues/5849

### What is changed and how it works?
remove useless opts for MQ sink.

This PR simply removes the dead code.
Before.
You pass opts it won't do anything, but it won't report an error.

After the change.
You pass opts again cli will report an error.

Upgrade
The original parameters won't work after the upgrade, and it won't panic.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No, I didn't find any docs about this arg.
### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
