### PR TITLE
scheduler,processor(ticdc): update capture liveness by heartbeat

### DIFF
--- a/cdc/capture/capture_test.go
+++ b/cdc/capture/capture_test.go
@@ -443,7 +443,8 @@ func TestCampaignLiveness(t *testing.T) {
 	require.Nil(t, err)
 	require.False(t, me.campaignFlag)
 
-	cp.liveness.Store(model.LivenessCaptureAlive)
+	// Force set alive.
+	cp.liveness = model.LivenessCaptureAlive
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {

--- a/cdc/model/http_model.go
+++ b/cdc/model/http_model.go
@@ -61,6 +61,7 @@ func NewHTTPError(err error) HTTPError {
 }
 
 // Liveness is the liveness status of a capture.
+// Liveness can only be changed from alive to stopping, and no way back.
 type Liveness int32
 
 const (
@@ -70,9 +71,10 @@ const (
 	LivenessCaptureStopping Liveness = 1
 )
 
-// Store the given liveness.
-func (l *Liveness) Store(v Liveness) {
-	atomic.StoreInt32((*int32)(l), int32(v))
+// Store the given liveness. Returns true if it success.
+func (l *Liveness) Store(v Liveness) bool {
+	return atomic.CompareAndSwapInt32(
+		(*int32)(l), int32(LivenessCaptureAlive), int32(v))
 }
 
 // Load the liveness.

--- a/cdc/model/http_model_test.go
+++ b/cdc/model/http_model_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestChangefeedCommonInfoMarshalJSON(t *testing.T) {
+	t.Parallel()
+
 	runningErr := &RunningError{
 		"",
 		string(errors.ErrProcessorUnknown.RFCCode()),
@@ -45,6 +47,8 @@ func TestChangefeedCommonInfoMarshalJSON(t *testing.T) {
 }
 
 func TestChangefeedDetailMarshalJSON(t *testing.T) {
+	t.Parallel()
+
 	runningErr := &RunningError{
 		"",
 		string(errors.ErrProcessorUnknown.RFCCode()),
@@ -65,4 +69,19 @@ func TestChangefeedDetailMarshalJSON(t *testing.T) {
 	cfInfoJSON, err = json.Marshal(cfDetail)
 	require.Nil(t, err)
 	require.Contains(t, string(cfInfoJSON), string(errors.ErrProcessorUnknown.RFCCode()))
+}
+
+func TestLiveness(t *testing.T) {
+	t.Parallel()
+
+	liveness := LivenessCaptureAlive
+
+	require.True(t, liveness.Store(LivenessCaptureAlive))
+	require.Equal(t, LivenessCaptureAlive, liveness.Load())
+
+	require.True(t, liveness.Store(LivenessCaptureStopping))
+	require.Equal(t, LivenessCaptureStopping, liveness.Load())
+
+	require.False(t, liveness.Store(LivenessCaptureAlive))
+	require.Equal(t, LivenessCaptureStopping, liveness.Load())
 }

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -77,7 +77,7 @@ type processor struct {
 
 	lazyInit            func(ctx cdcContext.Context) error
 	createTablePipeline func(ctx cdcContext.Context, tableID model.TableID, replicaInfo *model.TableReplicaInfo) (pipeline.TablePipeline, error)
-	newAgent            func(ctx cdcContext.Context) (scheduler.Agent, error)
+	newAgent            func(cdcContext.Context, *model.Liveness) (scheduler.Agent, error)
 
 	liveness     *model.Liveness
 	agent        scheduler.Agent
@@ -576,7 +576,7 @@ func (p *processor) tick(ctx cdcContext.Context, state *orchestrator.ChangefeedR
 
 	p.doGCSchemaStorage()
 
-	if err := p.agent.Tick(ctx, p.liveness.Load()); err != nil {
+	if err := p.agent.Tick(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
@@ -692,7 +692,7 @@ func (p *processor) lazyInitImpl(ctx cdcContext.Context) error {
 		return err
 	}
 
-	p.agent, err = p.newAgent(ctx)
+	p.agent, err = p.newAgent(ctx, p.liveness)
 	if err != nil {
 		return err
 	}
@@ -705,7 +705,9 @@ func (p *processor) lazyInitImpl(ctx cdcContext.Context) error {
 	return nil
 }
 
-func (p *processor) newAgentImpl(ctx cdcContext.Context) (ret scheduler.Agent, err error) {
+func (p *processor) newAgentImpl(
+	ctx cdcContext.Context, liveness *model.Liveness,
+) (ret scheduler.Agent, err error) {
 	messageServer := ctx.GlobalVars().MessageServer
 	messageRouter := ctx.GlobalVars().MessageRouter
 	etcdClient := ctx.GlobalVars().EtcdClient
@@ -713,10 +715,12 @@ func (p *processor) newAgentImpl(ctx cdcContext.Context) (ret scheduler.Agent, e
 	cfg := config.GetGlobalServerConfig().Debug
 	if cfg.EnableSchedulerV3 {
 		ret, err = scheduler.NewAgentV3(
-			ctx, captureID, messageServer, messageRouter, etcdClient, p, p.changefeedID)
+			ctx, captureID, liveness,
+			messageServer, messageRouter, etcdClient, p, p.changefeedID)
 	} else {
 		ret, err = scheduler.NewAgent(
-			ctx, captureID, messageServer, messageRouter, etcdClient, p, p.changefeedID)
+			ctx, captureID, liveness,
+			messageServer, messageRouter, etcdClient, p, p.changefeedID)
 	}
 	return ret, errors.Trace(err)
 }

--- a/cdc/processor/processor_test.go
+++ b/cdc/processor/processor_test.go
@@ -236,12 +236,11 @@ type mockAgent struct {
 
 	executor         scheduler.TableExecutor
 	lastCheckpointTs model.Ts
-	lastLiveness     model.Liveness
+	liveness         *model.Liveness
 	isClosed         bool
 }
 
-func (a *mockAgent) Tick(_ context.Context, liveness model.Liveness) error {
-	a.lastLiveness = liveness
+func (a *mockAgent) Tick(_ context.Context) error {
 	if len(a.executor.GetAllCurrentTables()) == 0 {
 		return nil
 	}
@@ -823,6 +822,12 @@ func TestProcessorLiveness(t *testing.T) {
 	ctx := cdcContext.NewBackendContext4Test(true)
 	liveness := model.LivenessCaptureAlive
 	p, tester := initProcessor4Test(ctx, t, &liveness)
+	p.lazyInit = func(ctx cdcContext.Context) error {
+		// Mock the newAgent procedure in p.lazyInitImpl,
+		// by passing p.liveness to mockAgent.
+		p.agent = &mockAgent{executor: p, liveness: p.liveness}
+		return nil
+	}
 
 	// First tick for creating position.
 	_, err := p.Tick(ctx, p.changefeed)
@@ -832,10 +837,12 @@ func TestProcessorLiveness(t *testing.T) {
 	// Second tick for init.
 	_, err = p.Tick(ctx, p.changefeed)
 	require.Nil(t, err)
-	require.Equal(t, model.LivenessCaptureAlive, p.agent.(*mockAgent).lastLiveness)
 
-	liveness.Store(model.LivenessCaptureStopping)
-	_, err = p.Tick(ctx, p.changefeed)
-	require.Nil(t, err)
-	require.Equal(t, model.LivenessCaptureStopping, p.agent.(*mockAgent).lastLiveness)
+	// Changing p.liveness affects p.agent liveness.
+	p.liveness.Store(model.LivenessCaptureStopping)
+	require.Equal(t, model.LivenessCaptureStopping, p.agent.(*mockAgent).liveness.Load())
+
+	// Changing p.agent liveness affects p.liveness.
+	p.agent.(*mockAgent).liveness.Store(model.LivenessCaptureAlive)
+	require.Equal(t, model.LivenessCaptureAlive, p.liveness.Load())
 }

--- a/cdc/processor/processor_test.go
+++ b/cdc/processor/processor_test.go
@@ -843,6 +843,7 @@ func TestProcessorLiveness(t *testing.T) {
 	require.Equal(t, model.LivenessCaptureStopping, p.agent.(*mockAgent).liveness.Load())
 
 	// Changing p.agent liveness affects p.liveness.
-	p.agent.(*mockAgent).liveness.Store(model.LivenessCaptureAlive)
+	// Force set liveness to alive.
+	*p.agent.(*mockAgent).liveness = model.LivenessCaptureAlive
 	require.Equal(t, model.LivenessCaptureAlive, p.liveness.Load())
 }

--- a/cdc/scheduler/internal/agent.go
+++ b/cdc/scheduler/internal/agent.go
@@ -26,7 +26,7 @@ import (
 // Note that Agent is not thread-safe
 type Agent interface {
 	// Tick is called periodically by the processor to drive the Agent's internal logic.
-	Tick(context.Context, model.Liveness) error
+	Tick(context.Context) error
 
 	// GetLastSentCheckpointTs returns the last checkpoint-ts already sent to the Owner.
 	GetLastSentCheckpointTs() (checkpointTs model.Ts)

--- a/cdc/scheduler/internal/v2/processor_agent.go
+++ b/cdc/scheduler/internal/v2/processor_agent.go
@@ -159,7 +159,7 @@ func NewAgent(
 	return ret, nil
 }
 
-func (a *agentImpl) Tick(ctx context.Context, liveness model.Liveness) error {
+func (a *agentImpl) Tick(ctx context.Context) error {
 	for _, errCh := range a.handlerErrChs {
 		select {
 		case <-ctx.Done():

--- a/cdc/scheduler/internal/v2/processor_agent_test.go
+++ b/cdc/scheduler/internal/v2/processor_agent_test.go
@@ -263,7 +263,7 @@ func TestAgentBasics(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test Point 2: First tick should sync the SyncMessage.
-	err = agent.Tick(suite.ctx, model.LivenessCaptureAlive)
+	err = agent.Tick(suite.ctx)
 	require.NoError(t, err)
 
 	select {
@@ -304,7 +304,7 @@ func TestAgentBasics(t *testing.T) {
 		Return(model.Ts(1000), model.Ts(1000))
 
 	require.Eventually(t, func() bool {
-		err = agent.Tick(suite.ctx, model.LivenessCaptureAlive)
+		err = agent.Tick(suite.ctx)
 		require.NoError(t, err)
 		if len(suite.tableExecutor.Running) != 1 {
 			return false
@@ -329,7 +329,7 @@ func TestAgentBasics(t *testing.T) {
 
 	suite.tableExecutor.On("GetCheckpoint").Return(model.Ts(1000), model.Ts(1000))
 	// Test Point 4: Accept an incoming DispatchTableMessage, and the AddTable method in TableExecutor can return true.
-	err = agent.Tick(suite.ctx, model.LivenessCaptureAlive)
+	err = agent.Tick(suite.ctx)
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
@@ -345,7 +345,7 @@ func TestAgentBasics(t *testing.T) {
 		default:
 		}
 
-		err = agent.Tick(suite.ctx, model.LivenessCaptureAlive)
+		err = agent.Tick(suite.ctx)
 		require.NoError(t, err)
 		return false
 	}, time.Second*3, time.Millisecond*10)
@@ -378,7 +378,7 @@ func TestAgentNoOwnerAtStartUp(t *testing.T) {
 
 	// Test Point 2: First ticks should not panic
 	for i := 0; i < 10; i++ {
-		err = agent.Tick(suite.ctx, model.LivenessCaptureAlive)
+		err = agent.Tick(suite.ctx)
 		require.NoError(t, err)
 	}
 
@@ -392,7 +392,7 @@ func TestAgentNoOwnerAtStartUp(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		err := agent.Tick(suite.ctx, model.LivenessCaptureAlive)
+		err := agent.Tick(suite.ctx)
 		require.NoError(t, err)
 		select {
 		case <-suite.ctx.Done():
@@ -452,7 +452,7 @@ func TestAgentTolerateClientClosed(t *testing.T) {
 
 	// Test Point 2: We should tolerate the error ErrPeerMessageClientClosed
 	for i := 0; i < 6; i++ {
-		err = agent.Tick(suite.ctx, model.LivenessCaptureAlive)
+		err = agent.Tick(suite.ctx)
 		require.NoError(t, err)
 	}
 
@@ -495,7 +495,7 @@ func TestNoFinishOperationBeforeSyncIsReceived(t *testing.T) {
 
 	suite.BlockSync()
 
-	err = agent.Tick(suite.ctx, model.LivenessCaptureAlive)
+	err = agent.Tick(suite.ctx)
 	require.NoError(t, err)
 
 	_, err = suite.ownerMessageClient.SendMessage(suite.ctx,
@@ -541,7 +541,7 @@ func TestNoFinishOperationBeforeSyncIsReceived(t *testing.T) {
 
 	start := time.Now()
 	for time.Since(start) < 100*time.Millisecond {
-		err := agent.Tick(suite.ctx, model.LivenessCaptureAlive)
+		err := agent.Tick(suite.ctx)
 		require.NoError(t, err)
 
 		select {
@@ -574,7 +574,7 @@ func TestNoFinishOperationBeforeSyncIsReceived(t *testing.T) {
 		default:
 		}
 
-		err := agent.Tick(suite.ctx, model.LivenessCaptureAlive)
+		err := agent.Tick(suite.ctx)
 		require.NoError(t, err)
 		return false
 	}, 1*time.Second, 10*time.Millisecond)
@@ -588,7 +588,7 @@ func TestNoFinishOperationBeforeSyncIsReceived(t *testing.T) {
 		default:
 		}
 
-		err := agent.Tick(suite.ctx, model.LivenessCaptureAlive)
+		err := agent.Tick(suite.ctx)
 		require.NoError(t, err)
 		return false
 	}, time.Second*3, time.Millisecond*10)
@@ -602,7 +602,7 @@ func TestNoFinishOperationBeforeSyncIsReceived(t *testing.T) {
 		default:
 		}
 
-		err := agent.Tick(suite.ctx, model.LivenessCaptureAlive)
+		err := agent.Tick(suite.ctx)
 		require.NoError(t, err)
 		return false
 	}, time.Second*3, time.Millisecond*10)

--- a/cdc/scheduler/internal/v3/agent/agent.go
+++ b/cdc/scheduler/internal/v3/agent/agent.go
@@ -193,14 +193,12 @@ func (a *agent) Tick(ctx context.Context) error {
 func (a *agent) handleLivenessUpdate(liveness model.Liveness) {
 	currentLiveness := a.liveness.Load()
 	if currentLiveness != liveness {
-		if currentLiveness == model.LivenessCaptureStopping {
-			// No way to go back, once it becomes shutting down,
-			return
+		ok := a.liveness.Store(liveness)
+		if ok {
+			log.Info("schedulerv3: agent updates liveness",
+				zap.String("old", currentLiveness.String()),
+				zap.String("new", liveness.String()))
 		}
-		log.Info("schedulerv3: agent updates liveness",
-			zap.String("old", currentLiveness.String()),
-			zap.String("new", liveness.String()))
-		a.liveness.Store(liveness)
 	}
 }
 

--- a/cdc/scheduler/internal/v3/agent/agent_test.go
+++ b/cdc/scheduler/internal/v3/agent/agent_test.go
@@ -157,8 +157,8 @@ func TestAgentHandleMessageDispatchTable(t *testing.T) {
 	}
 
 	// addTableRequest should be not ignored even if it's stopping.
-	a.liveness.Store(model.LivenessCaptureAlive)
 	a.handleLivenessUpdate(model.LivenessCaptureStopping)
+	require.Equal(t, model.LivenessCaptureStopping, a.liveness.Load())
 	mockTableExecutor.On("AddTable", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything).Return(false, nil)
 	a.handleMessageDispatchTableRequest(addTableRequest, processorEpoch)
@@ -174,7 +174,8 @@ func TestAgentHandleMessageDispatchTable(t *testing.T) {
 	require.NotContains(t, a.tableM.tables, model.TableID(1))
 
 	// Force set liveness to alive.
-	a.liveness.Store(model.LivenessCaptureAlive)
+	*a.liveness = model.LivenessCaptureAlive
+	require.Equal(t, model.LivenessCaptureAlive, a.liveness.Load())
 	mockTableExecutor.ExpectedCalls = nil
 	mockTableExecutor.On("AddTable", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything).Return(true, nil)

--- a/cdc/scheduler/internal/v3/agent/agent_test.go
+++ b/cdc/scheduler/internal/v3/agent/agent_test.go
@@ -69,13 +69,15 @@ func newAgent4Test() *agent {
 	a.Version = "agent-version-1"
 	a.Epoch = schedulepb.ProcessorEpoch{Epoch: "agent-epoch-1"}
 	a.CaptureID = "agent-1"
-
+	liveness := model.LivenessCaptureAlive
+	a.liveness = &liveness
 	return a
 }
 
 func TestNewAgent(t *testing.T) {
 	t.Parallel()
 
+	liveness := model.LivenessCaptureAlive
 	changefeed := model.DefaultChangeFeedID("changefeed-test")
 	me := mock_etcd.NewMockCDCEtcdClient(gomock.NewController(t))
 
@@ -84,20 +86,23 @@ func TestNewAgent(t *testing.T) {
 	// owner and revision found successfully
 	me.EXPECT().GetOwnerID(gomock.Any()).Return("owneID", nil).Times(1)
 	me.EXPECT().GetOwnerRevision(gomock.Any(), gomock.Any()).Return(int64(2333), nil).Times(1)
-	a, err := newAgent(context.Background(), "capture-test", changefeed, me, tableExector)
+	a, err := newAgent(
+		context.Background(), "capture-test", &liveness, changefeed, me, tableExector)
 	require.NoError(t, err)
 	require.NotNil(t, a)
 
 	// owner not found temporarily, it's ok.
 	me.EXPECT().GetOwnerID(gomock.Any()).
 		Return("", concurrency.ErrElectionNoLeader).Times(1)
-	a, err = newAgent(context.Background(), "capture-test", changefeed, me, tableExector)
+	a, err = newAgent(
+		context.Background(), "capture-test", &liveness, changefeed, me, tableExector)
 	require.NoError(t, err)
 	require.NotNil(t, a)
 
 	// owner not found since pd is unstable
 	me.EXPECT().GetOwnerID(gomock.Any()).Return("", cerror.ErrPDEtcdAPIError).Times(1)
-	a, err = newAgent(context.Background(), "capture-test", changefeed, me, tableExector)
+	a, err = newAgent(
+		context.Background(), "capture-test", &liveness, changefeed, me, tableExector)
 	require.Error(t, err)
 	require.Nil(t, a)
 
@@ -105,14 +110,16 @@ func TestNewAgent(t *testing.T) {
 	me.EXPECT().GetOwnerID(gomock.Any()).Return("ownerID", nil).Times(1)
 	me.EXPECT().GetOwnerRevision(gomock.Any(), gomock.Any()).
 		Return(int64(0), cerror.ErrPDEtcdAPIError).Times(1)
-	a, err = newAgent(context.Background(), "capture-test", changefeed, me, tableExector)
+	a, err = newAgent(
+		context.Background(), "capture-test", &liveness, changefeed, me, tableExector)
 	require.Error(t, err)
 	require.Nil(t, a)
 
 	me.EXPECT().GetOwnerID(gomock.Any()).Return("ownerID", nil).Times(1)
 	me.EXPECT().GetOwnerRevision(gomock.Any(), gomock.Any()).
 		Return(int64(0), cerror.ErrOwnerNotFound).Times(1)
-	a, err = newAgent(context.Background(), "capture-test", changefeed, me, tableExector)
+	a, err = newAgent(
+		context.Background(), "capture-test", &liveness, changefeed, me, tableExector)
 	require.NoError(t, err)
 	require.NotNil(t, a)
 }
@@ -150,7 +157,8 @@ func TestAgentHandleMessageDispatchTable(t *testing.T) {
 	}
 
 	// addTableRequest should be not ignored even if it's stopping.
-	a.handleLivenessUpdate(model.LivenessCaptureStopping, livenessSourceTick)
+	a.liveness.Store(model.LivenessCaptureAlive)
+	a.handleLivenessUpdate(model.LivenessCaptureStopping)
 	mockTableExecutor.On("AddTable", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything).Return(false, nil)
 	a.handleMessageDispatchTableRequest(addTableRequest, processorEpoch)
@@ -166,7 +174,7 @@ func TestAgentHandleMessageDispatchTable(t *testing.T) {
 	require.NotContains(t, a.tableM.tables, model.TableID(1))
 
 	// Force set liveness to alive.
-	a.liveness = model.LivenessCaptureAlive
+	a.liveness.Store(model.LivenessCaptureAlive)
 	mockTableExecutor.ExpectedCalls = nil
 	mockTableExecutor.On("AddTable", mock.Anything, mock.Anything,
 		mock.Anything, mock.Anything).Return(true, nil)
@@ -336,17 +344,16 @@ func TestAgentHandleMessageHeartbeat(t *testing.T) {
 	})
 	require.Equal(t, schedulepb.TableStateStopping, result[1].State)
 
-	a.handleLivenessUpdate(model.LivenessCaptureStopping, livenessSourceTick)
+	a.handleLivenessUpdate(model.LivenessCaptureStopping)
 	response = a.handleMessage([]*schedulepb.Message{heartbeat})
 	require.Len(t, response, 1)
 	require.Equal(t, model.LivenessCaptureStopping, response[0].GetHeartbeatResponse().Liveness)
 
-	a.handleLivenessUpdate(model.LivenessCaptureAlive, livenessSourceTick)
-
+	a.handleLivenessUpdate(model.LivenessCaptureAlive)
 	heartbeat.Heartbeat.IsStopping = true
 	response = a.handleMessage([]*schedulepb.Message{heartbeat})
 	require.Equal(t, model.LivenessCaptureStopping, response[0].GetHeartbeatResponse().Liveness)
-	require.Equal(t, model.LivenessCaptureStopping, a.liveness)
+	require.Equal(t, model.LivenessCaptureStopping, a.liveness.Load())
 }
 
 func TestAgentPermuteMessages(t *testing.T) {
@@ -444,7 +451,7 @@ func TestAgentPermuteMessages(t *testing.T) {
 				message := inboundMessages[idx]
 				if message.MsgType == schedulepb.MsgHeartbeat {
 					trans.RecvBuffer = append(trans.RecvBuffer, message)
-					err := a.Tick(ctx, model.LivenessCaptureAlive)
+					err := a.Tick(ctx)
 					require.NoError(t, err)
 					require.Len(t, trans.SendBuffer, 1)
 					heartbeatResponse := trans.SendBuffer[0].HeartbeatResponse
@@ -464,7 +471,7 @@ func TestAgentPermuteMessages(t *testing.T) {
 								mock.Anything, mock.Anything).Return(ok1, nil)
 
 							trans.RecvBuffer = append(trans.RecvBuffer, message)
-							err := a.Tick(ctx, model.LivenessCaptureAlive)
+							err := a.Tick(ctx)
 							require.NoError(t, err)
 							trans.SendBuffer = trans.SendBuffer[:0]
 
@@ -480,7 +487,7 @@ func TestAgentPermuteMessages(t *testing.T) {
 							trans.RecvBuffer = append(trans.RecvBuffer, message)
 							mockTableExecutor.On("IsRemoveTableFinished",
 								mock.Anything, mock.Anything).Return(0, ok1)
-							err := a.Tick(ctx, model.LivenessCaptureAlive)
+							err := a.Tick(ctx)
 							require.NoError(t, err)
 							if len(trans.SendBuffer) != 0 {
 								require.Len(t, trans.SendBuffer, 1)
@@ -623,7 +630,7 @@ func TestAgentTick(t *testing.T) {
 	trans.RecvBuffer = append(trans.RecvBuffer, heartbeat)
 
 	ctx := context.Background()
-	require.NoError(t, a.Tick(ctx, model.LivenessCaptureAlive))
+	require.NoError(t, a.Tick(ctx))
 	require.Len(t, trans.SendBuffer, 1)
 	heartbeatResponse := trans.SendBuffer[0]
 	trans.SendBuffer = trans.SendBuffer[:0]
@@ -676,7 +683,7 @@ func TestAgentTick(t *testing.T) {
 		mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 	mockTableExecutor.On("IsAddTableFinished", mock.Anything,
 		mock.Anything, mock.Anything).Return(false, nil)
-	require.NoError(t, a.Tick(ctx, model.LivenessCaptureAlive))
+	require.NoError(t, a.Tick(ctx))
 	trans.SendBuffer = trans.SendBuffer[:0]
 
 	trans.RecvBuffer = append(trans.RecvBuffer, addTableRequest)
@@ -684,7 +691,7 @@ func TestAgentTick(t *testing.T) {
 	mockTableExecutor.ExpectedCalls = mockTableExecutor.ExpectedCalls[:1]
 	mockTableExecutor.On("IsAddTableFinished", mock.Anything,
 		mock.Anything, mock.Anything).Return(true, nil)
-	require.NoError(t, a.Tick(ctx, model.LivenessCaptureAlive))
+	require.NoError(t, a.Tick(ctx))
 	responses := trans.SendBuffer[:len(trans.SendBuffer)]
 	trans.SendBuffer = trans.SendBuffer[:0]
 	require.Len(t, responses, 1)
@@ -700,23 +707,12 @@ func TestAgentTick(t *testing.T) {
 func TestAgentHandleLivenessUpdate(t *testing.T) {
 	t.Parallel()
 
-	// Test liveness via tick.
-	a := newAgent4Test()
-	a.handleLivenessUpdate(model.LivenessCaptureAlive, livenessSourceTick)
-	require.Equal(t, model.LivenessCaptureAlive, a.liveness)
-
-	a.handleLivenessUpdate(model.LivenessCaptureStopping, livenessSourceTick)
-	require.Equal(t, model.LivenessCaptureStopping, a.liveness)
-
-	a.handleLivenessUpdate(model.LivenessCaptureAlive, livenessSourceTick)
-	require.Equal(t, model.LivenessCaptureStopping, a.liveness)
-
 	// Test liveness via heartbeat.
 	mockTableExecutor := newMockTableExecutor()
 	tableM := newTableManager(model.ChangeFeedID{}, mockTableExecutor)
-	a = newAgent4Test()
+	a := newAgent4Test()
 	a.tableM = tableM
-	require.Equal(t, model.LivenessCaptureAlive, a.liveness)
+	require.Equal(t, model.LivenessCaptureAlive, a.liveness.Load())
 	a.handleMessage([]*schedulepb.Message{{
 		Header: &schedulepb.Message_Header{
 			Version:        a.ownerInfo.Version,
@@ -729,10 +725,10 @@ func TestAgentHandleLivenessUpdate(t *testing.T) {
 			IsStopping: true,
 		},
 	}})
-	require.Equal(t, model.LivenessCaptureStopping, a.liveness)
+	require.Equal(t, model.LivenessCaptureStopping, a.liveness.Load())
 
-	a.handleLivenessUpdate(model.LivenessCaptureAlive, livenessSourceTick)
-	require.Equal(t, model.LivenessCaptureStopping, a.liveness)
+	a.handleLivenessUpdate(model.LivenessCaptureAlive)
+	require.Equal(t, model.LivenessCaptureStopping, a.liveness.Load())
 }
 
 func TestAgentCommitAddTableDuringStopping(t *testing.T) {
@@ -771,7 +767,7 @@ func TestAgentCommitAddTableDuringStopping(t *testing.T) {
 	mockTableExecutor.
 		On("IsAddTableFinished", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(false, nil).Once()
-	err := a.Tick(context.Background(), model.LivenessCaptureAlive)
+	err := a.Tick(context.Background())
 	require.Nil(t, err)
 	require.Len(t, trans.SendBuffer, 0)
 
@@ -781,7 +777,7 @@ func TestAgentCommitAddTableDuringStopping(t *testing.T) {
 	mockTableExecutor.
 		On("IsAddTableFinished", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(true, nil).Once()
-	err = a.Tick(context.Background(), model.LivenessCaptureAlive)
+	err = a.Tick(context.Background())
 	require.Nil(t, err)
 	require.Len(t, trans.SendBuffer, 1)
 	require.Equal(t, trans.SendBuffer[0].MsgType, schedulepb.MsgDispatchTableResponse)
@@ -813,7 +809,9 @@ func TestAgentCommitAddTableDuringStopping(t *testing.T) {
 	mockTableExecutor.
 		On("IsAddTableFinished", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(false, nil).Once()
-	err = a.Tick(context.Background(), model.LivenessCaptureStopping)
+	// Set liveness to stopping.
+	a.liveness.Store(model.LivenessCaptureStopping)
+	err = a.Tick(context.Background())
 	require.Nil(t, err)
 	require.Len(t, trans.SendBuffer, 1)
 
@@ -822,7 +820,7 @@ func TestAgentCommitAddTableDuringStopping(t *testing.T) {
 	mockTableExecutor.
 		On("IsAddTableFinished", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(true, nil).Once()
-	err = a.Tick(context.Background(), model.LivenessCaptureStopping)
+	err = a.Tick(context.Background())
 	require.Nil(t, err)
 	require.Len(t, trans.SendBuffer, 1)
 	require.Equal(t, schedulepb.MsgDispatchTableResponse, trans.SendBuffer[0].MsgType)

--- a/cdc/scheduler/rexport.go
+++ b/cdc/scheduler/rexport.go
@@ -63,6 +63,7 @@ const CheckpointCannotProceed = internal.CheckpointCannotProceed
 func NewAgent(
 	ctx context.Context,
 	captureID model.CaptureID,
+	liveness *model.Liveness,
 	messageServer *p2p.MessageServer,
 	messageRouter p2p.MessageRouter,
 	etcdClient etcd.CDCEtcdClient,
@@ -92,6 +93,7 @@ func NewScheduler(
 func NewAgentV3(
 	ctx context.Context,
 	captureID model.CaptureID,
+	liveness *model.Liveness,
 	messageServer *p2p.MessageServer,
 	messageRouter p2p.MessageRouter,
 	etcdClient etcd.CDCEtcdClient,
@@ -99,7 +101,9 @@ func NewAgentV3(
 	changefeedID model.ChangeFeedID,
 ) (Agent, error) {
 	return v3agent.NewAgent(
-		ctx, captureID, changefeedID, messageServer, messageRouter, etcdClient, executor)
+		ctx, captureID, liveness, changefeedID,
+		messageServer, messageRouter, etcdClient, executor,
+	)
 }
 
 // NewSchedulerV3 returns two-phase scheduler.


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #4757 

### What is changed and how it works?

Set liveness to stopping when it is drained by DrainCapture API.
It prevents unnecessary owner switch during rolling upgrade.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

| master branch | this PR |
| -- | -- |
| <img width="922" alt="image" src="https://user-images.githubusercontent.com/2150711/182794842-e00059be-6262-494d-9505-6f8a395e2485.png"> | <img width="919" alt="image" src="https://user-images.githubusercontent.com/2150711/182790823-e443da77-3849-45b1-9fd1-67c31cea261a.png"> |


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
