### PR TITLE
config(ticdc): Support configurable BackoffMaxElapsedTime

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -67,6 +67,7 @@ func (o *options) addFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.serverConfig.TZ, "tz", o.serverConfig.TZ, "Specify time zone of TiCDC cluster")
 	cmd.Flags().Int64Var(&o.serverConfig.GcTTL, "gc-ttl", o.serverConfig.GcTTL, "CDC GC safepoint TTL duration, specified in seconds")
+	cmd.Flags().Int64Var(&o.serverConfig.MaxElapsedTime, "max-elapsed-time", o.serverConfig.MaxElapsedTime, "CDC MaxElapsedTime duration, specified in minutes")
 
 	cmd.Flags().StringVar(&o.serverConfig.LogFile, "log-file", o.serverConfig.LogFile, "log file path")
 	cmd.Flags().StringVar(&o.serverConfig.LogLevel, "log-level", o.serverConfig.LogLevel, "log level (etc: debug|info|warn|error)")
@@ -191,6 +192,8 @@ func (o *options) complete(cmd *cobra.Command) error {
 			cfg.TZ = o.serverConfig.TZ
 		case "gc-ttl":
 			cfg.GcTTL = o.serverConfig.GcTTL
+		case "max-elapsed-time":
+			cfg.MaxElapsedTime = o.serverConfig.MaxElapsedTime
 		case "log-file":
 			cfg.LogFile = o.serverConfig.LogFile
 		case "log-level":

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -118,6 +118,7 @@ func TestParseCfg(t *testing.T) {
 		"--log-level", "debug",
 		"--data-dir", dataDir,
 		"--gc-ttl", "10",
+		"--max-elapsed-time", "100",
 		"--tz", "UTC",
 		"--owner-flush-interval", "150ms",
 		"--processor-flush-interval", "150ms",
@@ -151,6 +152,7 @@ func TestParseCfg(t *testing.T) {
 		},
 		DataDir:                dataDir,
 		GcTTL:                  10,
+		MaxElapsedTime:         100,
 		TZ:                     "UTC",
 		CaptureSessionTTL:      10,
 		OwnerFlushInterval:     config.TomlDuration(150 * time.Millisecond),
@@ -226,6 +228,7 @@ log-level = "warn"
 data-dir = "%+v"
 gc-ttl = 500
 tz = "US"
+max-elapsed-time=300
 capture-session-ttl = 10
 
 owner-flush-interval = "600ms"
@@ -301,6 +304,7 @@ server-worker-pool-size = 16
 		},
 		DataDir:                dataDir,
 		GcTTL:                  500,
+		MaxElapsedTime:         300,
 		TZ:                     "US",
 		CaptureSessionTTL:      10,
 		OwnerFlushInterval:     config.TomlDuration(600 * time.Millisecond),
@@ -408,6 +412,7 @@ cert-allowed-cn = ["dd","ee"]
 		"--log-level", "debug",
 		"--data-dir", dataDir,
 		"--gc-ttl", "10",
+		"--max-elapsed-time", "200",
 		"--tz", "UTC",
 		"--owner-flush-interval", "150ms",
 		"--processor-flush-interval", "150ms",
@@ -438,6 +443,7 @@ cert-allowed-cn = ["dd","ee"]
 		},
 		DataDir:                dataDir,
 		GcTTL:                  10,
+		MaxElapsedTime:         200,
 		TZ:                     "UTC",
 		CaptureSessionTTL:      10,
 		OwnerFlushInterval:     config.TomlDuration(150 * time.Millisecond),

--- a/pkg/config/config_test_data.go
+++ b/pkg/config/config_test_data.go
@@ -73,6 +73,7 @@ const (
   "data-dir": "",
   "gc-ttl": 86400,
   "tz": "System",
+  "max-elapsed-time": 90,
   "capture-session-ttl": 10,
   "owner-flush-interval": 200000000,
   "processor-flush-interval": 100000000,

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -75,9 +75,10 @@ var defaultServerConfig = &ServerConfig{
 		},
 		InternalErrOutput: "stderr",
 	},
-	DataDir: "",
-	GcTTL:   24 * 60 * 60, // 24H
-	TZ:      "System",
+	DataDir:        "",
+	GcTTL:          24 * 60 * 60, // 24H
+	TZ:             "System",
+	MaxElapsedTime: 90,
 	// The default election-timeout in PD is 3s and minimum session TTL is 5s,
 	// which is calculated by `math.Ceil(3 * election-timeout / 2)`, we choose
 	// default capture session ttl to 10s to increase robust to PD jitter,
