### PR TITLE
servermaster(engine): add readiness probe and advertise-leader-addr

### DIFF
--- a/engine/docs/swagger/docs.go
+++ b/engine/docs/swagger/docs.go
@@ -191,6 +191,23 @@ var doc = `{
                     }
                 }
             }
+        },
+        "/readyz": {
+            "get": {
+                "description": "check if the servermaster is ready to serve requests",
+                "tags": [
+                    "servermaster"
+                ],
+                "summary": "Check if the servermaster is ready to serve requests",
+                "responses": {
+                    "200": {
+                        "description": ""
+                    },
+                    "503": {
+                        "description": ""
+                    }
+                }
+            }
         }
     }
 }`

--- a/engine/docs/swagger/swagger.json
+++ b/engine/docs/swagger/swagger.json
@@ -172,6 +172,23 @@
                     }
                 }
             }
+        },
+        "/readyz": {
+            "get": {
+                "description": "check if the servermaster is ready to serve requests",
+                "tags": [
+                    "servermaster"
+                ],
+                "summary": "Check if the servermaster is ready to serve requests",
+                "responses": {
+                    "200": {
+                        "description": ""
+                    },
+                    "503": {
+                        "description": ""
+                    }
+                }
+            }
         }
     }
 }

--- a/engine/docs/swagger/swagger.yaml
+++ b/engine/docs/swagger/swagger.yaml
@@ -112,4 +112,15 @@ paths:
       summary: Pause a job
       tags:
       - jobs
+  /readyz:
+    get:
+      description: check if the servermaster is ready to serve requests
+      responses:
+        "200":
+          description: ""
+        "503":
+          description: ""
+      summary: Check if the servermaster is ready to serve requests
+      tags:
+      - servermaster
 swagger: "2.0"

--- a/engine/pkg/cmd/master/master.go
+++ b/engine/pkg/cmd/master/master.go
@@ -57,6 +57,8 @@ func newOptions() *options {
 func (o *options) addFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.masterConfig.Addr, "addr", o.masterConfig.Addr, "Set the listening address for server master")
 	cmd.Flags().StringVar(&o.masterConfig.AdvertiseAddr, "advertise-addr", o.masterConfig.AdvertiseAddr, "Set the advertise listening address for client communication")
+	cmd.Flags().StringVar(&o.masterConfig.AdvertiseLeaderAddr, "advertise-leader-addr", o.masterConfig.AdvertiseLeaderAddr,
+		"Set the advertise listening address for follower forwarding. If not set, use the value of `--advertise-addr` instead.")
 	cmd.Flags().StringSliceVar(&o.masterConfig.ETCDEndpoints, "etcd-endpoints", o.masterConfig.ETCDEndpoints, "etcd endpoints")
 
 	cmd.Flags().StringVar(&o.masterConfig.LogConf.File, "log-file", o.masterConfig.LogConf.File, "log file path")
@@ -137,6 +139,8 @@ func (o *options) complete(cmd *cobra.Command) error {
 			cfg.Addr = o.masterConfig.Addr
 		case "advertise-addr":
 			cfg.AdvertiseAddr = o.masterConfig.AdvertiseAddr
+		case "advertise-leader-addr":
+			cfg.AdvertiseLeaderAddr = o.masterConfig.AdvertiseLeaderAddr
 		case "etcd-endpoints":
 			cfg.ETCDEndpoints = o.masterConfig.ETCDEndpoints
 		case "log-file":

--- a/engine/pkg/rpcutil/server.go
+++ b/engine/pkg/rpcutil/server.go
@@ -33,10 +33,13 @@ import (
 
 // Member stores server member information
 // TODO: make it a protobuf field and can be shared by gRPC API
+// Note: member information is used for leader election and follower forwarding
+// only, do not use it for other purposes.
 type Member struct {
-	Name          string `json:"name"`
-	AdvertiseAddr string `json:"advertise-addr"`
-	IsLeader      bool   `json:"is-leader"`
+	Name                string `json:"name"`
+	AdvertiseAddr       string `json:"advertise-addr"`
+	AdvertiseLeaderAddr string `json:"advertise-leader-addr"`
+	IsLeader            bool   `json:"is-leader"`
 }
 
 // String implements json marshal

--- a/engine/servermaster/campaign.go
+++ b/engine/servermaster/campaign.go
@@ -141,7 +141,7 @@ func (s *Server) checkLeaderExists(ctx context.Context) (retry bool, err error) 
 		}
 
 		// step-2, case-b
-		if leader.Name == s.name() || leader.AdvertiseAddr == s.cfg.AdvertiseAddr {
+		if leader.Name == s.name() || leader.AdvertiseLeaderAddr == s.cfg.AdvertiseLeaderAddr {
 			// - leader.Name == s.name() means this server should be leader
 			// - leader.AdvertiseAddr == s.cfg.AdvertiseAddr means the old leader
 			//   has the same advertise addr as current server
@@ -160,7 +160,7 @@ func (s *Server) checkLeaderExists(ctx context.Context) (retry bool, err error) 
 		// step-2, case-c
 		leader.IsLeader = true
 		log.Info("start to watch server master leader",
-			zap.String("leader-name", leader.Name), zap.String("addr", leader.AdvertiseAddr))
+			zap.String("leader-name", leader.Name), zap.String("addr", leader.AdvertiseLeaderAddr))
 		s.watchLeader(ctx, leader, key, rev)
 		log.Info("server master leader changed")
 	}
@@ -169,7 +169,7 @@ func (s *Server) checkLeaderExists(ctx context.Context) (retry bool, err error) 
 }
 
 // TODO: we can use UpdateClients, don't need to close and re-create it.
