### PR TITLE
processor(ticdc): fix log make cdc instance panic

### DIFF
--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -483,9 +483,9 @@ func (c *captureImpl) campaignOwner(ctx cdcContext.Context) error {
 		if resignErr := c.resign(resignCtx); resignErr != nil {
 			if errors.Cause(resignErr) != context.DeadlineExceeded {
 				log.Info("owner resign failed", zap.String("captureID", c.info.ID),
-					zap.Error(err), zap.Int64("ownerRev", ownerRev))
+					zap.Error(resignErr), zap.Int64("ownerRev", ownerRev))
 				cancel()
-				return errors.Trace(err)
+				return errors.Trace(resignErr)
 			}
 
 			log.Warn("owner resign timeout", zap.String("captureID", c.info.ID),

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -475,6 +475,7 @@ func isProcessorIgnorableError(err error) bool {
 // the `state` parameter is sent by the etcd worker, the `state` must be a snapshot of KVs in etcd
 // The main logic of processor is in this function, including the calculation of many kinds of ts, maintain table pipeline, error handling, etc.
 func (p *processor) Tick(ctx cdcContext.Context, state *orchestrator.ChangefeedReactorState) (orchestrator.ReactorState, error) {
+	p.changefeed = state
 	// check upstream error first
 	if err := p.upstream.Error(); err != nil {
 		return p.handleErr(state, err)
@@ -493,7 +494,6 @@ func (p *processor) Tick(ctx cdcContext.Context, state *orchestrator.ChangefeedR
 		return state, nil
 	}
 	startTime := time.Now()
-	p.changefeed = state
 	state.CheckCaptureAlive(ctx.GlobalVars().CaptureInfo.ID)
 	ctx = cdcContext.WithChangefeedVars(ctx, &cdcContext.ChangefeedVars{
 		ID:   state.ID,

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -656,7 +656,7 @@ func (p *processor) lazyInitImpl(ctx cdcContext.Context) error {
 		return errors.Trace(err)
 	}
 
-	stdCtx := contextutil.PutChangefeedIDInCtx(ctx, p.changefeed.ID)
+	stdCtx := contextutil.PutChangefeedIDInCtx(ctx, p.changefeedID)
 	stdCtx = contextutil.PutRoleInCtx(stdCtx, util.RoleProcessor)
 
 	p.mounter = entry.NewMounter(p.schemaStorage,
@@ -668,7 +668,7 @@ func (p *processor) lazyInitImpl(ctx cdcContext.Context) error {
 
 	log.Info("processor try new sink",
 		zap.String("namespace", p.changefeedID.Namespace),
-		zap.String("changefeed", p.changefeed.ID.ID))
+		zap.String("changefeed", p.changefeedID.ID))
 
 	start := time.Now()
 	conf := config.GetGlobalServerConfig()
@@ -676,7 +676,7 @@ func (p *processor) lazyInitImpl(ctx cdcContext.Context) error {
 		log.Info("Try to create sinkV1")
 		p.sinkV1, err = sinkv1.New(
 			stdCtx,
-			p.changefeed.ID,
+			p.changefeedID,
 			p.changefeed.Info.SinkURI,
 			p.changefeed.Info.Config,
 			errCh,
@@ -691,7 +691,7 @@ func (p *processor) lazyInitImpl(ctx cdcContext.Context) error {
 	if err != nil {
 		log.Info("processor new sink failed",
 			zap.String("namespace", p.changefeedID.Namespace),
-			zap.String("changefeed", p.changefeed.ID.ID),
+			zap.String("changefeed", p.changefeedID.ID),
 			zap.Duration("duration", time.Since(start)))
 		return errors.Trace(err)
 	}
@@ -1036,7 +1036,7 @@ func (p *processor) refreshMetrics() {
 func (p *processor) Close() error {
 	log.Info("processor closing ...",
 		zap.String("namespace", p.changefeedID.Namespace),
-		zap.String("changefeed", p.changefeed.ID.ID))
+		zap.String("changefeed", p.changefeedID.ID))
 	for _, tbl := range p.tables {
 		tbl.Cancel()
 	}

--- a/pkg/upstream/upstream.go
+++ b/pkg/upstream/upstream.go
@@ -158,6 +158,7 @@ func initUpstream(ctx context.Context, up *Upstream, gcServiceID string) error {
 	if err != nil {
 		up.err.Store(err)
 		log.Error("init upstream error", zap.Error(err))
+		return errors.Trace(err)
 	}
 
 	up.KVStorage, err = kv.CreateTiStore(strings.Join(up.PdEndpoints, ","), up.SecurityConfig)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6714 

cdc panic due to visit nil pointer of `*ChangefeedReactorState`

### What is changed and how it works?

* print log by use non-nil `changefeedID`, instead of `*ChangefeedReactorState` to prevent nil pointer, which cause the panic.

Upgrade pd to `v6.3.0`, which is not supported by `v6.2.0`, init upstream failed, `processor.changefeed` is not initialized, so cause the nil.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
