### PR TITLE
test(engine): fix 'database table is lock' bug for sqlite backend test

### DIFF
--- a/engine/pkg/meta/mock/clientconn_mock.go
+++ b/engine/pkg/meta/mock/clientconn_mock.go
@@ -42,6 +42,8 @@ func NewClientConnForSQLite(dsn string) (metaModel.ClientConn, error) {
 		return nil, err
 	}
 
+	db.SetMaxOpenConns(1)
+
 	return &sqliteClientConn{
 		db: db,
 	}, nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6665 

### What is changed and how it works?
We don't use connection pool in sqlite, 
so set `MaxOpenConns` to 1 for sqlite connection to avoid unexpected `database table is lock` error.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
