### PR TITLE
schedulerV3 (cdc): ignore manual request if capture is stopping

### DIFF
--- a/cdc/scheduler/internal/tp/scheduler_move_table.go
+++ b/cdc/scheduler/internal/tp/scheduler_move_table.go
@@ -93,8 +93,9 @@ func (m *moveTableScheduler) Schedule(
 			delete(m.tasks, tableID)
 			continue
 		}
+
 		// the target capture may offline after manual move table triggered.
-		_, ok := captures[task.moveTable.DestCapture]
+		status, ok := captures[task.moveTable.DestCapture]
 		if !ok {
 			log.Info("tpscheduler: move table ignored, since the target capture cannot found",
 				zap.Int64("tableID", tableID),
@@ -102,6 +103,16 @@ func (m *moveTableScheduler) Schedule(
 			delete(m.tasks, tableID)
 			continue
 		}
+		if status.State != CaptureStateInitialized {
+			log.Warn("tpscheduler: move table ignored,"+
+				"since the target capture is not initialized",
+				zap.Int64("tableID", tableID),
+				zap.String("captureID", task.moveTable.DestCapture),
+				zap.Any("state", status.State))
+			delete(m.tasks, tableID)
+			continue
+		}
+
 		rep, ok := replications[tableID]
 		if !ok {
 			log.Warn("tpscheduler: move table ignored, "+

--- a/cdc/scheduler/internal/tp/scheduler_move_table_test.go
+++ b/cdc/scheduler/internal/tp/scheduler_move_table_test.go
@@ -24,7 +24,11 @@ func TestSchedulerMoveTable(t *testing.T) {
 	t.Parallel()
 
 	var checkpointTs model.Ts
-	captures := map[model.CaptureID]*CaptureStatus{"a": {}, "b": {}}
+	captures := map[model.CaptureID]*CaptureStatus{"a": {
+		State: CaptureStateInitialized,
+	}, "b": {
+		State: CaptureStateInitialized,
+	}}
 	currentTables := []model.TableID{1, 2, 3, 4}
 
 	replications := map[model.TableID]*ReplicationSet{
@@ -34,11 +38,13 @@ func TestSchedulerMoveTable(t *testing.T) {
 	scheduler := newMoveTableScheduler()
 	require.Equal(t, "move-table-scheduler", scheduler.Name())
 
-	tasks := scheduler.Schedule(checkpointTs, currentTables, map[model.CaptureID]*CaptureStatus{}, replications)
+	tasks := scheduler.Schedule(
+		checkpointTs, currentTables, map[model.CaptureID]*CaptureStatus{}, replications)
 	require.Len(t, tasks, 0)
 
 	scheduler.addTask(model.TableID(0), "a")
-	tasks = scheduler.Schedule(checkpointTs, currentTables, map[model.CaptureID]*CaptureStatus{}, replications)
+	tasks = scheduler.Schedule(
+		checkpointTs, currentTables, map[model.CaptureID]*CaptureStatus{}, replications)
 	require.Len(t, tasks, 0)
 
 	// move a not exist table
@@ -53,7 +59,8 @@ func TestSchedulerMoveTable(t *testing.T) {
 
 	// move table not replicating
 	scheduler.addTask(model.TableID(1), "b")
-	tasks = scheduler.Schedule(checkpointTs, currentTables, captures, map[model.TableID]*ReplicationSet{})
+	tasks = scheduler.Schedule(
+		checkpointTs, currentTables, captures, map[model.TableID]*ReplicationSet{})
 	require.Len(t, tasks, 0)
 
 	scheduler.addTask(model.TableID(1), "b")
@@ -68,4 +75,11 @@ func TestSchedulerMoveTable(t *testing.T) {
 	require.Equal(t, model.TableID(1), tasks[0].moveTable.TableID)
 	require.Equal(t, "b", tasks[0].moveTable.DestCapture)
 	require.Equal(t, scheduler.tasks[model.TableID(1)], tasks[0])
+
+	// the target capture is stopping
+	scheduler.addTask(model.TableID(1), "b")
+	captures["b"].State = CaptureStateStopping
+	tasks = scheduler.Schedule(checkpointTs, currentTables, captures, replications)
+	require.Len(t, tasks, 0)
+	require.NotContains(t, scheduler.tasks, model.TableID(1))
 }

--- a/cdc/scheduler/internal/tp/scheduler_rebalance.go
+++ b/cdc/scheduler/internal/tp/scheduler_rebalance.go
@@ -58,6 +58,15 @@ func (r *rebalanceScheduler) Schedule(
 		return nil
 	}
 
+	for _, capture := range captures {
+		if capture.State == CaptureStateStopping {
+			log.Debug("tpscheduler: capture is stopping, " +
+				"ignore manual rebalance request")
+			atomic.StoreInt32(&r.rebalance, 0)
+			return nil
+		}
+	}
+
 	// only rebalance when all tables are replicating
 	for _, tableID := range currentTables {
 		rep, ok := replications[tableID]

--- a/cdc/scheduler/internal/tp/scheduler_rebalance_test.go
+++ b/cdc/scheduler/internal/tp/scheduler_rebalance_test.go
@@ -75,6 +75,14 @@ func TestSchedulerRebalance(t *testing.T) {
 		Primary: "a",
 	}
 
+	// capture is stopping, ignore the request
+	captures["a"].State = CaptureStateStopping
+	tasks = scheduler.Schedule(checkpointTs, currentTables, captures, replications)
+	require.Len(t, tasks, 0)
+	require.Equal(t, atomic.LoadInt32(&scheduler.rebalance), int32(0))
+
+	captures["a"].State = CaptureStateInitialized
+	atomic.StoreInt32(&scheduler.rebalance, 1)
 	scheduler.random = nil // disable random to make test easier.
 	tasks = scheduler.Schedule(checkpointTs, currentTables, captures, replications)
 	require.Len(t, tasks, 1)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6098

### What is changed and how it works?

`MoveTable` and `Rebalance` may be triggered when the capture is draining.

After the capture drained, it becomes `stopping`, then `MoveTable` and `Rebalance` request should be ignored, otherwise the drained capture will always reject add the table.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
