### PR TITLE
chaos(engine): add pr trigger in engine chaos test

### DIFF
--- a/.github/workflows/dataflow_engine_chaos.yaml
+++ b/.github/workflows/dataflow_engine_chaos.yaml
@@ -3,6 +3,12 @@ name: Dataflow Engine Chaos
 on:
   schedule:
     - cron: '0 17-23 * * *' # run at minute 0 every hour from 01:00 ~ 07:00 UTC+8
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'Which PR do you want to trigger'
+        required: true
+        default: ''
 
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 concurrency:

--- a/.github/workflows/dataflow_engine_chaos.yaml
+++ b/.github/workflows/dataflow_engine_chaos.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       pr:
-        description: 'Which PR do you want to trigger'
+        description: 'Which PR do you want to trigger (use PR number, such as 6127)'
         required: true
         default: ''
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #5640

### What is changed and how it works?

Support to trigger dataflow engine chaos test in workflow.

The same as dm chaos test workflow, usage example:

<img width="942" alt="Screen Shot 2022-06-30 at 13 08 11" src="https://user-images.githubusercontent.com/1527315/176597295-57f51826-3d79-4cb1-b193-115482525ce2.png">


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
