### PR TITLE
framework(engine): record error message when job master closes

### DIFF
--- a/engine/framework/base_jobmaster.go
+++ b/engine/framework/base_jobmaster.go
@@ -201,6 +201,7 @@ func (d *DefaultBaseJobMaster) Init(ctx context.Context) error {
 
 	if isFirstStartUp {
 		if err := d.impl.InitImpl(ctx); err != nil {
+			d.errCenter.OnError(err)
 			return errors.Trace(err)
 		}
 		if err := d.master.markStateInMetadata(ctx, frameModel.MasterStateInit); err != nil {
@@ -208,6 +209,7 @@ func (d *DefaultBaseJobMaster) Init(ctx context.Context) error {
 		}
 	} else {
 		if err := d.impl.OnMasterRecovered(ctx); err != nil {
+			d.errCenter.OnError(err)
 			return errors.Trace(err)
 		}
 	}
@@ -234,6 +236,7 @@ func (d *DefaultBaseJobMaster) Poll(ctx context.Context) error {
 		return nil
 	}
 	if err := d.impl.Tick(ctx); err != nil {
+		d.errCenter.OnError(err)
 		return errors.Trace(err)
 	}
 	return nil
@@ -253,6 +256,7 @@ func (d *DefaultBaseJobMaster) Close(ctx context.Context) error {
 		}
 	})
 
+	d.master.persistMetaError()
 	d.master.doClose()
 	d.worker.doClose()
 	return nil

