### PR TITLE
model(engine): support ext field in MasterMetaKVData

### DIFF
--- a/engine/framework/model/master.go
+++ b/engine/framework/model/master.go
@@ -14,6 +14,7 @@
 package model
 
 import (
+	"database/sql/driver"
 	"encoding/json"
 
 	"gorm.io/gorm"
@@ -21,6 +22,7 @@ import (
 	ormModel "github.com/pingcap/tiflow/engine/pkg/orm/model"
 	"github.com/pingcap/tiflow/engine/pkg/p2p"
 	"github.com/pingcap/tiflow/engine/pkg/tenant"
+	"github.com/pingcap/tiflow/pkg/label"
 )
 
 type (
@@ -39,6 +41,27 @@ const (
 	MasterStatusFailed   = MasterStatusCode(5)
 	// extend the status code here
 )
+
+// MasterMetaExt stores some attributes of job masters that do not need
+// to be indexed.
+type MasterMetaExt struct {
+	Selectors []*label.Selector `json:"selectors"`
+}
+
+// Value implements driver.Valuer.
+func (e MasterMetaExt) Value() (driver.Value, error) {
+	b, err := json.Marshal(e)
+	return string(b), err
+}
+
+// Scan implements sql.Scanner.
+func (e *MasterMetaExt) Scan(input interface{}) error {
+	str := input.(string)
+	if len(str) == 0 {
+		return nil
+	}
+	return json.Unmarshal([]byte(input.(string)), e)
+}
 
 // MasterMetaKVData defines the metadata of job master
 type MasterMetaKVData struct {
@@ -59,6 +82,8 @@ type MasterMetaKVData struct {
 
 	// if job is finished or canceled, business logic can set self-defined job info to `ExtMsg`
 	ExtMsg string `json:"extend-message" gorm:"column:extend_message;type:text"`
+
+	Ext MasterMetaExt `json:"ext" gorm:"column:ext;type:JSON"`
 
 	// Deleted is a nullable timestamp. Then master is deleted
 	// if Deleted is not null.
@@ -88,6 +113,7 @@ func (m *MasterMetaKVData) Map() map[string]interface{} {
 		"config":         m.Config,
 		"error_message":  m.ErrorMsg,
 		"extend_message": m.ExtMsg,
+		"ext":            m.Ext,
 	}
 }
 
@@ -106,4 +132,5 @@ var MasterUpdateColumns = []string{
 	"config",
 	"error_message",
 	"extend_message",
+	"ext",
 }

--- a/engine/framework/model/master.go
+++ b/engine/framework/model/master.go
@@ -16,13 +16,14 @@ package model
 import (
 	"database/sql/driver"
 	"encoding/json"
+	"reflect"
 
-	"gorm.io/gorm"
-
+	"github.com/pingcap/errors"
 	ormModel "github.com/pingcap/tiflow/engine/pkg/orm/model"
 	"github.com/pingcap/tiflow/engine/pkg/p2p"
 	"github.com/pingcap/tiflow/engine/pkg/tenant"
 	"github.com/pingcap/tiflow/pkg/label"
+	"gorm.io/gorm"
 )
 
 type (
@@ -56,7 +57,14 @@ func (e MasterMetaExt) Value() (driver.Value, error) {
 
 // Scan implements sql.Scanner.
 func (e *MasterMetaExt) Scan(input interface{}) error {
-	str := input.(string)
+	if input == nil {
+		return nil
+	}
+	str, ok := input.(string)
+	if !ok {
+		return errors.Errorf("failed to scan. Expected string, got %s",
+			reflect.TypeOf(input))
+	}
 	if len(str) == 0 {
 		return nil
 	}

--- a/engine/framework/model/master.go
+++ b/engine/framework/model/master.go
@@ -56,19 +56,29 @@ func (e MasterMetaExt) Value() (driver.Value, error) {
 }
 
 // Scan implements sql.Scanner.
-func (e *MasterMetaExt) Scan(input interface{}) error {
-	if input == nil {
+func (e *MasterMetaExt) Scan(rawInput interface{}) error {
+	if rawInput == nil {
 		return nil
 	}
-	str, ok := input.(string)
-	if !ok {
+
+	var bytes []byte
+	switch input := rawInput.(type) {
+	case string:
+		if len(input) == 0 {
+			return nil
+		}
+		bytes = []byte(input)
+	case []byte:
+		if len(input) == 0 {
+			return nil
+		}
+		bytes = input
+	default:
 		return errors.Errorf("failed to scan. Expected string, got %s",
-			reflect.TypeOf(input))
+			reflect.TypeOf(rawInput))
 	}
-	if len(str) == 0 {
-		return nil
-	}
-	return json.Unmarshal([]byte(input.(string)), e)
+
+	return json.Unmarshal(bytes, e)
 }
 
 // MasterMetaKVData defines the metadata of job master

--- a/engine/framework/model/master.go
+++ b/engine/framework/model/master.go
@@ -60,6 +60,9 @@ func (e MasterMetaExt) Value() (driver.Value, error) {
 
 // Scan implements sql.Scanner.
 func (e *MasterMetaExt) Scan(rawInput interface{}) error {
+	// Zero the fields.
+	*e = MasterMetaExt{}
+
 	if rawInput == nil {
 		return nil
 	}
@@ -83,7 +86,7 @@ func (e *MasterMetaExt) Scan(rawInput interface{}) error {
 		bytes = input
 	default:
 		return errors.Errorf("failed to scan MasterMetaExt. "+
-			"Expected string, got %s", reflect.TypeOf(rawInput))
+			"Expected string or []byte, got %s", reflect.TypeOf(rawInput))
 	}
 
 	if err := json.Unmarshal(bytes, e); err != nil {

--- a/engine/framework/model/master_test.go
+++ b/engine/framework/model/master_test.go
@@ -56,7 +56,7 @@ func TestMasterMetaExtScan(t *testing.T) {
 			checkErr: func(t *testing.T, err error) {
 				require.Regexp(
 					t,
-					regexp.QuoteMeta("failed to scan MasterMetaExt. Expected string, got int"),
+					regexp.QuoteMeta("failed to scan MasterMetaExt. Expected string or []byte, got int"),
 					err)
 			},
 			result: &MasterMetaExt{},

--- a/engine/framework/model/master_test.go
+++ b/engine/framework/model/master_test.go
@@ -1,0 +1,123 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/pingcap/tiflow/pkg/label"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMasterMetaExtScan(t *testing.T) {
+	// This test case aims to check MasterMetaExt implements
+	// Scan() correctly so that it can work with the SQL driver.
+	t.Parallel()
+
+	expectNoError := func(t *testing.T, err error) {
+		require.NoError(t, err)
+	}
+
+	cases := []struct {
+		input    any
+		checkErr func(*testing.T, error)
+		result   *MasterMetaExt
+	}{
+		{
+			input:    nil,
+			checkErr: expectNoError,
+			result:   &MasterMetaExt{},
+		},
+		{
+			input:    "",
+			checkErr: expectNoError,
+			result:   &MasterMetaExt{},
+		},
+		{
+			input:    []byte(""),
+			checkErr: expectNoError,
+			result:   &MasterMetaExt{},
+		},
+		{
+			input: 123,
+			checkErr: func(t *testing.T, err error) {
+				require.Regexp(
+					t,
+					regexp.QuoteMeta("failed to scan MasterMetaExt. Expected string, got int"),
+					err)
+			},
+			result: &MasterMetaExt{},
+		},
+		{
+			input:    `{"selectors":[{"label":"test","target":"test-val","op":"eq"}]}`,
+			checkErr: expectNoError,
+			result: &MasterMetaExt{
+				Selectors: []*label.Selector{
+					{
+						Key:    "test",
+						Target: "test-val",
+						Op:     label.OpEq,
+					},
+				},
+			},
+		},
+		{
+			input:    []byte(`{"selectors":[{"label":"test","target":"test-val","op":"eq"}]}`),
+			checkErr: expectNoError,
+			result: &MasterMetaExt{
+				Selectors: []*label.Selector{
+					{
+						Key:    "test",
+						Target: "test-val",
+						Op:     label.OpEq,
+					},
+				},
+			},
+		},
+		{
+			input: []byte(`{"selecto`),
+			checkErr: func(t *testing.T, err error) {
+				require.Regexp(t, "failed to unmarshal MasterMetaExt", err)
+			},
+			result: &MasterMetaExt{},
+		},
+	}
+
+	for i := range cases {
+		t.Run(fmt.Sprintf("subcase-%d", i), func(t *testing.T) {
+			var ext MasterMetaExt
+			c := cases[i]
+			c.checkErr(t, ext.Scan(c.input))
+			require.Equal(t, c.result, &ext)
+		})
+	}
+}
+
+func TestMasterMetaExtValue(t *testing.T) {
+	t.Parallel()
+
+	ext := &MasterMetaExt{Selectors: []*label.Selector{
+		{
+			Key:    "test",
+			Target: "test-val",
+			Op:     label.OpEq,
+		},
+	}}
+	val, err := ext.Value()
+	require.NoError(t, err)
+	require.IsType(t, "" /* string */, val)
+	require.Equal(t, `{"selectors":[{"label":"test","target":"test-val","op":"eq"}]}`, val)
+}

--- a/engine/pkg/orm/client_test.go
+++ b/engine/pkg/orm/client_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tiflow/pkg/label"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-sql-driver/mysql"
 	perrors "github.com/pingcap/errors"
@@ -358,6 +360,17 @@ func TestJob(t *testing.T) {
 	createdAt := tm.Add(time.Duration(1))
 	updatedAt := tm.Add(time.Duration(1))
 
+	extForTest := frameModel.MasterMetaExt{
+		Selectors: []*label.Selector{
+			{
+				Key:    "test",
+				Target: "test-val",
+				Op:     label.OpEq,
+			},
+		},
+	}
+	extJSONForTest := `{"selectors":[{"label":"test","target":"test-val","op":"eq"}]}`
+
 	testCases := []tCase{
 		{
 			fn: "UpsertJob",
@@ -371,6 +384,7 @@ func TestJob(t *testing.T) {
 					StatusCode: 1,
 					Addr:       "127.0.0.1",
 					Config:     []byte{0x11, 0x22},
+					Ext:        extForTest,
 				},
 			},
 			mockExpectResFn: func(mock sqlmock.Sqlmock) {
@@ -442,15 +456,17 @@ func TestJob(t *testing.T) {
 				StatusCode: 1,
 				Addr:       "127.0.0.1",
 				Config:     []byte{0x11, 0x22},
+				Ext:        extForTest,
 			},
 			mockExpectResFn: func(mock sqlmock.Sqlmock) {
 				expectedSQL := "SELECT * FROM `master_meta_kv_data` WHERE id = ? AND `master_meta_kv_data`.`deleted` IS NULL"
 				mock.ExpectQuery(regexp.QuoteMeta(expectedSQL)).WithArgs("j111").WillReturnRows(
 					sqlmock.NewRows([]string{
 						"created_at", "updated_at", "project_id", "id",
-						"type", "status", "node_id", "address", "epoch", "config", "seq_id",
+						"type", "status", "node_id", "address", "epoch", "config", "seq_id", "ext",
 					}).AddRow(
-						createdAt, updatedAt, "p111", "j111", 1, 1, "n111", "127.0.0.1", 1, []byte{0x11, 0x22}, 1))
+						createdAt, updatedAt, "p111", "j111", 1, 1, "n111", "127.0.0.1", 1, []byte{0x11, 0x22}, 1,
+						extJSONForTest))
 			},
 		},
 		{
@@ -485,15 +501,16 @@ func TestJob(t *testing.T) {
 					StatusCode: 1,
 					Addr:       "1.1.1.1",
 					Config:     []byte{0x11, 0x22},
+					Ext:        extForTest,
 				},
 			},
 			mockExpectResFn: func(mock sqlmock.Sqlmock) {
 				mock.ExpectQuery("SELECT [*] FROM `master_meta_kv_data` WHERE project_id").WithArgs("p111").WillReturnRows(
 					sqlmock.NewRows([]string{
 						"created_at", "updated_at", "project_id", "id",
-						"type", "status", "node_id", "address", "epoch", "config", "seq_id",
+						"type", "status", "node_id", "address", "epoch", "config", "seq_id", "ext",
 					}).AddRow(
-						createdAt, updatedAt, "p111", "j111", 1, 1, "n111", "1.1.1.1", 1, []byte{0x11, 0x22}, 1))
+						createdAt, updatedAt, "p111", "j111", 1, 1, "n111", "1.1.1.1", 1, []byte{0x11, 0x22}, 1, extJSONForTest))
 			},
 		},
 		{
@@ -529,6 +546,7 @@ func TestJob(t *testing.T) {
 					StatusCode: 1,
 					Addr:       "127.0.0.1",
 					Config:     []byte{0x11, 0x22},
+					Ext:        extForTest,
 				},
 			},
 			mockExpectResFn: func(mock sqlmock.Sqlmock) {
@@ -536,9 +554,9 @@ func TestJob(t *testing.T) {
 				mock.ExpectQuery(regexp.QuoteMeta(expectedSQL)).WithArgs("j111", 1).WillReturnRows(
 					sqlmock.NewRows([]string{
 						"created_at", "updated_at", "project_id", "id",
-						"type", "status", "node_id", "address", "epoch", "config", "seq_id",
+						"type", "status", "node_id", "address", "epoch", "config", "seq_id", "ext",
 					}).AddRow(
-						createdAt, updatedAt, "p111", "j111", 1, 1, "n111", "127.0.0.1", 1, []byte{0x11, 0x22}, 1))
+						createdAt, updatedAt, "p111", "j111", 1, 1, "n111", "127.0.0.1", 1, []byte{0x11, 0x22}, 1, extJSONForTest))
 			},
 		},
 		{


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #6270

### What is changed and how it works?
- Added an `ext` field in `MasterMetaKVData` for better extensibility.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No.

##### Do you need to update user documentation, design documentation or monitoring documentation?
No.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
