### PR TITLE
tp: cleanup metrics and fix a bug that ignore schedule task mistakenly

### DIFF
--- a/cdc/scheduler/internal/tp/capture_manager.go
+++ b/cdc/scheduler/internal/tp/capture_manager.go
@@ -229,6 +229,8 @@ func (c *captureManager) HandleAliveCaptureUpdate(
 		for id, capture := range c.Captures {
 			c.changes.Init[id] = capture.Tables
 		}
+		log.Info("tpscheduler: all capture initialized",
+			zap.Int("captureCount", len(c.Captures)))
 		c.initialized = true
 	}
 
@@ -251,5 +253,12 @@ func (c *captureManager) CollectMetrics() {
 		captureTableGauge.
 			WithLabelValues(cf.Namespace, cf.ID, capture.Addr).
 			Set(float64(len(capture.Tables)))
+	}
+}
+
+func (c *captureManager) CleanMetrics() {
+	cf := c.changefeedID
+	for _, capture := range c.Captures {
+		captureTableGauge.DeleteLabelValues(cf.Namespace, cf.ID, capture.Addr)
 	}
 }

--- a/cdc/scheduler/internal/tp/coordinator.go
+++ b/cdc/scheduler/internal/tp/coordinator.go
@@ -95,6 +95,7 @@ func newCoordinator(
 		schedulers:   schedulers,
 		replicationM: newReplicationManager(cfg.MaxTaskConcurrency, changefeedID),
 		captureM:     newCaptureManager(changefeedID, revision, cfg.HeartbeatTick),
+		changefeedID: changefeedID,
 		tasksCounter: make(map[struct {
 			scheduler string
 			task      string
@@ -169,6 +170,13 @@ func (c *coordinator) Close(ctx context.Context) {
 	defer c.mu.Unlock()
 
 	_ = c.trans.Close()
+	c.captureM.CleanMetrics()
+	c.replicationM.CleanMetrics()
+
+	log.Info("tpscheduler: coordinator closed",
+		zap.Any("ownerRev", c.captureM.OwnerRev),
+		zap.String("namespace", c.changefeedID.Namespace),
+		zap.String("name", c.changefeedID.ID))
 }
 
 // ===========

--- a/cdc/scheduler/internal/tp/scheduler_basic.go
+++ b/cdc/scheduler/internal/tp/scheduler_basic.go
@@ -77,6 +77,13 @@ func (b *basicScheduler) Schedule(
 		for captureID := range captures {
 			captureIDs = append(captureIDs, captureID)
 		}
+		const logTableIDThreshold = 50
+		tableField := zap.Skip()
+		if len(newTables) < logTableIDThreshold {
+			tableField = zap.Int64s("tableIDs", newTables)
+		}
+		log.Info("tpscheduler: burst add table",
+			tableField, zap.Strings("captureIDs", captureIDs))
 		tasks = append(
 			tasks, newBurstBalanceAddTables(checkpointTs, newTables, captureIDs))
 		if len(newTables) == len(currentTables) {

--- a/tests/integration_tests/move_table/main.go
+++ b/tests/integration_tests/move_table/main.go
@@ -177,33 +177,6 @@ func (c *cluster) moveAllTables(ctx context.Context, sourceCapture, targetCaptur
 		log.Info("moved table successful", zap.Int64("tableID", table.ID))
 	}
 
-	for counter := 0; counter < maxCheckSourceEmptyRetries; counter++ {
-		err := retry.Do(ctx, func() error {
-			return c.refreshInfo(ctx)
-		}, retry.WithBackoffBaseDelay(100), retry.WithMaxTries(5+1), retry.WithIsRetryableErr(cerrors.IsRetryableError))
-		if err != nil {
-			log.Warn("error refreshing cluster info", zap.Error(err))
-		}
-
-		tables, ok := c.captures[sourceCapture]
-		if !ok {
-			log.Warn("source capture is gone", zap.String("sourceCapture", sourceCapture))
-			return errors.New("source capture is gone")
-		}
-
-		if len(tables) == 0 {
-			log.Info("source capture is now empty", zap.String("sourceCapture", sourceCapture))
-			break
-		}
-
-		if counter != maxCheckSourceEmptyRetries {
-			log.Debug("source capture is not empty, will try again", zap.String("sourceCapture", sourceCapture))
-			time.Sleep(time.Second * 10)
-		} else {
-			return errors.New("source capture is not empty after retries")
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4757 

### What is changed and how it works?

* tp: clean up metrics and add logs
* tp: cleanup running task when a table has shutdown
* tests: skip check move table results

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Run tests/integration_tests/move_table/main.go to test move tables.

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
