### PR TITLE
test(engine): fix fake job integration test fail when the worker is finished

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -502,7 +502,7 @@ engine_unit_test: check_failpoint_ctl
 
 engine_integration_test: check_third_party_binary_for_engine
 	mkdir -p /tmp/tiflow_engine_test || true
-	./engine/test/integration_tests/run.sh "$(CASE)" "$(START_AT)" | tee /tmp/tiflow_engine_test/engine_it.log
+	./engine/test/integration_tests/run.sh "$(CASE)" "$(START_AT)" 2>&1 | tee /tmp/tiflow_engine_test/engine_it.log
 	./engine/test/utils/check_log.sh
 
 check_third_party_binary_for_engine:

--- a/engine/framework/fake/fake_worker.go
+++ b/engine/framework/fake/fake_worker.go
@@ -155,14 +155,19 @@ func (d *dummyWorker) Tick(ctx context.Context) error {
 		return nil
 	}
 
+	extMsg, err := d.status.Marshal()
+	if err != nil {
+		return err
+	}
+
 	if d.getState() == frameModel.WorkerStateStopped {
 		d.setState(frameModel.WorkerStateStopped)
-		return d.Exit(ctx, framework.ExitReasonCanceled, nil, []byte("worker has been canceled"))
+		return d.Exit(ctx, framework.ExitReasonCanceled, nil, extMsg)
 	}
 
 	if d.status.Tick >= d.config.TargetTick {
 		d.setState(frameModel.WorkerStateFinished)
-		return d.Exit(ctx, framework.ExitReasonFinished, nil, []byte("worker has reached target tick"))
+		return d.Exit(ctx, framework.ExitReasonFinished, nil, extMsg)
 	}
 
 	if d.config.InjectErrorInterval != 0 {

--- a/engine/test/integration_tests/tiflow_job_finished/conf/fake_job.json
+++ b/engine/test/integration_tests/tiflow_job_finished/conf/fake_job.json
@@ -1,0 +1,8 @@
+{
+  "job-name": "test_job_finished",
+  "worker-count": 2,
+  "target-tick": 100,
+  "etcd-watch-enable": true,
+  "etcd-endpoints": ["etcd-standalone:2379"],
+  "etcd-watch-prefix": "/test_job_finished/"
+}

--- a/engine/test/integration_tests/tiflow_job_finished/run.sh
+++ b/engine/test/integration_tests/tiflow_job_finished/run.sh
@@ -13,10 +13,10 @@ function run() {
 	start_engine_cluster $CONFIG
 	# add a delay in case that the cluster is not ready
 	sleep 3s
-    
-    create_job_json=$(base64 -i $CUR_DIR/conf/fake_job.json | tr -d \\n | jq -Rs '{ type: "FakeJob", config: . }')
+
+	create_job_json=$(base64 -i $CUR_DIR/conf/fake_job.json | tr -d \\n | jq -Rs '{ type: "FakeJob", config: . }')
 	echo "create_job_json: $create_job_json"
-    job_id=$(curl -X POST -H "Content-Type: application/json" -d "$create_job_json" "http://127.0.0.1:10245/api/v1/jobs?tenant_id=tiflow_job_finished&project_id=tiflow_job_finished)" | tee /dev/stderr | jq -r .id)
+	job_id=$(curl -X POST -H "Content-Type: application/json" -d "$create_job_json" "http://127.0.0.1:10245/api/v1/jobs?tenant_id=tiflow_job_finished&project_id=tiflow_job_finished)" | tee /dev/stderr | jq -r .id)
 	echo "job_id: $job_id"
 
 	exec_with_retry --count 100 "curl \"http://127.0.0.1:10245/api/v1/jobs/$job_id\" | tee /dev/stderr | jq -e '.state == \"Finished\"'"

--- a/engine/test/integration_tests/tiflow_job_finished/run.sh
+++ b/engine/test/integration_tests/tiflow_job_finished/run.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eu
+
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+CONFIG="$DOCKER_COMPOSE_DIR/3m3e.yaml $DOCKER_COMPOSE_DIR/demo.yaml"
+CONFIG=$(adjust_config $OUT_DIR $TEST_NAME $CONFIG)
+echo "using adjusted configs to deploy cluster: $CONFIG"
+
+function run() {
+	start_engine_cluster $CONFIG
+	# add a delay in case that the cluster is not ready
+	sleep 3s
+    
+    create_job_json=$(base64 -i $CUR_DIR/conf/fake_job.json | tr -d \\n | jq -Rs '{ type: "FakeJob", config: . }')
+	echo "create_job_json: $create_job_json"
+    job_id=$(curl -X POST -H "Content-Type: application/json" -d "$create_job_json" "http://127.0.0.1:10245/api/v1/jobs?tenant_id=tiflow_job_finished&project_id=tiflow_job_finished)" | tee /dev/stderr | jq -r .id)
+	echo "job_id: $job_id"
+
+	exec_with_retry --count 100 "curl \"http://127.0.0.1:10245/api/v1/jobs/$job_id\" | tee /dev/stderr | jq -e '.status == \"Finished\"'"
+}
+
+trap "stop_engine_cluster $WORK_DIR $CONFIG" EXIT
+run $*
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"

--- a/engine/test/integration_tests/tiflow_job_finished/run.sh
+++ b/engine/test/integration_tests/tiflow_job_finished/run.sh
@@ -5,7 +5,7 @@ set -eu
 WORK_DIR=$OUT_DIR/$TEST_NAME
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-CONFIG="$DOCKER_COMPOSE_DIR/3m3e.yaml $DOCKER_COMPOSE_DIR/demo.yaml"
+CONFIG="$DOCKER_COMPOSE_DIR/3m3e.yaml"
 CONFIG=$(adjust_config $OUT_DIR $TEST_NAME $CONFIG)
 echo "using adjusted configs to deploy cluster: $CONFIG"
 

--- a/engine/test/integration_tests/tiflow_job_finished/run.sh
+++ b/engine/test/integration_tests/tiflow_job_finished/run.sh
@@ -19,7 +19,7 @@ function run() {
     job_id=$(curl -X POST -H "Content-Type: application/json" -d "$create_job_json" "http://127.0.0.1:10245/api/v1/jobs?tenant_id=tiflow_job_finished&project_id=tiflow_job_finished)" | tee /dev/stderr | jq -r .id)
 	echo "job_id: $job_id"
 
-	exec_with_retry --count 100 "curl \"http://127.0.0.1:10245/api/v1/jobs/$job_id\" | tee /dev/stderr | jq -e '.status == \"Finished\"'"
+	exec_with_retry --count 100 "curl \"http://127.0.0.1:10245/api/v1/jobs/$job_id\" | tee /dev/stderr | jq -e '\"state\"\:\"Finished\"'"
 }
 
 trap "stop_engine_cluster $WORK_DIR $CONFIG" EXIT

--- a/engine/test/integration_tests/tiflow_job_finished/run.sh
+++ b/engine/test/integration_tests/tiflow_job_finished/run.sh
@@ -19,7 +19,7 @@ function run() {
     job_id=$(curl -X POST -H "Content-Type: application/json" -d "$create_job_json" "http://127.0.0.1:10245/api/v1/jobs?tenant_id=tiflow_job_finished&project_id=tiflow_job_finished)" | tee /dev/stderr | jq -r .id)
 	echo "job_id: $job_id"
 
-	exec_with_retry --count 100 "curl \"http://127.0.0.1:10245/api/v1/jobs/$job_id\" | tee /dev/stderr | jq -e '\"state\"\:\"Finished\"'"
+	exec_with_retry --count 100 "curl \"http://127.0.0.1:10245/api/v1/jobs/$job_id\" | tee /dev/stderr | jq -e '.state == \"Finished\"'"
 }
 
 trap "stop_engine_cluster $WORK_DIR $CONFIG" EXIT


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6978 

### What is changed and how it works?
Set fake worker inner status to extMsg even the case when worker is finished or canceled

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
