### PR TITLE
owner(ticdc): fix query healthy 500 since changefeed paused.

### DIFF
--- a/cdc/owner/owner.go
+++ b/cdc/owner/owner.go
@@ -633,7 +633,7 @@ func (o *ownerImpl) isHealthy() bool {
 			continue
 		}
 		if changefeed.state.Info.State != model.StateNormal {
-			log.Warn("changefeed not normal",
+			log.Warn("isHealthy: changefeed not normal",
 				zap.String("namespace", changefeed.id.Namespace),
 				zap.String("changefeed", changefeed.id.ID),
 				zap.Any("state", changefeed.state.Info.State))

--- a/cdc/owner/owner.go
+++ b/cdc/owner/owner.go
@@ -626,7 +626,7 @@ func (o *ownerImpl) isHealthy() bool {
 		return false
 	}
 	for _, changefeed := range o.changefeeds {
-		if changefeed.state == nil && changefeed.state.Info.State != model.StateNormal {
+		if changefeed.state == nil || changefeed.state.Info.State != model.StateNormal {
 			log.Warn("changefeed not normal", zap.Any("state", changefeed.state))
 			continue
 		}

--- a/cdc/owner/owner.go
+++ b/cdc/owner/owner.go
@@ -626,16 +626,25 @@ func (o *ownerImpl) isHealthy() bool {
 		return false
 	}
 	for _, changefeed := range o.changefeeds {
-		if changefeed.state == nil || changefeed.state.Info.State != model.StateNormal {
-			log.Warn("changefeed not normal", zap.Any("state", changefeed.state))
+		if changefeed.state == nil {
+			log.Warn("changefeed state is nil",
+				zap.String("namespace", changefeed.id.Namespace),
+				zap.String("changefeed", changefeed.id.ID))
 			continue
 		}
+		if changefeed.state.Info.State != model.StateNormal {
+			log.Warn("changefeed not normal",
+				zap.String("namespace", changefeed.id.Namespace),
+				zap.String("changefeed", changefeed.id.ID),
+				zap.Any("state", changefeed.state.Info.State))
+			continue
+		}
+
 		provider := changefeed.GetInfoProvider()
 		if provider == nil || !provider.IsInitialized() {
 			// The scheduler has not been initialized yet, it is considered
 			// unhealthy, because owner can not schedule tables for now.
-			// todo: this may caused by the paused changefeeds.
-			log.Warn("owner is not healthy since not all changefeeds are initialized",
+			log.Warn("owner is not healthy since changefeed not initialized",
 				zap.String("namespace", changefeed.id.Namespace),
 				zap.String("changefeed", changefeed.id.ID))
 			return false

--- a/cdc/owner/owner.go
+++ b/cdc/owner/owner.go
@@ -644,7 +644,7 @@ func (o *ownerImpl) isHealthy() bool {
 		if provider == nil || !provider.IsInitialized() {
 			// The scheduler has not been initialized yet, it is considered
 			// unhealthy, because owner can not schedule tables for now.
-			log.Warn("owner is not healthy since changefeed not initialized",
+			log.Warn("isHealthy: changefeed is not initialized",
 				zap.String("namespace", changefeed.id.Namespace),
 				zap.String("changefeed", changefeed.id.ID))
 			return false

--- a/cdc/owner/owner.go
+++ b/cdc/owner/owner.go
@@ -627,7 +627,7 @@ func (o *ownerImpl) isHealthy() bool {
 	}
 	for _, changefeed := range o.changefeeds {
 		if changefeed.state == nil {
-			log.Warn("changefeed state is nil",
+			log.Warn("isHealthy: changefeed state is nil",
 				zap.String("namespace", changefeed.id.Namespace),
 				zap.String("changefeed", changefeed.id.ID))
 			continue

--- a/cdc/owner/owner_test.go
+++ b/cdc/owner/owner_test.go
@@ -773,14 +773,58 @@ func TestHandleDrainCapturesSchedulerNotReady(t *testing.T) {
 	require.Nil(t, <-done)
 }
 
-type heathScheduler struct {
+type healthScheduler struct {
 	scheduler.Scheduler
 	scheduler.InfoProvider
 	init bool
 }
 
-func (h *heathScheduler) IsInitialized() bool {
+func (h *healthScheduler) IsInitialized() bool {
 	return h.init
+}
+
+func TestIsHealthyWithAbnormalChangefeeds(t *testing.T) {
+	t.Parallel()
+
+	// There is at least one changefeed not in the normal state, the whole cluster should
+	// still be healthy, since abnormal changefeeds does not affect other normal changefeeds.
+	o := &ownerImpl{
+		changefeeds:      make(map[model.ChangeFeedID]*changefeed),
+		changefeedTicked: true,
+	}
+
+	query := &Query{Tp: QueryHealth}
+
+	// no changefeed at the first, should be healthy
+	err := o.handleQueries(query)
+	require.NoError(t, err)
+	require.True(t, query.Data.(bool))
+
+	// 1 changefeed, state is nil
+	cf := &changefeed{}
+	o.changefeeds[model.ChangeFeedID{ID: "1"}] = cf
+	err = o.handleQueries(query)
+	require.NoError(t, err)
+	require.True(t, query.Data.(bool))
+
+	// state is not normal
+	cf.state = &orchestrator.ChangefeedReactorState{
+		Info: &model.ChangeFeedInfo{State: model.StateStopped},
+	}
+	err = o.handleQueries(query)
+	require.NoError(t, err)
+	require.True(t, query.Data.(bool))
+
+	// 2 changefeeds, another is normal, and scheduler initialized.
+	o.changefeeds[model.ChangeFeedID{ID: "2"}] = &changefeed{
+		state: &orchestrator.ChangefeedReactorState{
+			Info: &model.ChangeFeedInfo{State: model.StateNormal},
+		},
+		scheduler: &healthScheduler{init: true},
+	}
+	err = o.handleQueries(query)
+	require.NoError(t, err)
+	require.False(t, query.Data.(bool))
 }
 
 func TestIsHealthy(t *testing.T) {
@@ -830,7 +874,7 @@ func TestIsHealthy(t *testing.T) {
 	require.False(t, query.Data.(bool))
 
 	// Healthy, scheduler is set and return true.
-	cf.scheduler = &heathScheduler{init: true}
+	cf.scheduler = &healthScheduler{init: true}
 	o.changefeedTicked = true
 	err = o.handleQueries(query)
 	require.NoError(t, err)
@@ -844,7 +888,7 @@ func TestIsHealthy(t *testing.T) {
 
 	// Unhealthy, there is another changefeed is not initialized.
 	o.changefeeds[model.ChangeFeedID{ID: "1"}] = &changefeed{
-		scheduler: &heathScheduler{init: false},
+		scheduler: &healthScheduler{init: false},
 	}
 	o.changefeedTicked = true
 	err = o.handleQueries(query)

--- a/cdc/owner/owner_test.go
+++ b/cdc/owner/owner_test.go
@@ -824,7 +824,7 @@ func TestIsHealthyWithAbnormalChangefeeds(t *testing.T) {
 	}
 	err = o.handleQueries(query)
 	require.NoError(t, err)
-	require.False(t, query.Data.(bool))
+	require.True(t, query.Data.(bool))
 }
 
 func TestIsHealthy(t *testing.T) {
@@ -863,8 +863,11 @@ func TestIsHealthy(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, query.Data.(bool))
 
-	// Unhealthy, scheduler is not set.
+	// changefeed in normal, but the scheduler is not set, Unhealthy.
 	cf := &changefeed{
+		state: &orchestrator.ChangefeedReactorState{
+			Info: &model.ChangeFeedInfo{State: model.StateNormal},
+		},
 		scheduler: nil, // scheduler is not set.
 	}
 	o.changefeeds[model.ChangeFeedID{ID: "1"}] = cf
@@ -888,6 +891,9 @@ func TestIsHealthy(t *testing.T) {
 
 	// Unhealthy, there is another changefeed is not initialized.
 	o.changefeeds[model.ChangeFeedID{ID: "1"}] = &changefeed{
+		state: &orchestrator.ChangefeedReactorState{
+			Info: &model.ChangeFeedInfo{State: model.StateNormal},
+		},
 		scheduler: &healthScheduler{init: false},
 	}
 	o.changefeedTicked = true


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7043, ref #4757

### What is changed and how it works?

allow changefeeds abnormal in the cluster when check the healthy

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
