### PR TITLE
deployment(engine): fix invalid variable type in docker compose env

### DIFF
--- a/deployments/engine/docker-compose/1m1e.yaml
+++ b/deployments/engine/docker-compose/1m1e.yaml
@@ -52,7 +52,7 @@ services:
     image: mysql:5.7
     container_name: mysql_standalone
     environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: true
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     volumes:
       - './config/mysql_meta.cnf:/etc/my.cnf'
     ports:

--- a/deployments/engine/docker-compose/1m3e.yaml
+++ b/deployments/engine/docker-compose/1m3e.yaml
@@ -78,7 +78,7 @@ services:
     image: mysql:5.7
     container_name: mysql-standalone
     environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: true
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     volumes:
       - './config/mysql_meta.cnf:/etc/my.cnf'
     ports:

--- a/deployments/engine/docker-compose/1meta.yaml
+++ b/deployments/engine/docker-compose/1meta.yaml
@@ -14,7 +14,7 @@ services:
     image: mysql:5.7
     container_name: mysql_standalone
     environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: true
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     volumes:
       - './config/mysql_meta.cnf:/etc/my.cnf'
     ports:

--- a/deployments/engine/docker-compose/dm_databases.yaml
+++ b/deployments/engine/docker-compose/dm_databases.yaml
@@ -9,7 +9,7 @@ services:
         volumes:
             - ./config/mysql.cnf:/etc/mysql/conf.d/mysql.cnf
         environment:
-            MYSQL_ALLOW_EMPTY_PASSWORD: 1
+            MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
 
     dm_upstream_mysql2:
         image: mysql:8.0
@@ -19,7 +19,7 @@ services:
         volumes:
             - ./config/mysql.cnf:/etc/mysql/conf.d/mysql2.cnf
         environment:
-            MYSQL_ALLOW_EMPTY_PASSWORD: true
+            MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
 
     dm_downstream_pd:
         image: pingcap/pd:v5.4.0


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #6554

Fix following error

```bash
$ docker-compose -f 1meta.yaml up -d
ERROR: The Compose file './1meta.yaml' is invalid because:
services.mysql-standalone.environment.MYSQL_ALLOW_EMPTY_PASSWORD contains true, which is an invalid type, it should be a string, number, or a null
```

### What is changed and how it works?

Either `MYSQL_ALLOW_EMPTY_PASSWORD: "yes"` or `MYSQL_ALLOW_EMPTY_PASSWORD: 1` is valid


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    - Check docker compose runs normally 

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
