### PR TITLE
chaos(engine): fix metastore selector in k8s

### DIFF
--- a/engine/chaos/cases/config.go
+++ b/engine/chaos/cases/config.go
@@ -38,7 +38,7 @@ func newConfig() *config {
 	fs := cfg.FlagSet
 
 	fs.StringVar(&cfg.MasterAddr, "master-addr", "server-master:10240", "address of server-master")
-	fs.StringVar(&cfg.EtcdAddr, "etcd-addr", "metastore:12479", "address of etcd server(used by fake job)")
+	fs.StringVar(&cfg.EtcdAddr, "etcd-addr", "metastore-business:12479", "address of etcd server(used by fake job)")
 	fs.DurationVar(&cfg.Duration, "duration", 20*time.Minute, "duration of cases running")
 
 	fs.IntVar(&cfg.MasterCount, "master-count", 3, "expect count of server-master")

--- a/engine/chaos/manifests/conf/server-master.toml
+++ b/engine/chaos/manifests/conf/server-master.toml
@@ -2,9 +2,9 @@
 data-dir = "/data/etcd"
 
 [frame-metastore-conf]
-endpoints = ["metastore-framework-mysql-0.metastore:3306"]
+endpoints = ["metastore-framework:13306"]
 auth.user = "root"
 auth.passwd = ""
 
 [business-metastore-conf]
-endpoints = ["metastore:12479"]
+endpoints = ["metastore-business:12479"]

--- a/engine/chaos/manifests/metastore.yaml
+++ b/engine/chaos/manifests/metastore.yaml
@@ -96,6 +96,9 @@ spec:
         - name: metastore-business-etcd
           image: quay.io/coreos/etcd:v3.5.4
           imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: "/data/etcd"
+              name: metastore-business-etcd
           ports:
             - containerPort: 2479
               name: port-etcd
@@ -103,6 +106,7 @@ spec:
             - "etcd"
           args:
             - "--name=metastore-business-etcd"
+            - "--data-dir=/data/etcd"
             - "--advertise-client-urls=http://0.0.0.0:2479"
             - "--listen-client-urls=http://0.0.0.0:2479"
             - "--listen-peer-urls=http://127.0.0.1:2480"

--- a/engine/chaos/manifests/metastore.yaml
+++ b/engine/chaos/manifests/metastore.yaml
@@ -1,19 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: metastore
+  name: metastore-framework
   labels:
-    app: metastore
+    app: metastore-framework
 spec:
   ports:
     - name: port-mysql # note the name is no more than 15 characters
-      port: 3306
+      port: 13306
       targetPort: 3306
-    - name: port-etcd # note the name is no more than 15 characters
-      port: 12479
-      targetPort: 2479
   selector:
-    app: metastore
+    app: metastore-framework
 
 ---
 apiVersion: apps/v1
@@ -21,18 +18,18 @@ kind: StatefulSet
 metadata:
   name: metastore-framework-mysql
   labels:
-    app: metastore
+    app: metastore-framework
 spec:
   selector:
     matchLabels:
-      app: metastore
-  serviceName: metastore
+      app: metastore-framework
+  serviceName: metastore-framework
   replicas: 1
   podManagementPolicy: Parallel
   template:
     metadata:
       labels:
-        app: metastore
+        app: metastore-framework
     spec:
       containers:
         - name: metastore-framework-mysql
@@ -59,24 +56,41 @@ spec:
           requests:
             storage: 5Gi
 
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metastore-business
+  labels:
+    app: metastore-business
+spec:
+  ports:
+    - name: port-etcd # note the name is no more than 15 characters
+      port: 12479
+      targetPort: 2479
+  selector:
+    app: metastore-business
+
+
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: metastore-business-etcd
   labels:
-    app: metastore
+    app: metastore-business
 spec:
   selector:
     matchLabels:
-      app: metastore
-  serviceName: metastore
+      app: metastore-business
+  serviceName: metastore-business
   replicas: 1
   podManagementPolicy: Parallel
   template:
     metadata:
       labels:
-        app: metastore
+        app: metastore-business
     spec:
       containers:
         - name: metastore-business-etcd


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #5640

### What is changed and how it works?

- We share the same app label between framework mysql pod and business etcd pod, which leads to an unexpected service router from metastore service

```
metastore svc --> mysql
            | --> etcd
```
- Just separate them

```
metastore-framework svc --> mysql
metastore-business svc --> etcd
```

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test
 - verified in https://github.com/pingcap/tiflow/runs/7442423420?check_suite_focus=true

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
