### PR TITLE
clients(engine): use non-blocking dial for executors

### DIFF
--- a/engine/client/base_executor_client.go
+++ b/engine/client/base_executor_client.go
@@ -61,11 +61,14 @@ func newBaseExecutorClient(addr string) (*baseExecutorClientImpl, error) {
 	if test.GetGlobalTestFlag() {
 		return newExecutorClientForTest(addr)
 	}
+	// NOTE We use a non-blocking dial (which is the default),
+	// so err could be nil even if an invalid address is given.
+	// TODO We need a way to 1) remove failed clients
+	// 2) prevent stale executor's client from being created
 	conn, err := grpc.Dial(
 		addr,
 		grpc.WithInsecure(),
 		grpc.WithConnectParams(grpc.ConnectParams{Backoff: backoff.DefaultConfig}),
-		grpc.WithBlock(),
 		// We log gRPC requests here to aid debugging
 		// TODO add a switch to turn off the gRPC request log.
 		grpc.WithUnaryInterceptor(grpc_zap.UnaryClientInterceptor(log.L().Logger)))

--- a/engine/client/client_test.go
+++ b/engine/client/client_test.go
@@ -18,15 +18,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pingcap/tiflow/engine/client"
 	"github.com/pingcap/tiflow/engine/executor"
 	"github.com/pingcap/tiflow/engine/pkg/etcdutil"
 	"github.com/pingcap/tiflow/engine/servermaster"
 	"github.com/pingcap/tiflow/engine/test"
-	"github.com/stretchr/testify/require"
 )
 
 func TestClientManager(t *testing.T) {
+	t.Parallel()
+
 	test.SetGlobalTestFlag(true)
 	defer test.SetGlobalTestFlag(false)
 
@@ -78,4 +81,16 @@ func TestClientManager(t *testing.T) {
 	err = manager.AddExecutor("executor", "127.0.0.1:1993")
 	require.Nil(t, err)
 	require.NotNil(t, manager.ExecutorClient("executor"))
+}
+
+func TestAddNonExistentExecutor(t *testing.T) {
+	t.Parallel()
+
+	manager := client.NewClientManager()
+
+	startTime := time.Now()
+	// We don't care about the error for now.
+	// As long as it does not block, it's fine.
+	_ = manager.AddExecutor("executor", "127.0.0.1:1111") // Bad address
+	require.Less(t, time.Since(startTime), time.Second)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6006 

### What is changed and how it works?
- Use non-blocking mode in `grpc.Dial`.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No.

##### Do you need to update user documentation, design documentation or monitoring documentation?
No.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
