### PR TITLE
tracker(dm): fix downstream table structure reports key too long (#6661)

### DIFF
--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -127,6 +127,8 @@ func NewTracker(ctx context.Context, task string, sessionCfg map[string]string, 
 		// explicitly disable new-collation for better compatibility as tidb only support a subset of all mysql collations.
 		conf.NewCollationsEnabledOnFirstBootstrap = false
 		conf.Performance.RunAutoAnalyze = false
+		// bypass "Specified key was too long"
+		conf.MaxIndexLength = 1<<32 - 1
 	})
 
 	if len(sessionCfg) == 0 {

--- a/dm/pkg/schema/tracker_test.go
+++ b/dm/pkg/schema/tracker_test.go
@@ -775,7 +775,7 @@ func (s *trackerSuite) TestGetDownStreamIndexInfo(c *C) {
 
 	mock.ExpectQuery("SHOW CREATE TABLE " + tableID).WillReturnRows(
 		sqlmock.NewRows([]string{"Table", "Create Table"}).
-			AddRow("test", "create table t(a int primary key, b int, c varchar(10))"))
+			AddRow("test", "create table t(a int primary key, b int, c varchar(20000), key(c(20000)))"))
 	dti, err := tracker.GetDownStreamTableInfo(tcontext.Background(), tableID, oriTi)
 	c.Assert(err, IsNil)
 	c.Assert(dti, NotNil)


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5315

### What is changed and how it works?

during the refactor of schema tracker, I found this issue is not hard to fix

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix a problem that DM will report `Specified key was too long` error
```

