### PR TITLE
chaos(engine): fix time shift case, use correct string type

### DIFF
--- a/engine/chaos/manifests/time-shift-dataflow.yaml
+++ b/engine/chaos/manifests/time-shift-dataflow.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     app: time-shift-dataflow
 spec:
-  mode: fixed
-  value: 5
+  mode: "random-max-percent"
+  value: "60"
   duration: "30s"
   selector:
     pods:


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #5640
and  #6143

### What is changed and how it works?

`v1alpha1.TimeChaosSpec.Value: ReadString: expects " or n, but found 5`

- Value should be a string type.
- Use random-max-percent to add some randomness.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
