### PR TITLE
version(ticdc): adjust cdc version range to 6.3.0-alpha ~ 8.0.0-alpha

### DIFF
--- a/pkg/version/check.go
+++ b/pkg/version/check.go
@@ -50,7 +50,7 @@ var (
 	defaultTiCDCVersion = semver.New("4.0.1")
 
 	// MinTiCDCVersion is the version of the minimal allowed TiCDC version.
-	MinTiCDCVersion = semver.New("6.3.0")
+	MinTiCDCVersion = semver.New("6.3.0-alpha")
 	// MaxTiCDCVersion is the version of the maximum allowed TiCDC version.
 	// for version `x.y.z`, max allowed `x+2.0.0`
 	MaxTiCDCVersion = semver.New("8.0.0")

--- a/pkg/version/check.go
+++ b/pkg/version/check.go
@@ -53,7 +53,7 @@ var (
 	MinTiCDCVersion = semver.New("6.3.0-alpha")
 	// MaxTiCDCVersion is the version of the maximum allowed TiCDC version.
 	// for version `x.y.z`, max allowed `x+2.0.0`
-	MaxTiCDCVersion = semver.New("8.0.0")
+	MaxTiCDCVersion = semver.New("8.0.0-alpha")
 )
 
 var versionHash = regexp.MustCompile("-[0-9]+-g[0-9a-f]{7,}(-dev)?")

--- a/pkg/version/check_test.go
+++ b/pkg/version/check_test.go
@@ -210,6 +210,22 @@ func TestCompareVersion(t *testing.T) {
 		Compare(*semver.New("3.0.5-beta.12")), 0)
 	require.Equal(t, semver.New(removeVAndHash("v2.1.0-rc.1-7-g38c939f-dirty")).
 		Compare(*semver.New("2.1.0-rc.1")), 0)
+
+	// build on master branch, `vx.y.z-master`
+	masterVersion := semver.New(removeVAndHash("v6.3.0-master"))
+	require.Equal(t, 1, masterVersion.Compare(*MinTiCDCVersion))
+
+	// pre-release version, `vx.y.z-alpha-nightly-yyyymmdd`
+	alphaVersion := semver.New(removeVAndHash("v6.3.0-alpha-nightly-20220202"))
+	require.Equal(t, 1, alphaVersion.Compare(*MinTiCDCVersion))
+
+	// release version, `vx.y.z.`
+	releaseVersion := semver.New(removeVAndHash("v6.3.0"))
+	require.Equal(t, 1, releaseVersion.Compare(*MinTiCDCVersion))
+
+	dirtyVersion := semver.New(removeVAndHash("v6.3.0-dirty"))
+	require.Equal(t, 1, dirtyVersion.Compare(*MinTiCDCVersion))
+
 }
 
 func TestReleaseSemver(t *testing.T) {
@@ -404,4 +420,11 @@ func TestCheckTiCDCVersion(t *testing.T) {
 	}
 	err = CheckTiCDCVersion(versions)
 	require.Regexp(t, "TiCDC .* not supported, the minimal compatible version.*", err)
+
+	versions = map[string]struct{}{
+		"v6.3.0-master": {},
+		"v7.0.0":        {},
+	}
+	err = CheckTiCDCVersion(versions)
+	require.NoError(t, err)
 }

