### PR TITLE
api(cdc): drain capture also check store version

### DIFF
--- a/cdc/owner/owner.go
+++ b/cdc/owner/owner.go
@@ -408,6 +408,7 @@ func (o *ownerImpl) handleDrainCaptures(ctx context.Context, query *scheduler.Qu
 	}); err != nil {
 		log.Info("owner handle drain capture failed, since check upstream store version failed",
 			zap.String("target", query.CaptureID), zap.Error(err))
+		query.Resp = &model.DrainCaptureResp{CurrentTableCount: 0}
 		done <- err
 		close(done)
 		return

--- a/cdc/owner/owner_test.go
+++ b/cdc/owner/owner_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/errors"
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/puller"
 	"github.com/pingcap/tiflow/cdc/scheduler"
@@ -726,12 +728,35 @@ func TestHandleDrainCapturesSchedulerNotReady(t *testing.T) {
 			Info: &model.ChangeFeedInfo{State: model.StateNormal},
 		},
 	}
-	o := &ownerImpl{changefeeds: make(map[model.ChangeFeedID]*changefeed)}
+
+	pdClient := &gc.MockPDClient{}
+	o := &ownerImpl{
+		changefeeds:     make(map[model.ChangeFeedID]*changefeed),
+		upstreamManager: upstream.NewManager4Test(pdClient),
+	}
 	o.changefeeds[model.ChangeFeedID{}] = cf
 
+	ctx := context.Background()
 	query := &scheduler.Query{CaptureID: "test"}
 	done := make(chan error, 1)
-	o.handleDrainCaptures(query, done)
+
+	// check store version failed.
+	pdClient.GetAllStoresFunc = func(
+		ctx context.Context, opts ...pd.GetStoreOption,
+	) ([]*metapb.Store, error) {
+		return nil, errors.New("store version check failed")
+	}
+	o.handleDrainCaptures(ctx, query, done)
+	require.Equal(t, 0, query.Resp.(*model.DrainCaptureResp).CurrentTableCount)
+	require.Error(t, <-done)
+
+	pdClient.GetAllStoresFunc = func(
+		ctx context.Context, opts ...pd.GetStoreOption,
+	) ([]*metapb.Store, error) {
+		return nil, nil
+	}
+	done = make(chan error, 1)
+	o.handleDrainCaptures(ctx, query, done)
 	require.NotEqualValues(t, 0, query.Resp.(*model.DrainCaptureResp).CurrentTableCount)
 	require.Nil(t, <-done)
 
@@ -739,7 +764,7 @@ func TestHandleDrainCapturesSchedulerNotReady(t *testing.T) {
 	cf.state.Info.State = model.StateStopped
 	query = &scheduler.Query{CaptureID: "test"}
 	done = make(chan error, 1)
-	o.handleDrainCaptures(query, done)
+	o.handleDrainCaptures(ctx, query, done)
 	require.EqualValues(t, 0, query.Resp.(*model.DrainCaptureResp).CurrentTableCount)
 	require.Nil(t, <-done)
 }

--- a/pkg/txnutil/gc/testing.go
+++ b/pkg/txnutil/gc/testing.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/tikv/client-go/v2/oracle"
 	pd "github.com/tikv/pd/client"
 )
@@ -24,7 +25,9 @@ import (
 // MockPDClient mocks pd.Client to facilitate unit testing.
 type MockPDClient struct {
 	pd.Client
-	ClusterID                    uint64
+	ClusterID        uint64
+	GetAllStoresFunc func(ctx context.Context, opts ...pd.GetStoreOption) ([]*metapb.Store, error)
+
 	UpdateServiceGCSafePointFunc func(ctx context.Context, serviceID string, ttl int64, safePoint uint64) (uint64, error)
 }
 
@@ -45,4 +48,11 @@ func (m *MockPDClient) Close() {}
 // GetClusterID gets the cluster ID from PD.
 func (m *MockPDClient) GetClusterID(ctx context.Context) uint64 {
 	return m.ClusterID
+}
+
+// GetAllStores gets all stores from PD.
+func (m *MockPDClient) GetAllStores(
+	ctx context.Context, opts ...pd.GetStoreOption,
+) ([]*metapb.Store, error) {
+	return m.GetAllStoresFunc(ctx, opts...)
 }

--- a/pkg/upstream/manager.go
+++ b/pkg/upstream/manager.go
@@ -172,6 +172,19 @@ func (m *Manager) Close() {
 	})
 }
 
+// Visit on each upstream, return error on the first
+func (m *Manager) Visit(visitor func(up *Upstream) error) error {
+	var err error
+	m.ups.Range(func(k, v interface{}) bool {
+		err = visitor(v.(*Upstream))
+		if err != nil {
+			return false
+		}
+		return true
+	})
+	return err
+}
+
 // Tick checks and frees upstream that have not been used
 // for a long time to save resources.
 func (m *Manager) Tick(ctx context.Context,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6677 

### What is changed and how it works?

when drain the capture, one capture drop all tables on it, and another capture add tables, which means the capture can contact tikv, which means tikv's version should be compatible with cdc.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
