### PR TITLE
framework(engine): close worker in notify exit before sending finish heartbeat

### DIFF
--- a/engine/framework/internal/eventloop/interfaces.go
+++ b/engine/framework/internal/eventloop/interfaces.go
@@ -29,7 +29,16 @@ type Task interface {
 
 	// NotifyExit does necessary bookkeeping job for exiting,
 	// such as notifying a master.
+	// Note before notifying master, master or worker resource must be cleaned
+	// up, except for heartbeat message handler.
 	// errIn describes the reason for exiting.
+	// TODO: find a better way for the exiting logic. The implement of NotifyExit
+	// is a little tricky but we can ensure that after step-2 master can recreate
+	// worker without any concern.
+	// 1. Close worker impl
+	// 2. Cleanup other resources, including base master and base worker
+	// 3. Send finished heartbeat to master, and waits for pong message or timeout
+	// 4. Cleanup heartbeat message handler
 	NotifyExit(ctx context.Context, errIn error) error
 
 	// Close does necessary clean up.

--- a/engine/framework/internal/eventloop/runner.go
+++ b/engine/framework/internal/eventloop/runner.go
@@ -65,6 +65,7 @@ func (r *Runner[R]) Run(ctx context.Context) error {
 	if !isForcefulExitError(err) {
 		// Exit gracefully.
 		r.doGracefulExit(ctx, err)
+		return err
 	}
 
 	if closeErr := r.task.Close(context.Background()); closeErr != nil {

--- a/engine/framework/internal/eventloop/runner_test.go
+++ b/engine/framework/internal/eventloop/runner_test.go
@@ -78,6 +78,7 @@ func (t *toyTask) Poll(ctx context.Context) error {
 
 func (t *toyTask) NotifyExit(ctx context.Context, errIn error) error {
 	require.True(t.t, t.status.CAS(toyTaskRunning, toyTaskClosing))
+	require.NoError(t.t, t.Close(ctx))
 
 	args := t.Called(ctx, errIn)
 	return args.Error(0)

--- a/engine/framework/internal/worker/master_client.go
+++ b/engine/framework/internal/worker/master_client.go
@@ -306,6 +306,12 @@ func (m *MasterClient) WaitClosed(ctx context.Context) error {
 		return nil
 	}
 
+	// Sends a heartbeat with is-finished=true mark to master, because background
+	// heartbeat goroutine has exited before calling `WaitClosed`
+	if err := m.SendHeartBeat(ctx); err != nil {
+		return err
+	}
+
 	timer := m.clk.Timer(workerExitWaitForMasterTimeout)
 	defer timer.Stop()
 

--- a/engine/framework/worker.go
+++ b/engine/framework/worker.go
@@ -252,6 +252,7 @@ func (w *DefaultBaseWorker) NotifyExit(ctx context.Context, errIn error) (retErr
 	w.logger.Info("worker start exiting", zap.NamedError("cause", errIn))
 	return w.masterClient.WaitClosed(ctx)
 }
+
 func (w *DefaultBaseWorker) doPreInit(ctx context.Context) (retErr error) {
 	defer func() {
 		if retErr != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6239

### What is changed and how it works?

1. When a worker meets error and prepares to exit, it sends a `is-finished=true` heartbeat to master and waits for pong message.
2. the `WaitClosed` of master client in step 1 could timeout(may be caused by unstable network), during that time master can re-create workers.
3. The stale worker in step-1 keeps sending `is-finished=true` heartbeat to master, which leads to new spawned worker timeout soon(from the point of master). However the workers created in step-2 doesn't know this.

**Note: worker and master in the above scenario is job master/job manager pair, because the ID of job master doesn't chagne.**

One way to solve this problem is to guarantee the worker exits really before sending `is-finished` heartbeat to master.

This PR uses a tricky way, making `NotifyExit` works as following

1. Close worker impl
2. Cleanup other resources, including base master and base worker
3. Send finished heartbeat to master, and waits for pong message or timeout
4. Cleanup heartbeat message handler

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
