### PR TITLE
test(dm): fix unstable test due to rely on sleep X seconds

### DIFF
--- a/dm/tests/checkpoint_transaction/run.sh
+++ b/dm/tests/checkpoint_transaction/run.sh
@@ -82,8 +82,7 @@ function run() {
 	check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
 	run_sql_file $cur/data/db1.increment1.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1
 	# wait transaction start
-	# you can see why sleep in https://github.com/pingcap/dm/pull/1928#issuecomment-895820239
-	sleep 2
+	check_log_contain_with_retry "receive dml job" $WORK_DIR/worker1/log/dm-worker.log
 	echo "pause task and check status"
 	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"pause-task test" \
@@ -124,8 +123,7 @@ function run() {
 
 	run_sql_file $cur/data/db1.increment2.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1
 	# wait transaction start
-	# you can see why sleep in https://github.com/pingcap/dm/pull/1928#issuecomment-895820239
-	sleep 2
+	check_log_contain_with_retry "receive dml job" $WORK_DIR/worker1/log/dm-worker.log
 	echo "stop task"
 	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"stop-task test" \


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6528

### What is changed and how it works?

syncer will sleep 0.5 seconds for each DML job, and there'are 30 DML jobs. So we have confident to check the log every seconds to know syncer is processing inside the transaction.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
