### PR TITLE
redo/(ticdc): Optimize redolog I/O performance

### DIFF
--- a/cdc/redo/writer/file_allocator.go
+++ b/cdc/redo/writer/file_allocator.go
@@ -1,0 +1,101 @@
+//  Copyright 2022 PingCAP, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package writer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pingcap/tiflow/cdc/redo/common"
+	"github.com/pingcap/tiflow/pkg/fsutil"
+)
+
+// ref: https://github.com/etcd-io/etcd/pull/4785
+// fileAllocator has two functionalities:
+// 1. create new file or reuse the existing file in advance
+//    before it will be written.
+// 2. pre-allocate disk space to mitigate the overhead of file metadata updating.
+type fileAllocator struct {
+	dir      string
+	fileType string
+	size     int64
+	count    int
+	fileCh   chan *os.File
+	errCh    chan error
+	doneCh   chan struct{}
+}
+
+func newFileAllocator(dir string, fileType string, size int64) *fileAllocator {
+	allocator := &fileAllocator{
+		dir:      dir,
+		fileType: fileType,
+		size:     size,
+		fileCh:   make(chan *os.File),
+		errCh:    make(chan error),
+		doneCh:   make(chan struct{}),
+	}
+
+	go allocator.run()
+
+	return allocator
+}
+
+// Open returns a file for writing, this tmp file needs to be renamed after calling Open().
+func (fl *fileAllocator) Open() (f *os.File, err error) {
+	select {
+	case f = <-fl.fileCh:
+	case err = <-fl.errCh:
+	}
+
+	return f, err
+}
+
+// Close close the doneCh to notify the background goroutine to exist.
+func (fl *fileAllocator) Close() error {
+	close(fl.doneCh)
+	return <-fl.errCh
+}
+
+func (fl *fileAllocator) alloc() (f *os.File, err error) {
+	filePath := filepath.Join(fl.dir, fmt.Sprintf("%s_%d.tmp", fl.fileType, fl.count))
+	f, err = os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, common.DefaultFileMode)
+	if err != nil {
+		return nil, err
+	}
+	err = fsutil.PreAllocate(f, fl.size)
+	if err != nil {
+		return nil, err
+	}
+	fl.count++
+	return f, nil
+}
+
+func (fl *fileAllocator) run() {
+	defer close(fl.errCh)
+	for {
+		f, err := fl.alloc()
+		if err != nil {
+			fl.errCh <- err
+			return
+		}
+		select {
+		case fl.fileCh <- f:
+		case <-fl.doneCh:
+			os.Remove(f.Name())
+			f.Close()
+			return
+		}
+	}
+}

--- a/cdc/redo/writer/file_allocator_test.go
+++ b/cdc/redo/writer/file_allocator_test.go
@@ -1,0 +1,41 @@
+//  Copyright 2022 PingCAP, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+package writer
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/pingcap/tiflow/cdc/redo/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileAllocateSuccess(t *testing.T) {
+	fl := newFileAllocator(t.TempDir(), common.DefaultRowLogFileType, defaultMaxLogSize)
+	defer fl.Close()
+
+	f, err := fl.Open()
+	require.Nil(t, err)
+	f.Close()
+}
+
+func TestFileAllocateFailed(t *testing.T) {
+	fl := newFileAllocator(t.TempDir(), common.DefaultRowLogFileType, math.MaxInt64)
+	defer fl.Close()
+
+	f, err := fl.Open()
+	require.Nil(t, f)
+	require.NotNil(t, err)
+	fmt.Println(err)
+}

--- a/errors.toml
+++ b/errors.toml
@@ -221,6 +221,11 @@ error = '''
 decode row data to datum failed
 '''
 
