### PR TITLE
framework(engine): remove 'JobMasterID' method from 'BaseJobMaster' interface

### DIFF
--- a/engine/framework/base_jobmaster.go
+++ b/engine/framework/base_jobmaster.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/log"
 	"go.uber.org/zap"
 
+	runtime "github.com/pingcap/tiflow/engine/executor/worker"
 	frameModel "github.com/pingcap/tiflow/engine/framework/model"
 	"github.com/pingcap/tiflow/engine/model"
 	dcontext "github.com/pingcap/tiflow/engine/pkg/context"
@@ -273,11 +274,11 @@ func (d *DefaultBaseJobMaster) Workload() model.RescUnit {
 	return d.worker.Workload()
 }
 
-// ID returns the id of the job master itself
-func (d *DefaultBaseJobMaster) ID() frameModel.MasterID {
+// ID delegates the ID of inner worker
+func (d *DefaultBaseJobMaster) ID() runtime.RunnableID {
 	// JobMaster is a combination of 'master' and 'worker'
 	// d.master.MasterID() == d.worker.ID() == JobID
-	return d.master.MasterID()
+	return d.worker.ID()
 }
 
 // UpdateJobStatus implements BaseJobMaster.UpdateJobStatus

--- a/engine/jobmaster/dm/api.go
+++ b/engine/jobmaster/dm/api.go
@@ -68,7 +68,7 @@ func (jm *JobMaster) QueryJobStatus(ctx context.Context, tasks []string) (*JobSt
 		wg              sync.WaitGroup
 		mu              sync.Mutex
 		jobStatus       = &JobStatus{
-			JobMasterID: jm.JobMasterID(),
+			JobMasterID: jm.ID(),
 			WorkerID:    jm.ID(),
 			TaskStatus:  make(map[string]TaskStatus),
 		}

--- a/engine/jobmaster/dm/api.go
+++ b/engine/jobmaster/dm/api.go
@@ -38,7 +38,6 @@ type TaskStatus struct {
 // JobStatus represents status of a job
 type JobStatus struct {
 	JobMasterID frameModel.MasterID
-	WorkerID    frameModel.WorkerID
 	// taskID -> Status
 	TaskStatus map[string]TaskStatus
 }
@@ -69,7 +68,6 @@ func (jm *JobMaster) QueryJobStatus(ctx context.Context, tasks []string) (*JobSt
 		mu              sync.Mutex
 		jobStatus       = &JobStatus{
 			JobMasterID: jm.ID(),
-			WorkerID:    jm.ID(),
 			TaskStatus:  make(map[string]TaskStatus),
 		}
 	)

--- a/engine/jobmaster/dm/api_test.go
+++ b/engine/jobmaster/dm/api_test.go
@@ -44,7 +44,6 @@ func TestQueryStatusAPI(t *testing.T) {
 		metaKVClient      = kvmock.NewMetaMock()
 		mockBaseJobmaster = &MockBaseJobmaster{}
 		jm                = &JobMaster{
-			workerID:      "jobmaster-worker-id",
 			BaseJobMaster: mockBaseJobmaster,
 			metadata:      metadata.NewMetaData(mockBaseJobmaster.ID(), metaKVClient),
 		}
@@ -146,7 +145,6 @@ func TestQueryStatusAPI(t *testing.T) {
 
 	expectedStatus := `{
 	"JobMasterID": "dm-jobmaster-id",
-	"WorkerID": "jobmaster-worker-id",
 	"TaskStatus": {
 		"task1": {
 			"ExpectedStage": 3,

--- a/engine/jobmaster/dm/api_test.go
+++ b/engine/jobmaster/dm/api_test.go
@@ -299,7 +299,7 @@ func TestUpdateJobCfg(t *testing.T) {
 		mockCheckpointAgent = &MockCheckpointAgent{}
 		messageAgent        = &dmpkg.MockMessageAgent{}
 		jobCfg              = &config.JobCfg{}
-		jobStore            = metadata.NewJobStore(mockBaseJobmaster.JobMasterID(), metaKVClient)
+		jobStore            = metadata.NewJobStore(mockBaseJobmaster.ID(), metaKVClient)
 		jm                  = &JobMaster{
 			BaseJobMaster:   mockBaseJobmaster,
 			checkpointAgent: mockCheckpointAgent,

--- a/engine/jobmaster/dm/api_test.go
+++ b/engine/jobmaster/dm/api_test.go
@@ -46,7 +46,7 @@ func TestQueryStatusAPI(t *testing.T) {
 		jm                = &JobMaster{
 			workerID:      "jobmaster-worker-id",
 			BaseJobMaster: mockBaseJobmaster,
-			metadata:      metadata.NewMetaData(mockBaseJobmaster.JobMasterID(), metaKVClient),
+			metadata:      metadata.NewMetaData(mockBaseJobmaster.ID(), metaKVClient),
 		}
 		job = &metadata.Job{
 			Tasks: map[string]*metadata.Task{

--- a/engine/jobmaster/dm/dm_jobmaster_test.go
+++ b/engine/jobmaster/dm/dm_jobmaster_test.go
@@ -195,7 +195,6 @@ func (t *testDMJobmasterSuite) TestDMJobmaster() {
 	jobCfg := &config.JobCfg{}
 	require.NoError(t.T(), jobCfg.DecodeFile(jobTemplatePath))
 	jm := &JobMaster{
-		workerID:      "jobmaster-id",
 		initJobCfg:    jobCfg,
 		BaseJobMaster: mockBaseJobmaster,
 	}
@@ -224,7 +223,6 @@ func (t *testDMJobmasterSuite) TestDMJobmaster() {
 
 	// recover
 	jm = &JobMaster{
-		workerID:      "jobmaster-id",
 		initJobCfg:    jobCfg,
 		BaseJobMaster: mockBaseJobmaster,
 		messageAgent:  mockMessageAgent,
@@ -316,7 +314,6 @@ func (t *testDMJobmasterSuite) TestDMJobmaster() {
 
 	// master failover
 	jm = &JobMaster{
-		workerID:        "jobmaster-id",
 		initJobCfg:      jobCfg,
 		BaseJobMaster:   mockBaseJobmaster,
 		checkpointAgent: mockCheckpointAgent,

--- a/engine/jobmaster/dm/dm_jobmaster_test.go
+++ b/engine/jobmaster/dm/dm_jobmaster_test.go
@@ -374,10 +374,6 @@ type MockBaseJobmaster struct {
 	framework.BaseJobMaster
 }
 
-func (m *MockBaseJobmaster) JobMasterID() frameModel.MasterID {
-	return "dm-jobmaster-id"
-}
-
 func (m *MockBaseJobmaster) GetWorkers() map[string]framework.WorkerHandle {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/engine/jobmaster/dm/dm_jobmaster_test.go
+++ b/engine/jobmaster/dm/dm_jobmaster_test.go
@@ -37,6 +37,7 @@ import (
 	dmconfig "github.com/pingcap/tiflow/dm/config"
 	"github.com/pingcap/tiflow/dm/master"
 	"github.com/pingcap/tiflow/dm/pkg/conn"
+	engineRuntime "github.com/pingcap/tiflow/engine/executor/worker"
 	"github.com/pingcap/tiflow/engine/framework"
 	libMetadata "github.com/pingcap/tiflow/engine/framework/metadata"
 	frameModel "github.com/pingcap/tiflow/engine/framework/model"
@@ -372,6 +373,10 @@ type MockBaseJobmaster struct {
 	mock.Mock
 
 	framework.BaseJobMaster
+}
+
+func (m *MockBaseJobmaster) ID() engineRuntime.RunnableID {
+	return "dm-jobmaster-id"
 }
 
 func (m *MockBaseJobmaster) GetWorkers() map[string]framework.WorkerHandle {

--- a/engine/jobmaster/dm/openapi_test.go
+++ b/engine/jobmaster/dm/openapi_test.go
@@ -61,7 +61,6 @@ func (t *testDMOpenAPISuite) SetupSuite() {
 		mockMessageAgent    = &dmpkg.MockMessageAgent{}
 		mockCheckpointAgent = &MockCheckpointAgent{}
 		jm                  = &JobMaster{
-			workerID:        "jobmaster-worker-id",
 			BaseJobMaster:   mockBaseJobmaster,
 			metadata:        metadata.NewMetaData(mockBaseJobmaster.ID(), mock.NewMetaMock()),
 			messageAgent:    mockMessageAgent,
@@ -183,7 +182,6 @@ func (t *testDMOpenAPISuite) TestDMAPIGetJobStatus() {
 
 	jobStatus := JobStatus{
 		JobMasterID: "dm-jobmaster-id",
-		WorkerID:    "jobmaster-worker-id",
 		TaskStatus:  map[string]TaskStatus{},
 	}
 	var jobStatus2 JobStatus

--- a/engine/jobmaster/dm/openapi_test.go
+++ b/engine/jobmaster/dm/openapi_test.go
@@ -63,7 +63,7 @@ func (t *testDMOpenAPISuite) SetupSuite() {
 		jm                  = &JobMaster{
 			workerID:        "jobmaster-worker-id",
 			BaseJobMaster:   mockBaseJobmaster,
-			metadata:        metadata.NewMetaData(mockBaseJobmaster.JobMasterID(), mock.NewMetaMock()),
+			metadata:        metadata.NewMetaData(mockBaseJobmaster.ID(), mock.NewMetaMock()),
 			messageAgent:    mockMessageAgent,
 			checkpointAgent: mockCheckpointAgent,
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6615 

### What is changed and how it works?
'JobMasterID' and 'ID' return the same id to user and we don't need the `JobMasterID` to return `JobManagerID` actually,
so remove 'JobMasterID'  method to avoid confusion


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
 `None`.
```
