### PR TITLE
redo(ticdc): owner and processores shouldn't share one redo log writer

### DIFF
--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -491,7 +491,7 @@ LOOP:
 	}
 	log.Info("owner creates redo manager",
 		zap.String("namespace", c.id.Namespace),
-		zap.String("namespace", c.id.ID))
+		zap.String("changefeed", c.id.ID))
 
 	// init metrics
 	c.metricsChangefeedBarrierTsGauge = changefeedBarrierTsGauge.

--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -338,7 +338,9 @@ func (c *changefeed) tick(ctx cdcContext.Context, state *orchestrator.Changefeed
 				zap.Uint64("flushedResolvedTs", flushedResolvedTs),
 				zap.Uint64("flushedCheckpointTs", flushedCheckpointTs),
 				zap.Uint64("newResolvedTs", newResolvedTs),
-				zap.Uint64("newCheckpointTs", newCheckpointTs))
+				zap.Uint64("newCheckpointTs", newCheckpointTs),
+				zap.String("namespace", c.id.Namespace),
+				zap.String("changefeed", c.id.ID))
 			if flushedResolvedTs != 0 {
 				// It's not necessary to replace newCheckpointTs with flushedResolvedTs,
 				// as cdc can ensure newCheckpointTs can never exceed prevResolvedTs.
@@ -350,7 +352,9 @@ func (c *changefeed) tick(ctx cdcContext.Context, state *orchestrator.Changefeed
 		log.Debug("owner prepares to update status",
 			zap.Uint64("prevResolvedTs", prevResolvedTs),
 			zap.Uint64("newResolvedTs", newResolvedTs),
-			zap.Uint64("newCheckpointTs", newCheckpointTs))
+			zap.Uint64("newCheckpointTs", newCheckpointTs),
+			zap.String("namespace", c.id.Namespace),
+			zap.String("changefeed", c.id.ID))
 		// resolvedTs should never regress but checkpointTs can, as checkpointTs has already
 		// been decreased when the owner is initialized.
 		if newResolvedTs < prevResolvedTs {
@@ -479,12 +483,15 @@ LOOP:
 	}()
 
 	stdCtx := contextutil.PutChangefeedIDInCtx(cancelCtx, c.id)
-	redoManagerOpts := &redo.ManagerOptions{EnableBgRunner: true}
-	redoManager, err := redo.NewManager(stdCtx, c.state.Info.Config.Consistent, redoManagerOpts)
+	redoManagerOpts := redo.NewOwnerManagerOptions(c.errCh)
+	mgr, err := redo.NewManager(stdCtx, c.state.Info.Config.Consistent, redoManagerOpts)
+	c.redoManager = mgr
 	if err != nil {
 		return err
 	}
-	c.redoManager = redoManager
+	log.Info("owner creates redo manager",
+		zap.String("namespace", c.id.Namespace),
+		zap.String("namespace", c.id.ID))
 
 	// init metrics
 	c.metricsChangefeedBarrierTsGauge = changefeedBarrierTsGauge.
@@ -737,6 +744,9 @@ func (c *changefeed) asyncExecDDLJob(ctx cdcContext.Context,
 		}
 		if c.redoManager.Enabled() {
 			for _, ddlEvent := range c.ddlEventCache {
+				// FIXME: seems it's not necessary to emit DDL to redo storage,
+				// because for a given redo meta with range (checkpointTs, resolvedTs],
+				// there must be no pending DDLs not flushed into DDL sink.
 				err = c.redoManager.EmitDDLEvent(ctx, ddlEvent)
 				if err != nil {
 					return false, err

--- a/cdc/processor/pipeline/sink.go
+++ b/cdc/processor/pipeline/sink.go
@@ -158,20 +158,17 @@ func (n *sinkNode) flushSink(ctx context.Context, resolved model.ResolvedTs) (er
 		resolved = model.NewResolvedTs(currentBarrierTs)
 	}
 	if n.redoManager != nil && n.redoManager.Enabled() {
-		redoTs := n.redoManager.GetMinResolvedTs()
 		redoFlushed := n.redoManager.GetResolvedTs(n.tableID)
-		if currentBarrierTs > redoTs {
+		if currentBarrierTs > redoFlushed {
 			// NOTE: How can barrierTs be greater than rodoTs?
 			// When scheduler moves a table from one place to another place, the table
 			// start position will be checkpointTs instead of resolvedTs, which means
 			// redoTs can be less than barrierTs.
-			log.Info("redoTs is less than current barrierTs",
+			log.Info("redo flushedTs is less than current barrierTs",
 				zap.Int64("tableID", n.tableID),
-				zap.Uint64("redoTs", redoTs),
 				zap.Uint64("barrierTs", currentBarrierTs),
 				zap.Uint64("tableRedoFlushed", redoFlushed))
-		}
-		if currentBarrierTs > redoFlushed {
+
 			// The latest above comment shows why barrierTs can be greater than redoTs.
 			// So here the aim is to avoid slow tables holding back the whole processor.
 			resolved = model.NewResolvedTs(redoFlushed)

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -710,7 +710,7 @@ func (p *processor) lazyInitImpl(ctx cdcContext.Context) error {
 	}
 	log.Info("processor creates redo manager",
 		zap.String("namespace", p.changefeedID.Namespace),
-		zap.String("namespace", p.changefeedID.ID))
+		zap.String("changefeed", p.changefeedID.ID))
 
 	p.agent, err = p.newAgent(ctx, p.liveness)
 	if err != nil {

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -578,6 +578,11 @@ func (p *processor) tick(ctx cdcContext.Context, state *orchestrator.ChangefeedR
 
 	p.doGCSchemaStorage()
 
+	if p.redoManager != nil && p.redoManager.Enabled() {
+		ckpt := p.changefeed.Status.CheckpointTs
+		p.redoManager.UpdateCheckpointTs(ckpt)
+	}
+
 	if err := p.agent.Tick(ctx); err != nil {
 		return errors.Trace(err)
 	}
@@ -698,11 +703,14 @@ func (p *processor) lazyInitImpl(ctx cdcContext.Context) error {
 	log.Info("processor try new sink success",
 		zap.Duration("duration", time.Since(start)))
 
-	redoManagerOpts := &redo.ManagerOptions{EnableBgRunner: true, ErrCh: errCh}
+	redoManagerOpts := redo.NewProcessorManagerOptions(errCh)
 	p.redoManager, err = redo.NewManager(stdCtx, p.changefeed.Info.Config.Consistent, redoManagerOpts)
 	if err != nil {
 		return err
 	}
+	log.Info("processor creates redo manager",
+		zap.String("namespace", p.changefeedID.Namespace),
+		zap.String("namespace", p.changefeedID.ID))
 
 	p.agent, err = p.newAgent(ctx, p.liveness)
 	if err != nil {

--- a/cdc/redo/main_test.go
+++ b/cdc/redo/main_test.go
@@ -20,5 +20,11 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	originValue := defaultGCIntervalInMs
+	defaultGCIntervalInMs = 1
+	defer func() {
+		defaultGCIntervalInMs = originValue
+	}()
+
 	leakutil.SetUpLeakTest(m)
 }

--- a/cdc/redo/manager.go
+++ b/cdc/redo/manager.go
@@ -643,7 +643,7 @@ func (m *ManagerImpl) bgGC(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			log.Info("redo manager GC exits as context canceled",
+			log.Info("redo manager GC exits as context cancelled",
 				zap.String("namespace", m.changeFeedID.Namespace),
 				zap.String("changefeed", m.changeFeedID.ID))
 			return

--- a/cdc/redo/manager.go
+++ b/cdc/redo/manager.go
@@ -38,6 +38,9 @@ import (
 var (
 	flushIntervalInMs int64 = 2000 // 2 seconds
 	flushTimeout            = time.Second * 20
+
+	// Redo Manager GC interval. It can be changed in tests.
+	defaultGCIntervalInMs = 5000 // 5 seconds
 )
 
 // ConsistentLevelType is the level of redo log consistent level.
@@ -95,7 +98,7 @@ type LogManager interface {
 	// Enabled returns whether the log manager is enabled
 	Enabled() bool
 
-	// The following APIs are called from processor only
+	// The following APIs are called from processor only.
 	AddTable(tableID model.TableID, startTs uint64)
 	RemoveTable(tableID model.TableID)
 	GetResolvedTs(tableID model.TableID) model.Ts
@@ -104,21 +107,16 @@ type LogManager interface {
 	EmitRowChangedEvents(ctx context.Context, tableID model.TableID,
 		rows ...*model.RowChangedEvent) error
 	UpdateResolvedTs(ctx context.Context, tableID model.TableID, resolvedTs uint64) error
+	// Update checkpoint so that it can GC stale files.
+	UpdateCheckpointTs(checkpointTs model.Ts)
 
-	// The following APIs are called from owner only
+	// The following APIs are called from owner only.
 	EmitDDLEvent(ctx context.Context, ddl *model.DDLEvent) error
 	UpdateMeta(checkpointTs, resolvedTs model.Ts)
 	GetFlushedMeta(checkpointTs, resolvedTs *model.Ts)
 
-	// Cleanup removes all redo logs
+	// Cleanup removes all redo logs. Only called from owner.
 	Cleanup(ctx context.Context) error
-}
-
-// ManagerOptions defines options for redo log manager
-type ManagerOptions struct {
-	// whether to run background goroutine to fetch table resolved ts
-	EnableBgRunner bool
-	ErrCh          chan<- error
 }
 
 type cacheEvents struct {
@@ -165,6 +163,8 @@ type ManagerImpl struct {
 	level        ConsistentLevelType
 	storageType  consistentStorage
 
+	opts *ManagerOptions
+
 	// rtsMap stores flushed and unflushed resolved timestamps for all tables.
 	// it's just like map[tableID]*statefulRts.
 	// For a given statefulRts, unflushed is updated in routine bgUpdateLog,
@@ -174,6 +174,10 @@ type ManagerImpl struct {
 	// A fast way to get min flushed timestamp in rtsMap. It can be updated
 	// in redo-flush goroutine and AddTable/RemoveTable.
 	minResolvedTs uint64
+
+	// Updated by `UpdateResolvedTs`. It's required by some internal places,
+	// such as GC.
+	checkpointTs uint64
 
 	metaCheckpointTs statefulRts
 	metaResolvedTs   statefulRts
@@ -208,9 +212,11 @@ func NewManager(ctx context.Context, cfg *config.ConsistentConfig, opts *Manager
 		enabled:       true,
 		level:         ConsistentLevelType(cfg.Level),
 		storageType:   consistentStorage(uri.Scheme),
+		opts:          opts,
 		rtsMap:        sync.Map{},
-		logBuffer:     chann.New[cacheEvents](),
 		minResolvedTs: math.MaxInt64,
+
+		logBuffer: chann.New[cacheEvents](),
 		metricWriteLogDuration: common.RedoWriteLogDurationHistogram.
 			WithLabelValues(changeFeedID.Namespace, changeFeedID.ID),
 		metricFlushLogDuration: common.RedoFlushLogDurationHistogram.
@@ -245,6 +251,10 @@ func NewManager(ctx context.Context, cfg *config.ConsistentConfig, opts *Manager
 			MaxLogSize:        cfg.MaxLogSize,
 			FlushIntervalInMs: cfg.FlushIntervalInMs,
 			S3Storage:         m.storageType == consistentStorageS3,
+
+			EmitMeta:      m.opts.EmitMeta,
+			EmitRowEvents: m.opts.EmitRowEvents,
+			EmitDDLEvents: m.opts.EmitDDLEvents,
 		}
 		if writerCfg.S3Storage {
 			writerCfg.S3URI = *uri
@@ -254,18 +264,26 @@ func NewManager(ctx context.Context, cfg *config.ConsistentConfig, opts *Manager
 			return nil, err
 		}
 		m.writer = writer
-		checkpointTs, resolvedTs := m.writer.GetMeta()
-		m.metaCheckpointTs.flushed = checkpointTs
-		m.metaCheckpointTs.unflushed = checkpointTs
-		m.metaResolvedTs.flushed = resolvedTs
-		m.metaResolvedTs.unflushed = resolvedTs
+
+		if m.opts.EmitMeta {
+			checkpointTs, resolvedTs := m.writer.GetMeta()
+			m.metaCheckpointTs.flushed = checkpointTs
+			m.metaCheckpointTs.unflushed = checkpointTs
+			m.metaResolvedTs.flushed = resolvedTs
+			m.metaResolvedTs.unflushed = resolvedTs
+		}
 	default:
 		return nil, cerror.ErrConsistentStorage.GenWithStackByArgs(m.storageType)
 	}
 
-	if opts.EnableBgRunner {
+	// TODO: better to wait background goroutines after the context is canceled.
+	if m.opts.EnableBgRunner {
 		go m.bgUpdateLog(ctx, opts.ErrCh)
 	}
+	if m.opts.EnableGCRunner {
+		go m.bgGC(ctx)
+	}
+
 	return m, nil
 }
 
@@ -280,12 +298,9 @@ func NewMockManager(ctx context.Context) (*ManagerImpl, error) {
 		Level:   string(ConsistentLevelEventual),
 		Storage: "blackhole://",
 	}
+
 	errCh := make(chan error, 1)
-	opts := &ManagerOptions{
-		EnableBgRunner: true,
-		ErrCh:          errCh,
-	}
-	logMgr, err := NewManager(ctx, cfg, opts)
+	logMgr, err := NewManager(ctx, cfg, newMockManagerOptions(errCh))
 	if err != nil {
 		return nil, err
 	}
@@ -347,6 +362,16 @@ func (m *ManagerImpl) UpdateResolvedTs(
 	}
 
 	return nil
+}
+
+// UpdateCheckpointTs updates checkpoint to the manager.
+func (m *ManagerImpl) UpdateCheckpointTs(ckpt model.Ts) {
+	for {
+		curr := atomic.LoadUint64(&m.checkpointTs)
+		if ckpt <= curr || atomic.CompareAndSwapUint64(&m.checkpointTs, curr, ckpt) {
+			break
+		}
+	}
 }
 
 // EmitDDLEvent sends DDL event to redo log writer
@@ -441,9 +466,10 @@ func (m *ManagerImpl) Cleanup(ctx context.Context) error {
 }
 
 func (m *ManagerImpl) prepareForFlush() (tableRtsMap map[model.TableID]model.Ts, minResolvedTs model.Ts) {
-	// FIXME: currently all table progresses are flushed into meta file. It can be an issue
-	// if there are lots of tables. If we can put table meta into row file, it's only necessary
-	// to take care updated tables.
+	if !m.opts.EmitRowEvents {
+		return
+	}
+
 	tableRtsMap = make(map[model.TableID]model.Ts)
 	minResolvedTs = math.MaxUint64
 	m.rtsMap.Range(func(key interface{}, value interface{}) bool {
@@ -468,11 +494,13 @@ func (m *ManagerImpl) prepareForFlush() (tableRtsMap map[model.TableID]model.Ts,
 }
 
 func (m *ManagerImpl) postFlush(tableRtsMap map[model.TableID]model.Ts, minResolvedTs model.Ts) {
+	if !m.opts.EmitRowEvents {
+		return
+	}
 	if minResolvedTs != 0 {
 		// m.minResolvedTs is only updated in flushLog, so no other one can change it.
 		atomic.StoreUint64(&m.minResolvedTs, minResolvedTs)
 	}
-
 	for tableID, flushed := range tableRtsMap {
 		if value, loaded := m.rtsMap.Load(tableID); loaded {
 			value.(*statefulRts).setFlushed(flushed)
@@ -481,12 +509,18 @@ func (m *ManagerImpl) postFlush(tableRtsMap map[model.TableID]model.Ts, minResol
 }
 
 func (m *ManagerImpl) prepareForFlushMeta() (metaCheckpoint, metaResolved model.Ts) {
+	if !m.opts.EmitMeta {
+		return
+	}
 	metaCheckpoint = m.metaCheckpointTs.getUnflushed()
 	metaResolved = m.metaResolvedTs.getUnflushed()
 	return
 }
 
 func (m *ManagerImpl) postFlushMeta(metaCheckpoint, metaResolved model.Ts) {
+	if !m.opts.EmitMeta {
+		return
+	}
 	m.metaResolvedTs.setFlushed(metaResolved)
 	m.metaCheckpointTs.setFlushed(metaCheckpoint)
 }
@@ -531,28 +565,29 @@ func (m *ManagerImpl) onResolvedTsMsg(tableID model.TableID, resolvedTs model.Ts
 }
 
 func (m *ManagerImpl) bgUpdateLog(ctx context.Context, errCh chan<- error) {
+	// logErrCh is used to retrieve errors from log flushing goroutines.
+	// if the channel is full, it's better to block subsequent flushings.
 	logErrCh := make(chan error, 1)
-	handleErr := func(err error) {
-		select {
-		case logErrCh <- err:
-		default:
-		}
-	}
+	handleErr := func(err error) { logErrCh <- err }
+
+	log.Info("redo manager bgUpdateLog is running",
+		zap.String("namespace", m.changeFeedID.Namespace),
+		zap.String("changefeed", m.changeFeedID.ID))
 
 	ticker := time.NewTicker(time.Duration(flushIntervalInMs) * time.Millisecond)
-	defer ticker.Stop()
+	defer func() {
+		ticker.Stop()
+		log.Info("redo manager bgUpdateLog exits",
+			zap.String("namespace", m.changeFeedID.Namespace),
+			zap.String("changefeed", m.changeFeedID.ID))
+	}()
 
+	var err error
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case err := <-logErrCh:
-			select {
-			case errCh <- err:
-			default:
-				log.Error("err channel in redoManager is full", zap.Error(err))
-			}
-			return
+		case err = <-logErrCh:
 		case <-ticker.C:
 			// interpolate tick message to flush writer if needed
 			m.flushLog(ctx, handleErr)
@@ -567,15 +602,65 @@ func (m *ManagerImpl) bgUpdateLog(ctx context.Context, errCh chan<- error) {
 				for _, row := range cache.rows {
 					logs = append(logs, RowToRedo(row))
 				}
-				err := m.writer.WriteLog(ctx, cache.tableID, logs)
-				if err != nil {
-					handleErr(err)
-				}
+				err = m.writer.WriteLog(ctx, cache.tableID, logs)
 				m.metricWriteLogDuration.Observe(time.Since(start).Seconds())
 			case model.MessageTypeResolved:
 				m.onResolvedTsMsg(cache.tableID, cache.resolvedTs)
 			default:
 				log.Debug("handle unknown event type")
+			}
+		}
+		if err != nil {
+			log.Warn("redo manager writer meets write or flush fail",
+				zap.String("namespace", m.changeFeedID.Namespace),
+				zap.String("changefeed", m.changeFeedID.ID),
+				zap.Error(err))
+			break
+		}
+	}
+
+	// NOTE: the goroutine should never exit until the err is put into errCh successfully
+	// or the context is canceled.
+	select {
+	case <-ctx.Done():
+	case errCh <- err:
+	}
+
+	m.logBuffer.Close()
+	for range m.logBuffer.Out() {
+	}
+	if err := m.writer.Close(); err != nil {
+		log.Error("redo manager fails to close writer",
+			zap.String("namespace", m.changeFeedID.Namespace),
+			zap.String("changefeed", m.changeFeedID.ID),
+			zap.Error(err))
+	}
+}
+
+func (m *ManagerImpl) bgGC(ctx context.Context) {
+	ticker := time.NewTicker(time.Duration(defaultGCIntervalInMs) * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("redo manager GC exits as context canceled",
+				zap.String("namespace", m.changeFeedID.Namespace),
+				zap.String("changefeed", m.changeFeedID.ID))
+			return
+		case <-ticker.C:
+			ckpt := atomic.LoadUint64(&m.checkpointTs)
+			if ckpt == 0 {
+				continue
+			}
+			log.Info("redo manager GC is triggered",
+				zap.Uint64("checkpointTs", ckpt),
+				zap.String("namespace", m.changeFeedID.Namespace),
+				zap.String("changefeed", m.changeFeedID.ID))
+			err := m.writer.GC(ctx, ckpt)
+			if err != nil {
+				log.Warn("redo manager log GC fail",
+					zap.String("namespace", m.changeFeedID.Namespace),
+					zap.String("changefeed", m.changeFeedID.ID), zap.Error(err))
 			}
 		}
 	}

--- a/cdc/redo/manager_test.go
+++ b/cdc/redo/manager_test.go
@@ -314,7 +314,7 @@ func TestManagerRtsMap(t *testing.T) {
 // TestManagerError tests whether internal error in bgUpdateLog could be managed correctly.
 func TestManagerError(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
 	cfg := &config.ConsistentConfig{

--- a/cdc/redo/manager_test.go
+++ b/cdc/redo/manager_test.go
@@ -327,8 +327,6 @@ func TestManagerError(t *testing.T) {
 	require.Nil(t, err)
 
 	logMgr.writer = writer.NewInvalidBlackHoleWriter(logMgr.writer)
-	defer logMgr.Cleanup(ctx)
-
 	go logMgr.bgUpdateLog(ctx, errCh)
 
 	testCases := []struct {

--- a/cdc/redo/manager_test.go
+++ b/cdc/redo/manager_test.go
@@ -323,9 +323,9 @@ func TestManagerError(t *testing.T) {
 	}
 	errCh := make(chan error, 1)
 	opts := &ManagerOptions{EnableBgRunner: false, ErrCh: errCh}
+
 	logMgr, err := NewManager(ctx, cfg, opts)
 	require.Nil(t, err)
-
 	logMgr.writer = writer.NewInvalidBlackHoleWriter(logMgr.writer)
 	go logMgr.bgUpdateLog(ctx, errCh)
 
@@ -356,8 +356,12 @@ func TestManagerError(t *testing.T) {
 		require.Regexp(t, ".*WriteLog.*", err)
 	}
 
-	// bgUpdateLog exists because of writer.FlushLog failure.
+	logMgr, err = NewManager(ctx, cfg, opts)
+	require.Nil(t, err)
+	logMgr.writer = writer.NewInvalidBlackHoleWriter(logMgr.writer)
 	go logMgr.bgUpdateLog(ctx, errCh)
+
+	// bgUpdateLog exists because of writer.FlushLog failure.
 	select {
 	case <-ctx.Done():
 		t.Fatal("bgUpdateLog should return error before context is done")

--- a/cdc/redo/manager_test.go
+++ b/cdc/redo/manager_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tiflow/cdc/contextutil"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/redo/writer"
+	"github.com/pingcap/tiflow/pkg/chann"
 	"github.com/pingcap/tiflow/pkg/config"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -327,6 +328,7 @@ func TestManagerError(t *testing.T) {
 	logMgr, err := NewManager(ctx, cfg, opts)
 	require.Nil(t, err)
 	logMgr.writer = writer.NewInvalidBlackHoleWriter(logMgr.writer)
+	logMgr.logBuffer = chann.New[cacheEvents]()
 	go logMgr.bgUpdateLog(ctx, errCh)
 
 	testCases := []struct {
@@ -359,6 +361,7 @@ func TestManagerError(t *testing.T) {
 	logMgr, err = NewManager(ctx, cfg, opts)
 	require.Nil(t, err)
 	logMgr.writer = writer.NewInvalidBlackHoleWriter(logMgr.writer)
+	logMgr.logBuffer = chann.New[cacheEvents]()
 	go logMgr.bgUpdateLog(ctx, errCh)
 
 	// bgUpdateLog exists because of writer.FlushLog failure.
@@ -408,4 +411,5 @@ func TestReuseWritter(t *testing.T) {
 		log.Panic("shouldn't get an error", zap.Error(x))
 	case <-time.NewTicker(time.Duration(100) * time.Millisecond).C:
 	}
+	cancels[1]()
 }

--- a/cdc/redo/options.go
+++ b/cdc/redo/options.go
@@ -33,7 +33,7 @@ type ManagerOptions struct {
 	ErrCh chan<- error
 }
 
-// NewOwnerManagerOptions creates a maanger options for owner.
+// NewOwnerManagerOptions creates a manager options for owner.
 func NewOwnerManagerOptions(errCh chan<- error) *ManagerOptions {
 	return &ManagerOptions{
 		EnableBgRunner: true,
@@ -44,7 +44,7 @@ func NewOwnerManagerOptions(errCh chan<- error) *ManagerOptions {
 	}
 }
 
-// NewProcessorManagerOptions creates a maanger options for processor.
+// NewProcessorManagerOptions creates a manager options for processor.
 func NewProcessorManagerOptions(errCh chan<- error) *ManagerOptions {
 	return &ManagerOptions{
 		EnableBgRunner: true,
@@ -55,7 +55,7 @@ func NewProcessorManagerOptions(errCh chan<- error) *ManagerOptions {
 	}
 }
 
-// newMockManagerOptions creates a maanger options for mock tests.
+// newMockManagerOptions creates a manager options for mock tests.
 func newMockManagerOptions(errCh chan<- error) *ManagerOptions {
 	return &ManagerOptions{
 		EnableBgRunner: true,

--- a/cdc/redo/options.go
+++ b/cdc/redo/options.go
@@ -1,0 +1,67 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redo
+
+// ManagerOptions defines options for redo log manager.
+type ManagerOptions struct {
+	// Whether to run background flush goroutine.
+	EnableBgRunner bool
+
+	// Whether to start a GC goroutine or not.
+	EnableGCRunner bool
+
+	// Whether it's created for emitting redo meta or not.
+	EmitMeta bool
+
+	// Whether it's created for emitting row events or not.
+	EmitRowEvents bool
+
+	// Whether it's created for emitting DDL events or not.
+	EmitDDLEvents bool
+
+	ErrCh chan<- error
+}
+
+// NewOwnerManagerOptions creates a maanger options for owner.
+func NewOwnerManagerOptions(errCh chan<- error) *ManagerOptions {
+	return &ManagerOptions{
+		EnableBgRunner: true,
+		EnableGCRunner: false,
+		EmitMeta:       true,
+		EmitRowEvents:  false,
+		EmitDDLEvents:  true,
+	}
+}
+
+// NewProcessorManagerOptions creates a maanger options for processor.
+func NewProcessorManagerOptions(errCh chan<- error) *ManagerOptions {
+	return &ManagerOptions{
+		EnableBgRunner: true,
+		EnableGCRunner: true,
+		EmitMeta:       false,
+		EmitRowEvents:  true,
+		EmitDDLEvents:  false,
+	}
+}
+
+// newMockManagerOptions creates a maanger options for mock tests.
+func newMockManagerOptions(errCh chan<- error) *ManagerOptions {
+	return &ManagerOptions{
+		EnableBgRunner: true,
+		EnableGCRunner: true,
+		EmitMeta:       true,
+		EmitRowEvents:  true,
+		EmitDDLEvents:  true,
+	}
+}

--- a/cdc/redo/writer/blackhole_writer.go
+++ b/cdc/redo/writer/blackhole_writer.go
@@ -36,6 +36,10 @@ func (bs *blackHoleWriter) DeleteAllLogs(ctx context.Context) error {
 	return nil
 }
 
+func (bs *blackHoleWriter) GC(ctx context.Context, checkpointTs model.Ts) error {
+	return nil
+}
+
 // NewBlackHoleWriter creates a blackHole writer
 func NewBlackHoleWriter() *blackHoleWriter {
 	return &blackHoleWriter{

--- a/cdc/redo/writer/file.go
+++ b/cdc/redo/writer/file.go
@@ -462,6 +462,8 @@ func (w *Writer) GC(checkPointTs uint64) error {
 	w.gcRunning.Store(true)
 	defer w.gcRunning.Store(false)
 
+	// FIXME: it will also delete other processor's files if the redo
+	// storage is a remote NFS path. Try to only clean itself's files.
 	remove, err := w.getShouldRemovedFiles(checkPointTs)
 	if err != nil {
 		return err

--- a/cdc/redo/writer/main_test.go
+++ b/cdc/redo/writer/main_test.go
@@ -20,11 +20,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	originValue := defaultGCIntervalInMs
-	defaultGCIntervalInMs = 1
-	defer func() {
-		defaultGCIntervalInMs = originValue
-	}()
-
 	leakutil.SetUpLeakTest(m)
 }

--- a/cdc/redo/writer/writer.go
+++ b/cdc/redo/writer/writer.go
@@ -16,7 +16,6 @@ package writer
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -38,34 +37,31 @@ import (
 )
 
 //go:generate mockery --name=RedoLogWriter --inpackage
-// RedoLogWriter defines the interfaces used to write redo log, all operations are thread-safe
+// RedoLogWriter defines the interfaces used to write redo log, all operations are thread-safe.
 type RedoLogWriter interface {
-	io.Closer
-
-	// WriteLog writer RedoRowChangedEvent to row log file
+	// WriteLog writer RedoRowChangedEvent to row log file.
 	WriteLog(ctx context.Context, tableID int64, rows []*model.RedoRowChangedEvent) error
 
-	// SendDDL writer RedoDDLEvent to ddl log file
+	// SendDDL writer RedoDDLEvent to ddl log file.
 	SendDDL(ctx context.Context, ddl *model.RedoDDLEvent) error
 
-	// FlushLog sends resolved-ts from table pipeline to log writer, it is
-	// essential to flush when a table doesn't have any row change event for
-	// some time, and the resolved ts of this table should be moved forward.
+	// FlushLog flushes all rows written by `WriteLog` into redo storage.
+	// `checkpointTs` and `resolvedTs` will be written into redo meta file.
+	// Regressions on them will be ignored.
 	FlushLog(ctx context.Context, checkpointTs, resolvedTs model.Ts) error
 
 	// Get the current meta.
 	GetMeta() (checkpointTs, resolvedTs model.Ts)
 
-	// DeleteAllLogs delete all log files related to the changefeed, called from owner only when delete changefeed
+	// DeleteAllLogs delete all log files related to the changefeed, called from owner only.
 	DeleteAllLogs(ctx context.Context) error
+
+	// GC cleans stale files before the given checkpoint.
+	GC(ctx context.Context, checkpointTs model.Ts) error
+
+	// Close is used to closed the writer.
+	Close() error
 }
-
-var defaultGCIntervalInMs = 5000
-
-var (
-	logWriters = map[model.ChangeFeedID]*LogWriter{}
-	initLock   sync.Mutex
-)
 
 var redoLogPool = sync.Pool{
 	New: func() interface{} {
@@ -85,6 +81,10 @@ type LogWriterConfig struct {
 	S3Storage         bool
 	// S3URI should be like S3URI="s3://logbucket/test-changefeed?endpoint=http://$S3_ENDPOINT/"
 	S3URI url.URL
+
+	EmitMeta      bool
+	EmitRowEvents bool
+	EmitDDLEvents bool
 }
 
 // LogWriter implement the RedoLogWriter interface
@@ -94,9 +94,7 @@ type LogWriter struct {
 	ddlWriter fileWriter
 	storage   storage.ExternalStorage
 
-	// Fields are protected by metaLock.
-	meta     *common.LogMeta
-	metaLock sync.RWMutex
+	meta *common.LogMeta
 
 	metricTotalRowsCount prometheus.Gauge
 }
@@ -104,90 +102,70 @@ type LogWriter struct {
 // NewLogWriter creates a LogWriter instance. It is guaranteed only one LogWriter per changefeed
 func NewLogWriter(
 	ctx context.Context, cfg *LogWriterConfig, opts ...Option,
-) (*LogWriter, error) {
+) (logWriter *LogWriter, err error) {
 	if cfg == nil {
 		return nil, cerror.WrapError(cerror.ErrRedoConfigInvalid, errors.New("LogWriterConfig can not be nil"))
 	}
 
-	initLock.Lock()
-	defer initLock.Unlock()
+	logWriter = &LogWriter{cfg: cfg}
 
-	if v, ok := logWriters[cfg.ChangeFeedID]; ok {
-		// if cfg changed or already closed need create a new LogWriter
-		if cfg.String() == v.cfg.String() && !v.isStopped() {
-			return v, nil
+	if logWriter.cfg.EmitRowEvents {
+		writerCfg := &FileWriterConfig{
+			Dir:          cfg.Dir,
+			ChangeFeedID: cfg.ChangeFeedID,
+			CaptureID:    cfg.CaptureID,
+			FileType:     common.DefaultRowLogFileType,
+			CreateTime:   cfg.CreateTime,
+			MaxLogSize:   cfg.MaxLogSize,
+			S3Storage:    cfg.S3Storage,
+			S3URI:        cfg.S3URI,
+		}
+		if logWriter.rowWriter, err = NewWriter(ctx, writerCfg, opts...); err != nil {
+			return
 		}
 	}
 
-	var err error
-	var logWriter *LogWriter
-	rowCfg := &FileWriterConfig{
-		Dir:          cfg.Dir,
-		ChangeFeedID: cfg.ChangeFeedID,
-		CaptureID:    cfg.CaptureID,
-		FileType:     common.DefaultRowLogFileType,
-		CreateTime:   cfg.CreateTime,
-		MaxLogSize:   cfg.MaxLogSize,
-		S3Storage:    cfg.S3Storage,
-		S3URI:        cfg.S3URI,
-	}
-	ddlCfg := &FileWriterConfig{
-		Dir:          cfg.Dir,
-		ChangeFeedID: cfg.ChangeFeedID,
-		CaptureID:    cfg.CaptureID,
-		FileType:     common.DefaultDDLLogFileType,
-		CreateTime:   cfg.CreateTime,
-		MaxLogSize:   cfg.MaxLogSize,
-		S3Storage:    cfg.S3Storage,
-		S3URI:        cfg.S3URI,
-	}
-	logWriter = &LogWriter{
-		cfg: cfg,
-	}
-	logWriter.rowWriter, err = NewWriter(ctx, rowCfg, opts...)
-	if err != nil {
-		return nil, err
-	}
-	logWriter.ddlWriter, err = NewWriter(ctx, ddlCfg, opts...)
-	if err != nil {
-		return nil, err
+	if logWriter.cfg.EmitDDLEvents {
+		writerCfg := &FileWriterConfig{
+			Dir:          cfg.Dir,
+			ChangeFeedID: cfg.ChangeFeedID,
+			CaptureID:    cfg.CaptureID,
+			FileType:     common.DefaultDDLLogFileType,
+			CreateTime:   cfg.CreateTime,
+			MaxLogSize:   cfg.MaxLogSize,
+			S3Storage:    cfg.S3Storage,
+			S3URI:        cfg.S3URI,
+		}
+		if logWriter.ddlWriter, err = NewWriter(ctx, writerCfg, opts...); err != nil {
+			return
+		}
 	}
 
-	// since the error will not block write log, so keep go to the next init process
-	err = logWriter.initMeta(ctx)
-	if err != nil {
-		log.Warn("init redo meta fail",
-			zap.String("namespace", cfg.ChangeFeedID.Namespace),
-			zap.String("changefeed", cfg.ChangeFeedID.ID),
-			zap.Error(err))
+	if logWriter.cfg.EmitMeta {
+		if err = logWriter.initMeta(ctx); err != nil {
+			log.Warn("init redo meta fail",
+				zap.String("namespace", cfg.ChangeFeedID.Namespace),
+				zap.String("changefeed", cfg.ChangeFeedID.ID),
+				zap.Error(err))
+			return
+		}
 	}
+
 	if cfg.S3Storage {
 		logWriter.storage, err = common.InitS3storage(ctx, cfg.S3URI)
 		if err != nil {
 			return nil, err
 		}
-	}
-	// close previous writer
-	if v, ok := logWriters[cfg.ChangeFeedID]; ok {
-		err = v.Close()
+		// since other process get the remove changefeed job async, may still write some logs after owner delete the log
+		err = logWriter.preCleanUpS3(ctx)
 		if err != nil {
 			return nil, err
-		}
-	} else {
-		if cfg.S3Storage {
-			// since other process get the remove changefeed job async, may still write some logs after owner delete the log
-			err = logWriter.preCleanUpS3(ctx)
-			if err != nil {
-				return nil, err
-			}
 		}
 	}
 
 	logWriter.metricTotalRowsCount = common.RedoTotalRowsCountGauge.
 		WithLabelValues(cfg.ChangeFeedID.Namespace, cfg.ChangeFeedID.ID)
-	logWriters[cfg.ChangeFeedID] = logWriter
-	go logWriter.runGC(ctx)
-	return logWriter, nil
+	return
 }
 
 func (l *LogWriter) preCleanUpS3(ctx context.Context) error {
@@ -247,42 +225,15 @@ func (l *LogWriter) initMeta(ctx context.Context) error {
 	return nil
 }
 
-func (l *LogWriter) runGC(ctx context.Context) {
-	ticker := time.NewTicker(time.Duration(defaultGCIntervalInMs) * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		if l.isStopped() {
-			return
-		}
-
-		select {
-		case <-ctx.Done():
-			err := l.Close()
-			if err != nil {
-				log.Error("runGC close fail",
-					zap.String("namespace", l.cfg.ChangeFeedID.Namespace),
-					zap.String("changefeed", l.cfg.ChangeFeedID.ID), zap.Error(err))
-			}
-		case <-ticker.C:
-			err := l.gc()
-			if err != nil {
-				log.Error("redo log GC fail",
-					zap.String("namespace", l.cfg.ChangeFeedID.Namespace),
-					zap.String("changefeed", l.cfg.ChangeFeedID.ID), zap.Error(err))
-			}
-		}
-	}
-}
-
-func (l *LogWriter) gc() error {
-	l.metaLock.RLock()
-	ts := l.meta.CheckpointTs
-	l.metaLock.RUnlock()
-
+// GC implement GC api
+func (l *LogWriter) GC(ctx context.Context, ts model.Ts) error {
 	var err error
-	err = multierr.Append(err, l.rowWriter.GC(ts))
-	err = multierr.Append(err, l.ddlWriter.GC(ts))
+	if l.cfg.EmitRowEvents {
+		err = multierr.Append(err, l.rowWriter.GC(ts))
+	}
+	if l.cfg.EmitDDLEvents {
+		err = multierr.Append(err, l.ddlWriter.GC(ts))
+	}
 	return err
 }
 
@@ -310,7 +261,6 @@ func (l *LogWriter) WriteLog(ctx context.Context, tableID int64, rows []*model.R
 		rl.RedoRow = r
 		rl.RedoDDL = nil
 		rl.Type = model.RedoLogTypeRow
-		// TODO: crc check
 		data, err := rl.MarshalMsg(nil)
 		if err != nil {
 			return cerror.WrapError(cerror.ErrMarshalFailed, err)
@@ -381,10 +331,12 @@ func (l *LogWriter) GetMeta() (checkpointTs, resolvedTs model.Ts) {
 }
 
 // DeleteAllLogs implement DeleteAllLogs api
-func (l *LogWriter) DeleteAllLogs(ctx context.Context) error {
-	err := l.Close()
-	if err != nil {
-		return err
+// FIXME: currently only owner will call this. We need to split it into 2 functions:
+//  1. cleanLocalStorage, which should be called on processors;
+//  2. cleanRemoteStorage, which should be called on owner.
+func (l *LogWriter) DeleteAllLogs(ctx context.Context) (err error) {
+	if err = l.Close(); err != nil {
+		return
 	}
 
 	err = os.RemoveAll(l.cfg.Dir)
@@ -393,26 +345,27 @@ func (l *LogWriter) DeleteAllLogs(ctx context.Context) error {
 	}
 
 	if !l.cfg.S3Storage {
-		// after delete logs, rm the LogWriter since it is already closed
-		l.cleanUpLogWriter()
-		return nil
+		return
 	}
 
-	files, err := getAllFilesInS3(ctx, l)
+	var files []string
+	files, err = getAllFilesInS3(ctx, l)
 	if err != nil {
 		return err
 	}
 
 	err = l.deleteFilesInS3(ctx, files)
 	if err != nil {
-		return err
+		return
 	}
-	// after delete logs, rm the LogWriter since it is already closed
-	l.cleanUpLogWriter()
 
-	// write a marker to s3, since other process get the remove changefeed job async,
-	// may still write some logs after owner delete the log
-	return l.writeDeletedMarkerToS3(ctx)
+	// Write the delete marker before clean any files.
+	err = l.writeDeletedMarkerToS3(ctx)
+	log.Info("redo manager write deleted mark",
+		zap.String("namespace", l.cfg.ChangeFeedID.Namespace),
+		zap.String("changefeed", l.cfg.ChangeFeedID.ID),
+		zap.Error(err))
+	return
 }
 
 func (l *LogWriter) getDeletedChangefeedMarker() string {
@@ -424,12 +377,6 @@ func (l *LogWriter) getDeletedChangefeedMarker() string {
 
 func (l *LogWriter) writeDeletedMarkerToS3(ctx context.Context) error {
 	return cerror.WrapError(cerror.ErrS3StorageAPI, l.storage.WriteFile(ctx, l.getDeletedChangefeedMarker(), []byte("D")))
-}
-
-func (l *LogWriter) cleanUpLogWriter() {
-	initLock.Lock()
-	defer initLock.Unlock()
-	delete(logWriters, l.cfg.ChangeFeedID)
 }
 
 func (l *LogWriter) deleteFilesInS3(ctx context.Context, files []string) error {
@@ -476,29 +423,42 @@ var getAllFilesInS3 = func(ctx context.Context, l *LogWriter) ([]string, error) 
 }
 
 // Close implements RedoLogWriter.Close.
-func (l *LogWriter) Close() error {
+func (l *LogWriter) Close() (err error) {
 	common.RedoTotalRowsCountGauge.
 		DeleteLabelValues(l.cfg.ChangeFeedID.Namespace, l.cfg.ChangeFeedID.ID)
 
-	var err error
-	err = multierr.Append(err, l.rowWriter.Close())
-	err = multierr.Append(err, l.ddlWriter.Close())
-	return err
+	if l.cfg.EmitRowEvents {
+		err = multierr.Append(err, l.rowWriter.Close())
+	}
+	if l.cfg.EmitDDLEvents {
+		err = multierr.Append(err, l.ddlWriter.Close())
+	}
+	return
 }
 
 // flush flushes all the buffered data to the disk.
-func (l *LogWriter) flush(checkpointTs, resolvedTs model.Ts) error {
-	err1 := l.ddlWriter.Flush()
-	err2 := l.rowWriter.Flush()
-	err3 := l.flushLogMeta(checkpointTs, resolvedTs)
-
-	err := multierr.Append(err1, err2)
-	err = multierr.Append(err, err3)
-	return err
+func (l *LogWriter) flush(checkpointTs, resolvedTs model.Ts) (err error) {
+	if l.cfg.EmitDDLEvents {
+		err = multierr.Append(err, l.ddlWriter.Flush())
+	}
+	if l.cfg.EmitRowEvents {
+		err = multierr.Append(err, l.rowWriter.Flush())
+	}
+	if l.cfg.EmitMeta {
+		err = multierr.Append(err, l.flushLogMeta(checkpointTs, resolvedTs))
+	}
+	return
 }
 
 func (l *LogWriter) isStopped() bool {
-	return !l.ddlWriter.IsRunning() || !l.rowWriter.IsRunning()
+	var rowStoped, ddlStoped bool
+	if l.cfg.EmitRowEvents {
+		rowStoped = !l.rowWriter.IsRunning()
+	}
+	if l.cfg.EmitDDLEvents {
+		ddlStoped = !l.ddlWriter.IsRunning()
+	}
+	return rowStoped || ddlStoped
 }
 
 func (l *LogWriter) getMetafileName() string {
@@ -512,9 +472,6 @@ func (l *LogWriter) getMetafileName() string {
 }
 
 func (l *LogWriter) maybeUpdateMeta(checkpointTs, resolvedTs uint64) ([]byte, error) {
-	l.metaLock.Lock()
-	defer l.metaLock.Unlock()
-
 	// NOTE: both checkpoint and resolved can regress if a cdc instance restarts.
 	hasChange := false
 	if checkpointTs > l.meta.CheckpointTs {
@@ -523,15 +480,19 @@ func (l *LogWriter) maybeUpdateMeta(checkpointTs, resolvedTs uint64) ([]byte, er
 	} else if checkpointTs > 0 && checkpointTs != l.meta.CheckpointTs {
 		log.Warn("flushLogMeta with a regressed checkpoint ts, ignore",
 			zap.Uint64("currCheckpointTs", l.meta.CheckpointTs),
-			zap.Uint64("recvCheckpointTs", checkpointTs))
+			zap.Uint64("recvCheckpointTs", checkpointTs),
+			zap.String("namespace", l.cfg.ChangeFeedID.Namespace),
+			zap.String("changefeed", l.cfg.ChangeFeedID.ID))
 	}
 	if resolvedTs > l.meta.ResolvedTs {
 		l.meta.ResolvedTs = resolvedTs
 		hasChange = true
 	} else if resolvedTs > 0 && resolvedTs != l.meta.ResolvedTs {
 		log.Warn("flushLogMeta with a regressed resolved ts, ignore",
-			zap.Uint64("currCheckpointTs", l.meta.ResolvedTs),
-			zap.Uint64("recvCheckpointTs", resolvedTs))
+			zap.Uint64("currResolvedTs", l.meta.ResolvedTs),
+			zap.Uint64("recvResolvedTs", resolvedTs),
+			zap.String("namespace", l.cfg.ChangeFeedID.Namespace),
+			zap.String("changefeed", l.cfg.ChangeFeedID.ID))
 	}
 
 	if !hasChange {

--- a/cdc/redo/writer/writer.go
+++ b/cdc/redo/writer/writer.go
@@ -451,14 +451,14 @@ func (l *LogWriter) flush(checkpointTs, resolvedTs model.Ts) (err error) {
 }
 
 func (l *LogWriter) isStopped() bool {
-	var rowStoped, ddlStoped bool
+	var rowStopped, ddlStopped bool
 	if l.cfg.EmitRowEvents {
-		rowStoped = !l.rowWriter.IsRunning()
+		rowStopped = !l.rowWriter.IsRunning()
 	}
 	if l.cfg.EmitDDLEvents {
-		ddlStoped = !l.ddlWriter.IsRunning()
+		ddlStopped = !l.ddlWriter.IsRunning()
 	}
-	return rowStoped || ddlStoped
+	return rowStopped || ddlStopped
 }
 
 func (l *LogWriter) getMetafileName() string {


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

Issue Number: close #6695 

### What is changed and how it works?

Reusing log write in redo manager should be in a correct way

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
