### PR TITLE
sinkv2(ticdc): remove useless role in eventsink

### DIFF
--- a/cdc/sinkv2/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
+++ b/cdc/sinkv2/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
@@ -178,13 +178,13 @@ func (k *kafkaDDLProducer) Close() {
 	go func() {
 		start := time.Now()
 		if err := k.client.Close(); err != nil {
-			log.Error("close sarama client with error in kafka "+
+			log.Error("Close sarama client with error in kafka "+
 				"DDL producer", zap.Error(err),
 				zap.Duration("duration", time.Since(start)),
 				zap.String("namespace", k.id.Namespace),
 				zap.String("changefeed", k.id.ID))
 		} else {
-			log.Info("sarama client closed in kafka "+
+			log.Info("Sarama client closed in kafka "+
 				"DDL producer", zap.Duration("duration", time.Since(start)),
 				zap.String("namespace", k.id.Namespace),
 				zap.String("changefeed", k.id.ID))

--- a/cdc/sinkv2/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
+++ b/cdc/sinkv2/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
@@ -73,7 +73,7 @@ func NewKafkaDDLProducer(ctx context.Context, client sarama.Client,
 					zap.String("changefeed", changefeedID.ID))
 			}
 			if err := adminClient.Close(); err != nil {
-				log.Error("Close kafka admin client with error in kafka "+
+				log.Error("Close sarama admin client with error in kafka "+
 					"DDL producer", zap.Error(err),
 					zap.String("namespace", changefeedID.Namespace),
 					zap.String("changefeed", changefeedID.ID))

--- a/cdc/sinkv2/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
+++ b/cdc/sinkv2/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
@@ -67,12 +67,14 @@ func NewKafkaDDLProducer(ctx context.Context, client sarama.Client,
 		go func() {
 			err := client.Close()
 			if err != nil {
-				log.Error("Close sarama client with error", zap.Error(err),
+				log.Error("Close sarama client with error in kafka "+
+					"DDL producer", zap.Error(err),
 					zap.String("namespace", changefeedID.Namespace),
 					zap.String("changefeed", changefeedID.ID))
 			}
 			if err := adminClient.Close(); err != nil {
-				log.Error("Close kafka admin client with error", zap.Error(err),
+				log.Error("Close kafka admin client with error in kafka "+
+					"DDL producer", zap.Error(err),
 					zap.String("namespace", changefeedID.Namespace),
 					zap.String("changefeed", changefeedID.ID))
 			}
@@ -176,12 +178,14 @@ func (k *kafkaDDLProducer) Close() {
 	go func() {
 		start := time.Now()
 		if err := k.client.Close(); err != nil {
-			log.Error("close sarama client with error", zap.Error(err),
+			log.Error("close sarama client with error in kafka "+
+				"DDL producer", zap.Error(err),
 				zap.Duration("duration", time.Since(start)),
 				zap.String("namespace", k.id.Namespace),
 				zap.String("changefeed", k.id.ID))
 		} else {
-			log.Info("sarama client closed", zap.Duration("duration", time.Since(start)),
+			log.Info("sarama client closed in kafka "+
+				"DDL producer", zap.Duration("duration", time.Since(start)),
 				zap.String("namespace", k.id.Namespace),
 				zap.String("changefeed", k.id.ID))
 		}

--- a/cdc/sinkv2/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
+++ b/cdc/sinkv2/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
@@ -159,8 +159,7 @@ func (k *kafkaDDLProducer) Close() {
 	if k.closed {
 		// We need to guard against double closed the clients,
 		// which could lead to panic.
-		log.Warn("Kafka producer already closed in kafka "+
-			"DDL producer",
+		log.Warn("Kafka DDL producer already closed",
 			zap.String("namespace", k.id.Namespace),
 			zap.String("changefeed", k.id.ID))
 		return

--- a/cdc/sinkv2/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
+++ b/cdc/sinkv2/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
@@ -159,7 +159,8 @@ func (k *kafkaDDLProducer) Close() {
 	if k.closed {
 		// We need to guard against double closed the clients,
 		// which could lead to panic.
-		log.Warn("kafka producer already closed",
+		log.Warn("Kafka producer already closed in kafka "+
+			"DDL producer",
 			zap.String("namespace", k.id.Namespace),
 			zap.String("changefeed", k.id.ID))
 		return
@@ -193,12 +194,14 @@ func (k *kafkaDDLProducer) Close() {
 		start = time.Now()
 		err := k.syncProducer.Close()
 		if err != nil {
-			log.Error("close sync client with error", zap.Error(err),
+			log.Error("Close sync client with error in kafka "+
+				"DDL producer", zap.Error(err),
 				zap.Duration("duration", time.Since(start)),
 				zap.String("namespace", k.id.Namespace),
 				zap.String("changefeed", k.id.ID))
 		} else {
-			log.Info("sync client closed", zap.Duration("duration", time.Since(start)),
+			log.Info("Sync client closed in kafka "+
+				"DDL producer", zap.Duration("duration", time.Since(start)),
 				zap.String("namespace", k.id.Namespace),
 				zap.String("changefeed", k.id.ID))
 		}

--- a/cdc/sinkv2/ddlsink/mq/kafka_ddl_sink.go
+++ b/cdc/sinkv2/ddlsink/mq/kafka_ddl_sink.go
@@ -62,7 +62,8 @@ func NewKafkaDDLSink(
 	defer func() {
 		if err != nil {
 			if err = adminClient.Close(); err != nil {
-				log.Error("close admin client failed", zap.Error(err))
+				log.Error("Close admin client failed in kafka "+
+					"DDL sink", zap.Error(err))
 			}
 		}
 	}()

--- a/cdc/sinkv2/ddlsink/mq/mq_ddl_sink.go
+++ b/cdc/sinkv2/ddlsink/mq/mq_ddl_sink.go
@@ -82,7 +82,7 @@ func (k *ddlSink) WriteDDLEvent(ctx context.Context, ddl *model.DDLEvent) error 
 		return errors.Trace(err)
 	}
 	if msg == nil {
-		log.Info("skip ddl event", zap.Uint64("commitTs", ddl.CommitTs),
+		log.Info("Skip ddl event", zap.Uint64("commitTs", ddl.CommitTs),
 			zap.String("query", ddl.Query),
 			zap.String("protocol", k.protocol.String()),
 			zap.String("namespace", k.id.Namespace),
@@ -92,7 +92,7 @@ func (k *ddlSink) WriteDDLEvent(ctx context.Context, ddl *model.DDLEvent) error 
 
 	topic := k.eventRouter.GetTopicForDDL(ddl)
 	partitionRule := k.eventRouter.GetDLLDispatchRuleByProtocol(k.protocol)
-	log.Debug("emit ddl event",
+	log.Debug("Emit ddl event",
 		zap.Uint64("commitTs", ddl.CommitTs),
 		zap.String("query", ddl.Query),
 		zap.String("namespace", k.id.Namespace),
@@ -137,7 +137,7 @@ func (k *ddlSink) WriteCheckpointTs(ctx context.Context,
 		if err != nil {
 			return errors.Trace(err)
 		}
-		log.Debug("emit checkpointTs to default topic",
+		log.Debug("Emit checkpointTs to default topic",
 			zap.String("topic", topic), zap.Uint64("checkpointTs", ts))
 		err = k.producer.SyncBroadcastMessage(ctx, topic, partitionNum, msg)
 		return errors.Trace(err)

--- a/cdc/sinkv2/eventsink/mq/dmlproducer/kafka_dml_producer.go
+++ b/cdc/sinkv2/eventsink/mq/dmlproducer/kafka_dml_producer.go
@@ -83,12 +83,14 @@ func NewKafkaDMLProducer(
 		// so close it asynchronously.
 		go func() {
 			if err := client.Close(); err != nil {
-				log.Error("Close sarama client with error in DML producer", zap.Error(err),
+				log.Error("Close sarama client with error in kafka "+
+					"DML producer", zap.Error(err),
 					zap.String("namespace", changefeedID.Namespace),
 					zap.String("changefeed", changefeedID.ID))
 			}
 			if err := adminClient.Close(); err != nil {
-				log.Error("Close kafka admin client with error in DML producer", zap.Error(err),
+				log.Error("Close kafka admin client with error in kafka "+
+					"DML producer", zap.Error(err),
 					zap.String("namespace", changefeedID.Namespace),
 					zap.String("changefeed", changefeedID.ID))
 			}

--- a/cdc/sinkv2/eventsink/mq/dmlproducer/kafka_dml_producer.go
+++ b/cdc/sinkv2/eventsink/mq/dmlproducer/kafka_dml_producer.go
@@ -187,7 +187,7 @@ func (k *kafkaDMLProducer) Close() {
 	if k.closed {
 		// We need to guard against double closing the clients,
 		// which could lead to panic.
-		log.Warn("kafka DML producer already closed",
+		log.Warn("Kafka DML producer already closed",
 			zap.String("namespace", k.id.Namespace),
 			zap.String("changefeed", k.id.ID))
 		return
@@ -216,13 +216,13 @@ func (k *kafkaDMLProducer) Close() {
 		// To prevent the scenario mentioned above, close the client first.
 		start := time.Now()
 		if err := k.client.Close(); err != nil {
-			log.Error("close sarama client with error in kafka "+
+			log.Error("Close sarama client with error in kafka "+
 				"DML producer", zap.Error(err),
 				zap.Duration("duration", time.Since(start)),
 				zap.String("namespace", k.id.Namespace),
 				zap.String("changefeed", k.id.ID))
 		} else {
-			log.Info("sarama client closed in kafka "+
+			log.Info("Sarama client closed in kafka "+
 				"DML producer", zap.Duration("duration", time.Since(start)),
 				zap.String("namespace", k.id.Namespace),
 				zap.String("changefeed", k.id.ID))
@@ -231,13 +231,13 @@ func (k *kafkaDMLProducer) Close() {
 		start = time.Now()
 		err := k.asyncProducer.Close()
 		if err != nil {
-			log.Error("close async client with error in kafka "+
+			log.Error("Close async client with error in kafka "+
 				"DML producer", zap.Error(err),
 				zap.Duration("duration", time.Since(start)),
 				zap.String("namespace", k.id.Namespace),
 				zap.String("changefeed", k.id.ID))
 		} else {
-			log.Info("async client closed in kafka "+
+			log.Info("Async client closed in kafka "+
 				"DML producer", zap.Duration("duration", time.Since(start)),
 				zap.String("namespace", k.id.Namespace),
 				zap.String("changefeed", k.id.ID))
@@ -255,7 +255,8 @@ func (k *kafkaDMLProducer) run(ctx context.Context) error {
 		case <-k.closedChan:
 			return nil
 		case err := <-k.failpointCh:
-			log.Warn("receive from failpoint chan in DML producer", zap.Error(err),
+			log.Warn("receive from failpoint chan in kafka "+
+				"DML producer", zap.Error(err),
 				zap.String("namespace", k.id.Namespace),
 				zap.String("changefeed", k.id.ID))
 			return errors.Trace(err)

--- a/cdc/sinkv2/eventsink/mq/dmlproducer/kafka_dml_producer.go
+++ b/cdc/sinkv2/eventsink/mq/dmlproducer/kafka_dml_producer.go
@@ -89,7 +89,7 @@ func NewKafkaDMLProducer(
 					zap.String("changefeed", changefeedID.ID))
 			}
 			if err := adminClient.Close(); err != nil {
-				log.Error("Close kafka admin client with error in kafka "+
+				log.Error("Close sarama admin client with error in kafka "+
 					"DML producer", zap.Error(err),
 					zap.String("namespace", changefeedID.Namespace),
 					zap.String("changefeed", changefeedID.ID))

--- a/cdc/sinkv2/eventsink/mq/dmlproducer/kafka_dml_producer.go
+++ b/cdc/sinkv2/eventsink/mq/dmlproducer/kafka_dml_producer.go
@@ -255,7 +255,7 @@ func (k *kafkaDMLProducer) run(ctx context.Context) error {
 		case <-k.closedChan:
 			return nil
 		case err := <-k.failpointCh:
-			log.Warn("receive from failpoint chan in kafka "+
+			log.Warn("Receive from failpoint chan in kafka "+
 				"DML producer", zap.Error(err),
 				zap.String("namespace", k.id.Namespace),
 				zap.String("changefeed", k.id.ID))

--- a/cdc/sinkv2/eventsink/mq/dmlproducer/kafka_dml_producer_test.go
+++ b/cdc/sinkv2/eventsink/mq/dmlproducer/kafka_dml_producer_test.go
@@ -22,12 +22,10 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
-	"github.com/pingcap/tiflow/cdc/contextutil"
 	"github.com/pingcap/tiflow/cdc/sink/mq/codec"
 	kafkav1 "github.com/pingcap/tiflow/cdc/sink/mq/producer/kafka"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/kafka"
-	"github.com/pingcap/tiflow/pkg/util"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 )
@@ -78,7 +76,6 @@ func TestProducerAck(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	ctx, cancel := context.WithCancel(context.Background())
-	ctx = contextutil.PutRoleInCtx(ctx, util.RoleTester)
 	saramaConfig, err := kafkav1.NewSaramaConfig(context.Background(), config)
 	require.Nil(t, err)
 	saramaConfig.Producer.Flush.MaxMessages = 1
@@ -142,7 +139,6 @@ func TestProducerSendMsgFailed(t *testing.T) {
 	errCh := make(chan error, 1)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
-	ctx = contextutil.PutRoleInCtx(ctx, util.RoleTester)
 	saramaConfig, err := kafkav1.NewSaramaConfig(context.Background(), config)
 	require.Nil(t, err)
 	saramaConfig.Producer.Flush.MaxMessages = 1
@@ -208,7 +204,6 @@ func TestProducerDoubleClose(t *testing.T) {
 	errCh := make(chan error, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ctx = contextutil.PutRoleInCtx(ctx, util.RoleTester)
 	saramaConfig, err := kafkav1.NewSaramaConfig(context.Background(), config)
 	require.Nil(t, err)
 	saramaConfig.Producer.Flush.MaxMessages = 1

--- a/cdc/sinkv2/eventsink/mq/kafka_dml_sink.go
+++ b/cdc/sinkv2/eventsink/mq/kafka_dml_sink.go
@@ -62,7 +62,8 @@ func NewKafkaDMLSink(
 	defer func() {
 		if err != nil {
 			if err = adminClient.Close(); err != nil {
-				log.Error("close admin client failed", zap.Error(err))
+				log.Error("Close admin client failed in kafka "+
+					"DML sink", zap.Error(err))
 			}
 		}
 	}()

--- a/cdc/sinkv2/eventsink/mq/mq_dml_sink.go
+++ b/cdc/sinkv2/eventsink/mq/mq_dml_sink.go
@@ -87,7 +87,7 @@ func newSink(ctx context.Context,
 				return
 			case errCh <- err:
 			default:
-				log.Error("error channel is full in DML sink", zap.Error(err),
+				log.Error("Error channel is full in DML sink", zap.Error(err),
 					zap.String("namespace", changefeedID.Namespace),
 					zap.String("changefeed", changefeedID.ID))
 			}

--- a/cdc/sinkv2/eventsink/txn/event.go
+++ b/cdc/sinkv2/eventsink/txn/event.go
@@ -23,7 +23,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var crcTable *crc64.Table = crc64.MakeTable(crc64.ISO)
+var crcTable = crc64.MakeTable(crc64.ISO)
 
 type txnEvent struct {
 	*eventsink.TxnCallbackableEvent
@@ -90,7 +90,7 @@ func genRowKeys(row *model.RowChangedEvent) [][]byte {
 	if len(keys) == 0 {
 		// use table ID as key if no key generated (no PK/UK),
 		// no concurrence for rows in the same table.
-		log.Debug("use table id as the key", zap.Int64("tableID", row.Table.TableID))
+		log.Debug("Use table id as the key", zap.Int64("tableID", row.Table.TableID))
 		tableKey := make([]byte, 8)
 		binary.BigEndian.PutUint64(tableKey, uint64(row.Table.TableID))
 		keys = [][]byte{tableKey}

--- a/cdc/sinkv2/eventsink/txn/worker.go
+++ b/cdc/sinkv2/eventsink/txn/worker.go
@@ -66,18 +66,18 @@ func (w *worker) runBackgroundLoop() {
 		for {
 			select {
 			case <-w.stopped:
-				log.Info("transaction sink backend worker exits expectedly",
+				log.Info("Transaction sink backend worker exits expectedly",
 					zap.Int("workerID", w.ID))
 				return
 			case txn := <-w.txnCh.Out():
 				txn.wantMore()
 				if w.backend.OnTxnEvent(txn.txnEvent.TxnCallbackableEvent) && w.doFlush() {
-					log.Warn("transaction sink backend exits unexceptedly")
+					log.Warn("Transaction sink backend exits unexceptedly")
 					return
 				}
 			case <-w.timer.C:
 				if w.doFlush() {
-					log.Warn("transaction sink backend exits unexceptedly")
+					log.Warn("Transaction sink backend exits unexceptedly")
 					return
 				}
 			}

--- a/cdc/sinkv2/metrics/kafka/collector.go
+++ b/cdc/sinkv2/metrics/kafka/collector.go
@@ -270,12 +270,14 @@ func (m *Collector) Close() {
 	namespace := m.changefeedID.Namespace
 	changefeedID := m.changefeedID.ID
 	if err := m.adminClient.Close(); err != nil {
-		log.Warn("close kafka cluster admin with error", zap.Error(err),
+		log.Warn("Close kafka cluster admin with error in "+
+			"metric collector", zap.Error(err),
 			zap.Duration("duration", time.Since(start)),
 			zap.String("namespace", namespace),
 			zap.String("changefeed", changefeedID), zap.Any("role", m.role))
 	} else {
-		log.Info("kafka cluster admin closed", zap.Duration("duration", time.Since(start)),
+		log.Info("Kafka cluster admin closed in "+
+			"metric collector", zap.Duration("duration", time.Since(start)),
 			zap.String("namespace", namespace),
 			zap.String("changefeed", changefeedID), zap.Any("role", m.role))
 	}

--- a/cdc/sinkv2/metrics/statistics.go
+++ b/cdc/sinkv2/metrics/statistics.go
@@ -179,7 +179,7 @@ func (b *Statistics) PrintStatus() {
 	totalDDLCount := atomic.LoadUint64(&b.totalDDLCount)
 	atomic.StoreUint64(&b.totalDDLCount, 0)
 
-	log.Info("sink replication status",
+	log.Info("DML sink replication status",
 		zap.Stringer("sinkType", b.sinkType),
 		zap.String("namespace", b.changefeedID.Namespace),
 		zap.String("changefeed", b.changefeedID.ID),

--- a/cdc/sinkv2/tablesink/progress_tracker.go
+++ b/cdc/sinkv2/tablesink/progress_tracker.go
@@ -163,7 +163,7 @@ func (r *progressTracker) close(ctx context.Context) error {
 		case <-ctx.Done():
 			return errors.Trace(ctx.Err())
 		case <-blockTicker.C:
-			log.Warn("close processor doesn't return in time, may be stuck",
+			log.Warn("Close process doesn't return in time, may be stuck",
 				zap.Int64("tableID", r.tableID),
 				zap.Int("trackingCount", r.trackingCount()),
 				zap.Any("lastMinResolvedTs", r.minTs()),


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref https://github.com/pingcap/tiflow/issues/5928

### What is changed and how it works?

remove useless role in eventsink, because we only use it in processor.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
