### PR TITLE
github(ticdc): make integration tests be executed after the build check is completed

### DIFF
--- a/.github/workflows/ticdc_integration.yaml
+++ b/.github/workflows/ticdc_integration.yaml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   MySQL-integration:
+    needs: [docker_build, mac_build, arm_build]
     runs-on: ubuntu-latest
 
     steps:
@@ -85,6 +86,7 @@ jobs:
           $GITHUB_WORKSPACE/scripts/avro-local-test.sh down
 
   OldValue-integration:
+    needs: [docker_build, mac_build, arm_build]
     runs-on: ubuntu-latest
 
     steps:
@@ -147,6 +149,7 @@ jobs:
           $GITHUB_WORKSPACE/scripts/avro-local-test.sh down
 
   Canal-integration:
+    needs: [docker_build, mac_build, arm_build]
     runs-on: ubuntu-latest
 
     steps:
@@ -209,6 +212,7 @@ jobs:
           $GITHUB_WORKSPACE/scripts/canal/canal-local-test.sh down
 
   Avro-integration:
+    needs: [docker_build, mac_build, arm_build]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref https://github.com/pingcap/tiflow/issues/3194

### What is changed and how it works?

make integration tests be executed after the build check is completed to reduce useless tests

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
