### PR TITLE
kv-client(ticdc): use a single deleteStream entrance

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -790,7 +790,7 @@ func (s *eventFeedSession) requestRegionToStore(
 			g.Go(func() error {
 				defer func() {
 					// TODO: add a random sleep, for test only
-					time.Sleep(time.Millisecond * time.Duration(rand.Intn(50)))
+					// time.Sleep(time.Millisecond * time.Duration(rand.Intn(50)))
 					s.deleteStream(rpcCtx.Addr)
 				}()
 				return s.receiveFromStream(ctx, g, rpcCtx.Addr, getStoreID(rpcCtx), stream.client, pendingRegions)


### PR DESCRIPTION
Signed-off-by: haojinming <jinming.hao@pingcap.com>

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?

DNM, test ony

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
