### PR TITLE
scheduler(cdc): speed up balancing when a new capture online

### DIFF
--- a/cdc/scheduler/internal/tp/scheduler_balance_test.go
+++ b/cdc/scheduler/internal/tp/scheduler_balance_test.go
@@ -44,8 +44,21 @@ func TestSchedulerBalanceCaptureOnline(t *testing.T) {
 	tasks = sched.Schedule(0, currentTables, captures, replications)
 	require.Len(t, tasks, 0)
 
+	// New capture "b" online, it keeps balancing, even though it has not pass
+	// balance interval yet.
+	sched.checkBalanceInterval = time.Hour
+	captures = map[model.CaptureID]*CaptureStatus{"a": {}, "b": {}}
+	currentTables = []model.TableID{1, 2}
+	replications = map[model.TableID]*ReplicationSet{
+		1: {State: ReplicationSetStateReplicating, Primary: "a"},
+		2: {State: ReplicationSetStateReplicating, Primary: "a"},
+	}
+	tasks = sched.Schedule(0, currentTables, captures, replications)
+	require.Len(t, tasks, 1)
+
 	// New capture "b" online, but this time it not pass check balance interval.
 	sched.checkBalanceInterval = time.Hour
+	sched.keepBalance = false
 	captures = map[model.CaptureID]*CaptureStatus{"a": {}, "b": {}}
 	currentTables = []model.TableID{1, 2}
 	replications = map[model.TableID]*ReplicationSet{


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #4757 

### What is changed and how it works?

Speeds up balancing by `keepBalance` if the last time schedule tasks is not empty.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

master | this branch
-- | --
 <img width="372" alt="image" src="https://user-images.githubusercontent.com/2150711/177125791-dd5365d1-0bee-406d-9b4a-4079ac958192.png"> | <img width="372" alt="image" src="https://user-images.githubusercontent.com/2150711/177125873-4f0bbd43-59ab-42de-9852-d44f09247f4e.png">


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
