### PR TITLE
lint(*): fix standard library is not checked in depguard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,7 +56,7 @@ linters-settings:
 
   depguard:
     list-type: blacklist
-    include-go-root: false
+    include-go-root: true
     packages:
       - log
       - github.com/juju/errors

--- a/engine/pkg/meta/internal/registry.go
+++ b/engine/pkg/meta/internal/registry.go
@@ -14,9 +14,9 @@
 package internal
 
 import (
-	"log"
 	"sync"
 
+	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/engine/pkg/meta/internal/etcdkv"
 	"github.com/pingcap/tiflow/engine/pkg/meta/internal/mockkv"
 	"github.com/pingcap/tiflow/engine/pkg/meta/internal/sqlkv"

--- a/engine/pkg/meta/mock/clientconn_mock.go
+++ b/engine/pkg/meta/mock/clientconn_mock.go
@@ -3,10 +3,10 @@ package mock
 import (
 	"database/sql"
 	"database/sql/driver"
-	"log"
 	"sync"
 
 	"github.com/glebarez/go-sqlite"
+	"github.com/pingcap/log"
 	metaModel "github.com/pingcap/tiflow/engine/pkg/meta/model"
 	"github.com/pingcap/tiflow/pkg/errors"
 )


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #2162

### What is changed and how it works?

- Turn on `include-go-root` in depguard check in order to check standard library
- Replace `log` with `github.com/pingcap/log`

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