+["CDC:ErrDiskFull"]
+error = '''
+failed to preallocate file because disk is full
+'''
+
 ["CDC:ErrEncodeFailed"]
 error = '''
 encode failed: %s

--- a/pkg/errors/cdc_errors.go
+++ b/pkg/errors/cdc_errors.go
@@ -445,6 +445,9 @@ var (
 		"operate on a closed notifier",
 		errors.RFCCodeText("CDC:ErrOperateOnClosedNotifier"),
 	)
+	ErrDiskFull = errors.Normalize(
+		"failed to preallocate file because disk is full",
+		errors.RFCCodeText("CDC:ErrDiskFull"))
 
 	// encode/decode, data format and data integrity errors
 	ErrInvalidRecordKey = errors.Normalize(

--- a/pkg/fsutil/fadvise_linux.go
+++ b/pkg/fsutil/fadvise_linux.go
@@ -1,0 +1,39 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//go:build linux
+// +build linux
+
+package fsutil
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// DropPageCache us fadvise to tell OS the reclaim memory associated with the file
+// as soon as possible, which can avoid the unexpected I/O latency spike risk.
+func DropPageCache(name string) error {
+	f, err := os.Open(name)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if err = unix.Fadvise(f.fd, 0, 0, unix.FADV_DONTNEED); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/fsutil/fadvise_other.go
+++ b/pkg/fsutil/fadvise_other.go
@@ -1,0 +1,23 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//go:build !linux
+// +build !linux
+
+package fsutil
+
+// DropPageCache us fadvise to tell OS the reclaim memory associated with the file
+// as soon as possible, which can avoid the unexpected I/O latency spike risk.
+func DropPageCache(name string) error {
+	return nil
+}

--- a/pkg/fsutil/fadvise_test.go
+++ b/pkg/fsutil/fadvise_test.go
@@ -1,0 +1,33 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDropPageCache(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.test")
+
+	err := os.WriteFile(path, []byte("hello world"), 0o600)
+	require.Nil(t, err)
+
+	err = DropPageCache(path)
+	require.Nil(t, err)
+}

--- a/pkg/fsutil/preallocate_linux.go
+++ b/pkg/fsutil/preallocate_linux.go
@@ -1,0 +1,43 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//go:build linux
+// +build linux
+
+package fsutil
+
+import (
+	cerror "github.com/pingcap/tiflow/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+// PreAllocate can allocate disk space beforehand in case of ENOSPC error occurs
+// when writing a file, which is not uncommon for a rigorous redolog/WAL design.
+// Besides, pre-allocating disk space can reduce the overhead of file metadata updating.
+func PreAllocate(f *os.File, size int64) error {
+	if size == 0 {
+		return nil
+	}
+
+	err := unix.Fallocate(int(f.Fd()), 0, 0, size)
+	if err == unix.ENOTSUP || err == syscall.EINTR {
+		// fallback to use truncate.
+		return f.Truncate(size)
+	}
+
+	if err == unix.ENOSPC {
+		return cerror.ErrDiskFull
+	}
+
+	return errr
+}

--- a/pkg/fsutil/preallocate_other.go
+++ b/pkg/fsutil/preallocate_other.go
@@ -1,0 +1,27 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//go:build !linux
+// +build !linux
+
+package fsutil
+
+import "os"
+
+// PreAllocate can allocate disk space beforehand in case of ENOSPC error occurs
+// when writing a file, which is not uncommon for a rigorous redolog/WAL design.
+// Besides, pre-allocating disk space can reduce the overhead of file metadata updating.
+func PreAllocate(f *os.File, size int64) error {
+	// if the OS is not linux, use truncate as a fallback.
+	return f.Truncate(size)
+}

--- a/pkg/fsutil/preallocate_test.go
+++ b/pkg/fsutil/preallocate_test.go
@@ -1,0 +1,34 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package fsutil
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreAllocate(t *testing.T) {
+	f, err := ioutil.TempFile("", "preallocate-test")
+	require.Nil(t, err)
+
+	size := int64(64 * 1024 * 1024)
+	err = PreAllocate(f, size)
+	require.Nil(t, err)
+
+	stat, err := f.Stat()
+	require.Nil(t, err)
+	require.Equal(t, size, stat.Size())
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5920 

### What is changed and how it works?
1. rotate file after flushing when we use s3 storage in order to save network bandwidth resource.
2. always write file to s3 before closing it in order to avoid the expensive s3 rename operation.
3. release the metaLock as soon as possible to shorten the lock holding time.
4. drop page cache of a file if it is successfully written to s3 in order to mitigate the I/O latency spike risk.
5. pre-allocate file before writing  in order to avoid the ENOSPC error when the redolog entries are written, and also to reduce the file metadata updating overhead.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