-func (s *Server) createLeaderClient(ctx context.Context, addr string) {
+func (s *Server) createLeaderClient(addr string) {
 	s.closeLeaderClient()
 
 	// TODO support TLS
@@ -198,7 +198,7 @@ func (s *Server) watchLeader(ctx context.Context, m *rpcutil.Member, key []byte,
 	m.IsLeader = true
 	s.leader.Store(m)
 
-	s.createLeaderClient(ctx, m.AdvertiseAddr)
+	s.createLeaderClient(m.AdvertiseLeaderAddr)
 	defer s.leader.Store(&rpcutil.Member{})
 
 	watcher := clientv3.NewWatcher(s.etcdClient)

--- a/engine/servermaster/campaign_test.go
+++ b/engine/servermaster/campaign_test.go
@@ -182,6 +182,7 @@ func TestLeaderLoopWatchLeader(t *testing.T) {
 		id := "servermaster" + strconv.Itoa(i)
 		cfg := GetDefaultMasterConfig()
 		cfg.AdvertiseAddr = "servermaster" + strconv.Itoa(i)
+		cfg.AdvertiseLeaderAddr = cfg.AdvertiseAddr
 
 		s := &Server{
 			id:         id,
@@ -201,9 +202,10 @@ func TestLeaderLoopWatchLeader(t *testing.T) {
 		s.masterRPCHook = preRPCHook
 		s.leaderServiceFn = func(ctx context.Context) error {
 			s.leader.Store(&rpcutil.Member{
-				Name:          s.name(),
-				AdvertiseAddr: s.cfg.AdvertiseAddr,
-				IsLeader:      true,
+				Name:                s.name(),
+				AdvertiseAddr:       s.cfg.AdvertiseAddr,
+				AdvertiseLeaderAddr: s.cfg.AdvertiseLeaderAddr,
+				IsLeader:            true,
 			})
 			<-ctx.Done()
 			return nil

--- a/engine/servermaster/config.go
+++ b/engine/servermaster/config.go
@@ -60,8 +60,9 @@ const (
 type Config struct {
 	LogConf logutil.Config `toml:"log" json:"log"`
 
-	Addr          string `toml:"addr" json:"addr"`
-	AdvertiseAddr string `toml:"advertise-addr" json:"advertise-addr"`
+	Addr                string `toml:"addr" json:"addr"`
+	AdvertiseAddr       string `toml:"advertise-addr" json:"advertise-addr"`
+	AdvertiseLeaderAddr string `toml:"advertise-leader-addr" json:"advertise-leader-addr"`
 
 	ETCDEndpoints []string `toml:"etcd-endpoints" json:"etcd-endpoints"`
 
@@ -108,6 +109,9 @@ func (c *Config) AdjustAndValidate() (err error) {
 
 	if c.AdvertiseAddr == "" {
 		c.AdvertiseAddr = c.Addr
+	}
+	if c.AdvertiseLeaderAddr == "" {
+		c.AdvertiseLeaderAddr = c.AdvertiseAddr
 	}
 
 	c.KeepAliveInterval, err = time.ParseDuration(c.KeepAliveIntervalStr)
@@ -157,6 +161,7 @@ func GetDefaultMasterConfig() *Config {
 		},
 		Addr:                 defaultMasterAddr,
 		AdvertiseAddr:        "",
+		AdvertiseLeaderAddr:  "",
 		FrameMetaConf:        newFrameMetaConfig(),
 		BusinessMetaConf:     NewDefaultBusinessMetaConfig(),
 		KeepAliveTTLStr:      defaultKeepAliveTTL,

--- a/engine/servermaster/config_test.go
+++ b/engine/servermaster/config_test.go
@@ -25,6 +25,8 @@ func TestMetaStoreConfig(t *testing.T) {
 	t.Parallel()
 
 	testToml := `
+advertise-addr = "http://127.0.0.1:10241"
+
 [framework-metastore-conf]
 endpoints = ["mysql-0:3306"]
 auth.user = "root"
@@ -39,9 +41,10 @@ store-type = "etcd"
 
 	config := GetDefaultMasterConfig()
 	err := config.configFromFile(fileName)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = config.AdjustAndValidate()
-	require.Nil(t, err)
+	require.NoError(t, err)
+	require.Equal(t, "http://127.0.0.1:10241", config.AdvertiseLeaderAddr)
 
 	require.Equal(t, "mysql-0:3306", config.FrameMetaConf.Endpoints[0])
 	require.Equal(t, "root", config.FrameMetaConf.Auth.User)

--- a/engine/servermaster/openapi.go
+++ b/engine/servermaster/openapi.go
@@ -75,6 +75,8 @@ func NewOpenAPI(infoProvider ServerInfoProvider) *OpenAPI {
 
 // RegisterOpenAPIRoutes registers routes for OpenAPI.
 func RegisterOpenAPIRoutes(router *gin.Engine, openapi *OpenAPI) {
+	router.GET("/readyz", openapi.Readyz)
+
 	v1 := router.Group("/api/v1")
 	v1.Use(openapi.ForwardToLeader)
 	v1.Use(openapi.httpErrorHandler)
@@ -244,6 +246,21 @@ func (o *OpenAPI) CancelJob(c *gin.Context) {
 	_, _, _ = tenantID, projectID, jobID
 	// TODO: Implement it.
 	c.AbortWithStatus(http.StatusNotImplemented)
+}
+
+// Readyz checks if the servermaster is ready to serve requests.
+// @Summary Check if the servermaster is ready to serve requests
+// @Description check if the servermaster is ready to serve requests
+// @Tags servermaster
+// @Success 200
+// @Failure 503
+// @Router /readyz [get]
+func (o *OpenAPI) Readyz(c *gin.Context) {
+	if o.infoProvider.IsLeader() {
+		c.String(http.StatusOK, "OK")
+	} else {
+		c.String(http.StatusServiceUnavailable, "Not ready")
+	}
 }
 
 // ForwardToJobMaster forwards the request to job master.

--- a/engine/servermaster/openapi_test.go
+++ b/engine/servermaster/openapi_test.go
@@ -208,3 +208,33 @@ func TestForwardToLeader(t *testing.T) {
 	forwardReq := <-reqs
 	require.Equal(t, "/api/v1/jobs", forwardReq.URL.Path)
 }
+
+func TestReadyzReady(t *testing.T) {
+	infoProvider := &mockServerInfoProvider{
+		serverAddr: "server-0",
+		leaderAddr: "server-0",
+	}
+	openapi := NewOpenAPI(infoProvider)
+	router := gin.New()
+	RegisterOpenAPIRoutes(router, openapi)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
+}
+
+func TestReadyzNotReady(t *testing.T) {
+	infoProvider := &mockServerInfoProvider{
+		serverAddr: "server-0",
+		leaderAddr: "server-1",
+	}
+	openapi := NewOpenAPI(infoProvider)
+	router := gin.New()
+	RegisterOpenAPIRoutes(router, openapi)
+
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusServiceUnavailable, resp.Code)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/6609

### What is changed and how it works?

* Add a readiness probe with path `/readyz`.
* Add `advertise-leader-addr` for leader election and follower forwarding.

`advertise-leader-addr` is used for leader election and follower forwarding only. It is invisible to clients. 
After this modification, multiple servermasters can share the same `advertise-addr` in the Kubernetes environment.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
