### PR TITLE
meta(engine): KV interface method 'Get' return an empty response when meets 'record not found'

### DIFF
--- a/engine/pkg/meta/internal/sqlkv/sql_impl.go
+++ b/engine/pkg/meta/internal/sqlkv/sql_impl.go
@@ -189,6 +189,14 @@ func (c *sqlKVClientImpl) doGet(ctx context.Context, db *gorm.DB, op *metaModel.
 		isPointGet = true
 	}
 	if err != nil {
+		// for Get method, `record not found` error should be translated to empty resp
+		if err == gorm.ErrRecordNotFound {
+			return &metaModel.GetResponse{
+				Header: &metaModel.ResponseHeader{},
+				Kvs:    []*metaModel.KeyValue{},
+			}, nil
+		}
+
 		return nil, sqlErrorFromOpFail(err)
 	}
 

--- a/engine/pkg/meta/internal/sqlkv/sql_impl_test.go
+++ b/engine/pkg/meta/internal/sqlkv/sql_impl_test.go
@@ -41,8 +41,9 @@ const (
 )
 
 type tCase struct {
-	fn     string        // function name
-	inputs []interface{} // function args
+	caseName string        // case name
+	fn       string        // function name
+	inputs   []interface{} // function args
 
 	output interface{} // function output
 	err    error       // function error
@@ -139,7 +140,25 @@ func TestGet(t *testing.T) {
 
 	testCases := []tCase{
 		{
-			fn: "Get",
+			caseName: "RecordNotFoundErrReturnEmptyResp",
+			fn:       "Get",
+			inputs: []interface{}{
+				"key0",
+			},
+			output: &metaModel.GetResponse{
+				Header: &metaModel.ResponseHeader{},
+				Kvs:    []*metaModel.KeyValue{},
+			},
+			mockExpectResFn: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `fakeTable` WHERE job_id = ? AND "+
+					"meta_key = ? ORDER BY `fakeTable`.`seq_id` LIMIT 1")).
+					WithArgs(fakeJob, []byte("key0")).
+					WillReturnRows(sqlmock.NewRows([]string{"meta_key", "meta_value"}))
+			},
+		},
+		{
+			caseName: "NormalGet",
+			fn:       "Get",
 			inputs: []interface{}{
 				"key0",
 			},
@@ -160,7 +179,8 @@ func TestGet(t *testing.T) {
 			},
 		},
 		{
-			fn: "Get",
+			caseName: "RangeGet",
+			fn:       "Get",
 			inputs: []interface{}{
 				"key0",
 				metaModel.WithRange("key999"),
@@ -187,7 +207,8 @@ func TestGet(t *testing.T) {
 			},
 		},
 		{
-			fn: "Get",
+			caseName: "FromKeyGet",
+			fn:       "Get",
 			inputs: []interface{}{
 				"key0",
 				metaModel.WithFromKey(),
@@ -209,7 +230,8 @@ func TestGet(t *testing.T) {
 			},
 		},
 		{
-			fn: "Get",
+			caseName: "PrefixGet",
+			fn:       "Get",
 			inputs: []interface{}{
 				"key0",
 				metaModel.WithPrefix(),


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6869 

### What is changed and how it works?
Return an empty resp when error is 'record not found'

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
 `None`.
```
