### PR TITLE
serverutil(engine): fix panic in WatchExecutors

### DIFF
--- a/engine/servermaster/serverutil/watch_executors.go
+++ b/engine/servermaster/serverutil/watch_executors.go
@@ -54,7 +54,6 @@ func WatchExecutors(ctx context.Context, watcher executorWatcher, user executorI
 
 	watchStart := time.Now()
 	snap, updates, err := watcher.WatchExecutors(ctx)
-	defer updates.Close()
 
 	if duration := time.Since(watchStart); duration >= 100*time.Millisecond {
 		log.Warn("WatchExecutors took too long",
@@ -64,6 +63,7 @@ func WatchExecutors(ctx context.Context, watcher executorWatcher, user executorI
 	if err != nil {
 		return errors.Annotate(err, "watch executors")
 	}
+	defer updates.Close()
 
 	log.Info("update executor list", zap.Any("list", snap))
 	if err := user.UpdateExecutorList(snap); err != nil {

--- a/engine/servermaster/serverutil/watch_executors_test.go
+++ b/engine/servermaster/serverutil/watch_executors_test.go
@@ -19,13 +19,13 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/atomic"
-
+	perrors "github.com/pingcap/errors"
 	"github.com/pingcap/tiflow/engine/model"
 	"github.com/pingcap/tiflow/engine/pkg/notifier"
 	"github.com/pingcap/tiflow/pkg/errors"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 type mockExecutorWatcher struct {
@@ -147,6 +147,28 @@ func TestWatchExecutors(t *testing.T) {
 
 	cancel()
 	wg.Wait()
+}
+
+func TestWatchExecutorFailed(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	watcher := newMockExecutorWatcher()
+	user := newMockExecutorInfoUser()
+
+	evNotifier := notifier.NewNotifier[model.ExecutorStatusChange]()
+	defer evNotifier.Close()
+
+	watcher.On("WatchExecutors", mock.Anything).
+		Return(map[model.ExecutorID]string(nil),
+			(*notifier.Receiver[model.ExecutorStatusChange])(nil),
+			perrors.New("test error"),
+		).Times(1)
+
+	err := WatchExecutors(ctx, watcher, user)
+	require.ErrorContains(t, err, "test error")
 }
 
 func TestCloseWatchExecutors(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?

Issue Number: close #6964

### What is changed and how it works?
- Fixed a bug in deferred closing of the receiver.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No.

##### Do you need to update user documentation, design documentation or monitoring documentation?
No.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
