### PR TITLE
cli(cdc): handle error correctly with wrong pd address but with a grpc service

### DIFF
--- a/pkg/cmd/cli/cli_unsafe_reset.go
+++ b/pkg/cmd/cli/cli_unsafe_reset.go
@@ -36,13 +36,18 @@ func newUnsafeResetOptions() *unsafeResetOptions {
 }
 
 // complete adapts from the command line args to the data and client required.
-func (o *unsafeResetOptions) complete(f factory.Factory) error {
+func (o *unsafeResetOptions) complete(f factory.Factory) (retErr error) {
 	pdClient, err := f.PdClient()
 	if err != nil {
 		return err
 	}
-	o.pdClient = pdClient
+	defer func() {
+		if retErr != nil {
+			pdClient.Close()
+		}
+	}()
 
+	o.pdClient = pdClient
 	etcdClient, err := f.EtcdClient()
 	if err != nil {
 		pdClient.Close()

--- a/pkg/cmd/cli/cli_unsafe_reset.go
+++ b/pkg/cmd/cli/cli_unsafe_reset.go
@@ -36,13 +36,13 @@ func newUnsafeResetOptions() *unsafeResetOptions {
 }
 
 // complete adapts from the command line args to the data and client required.
-func (o *unsafeResetOptions) complete(f factory.Factory) (retErr error) {
+func (o *unsafeResetOptions) complete(f factory.Factory) (err error) {
 	pdClient, err := f.PdClient()
 	if err != nil {
 		return err
 	}
 	defer func() {
-		if retErr != nil {
+		if err != nil {
 			pdClient.Close()
 		}
 	}()

--- a/pkg/cmd/cli/cli_unsafe_reset.go
+++ b/pkg/cmd/cli/cli_unsafe_reset.go
@@ -45,6 +45,7 @@ func (o *unsafeResetOptions) complete(f factory.Factory) error {
 
 	etcdClient, err := f.EtcdClient()
 	if err != nil {
+		pdClient.Close()
 		return err
 	}
 	etcdClient.ClusterID = o.clusterID
@@ -60,6 +61,8 @@ func (o *unsafeResetOptions) addFlags(cmd *cobra.Command) {
 // run runs the `cli unsafe reset` command.
 func (o *unsafeResetOptions) run(cmd *cobra.Command) error {
 	ctx := context.GetDefaultContext()
+	defer o.pdClient.Close()
+	defer o.etcdClient.Close()
 
 	leases, err := o.etcdClient.GetCaptureLeases(ctx)
 	if err != nil {

--- a/pkg/cmd/cli/cli_unsafe_reset.go
+++ b/pkg/cmd/cli/cli_unsafe_reset.go
@@ -37,19 +37,18 @@ func newUnsafeResetOptions() *unsafeResetOptions {
 
 // complete adapts from the command line args to the data and client required.
 func (o *unsafeResetOptions) complete(f factory.Factory) error {
+	pdClient, err := f.PdClient()
+	if err != nil {
+		return err
+	}
+	o.pdClient = pdClient
+
 	etcdClient, err := f.EtcdClient()
 	if err != nil {
 		return err
 	}
 	etcdClient.ClusterID = o.clusterID
 	o.etcdClient = etcdClient
-
-	pdClient, err := f.PdClient()
-	if err != nil {
-		return err
-	}
-
-	o.pdClient = pdClient
 
 	return nil
 }

--- a/pkg/cmd/cli/cli_unsafe_reset.go
+++ b/pkg/cmd/cli/cli_unsafe_reset.go
@@ -48,9 +48,9 @@ func (o *unsafeResetOptions) complete(f factory.Factory) (retErr error) {
 	}()
 
 	o.pdClient = pdClient
+
 	etcdClient, err := f.EtcdClient()
 	if err != nil {
-		pdClient.Close()
 		return err
 	}
 	etcdClient.ClusterID = o.clusterID

--- a/pkg/cmd/factory/factory_impl.go
+++ b/pkg/cmd/factory/factory_impl.go
@@ -161,7 +161,7 @@ func (f factoryImpl) PdClient() (pd.Client, error) {
 	pdAddr := f.GetPdAddr()
 	if len(pdAddr) == 0 {
 		return nil, cerror.ErrInvalidServerOption.
-			GenWithStack("empty PD address. Please use --pd to specify PD cluster addresses")
+			GenWithStack("Empty PD address. Please use --pd to specify PD cluster addresses")
 	}
 	pdEndpoints := strings.Split(pdAddr, ",")
 	for _, ep := range pdEndpoints {

--- a/pkg/cmd/factory/factory_impl.go
+++ b/pkg/cmd/factory/factory_impl.go
@@ -90,6 +90,12 @@ func (f *factoryImpl) GetCredential() *security.Credential {
 
 // EtcdClient creates new cdc etcd client.
 func (f *factoryImpl) EtcdClient() (*etcd.CDCEtcdClient, error) {
+	// check pd-address is an actual pd cluster
+	_, err := f.PdClient()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	ctx := cmdconetxt.GetDefaultContext()
 	tlsConfig, err := f.ToTLSConfig()
 	if err != nil {

--- a/pkg/cmd/factory/factory_impl.go
+++ b/pkg/cmd/factory/factory_impl.go
@@ -232,6 +232,15 @@ func (f *factoryImpl) APIV2Client() (apiv2client.APIV2Interface, error) {
 	return apiv2client.NewAPIClient(serverAddr, f.clientGetter.GetCredential())
 }
 
+// findServerAddr find the cdc server address by the following logic
+// a) Only the cdc server address is specified: use it;
+// b) Only the PD address is specified:
+//   1) check the address and create a etcdClient
+// 	 2) check the etcd keys and find cdc cluster addresses:
+//	 	If there are multiple CDC clusters exist, report an error; otherwise,
+//	 	cache the server address in f.fetchedServerAddr and return it (since
+//	 	some cli cmds use both apiV1 and apiV2)
+// c) Both PD and cdc server addresses are specified: report an error
 func (f *factoryImpl) findServerAddr() (string, error) {
 	if f.fetchedServerAddr != "" {
 		return f.fetchedServerAddr, nil

--- a/pkg/cmd/factory/factory_impl.go
+++ b/pkg/cmd/factory/factory_impl.go
@@ -254,12 +254,13 @@ func (f *factoryImpl) findServerAddr() (string, error) {
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	pdClient.Close()
+	defer pdClient.Close()
 	// use pd to get server addr from etcd
 	etcdClient, err := f.EtcdClient()
 	if err != nil {
 		return "", errors.Trace(err)
 	}
+	defer etcdClient.Close()
 
 	ctx := cmdconetxt.GetDefaultContext()
 	err = etcdClient.CheckMultipleCDCClusterExist(ctx)

--- a/pkg/cmd/factory/factory_impl.go
+++ b/pkg/cmd/factory/factory_impl.go
@@ -141,7 +141,8 @@ func (f *factoryImpl) EtcdClient() (*etcd.CDCEtcdClient, error) {
 	client, err := etcd.NewCDCEtcdClient(ctx, etcdClient, etcd.DefaultCDCClusterID)
 	if err != nil {
 		return nil, cerror.ErrEtcdAPIError.GenWithStack(
-			"Etcd operation error. Please check the cluster's status and the pd address(es)  \"%s\"")
+			"Etcd operation error. Please check the cluster's status " +
+				" and the pd address(es) \"%s\"")
 	}
 
 	return &client, err

--- a/pkg/cmd/factory/factory_impl.go
+++ b/pkg/cmd/factory/factory_impl.go
@@ -135,13 +135,13 @@ func (f *factoryImpl) EtcdClient() (*etcd.CDCEtcdClient, error) {
 	})
 	if err != nil {
 		return nil, errors.Annotatef(err,
-			"fail to open PD client, please check pd address \"%s\"", pdAddr)
+			"Fail to open PD client. Please check the pd address(es) \"%s\"", pdAddr)
 	}
 
 	client, err := etcd.NewCDCEtcdClient(ctx, etcdClient, etcd.DefaultCDCClusterID)
 	if err != nil {
 		return nil, cerror.ErrEtcdAPIError.GenWithStack(
-			"etcd operation error, please the cluster status and the address is correct: \"%s\"")
+			"Etcd operation error. Please check the cluster's status and the pd address(es)  \"%s\"")
 	}
 
 	return &client, err
@@ -160,7 +160,7 @@ func (f factoryImpl) PdClient() (pd.Client, error) {
 	pdAddr := f.GetPdAddr()
 	if len(pdAddr) == 0 {
 		return nil, cerror.ErrInvalidServerOption.
-			GenWithStack("empty PD address, please use --pd to specify PD cluster addresses")
+			GenWithStack("empty PD address. Please use --pd to specify PD cluster addresses")
 	}
 	pdEndpoints := strings.Split(pdAddr, ",")
 	for _, ep := range pdEndpoints {
@@ -189,7 +189,7 @@ func (f factoryImpl) PdClient() (pd.Client, error) {
 		))
 	if err != nil {
 		return nil, errors.Annotatef(err,
-			"fail to open PD client, please check pd address \"%s\"", pdAddr)
+			"Fail to open PD client. Please check the pd address(es)  \"%s\"", pdAddr)
 	}
 
 	err = version.CheckClusterVersion(ctx, pdClient, pdEndpoints, credential, true)

--- a/pkg/cmd/factory/factory_impl_test.go
+++ b/pkg/cmd/factory/factory_impl_test.go
@@ -71,7 +71,7 @@ func TestFactoryImplPdClient(t *testing.T) {
 	c.EXPECT().GetPdAddr().Return(pdAddr).Times(1)
 	pdClient, err = f.PdClient()
 	require.Nil(t, pdClient)
-	require.Contains(t, err.Error(), "fail to open PD client")
+	require.Contains(t, err.Error(), "Fail to open PD client")
 }
 
 type mockAPIClient struct {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6458 

### What is changed and how it works?
Check the PD address(es) by trying to create a PDClient before creating the EtcdClient. The address is guaranteed to represent a valid PD cluster if the PDClient was created successfully.

Previous checks assume the PD address is correct if the EtcdClient got created successfully. However, the EtcdClient can be created without error as long as there is a gRPC service, and it may not a real PD/Etcd cluster. 

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->
 - Manual test
   - Start a tidb cluster and a ticdc cluster
   - Operate cdc cli `cdc cli changefeed list --pd=xxx`, but use the cdc server address as the wrong pd address. 
   - Check the error message. It should tell the user to check the pd address 
<img width="978" alt="image" src="https://user-images.githubusercontent.com/25715282/181700868-89db950a-0e31-4b1d-bcb6-4406514c6294.png">

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`Bug fix: handle error correctly with wrong pd address but with a grpc service`
```
