### PR TITLE
srvdiscovery(engine): disable etcd auto sync, add timeout to snapshot op

### DIFF
--- a/engine/pkg/config/constants.go
+++ b/engine/pkg/config/constants.go
@@ -19,6 +19,9 @@ import (
 
 // Define some constants
 const (
-	ServerMasterEtcdDialTimeout  = 5 * time.Second
-	ServerMasterEtcdSyncInterval = 3 * time.Second
+	ServerMasterEtcdDialTimeout = 5 * time.Second
+	// Disable endpoints auto sync in etcd client. Make sure to pass a load
+	// balancer address(such as service endpoint in K8s), or all advertise-addrs
+	// of the etcd cluster.
+	ServerMasterEtcdSyncInterval = time.Duration(0)
 )

--- a/engine/pkg/srvdiscovery/etcd_impl.go
+++ b/engine/pkg/srvdiscovery/etcd_impl.go
@@ -26,6 +26,8 @@ import (
 
 const defaultWatchChanSize = 8
 
+const defaultGetSnapshotTimeout = 5 * time.Second
+
 // EtcdSrvDiscovery implements Discovery interface based on etcd as backend storage
 // Note this struct is not thread-safe, and can be watched only once.
 type EtcdSrvDiscovery struct {
@@ -139,6 +141,8 @@ func (d *EtcdSrvDiscovery) delta(ctx context.Context) (
 func (d *EtcdSrvDiscovery) getSnapshot(ctx context.Context) (
 	map[UUID]ServiceResource, error,
 ) {
+	ctx, cancel := context.WithTimeout(ctx, defaultGetSnapshotTimeout)
+	defer cancel()
 	resp, err := d.etcdCli.Get(ctx, d.keyAdapter.Path(), clientv3.WithPrefix())
 	if err != nil {
 		return nil, errors.WrapError(errors.ErrEtcdAPIError, err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6524

### What is changed and how it works?

- Disable endpoints auto sync in etcd client.
- Add a timeout to `getSnapshot` operation in service discovery lib.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