@@ -146,6 +147,8 @@ type ServerConfig struct {
 
 	GcTTL int64  `toml:"gc-ttl" json:"gc-ttl"`
 	TZ    string `toml:"tz" json:"tz"`
+
+	MaxElapsedTime int64 `toml:"max-elapsed-time" json:"max-elapsed-time"`
 
 	CaptureSessionTTL int `toml:"capture-session-ttl" json:"capture-session-ttl"`
 
@@ -219,6 +222,9 @@ func (c *ServerConfig) ValidateAndAdjust() error {
 	}
 	if c.GcTTL == 0 {
 		return cerror.ErrInvalidServerOption.GenWithStack("empty GC TTL is not allowed")
+	}
+	if c.MaxElapsedTime == 0 {
+		return cerror.ErrInvalidServerOption.GenWithStack("empty MaxElapsedTime is not allowed")
 	}
 	// 5s is minimum lease ttl in etcd(PD)
 	if c.CaptureSessionTTL < 5 {

--- a/pkg/config/server_config_test.go
+++ b/pkg/config/server_config_test.go
@@ -56,6 +56,8 @@ func TestServerConfigValidateAndAdjust(t *testing.T) {
 	conf.Addr = "cdc:1234"
 	require.Regexp(t, ".*empty GC TTL is not allowed", conf.ValidateAndAdjust())
 	conf.GcTTL = 60
+	require.Regexp(t, ".*empty MaxElapsedTime is not allowed", conf.ValidateAndAdjust())
+	conf.MaxElapsedTime = 90
 	require.Nil(t, conf.ValidateAndAdjust())
 	require.Equal(t, conf.Addr, conf.AdvertiseAddr)
 	conf.AdvertiseAddr = "advertise:1234"


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5684

### What is changed and how it works?
Add "max-Elapsed -time" parameter of TICDC server configuration to support that change internal BackoffMaxElapsedTime size. So that GC can be advenced normally when downstream Kafka is not available.Although gc-ttl is in the valid period, the data after checkpoint may be cleaned when tidb_gc_life_time variable remains default.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

```
$ tiup cluster display szp-tidbtiup is checking updates for component cluster ...
Starting component `cluster`: /home/tidb/.tiup/components/cluster/v1.10.2/tiup-cluster display szp-tidb
Cluster type:       tidb
Cluster name:       szp-tidb
Cluster version:    v6.1.0
Deploy user:        tidb
SSH type:           builtin
Dashboard URL:      http://172.16.120.122:2479/dashboard
Grafana URL:        http://172.16.120.122:3001
ID                    Role          Host            Ports        OS/Arch       Status   Data Dir                                     Deploy Dir
--                    ----          ----            -----        -------       ------   --------                                     ----------
172.16.120.122:9193   alertmanager  172.16.120.122  9193/9194    linux/x86_64  Up       /DATA/disk1/szp/tidb-data/alertmanager-9193  /DATA/disk1/szp/tidb-deploy/alertmanager-9193
120.92.106.23:8300    cdc           120.92.106.23   8300         linux/x86_64  Up       /DATA/disk1/szp/ticdc-data/cdc-8300          /DATA/disk1/szp/tidb-deploy/cdc-8300
172.16.120.122:3001   grafana       172.16.120.122  3001         linux/x86_64  Up       -                                            /DATA/disk1/szp/tidb-deploy/grafana-3001
172.16.120.122:2479   pd            172.16.120.122  2479/2480    linux/x86_64  Up|L|UI  /DATA/disk2/szp/tidb-data/pd-2479            /DATA/disk2/szp/tidb-deploy/pd-2479
172.16.120.122:9091   prometheus    172.16.120.122  9091/12021   linux/x86_64  Up       /DATA/disk1/szp/tidb-data/prometheus-8250    /DATA/disk1/szp/tidb-deploy/prometheus-8250
172.16.120.122:6000   tidb          172.16.120.122  6000/60081   linux/x86_64  Up       -                                            /DATA/disk2/szp/tidb-deploy/tidb-6000
172.16.120.122:40161  tikv          172.16.120.122  40161/40181  linux/x86_64  Up       /DATA/disk1/szp/tidb-data/tikv-40161         /DATA/disk1/szp/tidb-deploy/tikv-40161

$ tiup cdc cli changefeed create --pd=http://127.0.0.1:2479 --sink-uri="mysql://root:123123@127.0.0.1:3306/?time-zone=" --changefeed-id="simple-task" --sort-engine="unified"
tiup is checking updates for component cdc ...
Starting component `cdc`: /home/tidb/.tiup/components/cdc/v6.1.0/cdc cli changefeed create --pd=http://127.0.0.1:2479 --sink-uri=mysql://root:123123@127.0.0.1:3306/?time-zone= --changefeed-id=simple-task --sort-engine=unified
Create changefeed successfully!
ID: simple-task
Info: {"upstream-id":0,"sink-uri":"mysql://root:123123@127.0.0.1:3306/?time-zone=","opts":{},"create-time":"2022-06-23T13:13:55.43236598+08:00","start-ts":434100302082473986,"target-ts":0,"admin-job-type":0,"sort-engine":"unified","sort-dir":"","config":{"case-sensitive":true,"enable-old-value":true,"force-replicate":false,"check-gc-safe-point":true,"filter":{"rules":["*.*"],"ignore-txn-start-ts":null},"mounter":{"worker-num":16},"sink":{"dispatchers":null,"protocol":"","column-selectors":null,"schema-registry":""},"cyclic-replication":{"enable":false,"replica-id":0,"filter-replica-ids":null,"id-buckets":0,"sync-ddl":false},"consistent":{"level":"none","max-log-size":64,"flush-interval":1000,"storage":""}},"state":"normal","error":null,"sync-point-enabled":false,"sync-point-interval":600000000000,"creator-version":"v6.1.0"}

$ tiup cluster edit-config szp-tidb
......
server_configs:
  tidb: {}
  tikv: {}
  pd: {}
  tiflash: {}
  tiflash-learner: {}
  pump: {}
  drainer: {}
  cdc:
    gc-ttl: 1800
    max-elapsed-time: 30
......

$ tiup cluster reload szp-tidb -R cdc

$ sysbench /usr/share/sysbench/oltp_read_write.lua --mysql-host=127.0.0.1 --mysql-port=6000 --mysql-db=test --mysql-user=root --mysql-password= --table_size=5000 --tables=10 prepare

$ systemctl stop mysqld

$ sysbench /usr/share/sysbench/oltp_read_write.lua --mysql-host=127.0.0.1 --mysql-port=6000 --mysql-db=test --mysql-user=root --mysql-password= --table_size=5000 --tables=10 cleanup

$ sysbench /usr/share/sysbench/oltp_read_write.lua --mysql-host=127.0.0.1 --mysql-port=6000 --mysql-db=test --mysql-user=root --mysql-password= --table_size=5000 --tables=10 prepare

$ date
Thu Jun 23 13:21:41 CST 2022

mysql> select * from mysql.tidb where VARIABLE_NAME='tikv_gc_life_time';
+-------------------+----------------+----------------------------------------------------------------------------------------+
| VARIABLE_NAME     | VARIABLE_VALUE | COMMENT                                                                                |
+-------------------+----------------+----------------------------------------------------------------------------------------+
| tikv_gc_life_time | 10m0s          | All versions within life time will not be collected by GC, at least 10m, in Go format. |
+-------------------+----------------+----------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

$ tail -f cdc.log 
[2022/06/23 13:54:08.017 +08:00] [INFO] [gc_manager.go:97] ["update gc safe point success"] [gcSafePointTs=434100410177814529]
[2022/06/23 13:54:46.414 +08:00] [WARN] [feed_state_manager.go:440] ["changefeed will not be restarted because it has been failing for a long time period"] [maxElapsedTime=30m0s]

$ tiup cluster edit-config szp-tidb
......
server_configs:
  tidb: {}
  tikv: {}
  pd: {}
  tiflash: {}
  tiflash-learner: {}
  pump: {}
  drainer: {}
  cdc:
    gc-ttl: 1200
    max-elapsed-time: 5
......
$ tiup cluster reload szp-tidb -R cdc
$ tail -f cdc.log 
[2022/06/23 14:22:35.696 +08:00] [WARN] [feed_state_manager.go:72] ["changefeed's MaxElapsedTime is not set to default (90 min)"] [maxElapsedTime=30m0s]
```






#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
no
##### Do you need to update user documentation, design documentation or monitoring documentation?
yes,need to update user documentation,others not.
### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Make BackoffMaxElapsedTime a TICDC server configuration.
```
