### PR TITLE
orm(engine): add job op metadata

### DIFF
--- a/engine/pkg/orm/model/jobop.go
+++ b/engine/pkg/orm/model/jobop.go
@@ -1,0 +1,50 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+// JobOpStatus represents the expected status of a job, note this status diffs
+// from the worker status defined in framework model, the relationship of these
+// two status system is as follows.
+// - JobOpStatusCanceling, no mapping
+// - JobOpStatusCanceled maps to WorkerStatusStopped
+type JobOpStatus int8
+
+// Defines all JobOpStatus
+const (
+	JobOpStatusCanceling = JobOpStatus(1)
+	JobOpStatusCanceled  = JobOpStatus(2)
+)
+
+// JobOpUpdateColumns is used in gorm update.
+// TODO: using reflect to generate it more generally
+// related to some implement of gorm
+var JobOpUpdateColumns = []string{
+	"updated_at",
+	"op",
+	"job_id",
+}
+
+// JobOp stores job operation recoreds
+type JobOp struct {
+	Model
+	Op    JobOpStatus `gorm:"type:tinyint not null;index:idx_op,priority:2;comment:Canceling(1),Canceled(2)"`
+	JobID string      `gorm:"type:varchar(128) not null;uniqueIndex:uk_job_id"`
+}
+
+// Map is used for update in orm model
+func (op *JobOp) Map() map[string]interface{} {
+	return map[string]interface{}{
+		"op": op.Op,
+	}
+}

--- a/engine/servermaster/jobop/operator.go
+++ b/engine/servermaster/jobop/operator.go
@@ -1,0 +1,70 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jobop
+
+import (
+	"go.uber.org/zap"
+	"golang.org/x/net/context"
+
+	"github.com/pingcap/log"
+	"github.com/pingcap/tiflow/engine/framework"
+	pkgOrm "github.com/pingcap/tiflow/engine/pkg/orm"
+	ormModel "github.com/pingcap/tiflow/engine/pkg/orm/model"
+)
+
+type messageHandleProvider interface {
+	getWorkerHandle(jobID string) (framework.WorkerHandle, bool)
+}
+
+// JobOperator abstracts a metastore based job operator, it encapsulates logic
+// to handle JobOp and a Tick API to ensure job moves towards to expected status.
+type JobOperator interface {
+	MarkJobCanceled(ctx context.Context, jobID string) error
+	Tick(ctx context.Context) error
+}
+
+// JobOperatorImpl implements JobOperator
+type JobOperatorImpl struct {
+	frameMetaClient   pkgOrm.Client
+	msgHandleProvider messageHandleProvider
+}
+
+// MarkJobCanceled implements JobOperator.MarkJobCanceled
+func (oper *JobOperatorImpl) MarkJobCanceled(ctx context.Context, jobID string) error {
+	result, err := oper.frameMetaClient.SetJobCanceled(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		log.Info("job is already marked as canceled", zap.String("job-id", jobID))
+	}
+	return nil
+}
+
+// Tick implements JobOperator.Tick
+func (oper *JobOperatorImpl) Tick(ctx context.Context) error {
+	ops, err := oper.frameMetaClient.QueryJobOpsByStatus(ctx, ormModel.JobOpStatusCanceling)
+	if err != nil {
+		return err
+	}
+	for _, op := range ops {
+		_, ok := oper.msgHandleProvider.getWorkerHandle(op.JobID)
+		if !ok {
+			log.Warn("worker handle not found", zap.String("job-id", op.JobID))
+			continue
+		}
+		// TODO: send cancel job message to online job master
+	}
+	return nil
+}

--- a/errors.toml
+++ b/errors.toml
@@ -1401,6 +1401,11 @@ error = '''
 invalid worker type: %s
 '''
 
+["DFLOW:ErrJobAlreadyCanceled"]
+error = '''
+job is already canceled: %s
+'''
+
 ["DFLOW:ErrLeaderCtxCanceled"]
 error = '''
 leader context is canceled

--- a/pkg/errors/engine_errors.go
+++ b/pkg/errors/engine_errors.go
@@ -468,6 +468,12 @@ var (
 		errors.RFCCodeText("DFLOW:ErrLocalFileDirNotWritable"),
 	)
 
+	// JobOps related error
+	ErrJobAlreadyCanceled = errors.Normalize(
+		"job is already canceled: %s",
+		errors.RFCCodeText("DFLOW:ErrJobAlreadyCanceled"),
+	)
+
 	// cli related errors
 	ErrInvalidCliParameter = errors.Normalize(
 		"invalid cli parameters",


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #6749

### What is changed and how it works?

- Add a new table `job_ops` to record job operation record. Currently we only have `canceling` and `canceled` operation.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
