### PR TITLE
cli(ticdc): drop interactive cmd support

### DIFF
--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -14,43 +14,16 @@
 package cli
 
 import (
-	"fmt"
-	"io"
-	"os"
-
-	"github.com/chzyer/readline"
-	"github.com/mattn/go-shellwords"
 	"github.com/pingcap/tiflow/pkg/cmd/factory"
 	"github.com/pingcap/tiflow/pkg/cmd/util"
 	"github.com/pingcap/tiflow/pkg/logutil"
 	"github.com/spf13/cobra"
 )
 
-// options defines flags for the `cli` command.
-type options struct {
-	interact bool
-}
-
-// newOptions creates new options for the `cli` command.
-func newOptions() *options {
-	return &options{}
-}
-
-// addFlags receives a *cobra.Command reference and binds
-// flags related to template printing to it.
-func (o *options) addFlags(c *cobra.Command) {
-	if o == nil {
-		return
-	}
-	c.PersistentFlags().BoolVarP(&o.interact, "interact", "i", false, "Run cdc cli with readline")
-}
-
 // NewCmdCli creates the `cli` command.
 func NewCmdCli() *cobra.Command {
 	// Bind the certificate and log options.
 	cf := factory.NewClientFlags()
-
-	o := newOptions()
 
 	cmds := &cobra.Command{
 		Use:   "cli",
@@ -69,16 +42,9 @@ func NewCmdCli() *cobra.Command {
 			return nil
 		},
 		Args: cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			// Whether to run interactively or not.
-			if o.interact {
-				run()
-			}
-		},
 	}
 
 	// Binding the `cli` command flags.
-	o.addFlags(cmds)
 	cf.AddFlags(cmds)
 
 	// Construct the client construction factory.
@@ -92,47 +58,4 @@ func NewCmdCli() *cobra.Command {
 	cmds.AddCommand(newCmdUnsafe(f))
 
 	return cmds
-}
-
-func run() {
-	l, err := readline.NewEx(&readline.Config{
-		Prompt:            "\033[31m»\033[0m ",
-		HistoryFile:       "/tmp/readline.tmp",
-		InterruptPrompt:   "^C",
-		EOFPrompt:         "^D",
-		HistorySearchFold: true,
-	})
-	if err != nil {
-		panic(err)
-	}
-	defer l.Close()
-
-	for {
-		line, err := l.Readline()
-		if err != nil {
-			if err == readline.ErrInterrupt {
-				break
-			} else if err == io.EOF {
-				break
-			}
-			continue
-		}
-		if line == "exit" {
-			os.Exit(0)
-		}
-		args, err := shellwords.Parse(line)
-		if err != nil {
-			fmt.Printf("parse command err: %v\n", err)
-			continue
-		}
-
-		command := NewCmdCli()
-		command.SetArgs(args)
-		_ = command.ParseFlags(args)
-		command.SetOut(os.Stdout)
-		command.SetErr(os.Stdout)
-		if err = command.Execute(); err != nil {
-			command.Println(err)
-		}
-	}
 }

--- a/pkg/cmd/cli/cli_changefeed_update.go
+++ b/pkg/cmd/cli/cli_changefeed_update.go
@@ -177,9 +177,6 @@ func (o *updateChangefeedOptions) applyChanges(oldInfo *v2.ChangeFeedInfo,
 		case "changefeed-id", "no-confirm":
 			// Do nothing, these are some flags from the changefeed command,
 			// we don't use it to update, but we do use these flags.
-		case "interact":
-			// Do nothing, this is a flags from the cli command
-			// we don't use it to update.
 		case "pd", "log-level", "key", "cert", "ca":
 		// Do nothing, this is a flags from the cli command
 		// we don't use it to update, but we do use these flags.

--- a/pkg/cmd/cli/cli_changefeed_update_test.go
+++ b/pkg/cmd/cli/cli_changefeed_update_test.go
@@ -44,7 +44,7 @@ func TestApplyChanges(t *testing.T) {
 
 	// Test for cli command flags that should be ignored.
 	oldInfo = &v2.ChangeFeedInfo{SinkURI: "blackhole://"}
-	require.Nil(t, cmd.ParseFlags([]string{"--interact"}))
+	require.Nil(t, cmd.ParseFlags([]string{"--log-level=debug"}))
 	_, err = o.applyChanges(oldInfo, cmd)
 	require.Nil(t, err)
 

--- a/pkg/cmd/cli/cli_test.go
+++ b/pkg/cmd/cli/cli_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,6 +25,10 @@ func TestCliCmdNoArgs(t *testing.T) {
 	t.Parallel()
 
 	cmd := NewCmdCli()
+	// Only for test.
+	cmd.RunE = func(_ *cobra.Command, _ []string) error {
+		return nil
+	}
 	// There is a DBC space before the flag pd.
 	flags := []string{"--log-level=info", "　--pd="}
 	os.Args = flags


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/6728

### What is changed and how it works?

Drop interactive cmd support.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
