### PR TITLE
config(ticdc): increase the default table memory quota to 64MiB

### DIFF
--- a/pkg/config/config_test_data.go
+++ b/pkg/config/config_test_data.go
@@ -92,7 +92,7 @@ const (
     "key-path": "",
     "cert-allowed-cn": null
   },
-  "per-table-memory-quota": 10485760,
+  "per-table-memory-quota": 67108864,
   "kv-client": {
     "worker-concurrent": 8,
     "worker-pool-size": 0,

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -43,7 +43,7 @@ const (
 	DebugConfigurationItem = "debug"
 
 	// DefaultTableMemoryQuota is the default memory quota for each table.
-	DefaultTableMemoryQuota = 10 * 1024 * 1024 // 10 MB
+	DefaultTableMemoryQuota = 64 * 1024 * 1024 // 64 MB
 )
 
 var (


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/7030

### What is changed and how it works?
Increase the default table memory quota to 64MiB.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Increase the default table memory quota to 64MiB
```