--- a/pkg/version/check_test.go
+++ b/pkg/version/check_test.go
@@ -400,6 +400,13 @@ func TestCheckTiCDCVersion(t *testing.T) {
 	require.Regexp(t, "TiCDC .* not supported, only support version less than.*", err)
 
 	versions = map[string]struct{}{
+		"v6.3.0":        {},
+		"v8.0.0-master": {},
+	}
+	err = CheckTiCDCVersion(versions)
+	require.Regexp(t, "TiCDC .* not supported, only support version less than.*", err)
+
+	versions = map[string]struct{}{
 		"v6.3.0": {},
 		"v8.0.0": {},
 	}

--- a/pkg/version/check_test.go
+++ b/pkg/version/check_test.go
@@ -195,22 +195,6 @@ func TestCheckClusterVersion(t *testing.T) {
 }
 
 func TestCompareVersion(t *testing.T) {
-	require.Equal(t, semver.New("4.0.0-rc").Compare(*semver.New("4.0.0-rc.2")), -1)
-	require.Equal(t, semver.New("4.0.0-rc.1").Compare(*semver.New("4.0.0-rc.2")), -1)
-	require.Equal(t, semver.New(removeVAndHash("4.0.0-rc-35-g31dae220")).Compare(*semver.New("4.0.0-rc.2")), -1)
-	require.Equal(t, semver.New(removeVAndHash("4.0.0-9-g30f0b014")).Compare(*semver.New("4.0.0-rc.1")), 1)
-
-	require.Equal(t, semver.New(removeVAndHash("4.0.0-rc-35-g31dae220")).Compare(*semver.New("4.0.0-rc.2")), -1)
-	require.Equal(t, semver.New(removeVAndHash("4.0.0-9-g30f0b014")).Compare(*semver.New("4.0.0-rc.1")), 1)
-	require.Equal(t, semver.New(removeVAndHash("v3.0.0-beta-211-g09beefbe0-dirty")).
-		Compare(*semver.New("3.0.0-beta")), 0)
-	require.Equal(t, semver.New(removeVAndHash("v3.0.5-dirty")).
-		Compare(*semver.New("3.0.5")), 0)
-	require.Equal(t, semver.New(removeVAndHash("v3.0.5-beta.12-dirty")).
-		Compare(*semver.New("3.0.5-beta.12")), 0)
-	require.Equal(t, semver.New(removeVAndHash("v2.1.0-rc.1-7-g38c939f-dirty")).
-		Compare(*semver.New("2.1.0-rc.1")), 0)
-
 	// build on master branch, `vx.y.z-master`
 	masterVersion := semver.New(removeVAndHash("v6.3.0-master"))
 	require.Equal(t, 1, masterVersion.Compare(*MinTiCDCVersion))
@@ -223,9 +207,10 @@ func TestCompareVersion(t *testing.T) {
 	releaseVersion := semver.New(removeVAndHash("v6.3.0"))
 	require.Equal(t, 1, releaseVersion.Compare(*MinTiCDCVersion))
 
+	// build with uncommitted changes, `vx.y.z-dirty`
 	dirtyVersion := semver.New(removeVAndHash("v6.3.0-dirty"))
 	require.Equal(t, 1, dirtyVersion.Compare(*MinTiCDCVersion))
-
+	require.Equal(t, 0, dirtyVersion.Compare(*semver.New("6.3.0")))
 }
 
 func TestReleaseSemver(t *testing.T) {
@@ -379,13 +364,13 @@ func TestCheckPDVersionError(t *testing.T) {
 func TestCheckTiCDCVersion(t *testing.T) {
 	t.Parallel()
 
-	// only one capture in the cluster, it's ok
+	// all captures in the cluster in the same version which is the minimum supported one.
 	versions := map[string]struct{}{
 		"v6.3.0": {},
 	}
 	require.NoError(t, CheckTiCDCVersion(versions))
 
-	// 2 running instances in different versions both within the range, it's ok
+	// 2  different versions both within the range, it's ok
 	versions = map[string]struct{}{
 		"v6.3.0": {},
 		"v6.4.0": {},
@@ -406,6 +391,13 @@ func TestCheckTiCDCVersion(t *testing.T) {
 	}
 	err = CheckTiCDCVersion(versions)
 	require.Regexp(t, ".*all running cdc instance belong to 3 different versions.*", err)
+
+	versions = map[string]struct{}{
+		"v6.3.0":       {},
+		"v8.0.0-alpha": {},
+	}
+	err = CheckTiCDCVersion(versions)
+	require.Regexp(t, "TiCDC .* not supported, only support version less than.*", err)
 
 	versions = map[string]struct{}{
 		"v6.3.0": {},


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #4757 

### What is changed and how it works?

change cdc version from [6.3.0, 8.0.0), to [6.3.0-alpha, 8.0.0-alpha), so that `6.3.0-master` in the range.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None`
```
