### PR TITLE
test(dm): fix some unstable test

### DIFF
--- a/dm/tests/drop_column_with_index/run.sh
+++ b/dm/tests/drop_column_with_index/run.sh
@@ -11,7 +11,7 @@ function run() {
 	# need to return error three times, first for switch to remote binlog, second for auto retry
 	inject_points=(
 		"github.com/pingcap/tiflow/dm/syncer/binlogstream/SyncerGetEventError=return"
-		"github.com/pingcap/tiflow/dm/syncer/binlogstream/GetEventError=3*return"
+		"github.com/pingcap/tiflow/dm/syncer/binlogstream/GetEventError=return"
 	)
 	export GO_FAILPOINTS="$(join_string \; ${inject_points[@]})"
 

--- a/dm/tests/drop_column_with_index/run.sh
+++ b/dm/tests/drop_column_with_index/run.sh
@@ -11,7 +11,7 @@ function run() {
 	# need to return error three times, first for switch to remote binlog, second for auto retry
 	inject_points=(
 		"github.com/pingcap/tiflow/dm/syncer/binlogstream/SyncerGetEventError=return"
-		"github.com/pingcap/tiflow/dm/syncer/binlogstream/GetEventError=return"
+		"github.com/pingcap/tiflow/dm/syncer/binlogstream/GetEventError=3*return"
 	)
 	export GO_FAILPOINTS="$(join_string \; ${inject_points[@]})"
 

--- a/dm/tests/gtid/conf/source1.yaml
+++ b/dm/tests/gtid/conf/source1.yaml
@@ -8,5 +8,3 @@ from:
   user: root
   password: /Q7B9DizNLLTTfiZHv9WoEAKamfpIUs=
   port: 3306
-checker:
-  check-enable: false

--- a/dm/tests/gtid/conf/source2.yaml
+++ b/dm/tests/gtid/conf/source2.yaml
@@ -8,5 +8,3 @@ from:
   user: root
   password: /Q7B9DizNLLTTfiZHv9WoEAKamfpIUs=
   port: 3307
-checker:
-  check-enable: false

--- a/dm/tests/shardddl_optimistic/run.sh
+++ b/dm/tests/shardddl_optimistic/run.sh
@@ -378,8 +378,7 @@ function DM_UPDATE_BA_ROUTE_CASE() {
 	run_sql_tidb "alter table ${shardddl}.${tb} add column new_col1 int"
 
 	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
-		"resume-task test" \
-		"\"result\": true" 3
+		"resume-task test"
 
 	run_sql_source1 "alter table ${shardddl2}.${tb1} drop column new_col1"
 	run_sql_source2 "alter table ${shardddl2}.${tb1} drop column new_col1"


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6105

### What is changed and how it works?

- if checking the resulte of resume too quickly, we will see the old error
- in `gtid` test case we manually removed relay log, so when relay log is download, the task may not be able to find the position in checkpoint. We rely on auto-resume to handle it.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
