### PR TITLE
scheduler(ticdc): fix premature promotion after restarting commit

### DIFF
--- a/cdc/scheduler/internal/v3/capture_manager.go
+++ b/cdc/scheduler/internal/v3/capture_manager.go
@@ -161,11 +161,8 @@ func (c *captureManager) Tick(
 	c.tickCounter = 0
 	tables := make(map[model.CaptureID][]model.TableID)
 	for tableID, rep := range reps {
-		if rep.Primary != "" {
-			tables[rep.Primary] = append(tables[rep.Primary], tableID)
-		}
-		if rep.Secondary != "" {
-			tables[rep.Secondary] = append(tables[rep.Secondary], tableID)
+		for captureID := range rep.Captures {
+			tables[captureID] = append(tables[captureID], tableID)
 		}
 	}
 	msgs := make([]*schedulepb.Message, 0, len(c.Captures))

--- a/cdc/scheduler/internal/v3/capture_manager_test.go
+++ b/cdc/scheduler/internal/v3/capture_manager_test.go
@@ -212,9 +212,9 @@ func TestCaptureManagerTick(t *testing.T) {
 	msgs = cm.Tick(nil, captureIDNotDraining)
 	require.Empty(t, msgs)
 	tables := map[model.TableID]*ReplicationSet{
-		1: {Primary: "1"},
-		2: {Primary: "1", Secondary: "2"},
-		3: {Secondary: "2"},
+		1: {Captures: map[model.CaptureID]struct{}{"1": {}}},
+		2: {Captures: map[model.CaptureID]struct{}{"1": {}, "2": {}}},
+		3: {Captures: map[model.CaptureID]struct{}{"2": {}}},
 		4: {},
 	}
 	msgs = cm.Tick(tables, captureIDNotDraining)

--- a/cdc/scheduler/internal/v3/replication_manager.go
+++ b/cdc/scheduler/internal/v3/replication_manager.go
@@ -384,7 +384,7 @@ func (r *replicationManager) handleBurstBalanceTasks(
 	for _, task := range task.RemoveTables {
 		perCapture[task.CaptureID]++
 	}
-	fields := make([]zap.Field, 0, len(perCapture)+3)
+	fields := make([]zap.Field, 0)
 	for captureID, count := range perCapture {
 		fields = append(fields, zap.Int(captureID, count))
 	}

--- a/cdc/scheduler/internal/v3/replication_manager_test.go
+++ b/cdc/scheduler/internal/v3/replication_manager_test.go
@@ -654,15 +654,17 @@ func TestReplicationManagerHandleCaptureChanges(t *testing.T) {
 			{TableID: 2, State: schedulepb.TableStatePreparing},
 		},
 		"4": {{TableID: 4, State: schedulepb.TableStateStopping}},
+		"5": {{TableID: 5, State: schedulepb.TableStateStopped}},
 	}}
 	msgs, err := r.HandleCaptureChanges(&changes, 0)
 	require.Nil(t, err)
 	require.Len(t, msgs, 0)
-	require.Len(t, r.tables, 4)
+	require.Len(t, r.tables, 5)
 	require.Equal(t, ReplicationSetStateReplicating, r.tables[1].State)
 	require.Equal(t, ReplicationSetStatePrepare, r.tables[2].State)
 	require.Equal(t, ReplicationSetStateReplicating, r.tables[3].State)
-	require.Equal(t, ReplicationSetStateAbsent, r.tables[4].State)
+	require.Equal(t, ReplicationSetStateRemoving, r.tables[4].State)
+	require.Equal(t, ReplicationSetStateAbsent, r.tables[5].State)
 
 	changes = captureChanges{Removed: map[string][]schedulepb.TableStatus{
 		"1": {{TableID: 1, State: schedulepb.TableStateReplicating}},
@@ -670,11 +672,12 @@ func TestReplicationManagerHandleCaptureChanges(t *testing.T) {
 	msgs, err = r.HandleCaptureChanges(&changes, 0)
 	require.Nil(t, err)
 	require.Len(t, msgs, 0)
-	require.Len(t, r.tables, 4)
+	require.Len(t, r.tables, 5)
 	require.Equal(t, ReplicationSetStateAbsent, r.tables[1].State)
 	require.Equal(t, ReplicationSetStatePrepare, r.tables[2].State)
 	require.Equal(t, ReplicationSetStateReplicating, r.tables[3].State)
-	require.Equal(t, ReplicationSetStateAbsent, r.tables[4].State)
+	require.Equal(t, ReplicationSetStateRemoving, r.tables[4].State)
+	require.Equal(t, ReplicationSetStateAbsent, r.tables[5].State)
 }
 
 func TestReplicationManagerHandleCaptureChangesDuringAddTable(t *testing.T) {

--- a/cdc/scheduler/internal/v3/replication_set_test.go
+++ b/cdc/scheduler/internal/v3/replication_set_test.go
@@ -139,7 +139,7 @@ func TestNewReplicationSet(t *testing.T) {
 			set: &ReplicationSet{
 				State:     ReplicationSetStateCommit,
 				Secondary: "1",
-				Captures:  map[string]struct{}{"1": {}},
+				Captures:  map[string]struct{}{"1": {}, "2": {}},
 			},
 			tableStatus: map[model.CaptureID]*schedulepb.TableStatus{
 				"1": {
@@ -173,8 +173,8 @@ func TestNewReplicationSet(t *testing.T) {
 		{
 			// Rebuild remove table state, Removing.
 			set: &ReplicationSet{
-				State:    ReplicationSetStateAbsent,
-				Captures: map[string]struct{}{},
+				State:    ReplicationSetStateRemoving,
+				Captures: map[string]struct{}{"1": {}, "2": {}},
 			},
 			tableStatus: map[model.CaptureID]*schedulepb.TableStatus{
 				"1": {
@@ -1195,4 +1195,137 @@ func TestReplicationSetMoveTableSameDestCapture(t *testing.T) {
 	require.Equal(t, ReplicationSetStateReplicating, r.State)
 	require.Equal(t, "", r.Secondary)
 	require.Equal(t, source, r.Primary)
+}
+
+func TestReplicationSetCommitRestart(t *testing.T) {
+	t.Parallel()
+
+	// Primary has received remove table message and is currently stopping.
+	tableStatus := map[model.CaptureID]*schedulepb.TableStatus{
+		"1": {
+			State:      schedulepb.TableStatePrepared,
+			Checkpoint: schedulepb.Checkpoint{},
+		},
+		"2": {
+			State:      schedulepb.TableStateStopping,
+			Checkpoint: schedulepb.Checkpoint{},
+		},
+	}
+	r, err := newReplicationSet(0, 0, tableStatus, model.ChangeFeedID{})
+	require.Nil(t, err)
+	require.Equal(t, ReplicationSetStateCommit, r.State)
+	require.Equal(t, "1", r.Secondary)
+	require.Equal(t, "", r.Primary)
+	require.Contains(t, r.Captures, "2")
+
+	// Can not promote to primary as there are other captures.
+	msgs, err := r.handleTableStatus("1", &schedulepb.TableStatus{
+		TableID: 0,
+		State:   schedulepb.TableStatePrepared,
+	})
+	require.Nil(t, err)
+	require.Len(t, msgs, 0)
+	require.Equal(t, ReplicationSetStateCommit, r.State)
+	require.Equal(t, "1", r.Secondary)
+	require.Equal(t, "", r.Primary)
+	require.Contains(t, r.Captures, "2")
+
+	// Table status reported by other captures does not change replication set.
+	msgs, err = r.handleTableStatus("2", &schedulepb.TableStatus{
+		TableID: 0,
+		State:   schedulepb.TableStateStopping,
+	})
+	require.Nil(t, err)
+	require.Len(t, msgs, 0)
+	require.Equal(t, ReplicationSetStateCommit, r.State)
+	require.Equal(t, "1", r.Secondary)
+	require.Equal(t, "", r.Primary)
+	require.Contains(t, r.Captures, "2")
+
+	// Only Stopped or Absent allows secondary to be promoted.
+	rClone := clone(r)
+	msgs, err = rClone.handleTableStatus("2", &schedulepb.TableStatus{
+		TableID: 0,
+		State:   schedulepb.TableStateAbsent,
+	})
+	require.Nil(t, err)
+	require.Len(t, msgs, 0)
+	require.Equal(t, ReplicationSetStateCommit, rClone.State)
+	require.Equal(t, "1", rClone.Secondary)
+	require.Equal(t, "", rClone.Primary)
+	require.NotContains(t, rClone.Captures, "2")
+	msgs, err = r.handleTableStatus("2", &schedulepb.TableStatus{
+		TableID: 0,
+		State:   schedulepb.TableStateStopped,
+	})
+	require.Nil(t, err)
+	require.Len(t, msgs, 0)
+	require.Equal(t, ReplicationSetStateCommit, r.State)
+	require.Equal(t, "1", r.Secondary)
+	require.Equal(t, "", r.Primary)
+	require.NotContains(t, r.Captures, "2")
+
+	// No other captures, promote secondary.
+	msgs, err = r.handleTableStatus("1", &schedulepb.TableStatus{
+		TableID: 0,
+		State:   schedulepb.TableStatePrepared,
+	})
+	require.Nil(t, err)
+	require.Len(t, msgs, 1)
+	require.Equal(t, "1", msgs[0].To)
+	require.False(t, msgs[0].DispatchTableRequest.GetAddTable().IsSecondary)
+	require.Equal(t, ReplicationSetStateCommit, r.State)
+	require.Equal(t, "1", r.Primary)
+	require.Equal(t, "", r.Secondary)
+}
+
+func TestReplicationSetRemoveRestart(t *testing.T) {
+	t.Parallel()
+
+	// Primary has received remove table message and is currently stopping.
+	tableStatus := map[model.CaptureID]*schedulepb.TableStatus{
+		"1": {
+			State:      schedulepb.TableStateStopping,
+			Checkpoint: schedulepb.Checkpoint{},
+		},
+		"2": {
+			State:      schedulepb.TableStateStopping,
+			Checkpoint: schedulepb.Checkpoint{},
+		},
+	}
+	r, err := newReplicationSet(0, 0, tableStatus, model.ChangeFeedID{})
+	require.Nil(t, err)
+	require.Equal(t, ReplicationSetStateRemoving, r.State)
+	require.Equal(t, "", r.Secondary)
+	require.Equal(t, "", r.Primary)
+	require.Contains(t, r.Captures, "1")
+	require.Contains(t, r.Captures, "2")
+	require.False(t, r.hasRemoved())
+
+	// A capture reports its status.
+	msgs, err := r.handleTableStatus("2", &schedulepb.TableStatus{
+		TableID: 0,
+		State:   schedulepb.TableStateStopping,
+	})
+	require.Nil(t, err)
+	require.Len(t, msgs, 0)
+	require.False(t, r.hasRemoved())
+
+	// A capture stopped.
+	msgs, err = r.handleTableStatus("2", &schedulepb.TableStatus{
+		TableID: 0,
+		State:   schedulepb.TableStateStopped,
+	})
+	require.Nil(t, err)
+	require.Len(t, msgs, 0)
+	require.False(t, r.hasRemoved())
+
+	// Another capture stopped too.
+	msgs, err = r.handleTableStatus("1", &schedulepb.TableStatus{
+		TableID: 0,
+		State:   schedulepb.TableStateAbsent,
+	})
+	require.Nil(t, err)
+	require.Len(t, msgs, 0)
+	require.True(t, r.hasRemoved())
 }

--- a/cdc/scheduler/internal/v3/scheduler_balance.go
+++ b/cdc/scheduler/internal/v3/scheduler_balance.go
@@ -92,11 +92,8 @@ func buildBalanceMoveTables(
 		if !ok {
 			continue
 		}
-		if rep.Primary != "" {
-			captureTables[rep.Primary] = append(captureTables[rep.Primary], tableID)
-		}
-		if rep.Secondary != "" {
-			captureTables[rep.Secondary] = append(captureTables[rep.Secondary], tableID)
+		for captureID := range rep.Captures {
+			captureTables[captureID] = append(captureTables[captureID], tableID)
 		}
 	}
 

--- a/cdc/scheduler/internal/v3/scheduler_basic.go
+++ b/cdc/scheduler/internal/v3/scheduler_basic.go
@@ -179,11 +179,11 @@ func newBurstBalanceRemoveTables(
 	for _, tableID := range rmTables {
 		rep := replications[tableID]
 		var captureID model.CaptureID
-		if rep.Primary != "" {
-			captureID = rep.Primary
-		} else if rep.Secondary != "" {
-			captureID = rep.Secondary
-		} else {
+		for id := range rep.Captures {
+			captureID = id
+			break
+		}
+		if captureID == "" {
 			log.Warn("schedulerv3: primary or secondary not found for removed table",
 				zap.String("namespace", changefeedID.Namespace),
 				zap.String("changefeed", changefeedID.ID),

--- a/cdc/scheduler/internal/v3/scheduler_basic_test.go
+++ b/cdc/scheduler/internal/v3/scheduler_basic_test.go
@@ -76,7 +76,9 @@ func TestSchedulerBasic(t *testing.T) {
 		1: {State: ReplicationSetStateReplicating, Primary: "a"},
 		2: {State: ReplicationSetStateCommit, Secondary: "b"},
 		3: {State: ReplicationSetStatePrepare, Primary: "a", Secondary: "b"},
-		5: {State: ReplicationSetStateCommit, Primary: "a", Secondary: "b"},
+		5: {State: ReplicationSetStateCommit, Captures: map[model.CaptureID]struct{}{
+			"a": {}, "b": {},
+		}},
 	}
 	tasks = b.Schedule(2, currentTables, captures, replications)
 	require.Len(t, tasks, 2)
@@ -96,7 +98,9 @@ func TestSchedulerBasic(t *testing.T) {
 		2: {State: ReplicationSetStateCommit, Secondary: "b"},
 		3: {State: ReplicationSetStatePrepare, Primary: "a", Secondary: "b"},
 		4: {State: ReplicationSetStatePrepare, Primary: "a", Secondary: "b"},
-		5: {State: ReplicationSetStatePrepare, Secondary: "b"},
+		5: {State: ReplicationSetStateCommit, Captures: map[model.CaptureID]struct{}{
+			"b": {},
+		}},
 	}
 	tasks = b.Schedule(3, currentTables, captures, replications)
 	require.Len(t, tasks, 1)


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6538

### What is changed and how it works?

Do not promote secondary when there are other captures. It prevents premature promotion after restarting commit.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
