### PR TITLE
engine(test): fix mysql authentication error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ check-static: tools/bin/golangci-lint
 
 check: check-copyright fmt check-static tidy terror_check errdoc \
 	check-merge-conflicts check-ticdc-dashboard check-diff-line-width \
-	swagger-spec check-makefiles
+	swagger-spec check-makefiles check_engine_integration_test
 	@git --no-pager diff --exit-code || echo "Please add changed files!"
 
 integration_test_coverage: tools/bin/gocovmerge tools/bin/goveralls
@@ -508,6 +508,9 @@ check_third_party_binary_for_engine:
 	@which go || (echo "go not found in ${PATH}"; exit 1)
 	@which mysql || (echo "mysql not found in ${PATH}"; exit 1)
 	@which jq || (echo "jq not found in ${PATH}"; exit 1)
+
+check_engine_integration_test:
+	./engine/test/utils/check_case.sh
 
 bin/sync_diff_inspector:
 	./scripts/download-sync-diff.sh

--- a/deployments/engine/docker-compose/1m1e.yaml
+++ b/deployments/engine/docker-compose/1m1e.yaml
@@ -55,8 +55,9 @@ services:
     ports:
       - "12479:2379"
   mysql-standalone:
-    image: mysql:5.7
-    container_name: mysql_standalone
+    image: mysql:8.0
+    container_name: mysql-standalone
+    command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     volumes:

--- a/deployments/engine/docker-compose/1m3e.yaml
+++ b/deployments/engine/docker-compose/1m3e.yaml
@@ -87,8 +87,9 @@ services:
     ports:
       - "12479:2379"
   mysql-standalone:
-    image: mysql:5.7
+    image: mysql:8.0
     container_name: mysql-standalone
+    command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     volumes:

--- a/deployments/engine/docker-compose/1meta.yaml
+++ b/deployments/engine/docker-compose/1meta.yaml
@@ -11,8 +11,9 @@ services:
     ports:
       - "12479:2379"
   mysql-standalone:
-    image: mysql:5.7
-    container_name: mysql_standalone
+    image: mysql:8.0
+    container_name: mysql-standalone
+    command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     volumes:

--- a/deployments/engine/docker-compose/3m3e.yaml
+++ b/deployments/engine/docker-compose/3m3e.yaml
@@ -142,13 +142,13 @@ services:
     ports:
       - "12479:2379"
   mysql-standalone:
-    image: mysql:5.7
+    image: mysql:8.0
     container_name: mysql-standalone
+    command: --default-authentication-plugin=mysql_native_password
     environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     volumes:
       - './config/mysql_meta.cnf:/etc/my.cnf'
-      - /tmp/tiflow_engine_test:/log
     ports:
       - "3336:3306"
     healthcheck:

--- a/deployments/engine/docker-compose/dm_databases.yaml
+++ b/deployments/engine/docker-compose/dm_databases.yaml
@@ -14,6 +14,7 @@ services:
     dm_upstream_mysql2:
         image: mysql:8.0
         container_name: dm_upstream_mysql2
+        command: --default-authentication-plugin=mysql_native_password
         ports:
             - "3307:3306"
         environment:

--- a/engine/test/integration_tests/run.sh
+++ b/engine/test/integration_tests/run.sh
@@ -36,14 +36,7 @@ run_case() {
 	local script=$2
 
 	# validate the case script
-	validated=$(
-		cat $script | grep "adjust_config " | grep -v "^#" &>/dev/null
-		echo $?
-	)
-	if [ $validated -ne 0 ]; then
-		echo "[Error] need adjust_config in $script"
-		exit 1
-	fi
+	check_case.sh
 
 	echo "=================>> Running test $script... <<================="
 	PATH="$PATH:$CUR_DIR/../utils" \

--- a/engine/test/utils/check_case.sh
+++ b/engine/test/utils/check_case.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+for script in $(ls ${CUR_DIR}/../integration_tests/*/run.sh); do
+	validated=$(
+		cat $script | grep "adjust_config " | grep -v "^#" &>/dev/null
+		echo $?
+	)
+	if [ $validated -ne 0 ]; then
+		echo "[Error] need adjust_config in $script"
+		exit 1
+	fi
+done
+
+echo "all integration tests of engine verified"


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #6255

### What is changed and how it works?
1. Use mysql8.0 in meta store to facilitate debugging integration tests in arm platform.
2. fix mysql authentication error of mysql8.0.
3. add check script to engine integration tests.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test

<img width="786" alt="image" src="https://user-images.githubusercontent.com/61726649/186610248-32405629-9d69-4704-b0f7-439e6d69e6eb.png">


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
