### PR TITLE
syncer(dm): Fix follow-up bugs after fixing nondeterministic DDL

### DIFF
--- a/dm/syncer/ddl.go
+++ b/dm/syncer/ddl.go
@@ -255,12 +255,13 @@ func (ddl *DDLWorker) HandleQueryEvent(ev *replication.QueryEvent, ec eventConte
 
 	qec.p, err = event.GetParserForStatusVars(ev.StatusVars)
 	if err != nil {
-		ddl.logger.Warn("found error when get sql_mode from binlog status_vars", zap.Error(err))
+		ddl.logger.Warn("found error when getting sql_mode from binlog status_vars", zap.Error(err))
 	}
 
 	qec.timezone, err = event.GetTimezoneByStatusVars(ev.StatusVars, ddl.upstreamTZStr)
-	if err != nil {
-		ddl.logger.Warn("found error when get timezone from binlog status_vars", zap.Error(err))
+	// no timezone information retrieved and upstream timezone not previously set
+	if err != nil && ddl.upstreamTZStr == "" {
+		ddl.logger.Warn("found error when getting timezone from binlog status_vars", zap.Error(err))
 	}
 
 	qec.timestamp = ec.header.Timestamp

--- a/engine/pkg/orm/client.go
+++ b/engine/pkg/orm/client.go
@@ -716,9 +716,9 @@ func (c *metaOpsClient) SetJobCanceling(ctx context.Context, jobID string) (Resu
 }
 
 // SetJobCanceled sets a cancelled status if a cancelling op exists.
-// - If cancelling operation is not found, it can be triggered by unexpected
-//   SetJobCanceled don't make any change and return nil error.
-// - If a job is already cancelled, don't make any change and return nil error.
+//   - If cancelling operation is not found, it can be triggered by unexpected
+//     SetJobCanceled don't make any change and return nil error.
+//   - If a job is already cancelled, don't make any change and return nil error.
 func (c *metaOpsClient) SetJobCanceled(ctx context.Context, jobID string) (Result, error) {
 	result := &ormResult{}
 	ops := &model.JobOp{

--- a/engine/servermaster/jobop/backoff.go
+++ b/engine/servermaster/jobop/backoff.go
@@ -53,10 +53,10 @@ func NewJobBackoff(jobID string, clocker clock.Clock, config *BackoffConfig) *Jo
 // JobBackoff is a job backoff manager, it recoreds job online and offline events
 // and determines whether a job can be re-created based on backoff mechanism.
 // The backoff stragegy is as following
-// - Each time a fail event arrives, the backoff time will be move forward by
-//   nextBackoff.
-// - If a job is success for more than `resetInterval`, the backoff history will
-//   be cleared, and backoff time will be re-calculated.
+//   - Each time a fail event arrives, the backoff time will be move forward by
+//     nextBackoff.
+//   - If a job is success for more than `resetInterval`, the backoff history will
+//     be cleared, and backoff time will be re-calculated.
 type JobBackoff struct {
 	jobID   string
 	clocker clock.Clock


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #6628 

### What is changed and how it works?
Modification to `job.ddls` is put to the place as late as possible, which is just before `db.ExecuteSQLWithIgnore`.

The appearing time of the Warn message is reduced by adding conditions to trigger it. Now only when no timezone information was retrieved from `GetTimezoneByStatusVars` and upstream timezone has not been previously set, the warn message would be triggered.

The changes in `engine/pkg/orm/client.go` and `engine/servermaster/jobop/backoff.go` are caused by `make fmt` of go version 1.19.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No.
##### Do you need to update user documentation, design documentation or monitoring documentation?
No.
### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Reduce the appearing time of the warning message "found error when getting timezone from binlog status_vars" in dm-worker log.
```
