### PR TITLE
test(engine): add option --try-nums to the wait_mysql_online script

### DIFF
--- a/engine/test/integration_tests/dm_basic/run.sh
+++ b/engine/test/integration_tests/dm_basic/run.sh
@@ -11,8 +11,8 @@ echo "using adjusted configs to deploy cluster: $CONFIG"
 
 function run() {
 	start_engine_cluster $CONFIG
-	wait_mysql_online.sh --host 127.0.0.1 --port 3306
-	wait_mysql_online.sh --host 127.0.0.1 --port 4000
+	wait_mysql_online.sh --host 127.0.0.1 --port 3306 --try-nums 100
+	wait_mysql_online.sh --host 127.0.0.1 --port 4000 --try-nums 100
 	CGO_ENABLED=0 go test -count=1 -v -run ^TestDMJob$ github.com/pingcap/tiflow/engine/test/e2e
 }
 

--- a/engine/test/utils/wait_mysql_online.sh
+++ b/engine/test/utils/wait_mysql_online.sh
@@ -5,6 +5,7 @@ host="127.0.0.1"
 port=3306
 user="root"
 password=""
+tryNums=30
 
 while [[ ${1} ]]; do
 	case "${1}" in
@@ -24,8 +25,13 @@ while [[ ${1} ]]; do
 		password=${2}
 		shift
 		;;
+	--try-nums)
+		tryNums=${2}
+		shift
+		;;
 	*)
 		echo "Unknown parameter: ${1}" >&2
+		echo "Only support: --host/--port/--user/--password/--try-nums" >&2
 		exit 1
 		;;
 	esac
@@ -45,7 +51,7 @@ else
 fi
 while ! eval $check_cmd; do
 	i=$((i + 1))
-	if [ "$i" -gt 30 ]; then
+	if [ "$i" -gt ${tryNums} ]; then
 		echo 'Failed to start database'
 		exit 2
 	fi


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6923 

### What is changed and how it works?
1. Add option --try-nums to the wait_mysql_online script
2. Increase the try nums for `dm_basic` test

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
```
$./wait_mysql_online.sh xxx
Unknown parameter: xxx
Only support: --host/--port/--user/--password/--try-nums
```

```
[Verifying database root@127.0.0.1:3306 is started...
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0
+------------+
| version()  |
+------------+
| 5.7.37-log |
+------------+
```
#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
 `None`.
```
