### PR TITLE
cli(ticdc): remove server version information from cdc version command

### DIFF
--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -14,54 +14,18 @@
 package version
 
 import (
-	"fmt"
-
-	"github.com/pingcap/log"
-	cmdcontext "github.com/pingcap/tiflow/pkg/cmd/context"
-	"github.com/pingcap/tiflow/pkg/cmd/factory"
-	"github.com/pingcap/tiflow/pkg/cmd/util"
-	"github.com/pingcap/tiflow/pkg/logutil"
 	"github.com/pingcap/tiflow/pkg/version"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 )
 
 // NewCmdVersion creates the `version` command.
 func NewCmdVersion() *cobra.Command {
-	cf := factory.NewClientFlags()
-	// Construct the client construction factory.
-	f := factory.NewFactory(cf)
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "version",
 		Short: "Output version information",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			// Here we will initialize the logging configuration
-			// and set the current default context.
-			util.InitCmd(cmd, &logutil.Config{Level: cf.GetLogLevel()})
-			util.LogHTTPProxies()
-			return nil
-		},
-		Args: cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.Println("cli version:")
-			cmd.Println(version.GetRawInfo())
-			apiClient, err := f.APIV1Client()
-			if err != nil {
-				return err
-			}
-			ctx := cmdcontext.GetDefaultContext()
-			status, err := apiClient.Status().Get(ctx)
-			if err != nil {
-				log.Warn("get server version failed", zap.Error(err))
-				return nil
-			}
-			cmd.Println("server version:")
-			cmd.Println(fmt.Sprintf(
-				"Release Version: %s\n"+
-					"Git Commit Hash: %s\n", status.Version, status.GitHash))
-			return nil
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Print(version.GetRawInfo())
 		},
 	}
-	cf.AddFlags(cmd)
-	return cmd
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #5663

### What is changed and how it works?
do not print the server info 


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
```
-> % bin/cdc version
Release Version: v6.2.0-master-dirty
Git Commit Hash: 4d2f8fea1f3aa849c0c0b0fba65a79d2d0d18ca8
Git Branch: remove-server-version-info-from-cli
UTC Build Time: 2022-07-11 09:37:08
Go Version: go version go1.18.1 darwin/arm64
Failpoint Build: false

```


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
