### PR TITLE
client(engine): implement tombstones in ExecutorGroup

### DIFF
--- a/engine/pkg/client/errors.go
+++ b/engine/pkg/client/errors.go
@@ -22,7 +22,8 @@ import (
 type ExecutorNotFoundErrInfo struct {
 	rpcerror.Error[rpcerror.Retryable, rpcerror.NotFound]
 
-	ExecutorID model.ExecutorID
+	ExecutorID  model.ExecutorID
+	IsTombstone bool
 }
 
 // ErrExecutorNotFound is used when an executor ID is not found for

--- a/engine/pkg/client/executor_group.go
+++ b/engine/pkg/client/executor_group.go
@@ -14,7 +14,9 @@
 package client
 
 import (
+	"container/list"
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -26,12 +28,26 @@ import (
 )
 
 const (
-	getExecutorBlockTimeout = 10 * time.Second
+	// getExecutorBlockTimeout indicates the maximum wait time
+	// when we would like to retrieve the client for a given executor ID.
+	//
+	// The scenarios where we may need to wait is that
+	// 1) Due to an inconsistency of the servermaster's and the executor's states,
+	//    the executor has not received the information of another peer yet,
+	// 2) The target executor has gone offline.
+	//
+	// Here we do not want to set getExecutorBlockTimeout to avoid a large
+	// tail latency for scheduling a worker.
+	getExecutorBlockTimeout = 1 * time.Second
+
+	// tombstoneKeepTime indicates how long we should keep tombstone records.
+	tombstoneKeepTime = 5 * time.Minute
 )
 
 // ExecutorGroup holds a group of ExecutorClients.
 type ExecutorGroup interface {
 	// GetExecutorClient tries to get the ExecutorClient for the given executor.
+	// It will return (nil, false) immediately if no such executor is found.
 	GetExecutorClient(id model.ExecutorID) (ExecutorClient, bool)
 
 	// GetExecutorClientB tries to get the ExecutorClient for the given executor.
@@ -39,13 +55,24 @@ type ExecutorGroup interface {
 	GetExecutorClientB(ctx context.Context, id model.ExecutorID) (ExecutorClient, error)
 }
 
+// A tombstoneEntry records when a given executor has been
+// removed from an ExecutorGroup.
+type tombstoneEntry struct {
+	id         model.ExecutorID
+	removeTime time.Time
+}
+
 // DefaultExecutorGroup is the default implementation for ExecutorGroup.
 type DefaultExecutorGroup struct {
 	mu      sync.RWMutex
 	clients map[model.ExecutorID]ExecutorClient
+	// tombstoneList stores a list of offline executors to reduce
+	// the tail latency of trying to get client for a non-existent executor.
+	tombstoneList *list.List // stores tombstoneEntry
 
-	logger        *zap.Logger
-	clientFactory executorClientFactory
+	logger            *zap.Logger
+	clientFactory     executorClientFactory
+	tombstoneKeepTime time.Duration
 }
 
 // NewExecutorGroup creates a new ExecutorGroup.
@@ -68,7 +95,10 @@ func newExecutorGroupWithClientFactory(
 	return &DefaultExecutorGroup{
 		clients:       make(map[model.ExecutorID]ExecutorClient),
 		clientFactory: factory,
-		logger:        logger,
+		tombstoneList: list.New(),
+
+		logger:            logger,
+		tombstoneKeepTime: tombstoneKeepTime,
 	}
 }
 
@@ -89,19 +119,44 @@ func (g *DefaultExecutorGroup) GetExecutorClientB(ctx context.Context, id model.
 	ctx, cancel := context.WithTimeout(ctx, getExecutorBlockTimeout)
 	defer cancel()
 
+	g.cleanTombstones()
+
 	var ret ExecutorClient
 	err := retry.Do(ctx, func() error {
-		if client, ok := g.GetExecutorClient(id); ok {
+		g.mu.RLock()
+		defer g.mu.RUnlock()
+
+		if client, ok := g.clients[id]; ok {
 			ret = client
 			return nil
+		}
+		for item := g.tombstoneList.Front(); item != nil; item = item.Next() {
+			tombstone := item.Value.(tombstoneEntry)
+			if tombstone.id == id {
+				return ErrExecutorNotFound.GenWithStack(
+					&ExecutorNotFoundErrInfo{
+						ExecutorID: id,
+						// Set IsTombstone to true to prevent retry
+						IsTombstone: true,
+					})
+			}
 		}
 		return ErrExecutorNotFound.GenWithStack(&ExecutorNotFoundErrInfo{ExecutorID: id})
 	},
 		retry.WithBackoffMaxDelay(10),
 		retry.WithIsRetryableErr(func(err error) bool {
-			return ErrExecutorNotFound.Is(err)
+			info, ok := ErrExecutorNotFound.Convert(err)
+			if !ok {
+				return false
+			}
+			// Do not retry on tombstones.
+			return !info.IsTombstone
 		}))
 	if err != nil {
+		if errors.Is(err, context.Canceled) ||
+			errors.Is(err, context.DeadlineExceeded) {
+			return nil, ErrExecutorNotFound.GenWithStack(&ExecutorNotFoundErrInfo{ExecutorID: id})
+		}
 		return nil, err
 	}
 	return ret, nil
@@ -202,8 +257,27 @@ func (g *DefaultExecutorGroup) RemoveExecutor(executorID model.ExecutorID) error
 	client.Close()
 
 	delete(g.clients, executorID)
+	g.tombstoneList.PushFront(tombstoneEntry{
+		id:         executorID,
+		removeTime: time.Now(),
+	})
 	g.logger.Info("executor client removed",
 		zap.String("executor-id", string(executorID)))
 
 	return nil
+}
+
+func (g *DefaultExecutorGroup) cleanTombstones() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	for g.tombstoneList.Len() > 0 {
+		elem := g.tombstoneList.Back()
+		tombstone := elem.Value.(tombstoneEntry)
+		if time.Since(tombstone.removeTime) > g.tombstoneKeepTime {
+			g.tombstoneList.Remove(elem)
+			continue
+		}
+		break
+	}
 }

--- a/engine/pkg/client/executor_group.go
+++ b/engine/pkg/client/executor_group.go
@@ -45,6 +45,8 @@ const (
 )
 
 // ExecutorGroup holds a group of ExecutorClients.
+// It is used by any component that would like to invoke RPC
+// methods on the executors.
 type ExecutorGroup interface {
 	// GetExecutorClient tries to get the ExecutorClient for the given executor.
 	// It will return (nil, false) immediately if no such executor is found.
@@ -115,6 +117,9 @@ func (g *DefaultExecutorGroup) GetExecutorClient(id model.ExecutorID) (ExecutorC
 
 // GetExecutorClientB tries to get the ExecutorClient for the given executor.
 // It blocks until either the context has been canceled or the executor ID becomes valid.
+//
+// When an Executor goes offline, the ID is added to a tombstone list so that
+// we can fail fast. The assumption here is that executor IDs will not be reused.
 func (g *DefaultExecutorGroup) GetExecutorClientB(ctx context.Context, id model.ExecutorID) (ExecutorClient, error) {
 	ctx, cancel := context.WithTimeout(ctx, getExecutorBlockTimeout)
 	defer cancel()


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6621 

### What is changed and how it works?
- Reduced the retry timeout for non-existent executors.
- Added a tombstone mechanism in `ExecutorGroup` to make such `GetExecutorClient` calls fail fast. 

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No.

##### Do you need to update user documentation, design documentation or monitoring documentation?
No.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
