### PR TITLE
framework(engine): add StopImpl callback in master impl

### DIFF
--- a/engine/executor/cvs/cvstask.go
+++ b/engine/executor/cvs/cvstask.go
@@ -208,7 +208,7 @@ func (task *cvsTask) Workload() model.RescUnit {
 	return 1
 }
 
-func (task *cvsTask) OnMasterMessage(topic p2p.Topic, message p2p.MessageValue) error {
+func (task *cvsTask) OnMasterMessage(ctx context.Context, topic p2p.Topic, message p2p.MessageValue) error {
 	switch msg := message.(type) {
 	case *frameModel.StatusChangeRequest:
 		switch msg.ExpectState {

--- a/engine/executor/dm/worker.go
+++ b/engine/executor/dm/worker.go
@@ -166,7 +166,7 @@ func (w *dmWorker) OnMasterFailover(reason framework.MasterFailoverReason) error
 }
 
 // OnMasterMessage implements lib.WorkerImpl.OnMasterMessage
-func (w *dmWorker) OnMasterMessage(topic p2p.Topic, message p2p.MessageValue) error {
+func (w *dmWorker) OnMasterMessage(ctx context.Context, topic p2p.Topic, message p2p.MessageValue) error {
 	w.Logger().Info("dmworker.OnMasterMessage", zap.String("topic", topic), zap.Any("message", message))
 	return nil
 }

--- a/engine/executor/dm/worker_test.go
+++ b/engine/executor/dm/worker_test.go
@@ -136,7 +136,7 @@ func TestWorker(t *testing.T) {
 	// placeholder
 	require.Equal(t, model.RescUnit(0), dmWorker.Workload())
 	require.NoError(t, dmWorker.OnMasterFailover(framework.MasterFailoverReason{}))
-	require.NoError(t, dmWorker.OnMasterMessage("", nil))
+	require.NoError(t, dmWorker.OnMasterMessage(context.Background(), "", nil))
 
 	// Finished
 	unitHolder.On("Stage").Return(metadata.StageFinished, nil).Times(3)

--- a/engine/executor/worker/test_util.go
+++ b/engine/executor/worker/test_util.go
@@ -70,6 +70,10 @@ func (d *dummyWorker) Poll(ctx context.Context) error {
 	return nil
 }
 
+func (d *dummyWorker) Stop(ctx context.Context) error {
+	return nil
+}
+
 func (d *dummyWorker) ID() RunnableID {
 	return d.id
 }

--- a/engine/framework/base_jobmaster_test.go
+++ b/engine/framework/base_jobmaster_test.go
@@ -78,6 +78,14 @@ func (m *testJobMasterImpl) CloseImpl(ctx context.Context) error {
 	return args.Error(0)
 }
 
+func (m *testJobMasterImpl) StopImpl(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
 func (m *testJobMasterImpl) OnMasterRecovered(ctx context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -134,14 +142,6 @@ func (m *testJobMasterImpl) Workload() model.RescUnit {
 	return args.Get(0).(model.RescUnit)
 }
 
-func (m *testJobMasterImpl) OnJobManagerMessage(topic p2p.Topic, message p2p.MessageValue) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	args := m.Called(topic, message)
-	return args.Error(0)
-}
-
 func (m *testJobMasterImpl) OnOpenAPIInitialized(apiGroup *gin.RouterGroup) {
 	apiGroup.GET("/status", func(c *gin.Context) {
 		c.String(http.StatusOK, "success")
@@ -156,6 +156,14 @@ func (m *testJobMasterImpl) Status() frameModel.WorkerStatus {
 	return frameModel.WorkerStatus{
 		State: frameModel.WorkerStateNormal,
 	}
+}
+
+func (m *testJobMasterImpl) OnCancel(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	args := m.Called(ctx)
+	return args.Error(0)
 }
 
 // simulate the job manager to insert a job record first since job master will only update the job

--- a/engine/framework/fake/fake_master.go
+++ b/engine/framework/fake/fake_master.go
@@ -130,45 +130,38 @@ type businessStatus struct {
 	status map[frameModel.WorkerID]*dummyWorkerStatus
 }
 
-// OnJobManagerMessage implements JobMasterImpl.OnJobManagerMessage
-func (m *Master) OnJobManagerMessage(topic p2p.Topic, message p2p.MessageValue) error {
-	log.Info("FakeMaster: OnJobManagerMessage", zap.Any("message", message))
-	switch msg := message.(type) {
-	case *frameModel.StatusChangeRequest:
-		switch msg.ExpectState {
-		case frameModel.WorkerStateStopped:
-			m.setState(frameModel.WorkerStateStopped)
-			m.workerListMu.Lock()
-			for _, worker := range m.workerList {
-				if worker == nil {
-					continue
-				}
-				wTopic := frameModel.WorkerStatusChangeRequestTopic(m.BaseJobMaster.ID(), worker.ID())
-				wMessage := &frameModel.StatusChangeRequest{
-					SendTime:     m.clocker.Mono(),
-					FromMasterID: m.BaseJobMaster.ID(),
-					Epoch:        m.BaseJobMaster.CurrentEpoch(),
-					ExpectState:  frameModel.WorkerStateStopped,
-				}
-				ctx, cancel := context.WithTimeout(m.ctx, time.Second*2)
-				runningHandle := worker.Unwrap()
-				if runningHandle == nil {
-					cancel()
-					continue
-				}
-				if err := runningHandle.SendMessage(ctx, wTopic, wMessage, false /*nonblocking*/); err != nil {
-					cancel()
-					m.workerListMu.Unlock()
-					return err
-				}
-				cancel()
-			}
-			m.workerListMu.Unlock()
-		default:
-			log.Info("FakeMaster: ignore status change state", zap.Int32("state", int32(msg.ExpectState)))
+// OnCancel implements JobMasterImpl.OnCancel
+func (m *Master) OnCancel(ctx context.Context) error {
+	log.Info("FakeMaster: OnCancel")
+	return m.cancelWorkers(ctx)
+}
+
+func (m *Master) cancelWorkers(ctx context.Context) error {
+	m.setState(frameModel.WorkerStateStopped)
+	m.workerListMu.Lock()
+	defer m.workerListMu.Unlock()
+	for _, worker := range m.workerList {
+		if worker == nil {
+			continue
 		}
-	default:
-		log.Info("unsupported message", zap.Any("message", message))
+		wTopic := frameModel.WorkerStatusChangeRequestTopic(m.BaseJobMaster.ID(), worker.ID())
+		wMessage := &frameModel.StatusChangeRequest{
+			SendTime:     m.clocker.Mono(),
+			FromMasterID: m.BaseJobMaster.ID(),
+			Epoch:        m.BaseJobMaster.CurrentEpoch(),
+			ExpectState:  frameModel.WorkerStateStopped,
+		}
+		ctx, cancel := context.WithTimeout(ctx, time.Second*2)
+		runningHandle := worker.Unwrap()
+		if runningHandle == nil {
+			cancel()
+			continue
+		}
+		if err := runningHandle.SendMessage(ctx, wTopic, wMessage, false /*nonblocking*/); err != nil {
+			cancel()
+			return err
+		}
+		cancel()
 	}
 	return nil
 }
@@ -505,8 +498,14 @@ func (m *Master) CloseImpl(ctx context.Context) error {
 	return nil
 }
 
+// StopImpl implements MasterImpl.StopImpl
+func (m *Master) StopImpl(ctx context.Context) error {
+	log.Info("FakeMaster: Stop", zap.Stack("stack"))
+	return nil
+}
+
 // OnMasterMessage implements MasterImpl.OnMasterMessage
-func (m *Master) OnMasterMessage(topic p2p.Topic, message p2p.MessageValue) error {
+func (m *Master) OnMasterMessage(ctx context.Context, topic p2p.Topic, message p2p.MessageValue) error {
 	log.Info("FakeMaster: OnMasterMessage", zap.Any("message", message))
 	return nil
 }

--- a/engine/framework/fake/fake_worker.go
+++ b/engine/framework/fake/fake_worker.go
@@ -191,7 +191,7 @@ func (d *dummyWorker) Workload() model.RescUnit {
 	return model.RescUnit(10)
 }
 
-func (d *dummyWorker) OnMasterMessage(topic p2p.Topic, message p2p.MessageValue) error {
+func (d *dummyWorker) OnMasterMessage(ctx context.Context, topic p2p.Topic, message p2p.MessageValue) error {
 	log.Info("fakeWorker: OnMasterMessage", zap.Any("message", message))
 	switch msg := message.(type) {
 	case *frameModel.StatusChangeRequest:

--- a/engine/framework/internal/eventloop/interfaces.go
+++ b/engine/framework/internal/eventloop/interfaces.go
@@ -36,6 +36,9 @@ type Task interface {
 	// TODO `ctx` is for compatibility, remove it.
 	Close(ctx context.Context) error
 
+	// Stop is called when a task is canceled
+	Stop(ctx context.Context) error
+
 	// ID returns an identifier for the Task.
 	ID() string
 }

--- a/engine/framework/internal/eventloop/runner.go
+++ b/engine/framework/internal/eventloop/runner.go
@@ -67,8 +67,15 @@ func (r *Runner[R]) Run(ctx context.Context) error {
 		r.doGracefulExit(ctx, err)
 	}
 
-	if closeErr := r.task.Close(context.Background()); closeErr != nil {
-		log.Warn("Closing task returned error", zap.String("label", r.task.ID()))
+	if IsTerminatedError(err) {
+		if stopErr := r.task.Stop(context.Background()); stopErr != nil {
+			log.Warn("Stop task returned error",
+				zap.String("label", r.task.ID()), zap.Error(stopErr))
+		}
+	} else {
+		if closeErr := r.task.Close(context.Background()); closeErr != nil {
+			log.Warn("Closing task returned error", zap.String("label", r.task.ID()))
+		}
 	}
 
 	return err
@@ -117,4 +124,12 @@ func isForcefulExitError(errIn error) bool {
 
 	// Suicides should result in a forceful exit.
 	return derrors.ErrWorkerSuicide.Equal(errIn)
+}
+
+// IsTerminatedError checks whether task enters a terminated state, which include
+// finished, canceled
+func IsTerminatedError(errIn error) bool {
+	return derrors.ErrWorkerCancel.Equal(errIn) ||
+		derrors.ErrWorkerFinish.Equal(errIn) ||
+		derrors.ErrWorkerFailed.Equal(errIn)
 }

--- a/engine/framework/internal/master/worker_manager.go
+++ b/engine/framework/internal/master/worker_manager.go
@@ -508,7 +508,9 @@ func (m *WorkerManager) checkWorkerEntriesOnce() error {
 			case frameModel.WorkerStateFinished:
 				offlineError = derror.ErrWorkerFinish.FastGenByArgs()
 			case frameModel.WorkerStateStopped:
-				offlineError = derror.ErrWorkerStop.FastGenByArgs()
+				offlineError = derror.ErrWorkerCancel.FastGenByArgs()
+			case frameModel.WorkerStateError:
+				offlineError = derror.ErrWorkerFailed.FastGenByArgs()
 			default:
 				offlineError = derror.ErrWorkerOffline.FastGenByArgs(workerID)
 			}

--- a/engine/framework/mock_master_impl.go
+++ b/engine/framework/mock_master_impl.go
@@ -236,6 +236,15 @@ func (m *MockMasterImpl) CloseImpl(ctx context.Context) error {
 	return args.Error(0)
 }
 
+// StopImpl implements MasterImpl.StopImpl
+func (m *MockMasterImpl) StopImpl(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
 // MasterClient returns internal server master client
 func (m *MockMasterImpl) MasterClient() *client.MockServerMasterClient {
 	return m.serverMasterClient

--- a/engine/framework/mock_worker_impl.go
+++ b/engine/framework/mock_worker_impl.go
@@ -94,11 +94,11 @@ func (w *mockWorkerImpl) Status() frameModel.WorkerStatus {
 	return args.Get(0).(frameModel.WorkerStatus)
 }
 
-func (w *mockWorkerImpl) OnMasterMessage(topic p2p.Topic, message p2p.MessageValue) error {
+func (w *mockWorkerImpl) OnMasterMessage(ctx context.Context, topic p2p.Topic, message p2p.MessageValue) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	args := w.Called(topic, message)
+	args := w.Called(ctx, topic, message)
 	return args.Error(0)
 }
 

--- a/engine/jobmaster/cvsjob/cvs_job_master.go
+++ b/engine/jobmaster/cvsjob/cvs_job_master.go
@@ -341,6 +341,11 @@ func (jm *JobMaster) CloseImpl(ctx context.Context) error {
 	return nil
 }
 
+// StopImpl is called when the master is being canceled
+func (jm *JobMaster) StopImpl(ctx context.Context) error {
+	return nil
+}
+
 // ID implements JobMasterImpl.ID
 func (jm *JobMaster) ID() worker.RunnableID {
 	return jm.workerID
@@ -352,53 +357,44 @@ func (jm *JobMaster) Workload() model.RescUnit {
 }
 
 // OnMasterMessage implements JobMasterImpl.OnMasterMessage
-func (jm *JobMaster) OnMasterMessage(topic p2p.Topic, message p2p.MessageValue) error {
+func (jm *JobMaster) OnMasterMessage(ctx context.Context, topic p2p.Topic, message p2p.MessageValue) error {
 	return nil
 }
 
-// OnJobManagerMessage implements JobMasterImpl.OnJobManagerMessage
-func (jm *JobMaster) OnJobManagerMessage(topic p2p.Topic, message p2p.MessageValue) error {
-	log.Info("cvs jobmaster: OnJobManagerMessage", zap.Any("message", message))
-	jm.Lock()
-	defer jm.Unlock()
-	switch msg := message.(type) {
-	case *frameModel.StatusChangeRequest:
-		switch msg.ExpectState {
-		case frameModel.WorkerStateStopped:
-			jm.setState(frameModel.WorkerStateStopped)
-			for _, worker := range jm.syncFilesInfo {
-				if worker.handle.Load() == nil {
-					continue
-				}
-				handle := *(*framework.WorkerHandle)(worker.handle.Load())
-				workerID := handle.ID()
-				wTopic := frameModel.WorkerStatusChangeRequestTopic(jm.BaseJobMaster.ID(), handle.ID())
-				wMessage := &frameModel.StatusChangeRequest{
-					SendTime:     jm.clocker.Mono(),
-					FromMasterID: jm.BaseJobMaster.ID(),
-					Epoch:        jm.BaseJobMaster.CurrentEpoch(),
-					ExpectState:  frameModel.WorkerStateStopped,
-				}
+// OnCancel implements JobMasterImpl.OnCancel
+func (jm *JobMaster) OnCancel(ctx context.Context) error {
+	log.Info("cvs jobmaster: OnCancel")
+	return jm.cancelWorkers(ctx)
+}
 
-				if handle := handle.Unwrap(); handle != nil {
-					ctx, cancel := context.WithTimeout(jm.ctx, time.Second*2)
-					if err := handle.SendMessage(ctx, wTopic, wMessage, false /*nonblocking*/); err != nil {
-						cancel()
-						return err
-					}
-					log.Info("sent message to worker", zap.String("topic", topic), zap.Any("message", wMessage))
-					cancel()
-				} else {
-					log.Info("skip sending message to tombstone worker", zap.String("worker-id", workerID))
-				}
-			}
-		default:
-			log.Info("FakeMaster: ignore status change state", zap.Int32("state", int32(msg.ExpectState)))
+func (jm *JobMaster) cancelWorkers(ctx context.Context) error {
+	jm.setState(frameModel.WorkerStateStopped)
+	for _, worker := range jm.syncFilesInfo {
+		if worker.handle.Load() == nil {
+			continue
 		}
-	default:
-		log.Info("unsupported message", zap.Any("message", message))
-	}
+		handle := *(*framework.WorkerHandle)(worker.handle.Load())
+		workerID := handle.ID()
+		wTopic := frameModel.WorkerStatusChangeRequestTopic(jm.BaseJobMaster.ID(), handle.ID())
+		wMessage := &frameModel.StatusChangeRequest{
+			SendTime:     jm.clocker.Mono(),
+			FromMasterID: jm.BaseJobMaster.ID(),
+			Epoch:        jm.BaseJobMaster.CurrentEpoch(),
+			ExpectState:  frameModel.WorkerStateStopped,
+		}
 
+		if handle := handle.Unwrap(); handle != nil {
+			ctx, cancel := context.WithTimeout(jm.ctx, time.Second*2)
+			if err := handle.SendMessage(ctx, wTopic, wMessage, false /*nonblocking*/); err != nil {
+				cancel()
+				return err
+			}
+			log.Info("sent message to worker", zap.String("topic", wTopic), zap.Any("message", wMessage))
+			cancel()
+		} else {
+			log.Info("skip sending message to tombstone worker", zap.String("worker-id", workerID))
+		}
+	}
 	return nil
 }
 

--- a/engine/jobmaster/dm/dm_jobmaster.go
+++ b/engine/jobmaster/dm/dm_jobmaster.go
@@ -251,7 +251,7 @@ func (jm *JobMaster) OnWorkerMessage(worker framework.WorkerHandle, topic p2p.To
 }
 
 // OnMasterMessage implements JobMasterImpl.OnMasterMessage
-func (jm *JobMaster) OnMasterMessage(topic p2p.Topic, message interface{}) error {
+func (jm *JobMaster) OnMasterMessage(ctx context.Context, topic p2p.Topic, message interface{}) error {
 	return nil
 }
 

--- a/engine/jobmaster/dm/dm_jobmaster_test.go
+++ b/engine/jobmaster/dm/dm_jobmaster_test.go
@@ -351,7 +351,7 @@ func (t *testDMJobmasterSuite) TestDMJobmaster() {
 
 	// placeholder
 	require.NoError(t.T(), jm.OnJobManagerMessage("", ""))
-	require.NoError(t.T(), jm.OnMasterMessage("", ""))
+	require.NoError(t.T(), jm.OnMasterMessage(context.Background(), "", ""))
 	require.NoError(t.T(), jm.OnWorkerMessage(&framework.MockWorkerHandler{}, "", ""))
 	require.Equal(t.T(), jm.Workload(), model.RescUnit(2))
 

--- a/engine/jobmaster/example/master_impl.go
+++ b/engine/jobmaster/example/master_impl.go
@@ -110,6 +110,11 @@ func (e *exampleMaster) CloseImpl(ctx context.Context) error {
 	return nil
 }
 
+func (e *exampleMaster) StopImpl(ctx context.Context) error {
+	log.Info("StopImpl")
+	return nil
+}
+
 func (e *exampleMaster) OnWorkerStatusUpdated(worker framework.WorkerHandle, newStatus *frameModel.WorkerStatus) error {
 	log.Info("OnWorkerStatusUpdated")
 	return nil

--- a/engine/jobmaster/example/worker_impl.go
+++ b/engine/jobmaster/example/worker_impl.go
@@ -112,7 +112,7 @@ func (w *exampleWorker) Status() frameModel.WorkerStatus {
 	return frameModel.WorkerStatus{State: code}
 }
 
-func (w *exampleWorker) OnMasterMessage(topic p2p.Topic, message p2p.MessageValue) error {
+func (w *exampleWorker) OnMasterMessage(ctx context.Context, topic p2p.Topic, message p2p.MessageValue) error {
 	log.Info("OnMasterMessage", zap.Any("message", message))
 	return nil
 }

--- a/engine/pkg/orm/client_test.go
+++ b/engine/pkg/orm/client_test.go
@@ -1246,6 +1246,175 @@ func TestContext(t *testing.T) {
 	failpoint.Disable("github.com/pingcap/tiflow/engine/pkg/orm/initializedDelay")
 }
 
+func TestJobOp(t *testing.T) {
+	t.Parallel()
+
+	sqlDB, mock, err := mockGetDBConn(t)
+	defer sqlDB.Close()
+	defer mock.ExpectClose()
+	require.Nil(t, err)
+	cli, err := newClient(sqlDB, defaultTestStoreType)
+	require.Nil(t, err)
+	require.NotNil(t, cli)
+
+	tm := time.Now()
+	createdAt := tm.Add(time.Duration(1))
+	updatedAt := tm.Add(time.Duration(1))
+
+	testCases := []tCase{
+		// SetJobCanceling successfully
+		{
+			fn: "SetJobCanceling",
+			inputs: []interface{}{
+				"job-111",
+			},
+			output: &ormResult{
+				rowsAffected: 1,
+			},
+			mockExpectResFn: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta(
+					"SELECT count(*) FROM `job_ops` WHERE job_id = ?")).
+					WithArgs("job-111").WillReturnRows(
+					sqlmock.NewRows([]string{
+						"count(0)",
+					}).AddRow(0))
+				mock.ExpectExec(regexp.QuoteMeta(
+					"INSERT INTO `job_ops` (`created_at`,`updated_at`,`op`,`job_id`")).
+					WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), model.JobOpStatusCanceling, "job-111").
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectCommit()
+			},
+		},
+		// SetJobCanceling does nothing because cancelling op exists
+		{
+			fn: "SetJobCanceling",
+			inputs: []interface{}{
+				"job-111",
+			},
+			output: &ormResult{
+				rowsAffected: 0,
+			},
+			mockExpectResFn: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta(
+					"SELECT count(*) FROM `job_ops` WHERE job_id = ?")).
+					WithArgs("job-111").WillReturnRows(
+					sqlmock.NewRows([]string{
+						"count(1)",
+					}).AddRow(1))
+				mock.ExpectQuery(
+					"SELECT [*] FROM `job_ops` WHERE job_id = ?").
+					WithArgs("job-111").WillReturnRows(
+					sqlmock.NewRows([]string{
+						"created_at", "updated_at", "op", "job_id", "seq_id",
+					}).AddRow(createdAt, updatedAt, model.JobOpStatusCanceling, "job-111", 1))
+				mock.ExpectCommit()
+			},
+		},
+		// SetJobCanceling returns error if job is already cancelled
+		{
+			fn: "SetJobCanceling",
+			inputs: []interface{}{
+				"job-111",
+			},
+			output: &ormResult{
+				rowsAffected: 0,
+			},
+			mockExpectResFn: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta(
+					"SELECT count(*) FROM `job_ops` WHERE job_id = ?")).
+					WithArgs("job-111").WillReturnRows(
+					sqlmock.NewRows([]string{
+						"count(1)",
+					}).AddRow(1))
+				mock.ExpectQuery(
+					"SELECT [*] FROM `job_ops` WHERE job_id = ?").
+					WithArgs("job-111").WillReturnRows(
+					sqlmock.NewRows([]string{
+						"created_at", "updated_at", "op", "job_id", "seq_id",
+					}).AddRow(createdAt, updatedAt, model.JobOpStatusCanceled, "job-111", 1))
+				mock.ExpectRollback()
+			},
+			err: derror.ErrJobAlreadyCanceled.GenWithStackByArgs("job-111"),
+		},
+		// SetJobCanceling updates job operation to canceling if exists a noop job operation
+		{
+			fn: "SetJobCanceling",
+			inputs: []interface{}{
+				"job-111",
+			},
+			output: &ormResult{
+				rowsAffected: 2,
+			},
+			mockExpectResFn: func(mock sqlmock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectQuery(regexp.QuoteMeta(
+					"SELECT count(*) FROM `job_ops` WHERE job_id = ?")).
+					WithArgs("job-111").WillReturnRows(
+					sqlmock.NewRows([]string{
+						"count(1)",
+					}).AddRow(1))
+				mock.ExpectQuery(
+					"SELECT [*] FROM `job_ops` WHERE job_id = ?").
+					WithArgs("job-111").WillReturnRows(
+					sqlmock.NewRows([]string{
+						"created_at", "updated_at", "op", "job_id", "seq_id",
+					}).AddRow(createdAt, updatedAt, model.JobOpStatusNoop, "job-111", 1))
+				mock.ExpectExec("ON DUPLICATE KEY UPDATE").WillReturnResult(sqlmock.NewResult(1, 2))
+				mock.ExpectCommit()
+			},
+		},
+		// SetJobCanceled
+		{
+			fn: "SetJobCanceled",
+			inputs: []interface{}{
+				"job-111",
+			},
+			output: &ormResult{
+				rowsAffected: 1,
+			},
+			mockExpectResFn: func(mock sqlmock.Sqlmock) {
+				expectedSQL := "UPDATE `job_ops` SET `op`=?,`updated_at`=? WHERE job_id = ? AND op = ?"
+				mock.ExpectExec(regexp.QuoteMeta(expectedSQL)).
+					WithArgs(model.JobOpStatusCanceled, anyTime{}, "job-111", model.JobOpStatusCanceling).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+			},
+		},
+		// QueryJobOpsByStatus
+		{
+			fn: "QueryJobOpsByStatus",
+			inputs: []interface{}{
+				model.JobOpStatusCanceling,
+			},
+			output: []*model.JobOp{
+				{
+					Model: model.Model{
+						SeqID:     1,
+						CreatedAt: createdAt,
+						UpdatedAt: updatedAt,
+					},
+					JobID: "job-1",
+					Op:    model.JobOpStatusCanceling,
+				},
+			},
+			mockExpectResFn: func(mock sqlmock.Sqlmock) {
+				expectedSQL := "SELECT * FROM `job_ops` WHERE op = ?"
+				mock.ExpectQuery(regexp.QuoteMeta(expectedSQL)).
+					WithArgs(model.JobOpStatusCanceling).
+					WillReturnRows(
+						sqlmock.NewRows([]string{"created_at", "updated_at", "op", "job_id", "seq_id"}).
+							AddRow(createdAt, updatedAt, model.JobOpStatusCanceling, "job-1", 1))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		testInner(t, mock, cli, tc)
+	}
+}
+
 func testInner(t *testing.T, m sqlmock.Sqlmock, cli Client, c tCase) {
 	// set the mock expectation
 	c.mockExpectResFn(m)

--- a/engine/pkg/orm/model/jobop.go
+++ b/engine/pkg/orm/model/jobop.go
@@ -1,0 +1,53 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+// JobOpStatus represents the expected status of a job, note this status diffs
+// from the worker status defined in framework model, the relationship of these
+// two status system is as follows.
+// - JobOpStatusCanceling, no mapping
+// - JobOpStatusCanceled maps to WorkerStatusStopped
+type JobOpStatus int8
+
+// Defines all JobOpStatus
+const (
+	// noop is reserved for some unexpected scenario, such as job operation of
+	// a nonexistent job
+	JobOpStatusNoop      = JobOpStatus(1)
+	JobOpStatusCanceling = JobOpStatus(2)
+	JobOpStatusCanceled  = JobOpStatus(3)
+)
+
+// JobOpUpdateColumns is used in gorm update.
+// TODO: using reflect to generate it more generally
+// related to some implement of gorm
+var JobOpUpdateColumns = []string{
+	"updated_at",
+	"op",
+	"job_id",
+}
+
+// JobOp stores job operation recoreds
+type JobOp struct {
+	Model
+	Op    JobOpStatus `gorm:"type:tinyint not null;index:idx_job_op,priority:2;comment:Canceling(1),Canceled(2)"`
+	JobID string      `gorm:"type:varchar(128) not null;uniqueIndex:uk_job_id"`
+}
+
+// Map is used for update in orm model
+func (op *JobOp) Map() map[string]interface{} {
+	return map[string]interface{}{
+		"op": op.Op,
+	}
+}

--- a/engine/servermaster/jobop/operator.go
+++ b/engine/servermaster/jobop/operator.go
@@ -1,0 +1,138 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jobop
+
+import (
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+	"golang.org/x/net/context"
+
+	"github.com/pingcap/log"
+	frameworkModel "github.com/pingcap/tiflow/engine/framework/model"
+	pkgOrm "github.com/pingcap/tiflow/engine/pkg/orm"
+	ormModel "github.com/pingcap/tiflow/engine/pkg/orm/model"
+)
+
+type operateRouter interface {
+	SendCancelJobMessage(ctx context.Context, jobID string) error
+}
+
+// JobOperator abstracts a metastore based job operator, it encapsulates logic
+// to handle JobOp and a Tick API to ensure job moves towards to expected status.
+type JobOperator interface {
+	MarkJobCanceling(ctx context.Context, jobID string) error
+	MarkJobCanceled(ctx context.Context, jobID string) error
+	Tick(ctx context.Context) error
+}
+
+// JobOperatorImpl implements JobOperator
+type JobOperatorImpl struct {
+	frameMetaClient pkgOrm.Client
+	router          operateRouter
+}
+
+// NewJobOperatorImpl creates a new JobOperatorImpl
+func NewJobOperatorImpl(cli pkgOrm.Client, router operateRouter) *JobOperatorImpl {
+	return &JobOperatorImpl{
+		frameMetaClient: cli,
+		router:          router,
+	}
+}
+
+func (oper *JobOperatorImpl) updateJobOperationStatus(
+	ctx context.Context, jobID string, op ormModel.JobOpStatus,
+) error {
+	var ormFn func(ctx context.Context, JobID string) (pkgOrm.Result, error)
+	switch op {
+	case ormModel.JobOpStatusNoop:
+		ormFn = oper.frameMetaClient.SetJobNoop
+	case ormModel.JobOpStatusCanceling:
+		ormFn = oper.frameMetaClient.SetJobCanceling
+	case ormModel.JobOpStatusCanceled:
+		ormFn = oper.frameMetaClient.SetJobCanceled
+	default:
+		log.Panic("unexpected job operate", zap.Any("op", op))
+	}
+	if result, err := ormFn(ctx, jobID); err != nil {
+		return err
+	} else if result.RowsAffected() == 0 {
+		log.Info("job status is already set", zap.String("job-id", jobID), zap.Any("op", op))
+	}
+	return nil
+}
+
+// MarkJobNoop implements JobOperator.MarkJobNoop
+func (oper *JobOperatorImpl) MarkJobNoop(ctx context.Context, jobID string) error {
+	return oper.updateJobOperationStatus(ctx, jobID, ormModel.JobOpStatusNoop)
+}
+
+// MarkJobCanceling implements JobOperator.MarkJobCanceling
+func (oper *JobOperatorImpl) MarkJobCanceling(ctx context.Context, jobID string) error {
+	return oper.updateJobOperationStatus(ctx, jobID, ormModel.JobOpStatusCanceling)
+}
+
+// MarkJobCanceled implements JobOperator.MarkJobCanceled
+func (oper *JobOperatorImpl) MarkJobCanceled(ctx context.Context, jobID string) error {
+	return oper.updateJobOperationStatus(ctx, jobID, ormModel.JobOpStatusCanceled)
+}
+
+// Tick implements JobOperator.Tick
+func (oper *JobOperatorImpl) Tick(ctx context.Context) error {
+	ops, err := oper.frameMetaClient.QueryJobOpsByStatus(ctx, ormModel.JobOpStatusCanceling)
+	if err != nil {
+		return err
+	}
+	var errs error
+	for _, op := range ops {
+		isJobTerminated, err := oper.checkJobStatus(ctx, op.JobID)
+		if err != nil {
+			errs = multierr.Append(errs, err)
+			continue
+		}
+		if isJobTerminated {
+			continue
+		}
+		if err := oper.router.SendCancelJobMessage(ctx, op.JobID); err != nil {
+			log.Warn("send cancel message to job master failed",
+				zap.String("job-id", op.JobID), zap.Error(err))
+		}
+	}
+	return errs
+}
+
+// check job status, if job is in terminated, return true, otherwise return false
+// and the upper logic needs to send canceling message. Return value
+// - whether job is in terminated state
+// - error
+func (oper *JobOperatorImpl) checkJobStatus(
+	ctx context.Context, jobID string,
+) (bool, error) {
+	isJobTerminated := false
+	meta, err := oper.frameMetaClient.GetJobByID(ctx, jobID)
+	if err != nil {
+		if pkgOrm.IsNotFoundError(err) {
+			log.Warn("found orphan job operation", zap.String("job-id", jobID))
+			isJobTerminated = true
+			return isJobTerminated, oper.MarkJobNoop(ctx, jobID)
+		}
+		return isJobTerminated, err
+	}
+	// TODO: add MasterStateFailed
+	switch meta.State {
+	case frameworkModel.MasterStateFinished, frameworkModel.MasterStateStopped:
+		isJobTerminated = true
+		return isJobTerminated, oper.MarkJobCanceled(ctx, jobID)
+	}
+	return isJobTerminated, nil
+}

--- a/engine/servermaster/jobop/operator_test.go
+++ b/engine/servermaster/jobop/operator_test.go
@@ -1,0 +1,138 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jobop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+
+	"github.com/pingcap/tiflow/engine/framework"
+	frameworkModel "github.com/pingcap/tiflow/engine/framework/model"
+	pkgOrm "github.com/pingcap/tiflow/engine/pkg/orm"
+	ormModel "github.com/pingcap/tiflow/engine/pkg/orm/model"
+	"github.com/pingcap/tiflow/pkg/errors"
+)
+
+type mockOperatorRouter struct {
+	onlineJobs  map[string]struct{}
+	cancelCalls map[string]int
+	cli         pkgOrm.Client
+}
+
+func newMockOperatorRouter(cli pkgOrm.Client) *mockOperatorRouter {
+	return &mockOperatorRouter{
+		onlineJobs:  make(map[string]struct{}),
+		cancelCalls: make(map[string]int),
+		cli:         cli,
+	}
+}
+
+func (r *mockOperatorRouter) SendCancelJobMessage(
+	ctx context.Context, jobID string,
+) error {
+	if _, ok := r.onlineJobs[jobID]; !ok {
+		return errors.ErrMasterNotFound.GenWithStackByArgs(jobID)
+	}
+	r.cancelCalls[jobID]++
+	return nil
+}
+
+func (r *mockOperatorRouter) checkCancelCalls(t *testing.T, jobID string, expected int) {
+	require.Contains(t, r.cancelCalls, jobID)
+	require.Equal(t, expected, r.cancelCalls[jobID])
+}
+
+func (r *mockOperatorRouter) jobOnline(
+	ctx context.Context, jobID string, meta *frameworkModel.MasterMeta,
+) error {
+	r.onlineJobs[jobID] = struct{}{}
+	return r.cli.UpsertJob(ctx, meta)
+}
+
+func (r *mockOperatorRouter) jobOffline(
+	ctx context.Context, jobID string, meta *frameworkModel.MasterMeta,
+) error {
+	delete(r.onlineJobs, jobID)
+	return r.cli.UpsertJob(ctx, meta)
+}
+
+func checkJobOpWithStatus(
+	ctx context.Context, t *testing.T, metaCli pkgOrm.Client,
+	expectedStatus ormModel.JobOpStatus, expectedCount int,
+) {
+	ops, err := metaCli.QueryJobOpsByStatus(ctx, expectedStatus)
+	require.NoError(t, err)
+	require.Len(t, ops, expectedCount)
+}
+
+func TestJobOperator(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	metaCli, err := pkgOrm.NewMockClient()
+	require.NoError(t, err)
+	router := newMockOperatorRouter(metaCli)
+	oper := NewJobOperatorImpl(metaCli, router)
+
+	jobID := "cancel-job-id"
+	meta := &frameworkModel.MasterMeta{
+		ID:    jobID,
+		Type:  framework.CvsJobMaster,
+		State: frameworkModel.MasterStateInit,
+	}
+	err = router.jobOnline(ctx, jobID, meta)
+	require.NoError(t, err)
+
+	err = oper.MarkJobCanceling(ctx, jobID)
+	require.NoError(t, err)
+	// cancel job repeatly is ok
+	err = oper.MarkJobCanceling(ctx, jobID)
+	require.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		err = oper.Tick(ctx)
+		require.NoError(t, err)
+		router.checkCancelCalls(t, jobID, i+1)
+		checkJobOpWithStatus(ctx, t, metaCli, ormModel.JobOpStatusCanceling, 1)
+	}
+
+	// mock job master is canceled and status persisted
+	meta.State = frameworkModel.MasterStateStopped
+	err = router.jobOffline(ctx, jobID, meta)
+	require.NoError(t, err)
+
+	err = oper.Tick(ctx)
+	require.NoError(t, err)
+	checkJobOpWithStatus(ctx, t, metaCli, ormModel.JobOpStatusCanceled, 1)
+}
+
+func TestJobOperatorMetOrphanJob(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	metaCli, err := pkgOrm.NewMockClient()
+	require.NoError(t, err)
+	router := newMockOperatorRouter(metaCli)
+	oper := NewJobOperatorImpl(metaCli, router)
+
+	jobID := "cancel-orphan-job-id"
+	err = oper.MarkJobCanceling(ctx, jobID)
+	require.NoError(t, err)
+
+	err = oper.Tick(ctx)
+	require.NoError(t, err)
+	checkJobOpWithStatus(ctx, t, metaCli, ormModel.JobOpStatusNoop, 1)
+}

--- a/engine/test/e2e/e2e_dm_test.go
+++ b/engine/test/e2e/e2e_dm_test.go
@@ -99,7 +99,7 @@ func TestDMJob(t *testing.T) {
 		"http://127.0.0.1:11242/metrics",
 		"http://127.0.0.1:11243/metrics",
 	}
-	re := regexp.MustCompile(`job_id="(.{36})"`)
+	re := regexp.MustCompile(`syncer.*\{job_id="(.{36})"`)
 	for _, metricsURL := range metricsURLs {
 		resp, err := http.Get(metricsURL)
 		require.NoError(t, err)

--- a/errors.toml
+++ b/errors.toml
@@ -1406,6 +1406,11 @@ error = '''
 invalid worker type: %s
 '''
 
+["DFLOW:ErrJobAlreadyCanceled"]
+error = '''
+job is already canceled: %s
+'''
+
 ["DFLOW:ErrLeaderCtxCanceled"]
 error = '''
 leader context is canceled
@@ -1711,6 +1716,16 @@ error = '''
 cannot find executor ID: %s
 '''
 
+["DFLOW:ErrWorkerCancel"]
+error = '''
+worker is canceled
+'''
+
+["DFLOW:ErrWorkerFailed"]
+error = '''
+worker is failed permanently
+'''
+
 ["DFLOW:ErrWorkerFinish"]
 error = '''
 worker finished and exited
@@ -1734,11 +1749,6 @@ worker is not found: worker ID %s
 ["DFLOW:ErrWorkerOffline"]
 error = '''
 worker is offline: workerID: %s, error message: %s
-'''
-
-["DFLOW:ErrWorkerStop"]
-error = '''
-worker is stopped
 '''
 
 ["DFLOW:ErrWorkerSuicide"]

--- a/pkg/errors/engine_errors.go
+++ b/pkg/errors/engine_errors.go
@@ -221,13 +221,18 @@ var (
 		"invalid job type: %s",
 		errors.RFCCodeText("DFLOW:ErrInvalidJobType"),
 	)
+	// TODO: unify the following three errors into one ErrWorkerTerminated
 	ErrWorkerFinish = errors.Normalize(
 		"worker finished and exited",
 		errors.RFCCodeText("DFLOW:ErrWorkerFinish"),
 	)
-	ErrWorkerStop = errors.Normalize(
-		"worker is stopped",
-		errors.RFCCodeText("DFLOW:ErrWorkerStop"),
+	ErrWorkerCancel = errors.Normalize(
+		"worker is canceled",
+		errors.RFCCodeText("DFLOW:ErrWorkerCancel"),
+	)
+	ErrWorkerFailed = errors.Normalize(
+		"worker is failed permanently",
+		errors.RFCCodeText("DFLOW:ErrWorkerFailed"),
 	)
 	ErrTooManyStatusUpdates = errors.Normalize(
 		"there are too many pending worker status updates: %d",
@@ -466,6 +471,12 @@ var (
 	ErrLocalFileDirNotWritable = errors.Normalize(
 		"local resource directory not writable",
 		errors.RFCCodeText("DFLOW:ErrLocalFileDirNotWritable"),
+	)
+
+	// JobOps related error
+	ErrJobAlreadyCanceled = errors.Normalize(
+		"job is already canceled: %s",
+		errors.RFCCodeText("DFLOW:ErrJobAlreadyCanceled"),
 	)
 
 	// cli related errors


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #6749

### What is changed and how it works?

This PR implements the normal path of job canceling, and adds `StopImpl` in job master callback

#### Review guide

- changes in `engine/framework/internal/eventloop`, add `Stop` interface to task
- changes in `engine/framework`, add `StopImpl`interface to MasterImpl.
- changes in `engine/pkg/orm`, support orm for new `job_ops` table.
- `engine/servermaster/jobop/operator.go`, a simple job operator, it provides `MarkJobCanceling` API and `Tick` entrance.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