--- a/engine/framework/base_jobmaster.go
+++ b/engine/framework/base_jobmaster.go
@@ -201,6 +201,8 @@ func (d *DefaultBaseJobMaster) Init(ctx context.Context) error {
 
 	if isFirstStartUp {
 		if err := d.impl.InitImpl(ctx); err != nil {
+			// Currently we only pass error to error center when calling busniess
+			// API returns error. Business API is also known as XxxImpl.
 			d.errCenter.OnError(err)
 			return errors.Trace(err)
 		}

--- a/engine/framework/base_jobmaster_test.go
+++ b/engine/framework/base_jobmaster_test.go
@@ -418,7 +418,7 @@ func TestJobMasterExit(t *testing.T) {
 	}
 }
 
-func TestJobMasterInitImplReturnError(t *testing.T) {
+func TestJobMasterInitReturnError(t *testing.T) {
 	t.Parallel()
 
 	jobMaster := &testJobMasterImpl{}
@@ -453,6 +453,7 @@ func TestJobMasterInitImplReturnError(t *testing.T) {
 
 	meta, err := jobMaster.base.master.frameMetaClient.GetJobByID(ctx, jobMaster.base.ID())
 	require.NoError(t, err)
+	require.Equal(t, frameModel.MasterStateUninit, meta.State)
 	require.Equal(t, initError.Error(), meta.ErrorMsg)
 }
 
@@ -505,5 +506,6 @@ func TestJobMasterPollReturnError(t *testing.T) {
 
 	meta, err := jobMaster.base.master.frameMetaClient.GetJobByID(ctx, jobMaster.base.ID())
 	require.NoError(t, err)
+	require.Equal(t, frameModel.MasterStateInit, meta.State)
 	require.Equal(t, pollError.Error(), meta.ErrorMsg)
 }

--- a/engine/framework/base_jobmaster_test.go
+++ b/engine/framework/base_jobmaster_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tiflow/engine/pkg/deps"
 	metaMock "github.com/pingcap/tiflow/engine/pkg/meta/mock"
 	pkgOrm "github.com/pingcap/tiflow/engine/pkg/orm"
+	ormModel "github.com/pingcap/tiflow/engine/pkg/orm/model"
 	"github.com/pingcap/tiflow/engine/pkg/p2p"
 	"github.com/pingcap/tiflow/engine/pkg/tenant"
 )
@@ -508,4 +509,47 @@ func TestJobMasterPollReturnError(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, frameModel.MasterStateInit, meta.State)
 	require.Equal(t, pollError.Error(), meta.ErrorMsg)
+}
+
+func TestJobMasterExitClearOldError(t *testing.T) {
+	t.Parallel()
+
+	jobMaster := &testJobMasterImpl{}
+	base := newBaseJobMasterForTests(t, jobMaster)
+	jobMaster.base = base
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// simulate job failed in last round, and failover again
+	err := jobMaster.base.master.frameMetaClient.UpdateJob(
+		ctx, jobMasterID, ormModel.KeyValueMap{
+			"state":         frameModel.MasterStateInit,
+			"error_message": "error in last period",
+		})
+	require.NoError(t, err)
+
+	jobMaster.mu.Lock()
+	jobMaster.On("OnMasterRecovered", mock.Anything).Return(nil)
+	jobMaster.mu.Unlock()
+
+	err = jobMaster.base.Init(ctx)
+	require.NoError(t, err)
+
+	jobMaster.mu.Lock()
+	jobMaster.AssertNumberOfCalls(t, "OnMasterRecovered", 1)
+	// clean status
+	jobMaster.ExpectedCalls = nil
+	jobMaster.Calls = nil
+	jobMaster.mu.Unlock()
+
+	status := jobMaster.Status()
+	jobMaster.base.Exit(ctx, ExitReasonFinished, nil, status.ExtBytes)
+	require.NoError(t, err)
+
+	meta, err := jobMaster.base.master.frameMetaClient.GetJobByID(ctx, jobMaster.base.ID())
+	require.NoError(t, err)
+	require.Equal(t, frameModel.MasterStateFinished, meta.State)
+	require.Equal(t, status.ExtBytes, meta.Detail)
+	require.Empty(t, meta.ErrorMsg)
 }

--- a/engine/framework/master.go
+++ b/engine/framework/master.go
@@ -349,10 +349,12 @@ func (m *DefaultBaseMaster) Init(ctx context.Context) error {
 
 	if isInit {
 		if err := m.Impl.InitImpl(ctx); err != nil {
+			m.errCenter.OnError(err)
 			return errors.Trace(err)
 		}
 	} else {
 		if err := m.Impl.OnMasterRecovered(ctx); err != nil {
+			m.errCenter.OnError(err)
 			return errors.Trace(err)
 		}
 	}
@@ -482,6 +484,7 @@ func (m *DefaultBaseMaster) Poll(ctx context.Context) error {
 	}
 
 	if err := m.Impl.Tick(ctx); err != nil {
+		m.errCenter.OnError(err)
 		return errors.Trace(err)
 	}
 

--- a/engine/framework/master.go
+++ b/engine/framework/master.go
@@ -745,6 +745,8 @@ func (m *DefaultBaseMaster) exitWithoutSetErrCenter(ctx context.Context, exitRea
 
 	if err != nil {
 		m.masterMeta.ErrorMsg = err.Error()
+	} else {
+		m.masterMeta.ErrorMsg = ""
 	}
 	m.masterMeta.Detail = detail
 	metaClient := metadata.NewMasterMetadataClient(m.id, m.frameMetaClient)

--- a/engine/framework/master.go
+++ b/engine/framework/master.go
@@ -528,7 +528,7 @@ func (m *DefaultBaseMaster) doClose() {
 	m.wg.Wait()
 	if err := m.messageHandlerManager.Clean(closeCtx); err != nil {
 		m.Logger().Warn("Failed to clean up message handlers",
-			zap.String("master-id", m.id))
+			zap.String("master-id", m.id), zap.Error(err))
 	}
 	promutil.UnregisterWorkerMetrics(m.id)
 	m.businessMetaKVClient.Close()
@@ -543,6 +543,7 @@ func (m *DefaultBaseMaster) Close(ctx context.Context) error {
 		m.Logger().Error("Failed to close MasterImpl", zap.Error(err))
 	}
 
+	m.persistMetaError()
 	m.doClose()
 	return errors.Trace(err)
 }
@@ -577,7 +578,7 @@ func (m *DefaultBaseMaster) refreshMetadata(ctx context.Context) (isInit bool, e
 	masterMeta.Addr = m.advertiseAddr
 	masterMeta.NodeID = m.nodeID
 
-	if err := metaClient.Update(ctx, masterMeta); err != nil {
+	if err := metaClient.Update(ctx, masterMeta.RefreshValues()); err != nil {
 		return false, 0, errors.Trace(err)
 	}
 
@@ -592,13 +593,22 @@ func (m *DefaultBaseMaster) markStateInMetadata(
 	ctx context.Context, code frameModel.MasterState,
 ) error {
 	metaClient := metadata.NewMasterMetadataClient(m.id, m.frameMetaClient)
-	masterMeta, err := metaClient.Load(ctx)
-	if err != nil {
-		return errors.Trace(err)
-	}
+	m.masterMeta.State = code
+	return metaClient.Update(ctx, m.masterMeta.UpdateStateValues())
+}
 
-	masterMeta.State = code
-	return metaClient.Update(ctx, masterMeta)
+func (m *DefaultBaseMaster) persistMetaError() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	defer cancel()
+
+	if err := m.errCenter.CheckError(); err != nil {
+		metaClient := metadata.NewMasterMetadataClient(m.id, m.frameMetaClient)
+		m.masterMeta.ErrorMsg = err.Error()
+		if err2 := metaClient.Update(ctx, m.masterMeta.UpdateErrorValues()); err2 != nil {
+			m.Logger().Warn("Failed to update error message",
+				zap.String("master-id", m.id), zap.Error(err2))
+		}
+	}
 }
 
 // PrepareWorkerConfig extracts information from WorkerConfig into detail fields.
@@ -737,9 +747,8 @@ func (m *DefaultBaseMaster) exitWithoutSetErrCenter(ctx context.Context, exitRea
 		m.masterMeta.ErrorMsg = err.Error()
 	}
 	m.masterMeta.Detail = detail
-
 	metaClient := metadata.NewMasterMetadataClient(m.id, m.frameMetaClient)
-	return metaClient.Update(ctx, m.masterMeta)
+	return metaClient.Update(ctx, m.masterMeta.ExitValues())
 }
 
 // SetProjectInfo set the project info of specific worker

--- a/engine/framework/metadata/metadata.go
+++ b/engine/framework/metadata/metadata.go
@@ -22,6 +22,7 @@ import (
 
 	frameModel "github.com/pingcap/tiflow/engine/framework/model"
 	pkgOrm "github.com/pingcap/tiflow/engine/pkg/orm"
+	ormModel "github.com/pingcap/tiflow/engine/pkg/orm/model"
 )
 
 // JobManagerUUID defines the global unique id for job manager
@@ -70,8 +71,10 @@ func (c *MasterMetadataClient) Store(ctx context.Context, data *frameModel.Maste
 }
 
 // Update update the data
-func (c *MasterMetadataClient) Update(ctx context.Context, data *frameModel.MasterMeta) error {
-	return errors.Trace(c.metaClient.UpdateJob(ctx, data))
+func (c *MasterMetadataClient) Update(
+	ctx context.Context, values ormModel.KeyValueMap,
+) error {
+	return errors.Trace(c.metaClient.UpdateJob(ctx, c.masterID, values))
 }
 
 // Delete deletes the metadata of this master

--- a/engine/framework/model/master.go
+++ b/engine/framework/model/master.go
@@ -143,20 +143,36 @@ func (m *MasterMeta) Unmarshal(data []byte) error {
 	return json.Unmarshal(data, m)
 }
 
-// Map is used for update the orm model
-func (m *MasterMeta) Map() map[string]interface{} {
-	return map[string]interface{}{
-		"project_id":    m.ProjectID,
-		"id":            m.ID,
-		"type":          m.Type,
-		"state":         m.State,
-		"node_id":       m.NodeID,
-		"address":       m.Addr,
-		"epoch":         m.Epoch,
-		"config":        m.Config,
+// RefreshValues is used to generate orm value map when refreshing metadata.
+func (m *MasterMeta) RefreshValues() ormModel.KeyValueMap {
+	return ormModel.KeyValueMap{
+		"node_id": m.NodeID,
+		"address": m.Addr,
+		"epoch":   m.Epoch,
+	}
+}
+
+// UpdateStateValues is used to generate orm value map when updating state of master meta.
+func (m *MasterMeta) UpdateStateValues() ormModel.KeyValueMap {
+	return ormModel.KeyValueMap{
+		"state": m.State,
+	}
+}
+
+// UpdateErrorValues is used to generate orm value map when job master meets error and records it.
+func (m *MasterMeta) UpdateErrorValues() ormModel.KeyValueMap {
+	return ormModel.KeyValueMap{
 		"error_message": m.ErrorMsg,
 		"detail":        m.Detail,
-		"ext":           m.Ext,
+	}
+}
+
+// ExitValues is used to generate orm value map when job master exits.
+func (m *MasterMeta) ExitValues() ormModel.KeyValueMap {
+	return ormModel.KeyValueMap{
+		"state":         m.State,
+		"error_message": m.ErrorMsg,
+		"detail":        m.Detail,
 	}
 }
 

--- a/engine/framework/model/master.go
+++ b/engine/framework/model/master.go
@@ -163,7 +163,6 @@ func (m *MasterMeta) UpdateStateValues() ormModel.KeyValueMap {
 func (m *MasterMeta) UpdateErrorValues() ormModel.KeyValueMap {
 	return ormModel.KeyValueMap{
 		"error_message": m.ErrorMsg,
-		"detail":        m.Detail,
 	}
 }
 

--- a/engine/framework/model/master_test.go
+++ b/engine/framework/model/master_test.go
@@ -167,7 +167,6 @@ func TestOrmKeyValues(t *testing.T) {
 
 	require.Equal(t, ormModel.KeyValueMap{
 		"error_message": meta.ErrorMsg,
-		"detail":        meta.Detail,
 	}, meta.UpdateErrorValues())
 
 	require.Equal(t, ormModel.KeyValueMap{

--- a/engine/framework/model/master_test.go
+++ b/engine/framework/model/master_test.go
@@ -18,6 +18,7 @@ import (
 	"regexp"
 	"testing"
 
+	ormModel "github.com/pingcap/tiflow/engine/pkg/orm/model"
 	"github.com/pingcap/tiflow/pkg/label"
 	"github.com/stretchr/testify/require"
 )
@@ -138,4 +139,40 @@ func TestMasterStateIsTerminated(t *testing.T) {
 	for _, tc := range testCases {
 		require.Equal(t, tc.isTerminated, tc.code.IsTerminatedState())
 	}
+}
+
+func TestOrmKeyValues(t *testing.T) {
+	t.Parallel()
+	meta := &MasterMeta{
+		ProjectID: "p-id",
+		ID:        "job-id",
+		Type:      1,
+		NodeID:    "node-id",
+		Epoch:     1,
+		State:     1,
+		Addr:      "127.0.0.1",
+		Config:    []byte{0x11, 0x22},
+		ErrorMsg:  "error message",
+		Detail:    []byte("job detail"),
+	}
+	require.Equal(t, ormModel.KeyValueMap{
+		"node_id": meta.NodeID,
+		"address": meta.Addr,
+		"epoch":   meta.Epoch,
+	}, meta.RefreshValues())
+
+	require.Equal(t, ormModel.KeyValueMap{
+		"state": meta.State,
+	}, meta.UpdateStateValues())
+
+	require.Equal(t, ormModel.KeyValueMap{
+		"error_message": meta.ErrorMsg,
+		"detail":        meta.Detail,
+	}, meta.UpdateErrorValues())
+
+	require.Equal(t, ormModel.KeyValueMap{
+		"state":         meta.State,
+		"error_message": meta.ErrorMsg,
+		"detail":        meta.Detail,
+	}, meta.ExitValues())
 }

--- a/engine/pkg/orm/client.go
+++ b/engine/pkg/orm/client.go
@@ -97,7 +97,7 @@ type ProjectOperationClient interface {
 // JobClient defines interface that manages job in metastore
 type JobClient interface {
 	UpsertJob(ctx context.Context, job *frameModel.MasterMeta) error
-	UpdateJob(ctx context.Context, job *frameModel.MasterMeta) error
+	UpdateJob(ctx context.Context, jobID string, values model.KeyValueMap) error
 	DeleteJob(ctx context.Context, jobID string) (Result, error)
 
 	GetJobByID(ctx context.Context, jobID string) (*frameModel.MasterMeta, error)
@@ -308,16 +308,13 @@ func (c *metaOpsClient) UpsertJob(ctx context.Context, job *frameModel.MasterMet
 }
 
 // UpdateJob update the jobInfo
-func (c *metaOpsClient) UpdateJob(ctx context.Context, job *frameModel.MasterMeta) error {
-	if job == nil {
-		return errors.ErrMetaParamsInvalid.GenWithStackByArgs("input master meta is nil")
-	}
-	// we don't use `Save` here to avoid user dealing with the basic model
-	// expected SQL: UPDATE xxx SET xxx='xxx', updated_at='2013-11-17 21:34:10' WHERE id=xxx;
+func (c *metaOpsClient) UpdateJob(
+	ctx context.Context, jobID string, values model.KeyValueMap,
+) error {
 	if err := c.db.WithContext(ctx).
 		Model(&frameModel.MasterMeta{}).
-		Where("id = ?", job.ID).
-		Updates(job.Map()).Error; err != nil {
+		Where("id = ?", jobID).
+		Updates(values).Error; err != nil {
 		return errors.ErrMetaOpFail.Wrap(err)
 	}
 

--- a/engine/pkg/orm/client_test.go
+++ b/engine/pkg/orm/client_test.go
@@ -479,7 +479,7 @@ func TestJob(t *testing.T) {
 			},
 			mockExpectResFn: func(mock sqlmock.Sqlmock) {
 				mock.ExpectExec(regexp.QuoteMeta(
-					"UPDATE `master_meta` SET `detail`=?,`error_message`=?,`updated_at`=? WHERE id = ? AND `master_meta`.`deleted` IS NULL")).
+					"UPDATE `master_meta` SET `error_message`=?,`updated_at`=? WHERE id = ? AND `master_meta`.`deleted` IS NULL")).
 					WillReturnResult(sqlmock.NewResult(0, 1))
 			},
 		},

--- a/engine/pkg/orm/client_test.go
+++ b/engine/pkg/orm/client_test.go
@@ -421,7 +421,8 @@ func TestJob(t *testing.T) {
 		{
 			fn: "UpdateJob",
 			inputs: []interface{}{
-				&frameModel.MasterMeta{
+				"j111",
+				(&frameModel.MasterMeta{
 					ProjectID: "p111",
 					ID:        "j111",
 					Type:      1,
@@ -430,10 +431,79 @@ func TestJob(t *testing.T) {
 					State:     1,
 					Addr:      "127.0.0.1",
 					Config:    []byte{0x11, 0x22},
-				},
+				}).RefreshValues(),
 			},
 			mockExpectResFn: func(mock sqlmock.Sqlmock) {
-				mock.ExpectExec("UPDATE `master_meta` SET").WillReturnResult(sqlmock.NewResult(0, 1))
+				mock.ExpectExec(regexp.QuoteMeta(
+					"UPDATE `master_meta` SET `address`=?,`epoch`=?,`node_id`=?,`updated_at`=? WHERE id = ? AND `master_meta`.`deleted` IS NULL")).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+			},
+		},
+		{
+			fn: "UpdateJob",
+			inputs: []interface{}{
+				"j111",
+				(&frameModel.MasterMeta{
+					ProjectID: "p111",
+					ID:        "j111",
+					Type:      1,
+					NodeID:    "n111",
+					Epoch:     1,
+					State:     1,
+					Addr:      "127.0.0.1",
+					Config:    []byte{0x11, 0x22},
+				}).UpdateStateValues(),
+			},
+			mockExpectResFn: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta(
+					"UPDATE `master_meta` SET `state`=?,`updated_at`=? WHERE id = ? AND `master_meta`.`deleted` IS NULL")).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+			},
+		},
+		{
+			fn: "UpdateJob",
+			inputs: []interface{}{
+				"j111",
+				(&frameModel.MasterMeta{
+					ProjectID: "p111",
+					ID:        "j111",
+					Type:      1,
+					NodeID:    "n111",
+					Epoch:     1,
+					State:     1,
+					Addr:      "127.0.0.1",
+					Config:    []byte{0x11, 0x22},
+					ErrorMsg:  "error message",
+					Detail:    []byte("job detail"),
+				}).UpdateErrorValues(),
+			},
+			mockExpectResFn: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta(
+					"UPDATE `master_meta` SET `detail`=?,`error_message`=?,`updated_at`=? WHERE id = ? AND `master_meta`.`deleted` IS NULL")).
+					WillReturnResult(sqlmock.NewResult(0, 1))
+			},
+		},
+		{
+			fn: "UpdateJob",
+			inputs: []interface{}{
+				"j111",
+				(&frameModel.MasterMeta{
+					ProjectID: "p111",
+					ID:        "j111",
+					Type:      1,
+					NodeID:    "n111",
+					Epoch:     1,
+					State:     1,
+					Addr:      "127.0.0.1",
+					Config:    []byte{0x11, 0x22},
+					ErrorMsg:  "error message",
+					Detail:    []byte("job detail"),
+				}).ExitValues(),
+			},
+			mockExpectResFn: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec(regexp.QuoteMeta(
+					"UPDATE `master_meta` SET `detail`=?,`error_message`=?,`state`=?,`updated_at`=? WHERE id = ? AND `master_meta`.`deleted` IS NULL")).
+					WillReturnResult(sqlmock.NewResult(0, 1))
 			},
 		},
 		{

--- a/engine/pkg/orm/model/common.go
+++ b/engine/pkg/orm/model/common.go
@@ -24,3 +24,6 @@ type Model struct {
 	CreatedAt time.Time `json:"created-at"`
 	UpdatedAt time.Time `json:"updated-at"`
 }
+
+// KeyValueMap alias to key value map when updating data in gorm
+type KeyValueMap = map[string]interface{}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7021

### What is changed and how it works?

- Update `error_message` field before job master calls `doClose`
- Change the interface signature of `UpdateJob` to explicit way, which means the parameter contains all fields that need to be updated.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
