### PR TITLE
test(dm): wait data is replicated to fix unstable test

### DIFF
--- a/dm/tests/gtid/run.sh
+++ b/dm/tests/gtid/run.sh
@@ -109,7 +109,7 @@ function run() {
 	run_sql_source2 "insert into gtid.t2 values (4)"
 	# now Previous_gtids event is 09bec856-ba95-11ea-850a-58f2b4af5188:1-4:6
 
-	sleep 1
+	check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
 	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"stop-task test" \
 		"\"result\": true" 3


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6105

### What is changed and how it works?

if the task is stopped at gtid set xxx:1-3, because we will remove local relay log files and it will start to pull relay log from 1-3:6 because we manually FLUSH LOGS here, the task will fail

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
 `None`.
```
