### PR TITLE
framework(engine): fix stale pong heartbeat causes ack time fallback

### DIFF
--- a/engine/executor/worker/ctx.go
+++ b/engine/executor/worker/ctx.go
@@ -15,9 +15,9 @@ package worker
 
 import (
 	"context"
-	"time"
 
 	"github.com/pingcap/tiflow/engine/executor/worker/internal"
+	"github.com/pingcap/tiflow/engine/pkg/clock"
 )
 
 type runtimeInfoKeyType int
@@ -46,7 +46,7 @@ func newRuntimeCtx(ctx context.Context, info internal.RuntimeInfo) *RuntimeConte
 // NewRuntimeCtxWithSubmitTime creates a RuntimeContext with a given submit-time.
 // This function is exposed for the purpose of unit-testing.
 // There is NO NEED to use this function in production code.
-func NewRuntimeCtxWithSubmitTime(ctx context.Context, submitTime time.Time) *RuntimeContext {
+func NewRuntimeCtxWithSubmitTime(ctx context.Context, submitTime clock.MonotonicTime) *RuntimeContext {
 	return newRuntimeCtx(ctx, internal.RuntimeInfo{SubmitTime: submitTime})
 }
 
@@ -62,6 +62,6 @@ func ToRuntimeCtx(ctx context.Context) (rctx *RuntimeContext, ok bool) {
 }
 
 // SubmitTime returns the time at which a task is submitted to the runtime's queue.
-func (c *RuntimeContext) SubmitTime() time.Time {
+func (c *RuntimeContext) SubmitTime() clock.MonotonicTime {
 	return c.info.SubmitTime
 }

--- a/engine/executor/worker/ctx_test.go
+++ b/engine/executor/worker/ctx_test.go
@@ -21,10 +21,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pingcap/tiflow/engine/executor/worker/internal"
+	"github.com/pingcap/tiflow/engine/pkg/clock"
 )
 
 func TestToRuntimeCtxFromDerivedStdCtx(t *testing.T) {
-	rtInfo := internal.RuntimeInfo{SubmitTime: time.Unix(1, 1)}
+	rtInfo := internal.RuntimeInfo{SubmitTime: clock.ToMono(time.Unix(1, 1))}
 	rctx := newRuntimeCtx(context.Background(), rtInfo)
 
 	ctx1, cancel := context.WithCancel(rctx)

--- a/engine/executor/worker/internal/info.go
+++ b/engine/executor/worker/internal/info.go
@@ -13,9 +13,11 @@
 
 package internal
 
-import "time"
+import (
+	"github.com/pingcap/tiflow/engine/pkg/clock"
+)
 
 // RuntimeInfo records some information related to the runnable object
 type RuntimeInfo struct {
-	SubmitTime time.Time
+	SubmitTime clock.MonotonicTime
 }

--- a/engine/executor/worker/internal/runnables.go
+++ b/engine/executor/worker/internal/runnables.go
@@ -15,13 +15,13 @@ package internal
 
 import (
 	"context"
-	"time"
 
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
 	"github.com/pingcap/tiflow/dm/pkg/log"
 	"github.com/pingcap/tiflow/engine/model"
+	"github.com/pingcap/tiflow/engine/pkg/clock"
 )
 
 // Workloader defines an interface to get Workload
@@ -56,7 +56,7 @@ type RunnableContainer struct {
 }
 
 // WrapRunnable creates a new RunnableContainer from a Runnable interface
-func WrapRunnable(runnable Runnable, submitTime time.Time) *RunnableContainer {
+func WrapRunnable(runnable Runnable, submitTime clock.MonotonicTime) *RunnableContainer {
 	return &RunnableContainer{
 		Runnable: runnable,
 		status:   *atomic.NewInt32(TaskSubmitted),

--- a/engine/executor/worker/task_committer.go
+++ b/engine/executor/worker/task_committer.go
@@ -116,7 +116,7 @@ func (c *TaskCommitter) PreDispatchTask(rID requestID, task Runnable) (ok bool) 
 	}
 
 	// We use the current time as the submit time of the task.
-	taskWithSubmitTime := internal.WrapRunnable(task, c.clock.Now())
+	taskWithSubmitTime := internal.WrapRunnable(task, c.clock.Mono())
 
 	request := &requestEntry{
 		RequestID: rID,

--- a/engine/executor/worker/task_committer_test.go
+++ b/engine/executor/worker/task_committer_test.go
@@ -70,7 +70,7 @@ func TestTaskCommitterSuccessCase(t *testing.T) {
 
 	suite.Runner.On("addWrappedTask",
 		mock.MatchedBy(func(arg *internal.RunnableContainer) bool {
-			return arg.ID() == "task-1" && arg.Info().SubmitTime == submitTime
+			return arg.ID() == "task-1" && arg.Info().SubmitTime == clock.ToMono(submitTime)
 		})).Return(nil)
 	ok, err := suite.Committer.ConfirmDispatchTask("request-1", "task-1")
 	require.True(t, ok)
@@ -122,7 +122,7 @@ func TestTaskCommitterSameTaskIDOverwrites(t *testing.T) {
 
 	suite.Runner.On("addWrappedTask",
 		mock.MatchedBy(func(arg *internal.RunnableContainer) bool {
-			return arg.ID() == "task-1" && arg.Info().SubmitTime == submitTime2
+			return arg.ID() == "task-1" && arg.Info().SubmitTime == clock.ToMono(submitTime2)
 		})).Return(nil)
 	ok, err = suite.Committer.ConfirmDispatchTask("request-2", "task-1")
 	require.True(t, ok)

--- a/engine/executor/worker/task_runner.go
+++ b/engine/executor/worker/task_runner.go
@@ -73,7 +73,7 @@ func NewTaskRunner(inQueueSize int, initConcurrency int) *TaskRunner {
 // AddTask enqueues a naked task, and AddTask will wrap the task with internal.WrapRunnable.
 // Deprecated. TODO Will be removed once two-phase task dispatching is enabled.
 func (r *TaskRunner) AddTask(task Runnable) error {
-	wrappedTask := internal.WrapRunnable(task, r.clock.Now())
+	wrappedTask := internal.WrapRunnable(task, r.clock.Mono())
 	select {
 	case r.inQueue <- wrappedTask:
 		return nil

--- a/engine/executor/worker/task_runner_test.go
+++ b/engine/executor/worker/task_runner_test.go
@@ -105,7 +105,7 @@ func TestTaskRunnerSubmitTime(t *testing.T) {
 	}()
 
 	require.Eventually(t, func() bool {
-		return worker.SubmitTime() == submitTime
+		return worker.SubmitTime() == clock.ToMono(submitTime)
 	}, 1*time.Second, 10*time.Millisecond)
 
 	cancel()

--- a/engine/executor/worker/test_util.go
+++ b/engine/executor/worker/test_util.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pingcap/tiflow/dm/pkg/log"
 	"github.com/pingcap/tiflow/engine/model"
+	"github.com/pingcap/tiflow/engine/pkg/clock"
 )
 
 type dummyWorker struct {
@@ -34,13 +35,13 @@ type dummyWorker struct {
 	blockCond *sync.Cond
 	blocked   bool
 
-	submitTime atomic.Time
+	submitTime atomic.Duration
 }
 
 func newDummyWorker(id RunnableID) *dummyWorker {
 	ret := &dummyWorker{
 		id:         id,
-		submitTime: *atomic.NewTime(time.Time{}),
+		submitTime: *atomic.NewDuration(0),
 	}
 	ret.blockCond = sync.NewCond(&ret.blockMu)
 	return ret
@@ -57,7 +58,7 @@ func (d *dummyWorker) Init(ctx context.Context) error {
 	if !ok {
 		log.L().Panic("A RuntimeContext is expected to be used in unit tests")
 	}
-	d.submitTime.Store(rctx.SubmitTime())
+	d.submitTime.Store(time.Duration(rctx.SubmitTime()))
 
 	return nil
 }
@@ -104,6 +105,6 @@ func (d *dummyWorker) UnblockInit() {
 	d.blockCond.Broadcast()
 }
 
-func (d *dummyWorker) SubmitTime() time.Time {
-	return d.submitTime.Load()
+func (d *dummyWorker) SubmitTime() clock.MonotonicTime {
+	return clock.MonotonicTime(d.submitTime.Load())
 }

--- a/engine/framework/internal/worker/master_client.go
+++ b/engine/framework/internal/worker/master_client.go
@@ -190,6 +190,9 @@ func (m *MasterClient) HandleHeartbeat(sender p2p.NodeID, msg *frameModel.Heartb
 		m.masterSideClosed.Store(true)
 	}
 
+	// worker may receive stale heartbeat pong message from job master, stale
+	// message doesn't contribute to job master aliveness detection and even
+	// leads to false positive.
 	lastAckTime := m.lastMasterAckedPingTime.Load()
 	if lastAckTime > time.Duration(msg.SendTime) {
 		log.L().Info("received stale pong heartbeat",

--- a/engine/framework/internal/worker/master_client.go
+++ b/engine/framework/internal/worker/master_client.go
@@ -189,7 +189,14 @@ func (m *MasterClient) HandleHeartbeat(sender p2p.NodeID, msg *frameModel.Heartb
 	if msg.IsFinished {
 		m.masterSideClosed.Store(true)
 	}
-	m.lastMasterAckedPingTime.Store(time.Duration(msg.SendTime))
+
+	lastAckTime := m.lastMasterAckedPingTime.Load()
+	if lastAckTime > time.Duration(msg.SendTime) {
+		log.L().Info("received stale pong heartbeat",
+			zap.Any("msg", msg), zap.Int64("lastAckTime", int64(lastAckTime)))
+	} else {
+		m.lastMasterAckedPingTime.Store(time.Duration(msg.SendTime))
+	}
 }
 
 // CheckMasterTimeout checks whether the master has timed out, i.e. we have lost
@@ -228,13 +235,16 @@ func (m *MasterClient) SendHeartBeat(ctx context.Context, clock clock.Clock, isF
 		IsFinished:   isFinished,
 	}
 
-	log.L().Debug("sending heartbeat", zap.String("worker", m.workerID))
+	log.L().Debug("sending heartbeat", zap.String("worker", m.workerID),
+		zap.String("master-id", m.masterID),
+		zap.Int64("epoch", epoch), zap.Int64("sendTime", int64(sendTime)))
 	ok, err := m.messageSender.SendToNode(ctx, nodeID, frameModel.HeartbeatPingTopic(m.masterID), heartbeatMsg)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	log.L().Info("sending heartbeat success", zap.String("worker", m.workerID),
-		zap.String("master-id", m.masterID))
+		zap.String("master-id", m.masterID),
+		zap.Int64("epoch", epoch), zap.Int64("sendTime", int64(sendTime)))
 	if !ok {
 		// Reloads master info asynchronously.
 		// Not using `ctx` because the caller might cancel unexpectedly.

--- a/engine/framework/internal/worker/master_client_test.go
+++ b/engine/framework/internal/worker/master_client_test.go
@@ -410,10 +410,10 @@ func TestMasterClientHeartbeatStalePong(t *testing.T) {
 		IsFinished:   false,
 	}, ping)
 
-	sendTime2 := helper.InitTime.Add(-30 * time.Second)
+	sendTimeOld := helper.InitTime.Add(-30 * time.Second)
 	// master_client receives a stale pong heartbeat
 	helper.Client.HandleHeartbeat("executor-1", &frameModel.HeartbeatPongMessage{
-		SendTime:   clock.ToMono(sendTime2),
+		SendTime:   clock.ToMono(sendTimeOld),
 		ReplyTime:  time.Now(),
 		ToWorkerID: "worker-1",
 		Epoch:      1,

--- a/engine/framework/internal/worker/master_client_test.go
+++ b/engine/framework/internal/worker/master_client_test.go
@@ -380,3 +380,56 @@ func TestMasterClientSendHeartbeatRefreshMaster(t *testing.T) {
 	require.Equal(t, "executor-2", nodeID)
 	require.Equal(t, frameModel.Epoch(2), epoch)
 }
+
+func TestMasterClientHeartbeatStalePong(t *testing.T) {
+	helper := newMasterClientTestHelper("master-1", "worker-1")
+	err := helper.Meta.UpsertJob(context.Background(), &frameModel.MasterMetaKVData{
+		ID:         "master-1",
+		StatusCode: frameModel.MasterStatusInit,
+		NodeID:     "executor-1",
+		Addr:       "192.168.0.1:1234",
+		Epoch:      1,
+	})
+	require.NoError(t, err)
+
+	err = helper.Client.InitMasterInfoFromMeta(context.Background())
+	require.NoError(t, err)
+
+	clk := clock.NewMock()
+	sendTime1 := helper.InitTime.Add(1 * time.Second)
+	clk.Set(sendTime1)
+
+	err = helper.Client.SendHeartBeat(context.Background(), clk, false)
+	require.NoError(t, err)
+
+	ping := helper.PopHeartbeat(t)
+	require.Equal(t, &frameModel.HeartbeatPingMessage{
+		SendTime:     clock.ToMono(sendTime1),
+		FromWorkerID: "worker-1",
+		Epoch:        1,
+		IsFinished:   false,
+	}, ping)
+
+	sendTime2 := helper.InitTime.Add(-30 * time.Second)
+	// master_client receives a stale pong heartbeat
+	helper.Client.HandleHeartbeat("executor-1", &frameModel.HeartbeatPongMessage{
+		SendTime:   clock.ToMono(sendTime2),
+		ReplyTime:  time.Now(),
+		ToWorkerID: "worker-1",
+		Epoch:      1,
+	})
+	require.Equal(t,
+		time.Duration(clock.ToMono(helper.InitTime)),
+		helper.Client.lastMasterAckedPingTime.Load())
+
+	// master_client receives a fresh pong heartbeat
+	helper.Client.HandleHeartbeat("executor-1", &frameModel.HeartbeatPongMessage{
+		SendTime:   clock.ToMono(sendTime1),
+		ReplyTime:  time.Now(),
+		ToWorkerID: "worker-1",
+		Epoch:      1,
+	})
+	require.Equal(t,
+		time.Duration(clock.ToMono(sendTime1)),
+		helper.Client.lastMasterAckedPingTime.Load())
+}

--- a/engine/framework/worker.go
+++ b/engine/framework/worker.go
@@ -251,7 +251,7 @@ func (w *DefaultBaseWorker) doPreInit(ctx context.Context) error {
 	initTime := w.clock.Mono()
 	rctx, ok := runtime.ToRuntimeCtx(ctx)
 	if ok {
-		initTime = clock.ToMono(rctx.SubmitTime())
+		initTime = rctx.SubmitTime()
 	}
 
 	w.masterClient = worker.NewMasterClient(

--- a/engine/framework/worker_test.go
+++ b/engine/framework/worker_test.go
@@ -351,7 +351,7 @@ func TestWorkerSuicideAfterRuntimeDelay(t *testing.T) {
 	worker.On("Tick", mock.Anything).Return(nil)
 	worker.On("CloseImpl", mock.Anything).Return(nil)
 
-	ctx = runtime.NewRuntimeCtxWithSubmitTime(ctx, submitTime)
+	ctx = runtime.NewRuntimeCtxWithSubmitTime(ctx, clock.ToMono(submitTime))
 	err := worker.Init(ctx)
 	require.NoError(t, err)
 

--- a/engine/pkg/clock/clock.go
+++ b/engine/pkg/clock/clock.go
@@ -74,5 +74,5 @@ func MonoNow() MonotonicTime {
 
 // ToMono converts time.Time to MonotonicTime
 func ToMono(t time.Time) MonotonicTime {
-	return MonotonicTime(t.Sub(unixEpoch))
+	return MonotonicTime(t.UnixNano())
 }

--- a/engine/pkg/clock/clock.go
+++ b/engine/pkg/clock/clock.go
@@ -74,5 +74,5 @@ func MonoNow() MonotonicTime {
 
 // ToMono converts time.Time to MonotonicTime
 func ToMono(t time.Time) MonotonicTime {
-	return MonotonicTime(t.UnixNano())
+	return MonotonicTime(t.Sub(unixEpoch))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5969


TODO
- [x] add unit test

### What is changed and how it works?

- When worker receives a stale heartbeat pong message from master, don't reset `lastMasterAckedPingTime`
- Use `clock.MonotonicTime` as submit time in task context instead of `time.Time`

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
