### PR TITLE
test(engine): use smaller dataset to stable e2e test

### DIFF
--- a/engine/test/e2e/docker.json
+++ b/engine/test/e2e/docker.json
@@ -2,7 +2,7 @@
     "demo_address": ["127.0.0.1:1234"],
     "demo_host": ["demo-server:1234"],
     "master_address_list": ["127.0.0.1:10245", "127.0.0.1:10246", "127.0.0.1:10247"],
-    "demo_record_num": 5000000,
+    "demo_record_num": 50000,
     "job_num": 2,
     "file_num": 5
 }

--- a/engine/test/e2e/e2e_test.go
+++ b/engine/test/e2e/e2e_test.go
@@ -81,14 +81,14 @@ func TestSubmitTest(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		democlient, err := NewDemoClient(ctx, demoAddr)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		fmt.Println("connect demo " + demoAddr)
 
 		resp, err := democlient.client.GenerateData(ctx, &pb.GenerateDataRequest{
 			FileNum:   int32(config.FileNum),
 			RecordNum: int32(config.RecordNum),
 		})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Empty(t, resp.ErrMsg)
 	}
 
@@ -131,12 +131,12 @@ func testSubmitTest(t *testing.T, cfg *cvs.Config, config *Config, demoAddr stri
 	ctx := context.Background()
 	fmt.Printf("connect demo\n")
 	democlient, err := NewDemoClient(ctx, demoAddr)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	fmt.Printf("connect clients\n")
 
 	for {
 		resp, err := democlient.client.IsReady(ctx, &pb.IsReadyRequest{})
-		require.Nil(t, err)
+		require.NoError(t, err)
 		if resp.Ready {
 			break
 		}
@@ -144,7 +144,7 @@ func testSubmitTest(t *testing.T, cfg *cvs.Config, config *Config, demoAddr stri
 	}
 
 	configBytes, err := json.Marshal(cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	<-flowControl
 	fmt.Printf("test is ready\n")
@@ -176,6 +176,6 @@ func testSubmitTest(t *testing.T, cfg *cvs.Config, config *Config, demoAddr stri
 	demoResp, err := democlient.client.CheckDir(ctx, &pb.CheckDirRequest{
 		Dir: cfg.DstDir,
 	})
-	require.Nil(t, err, jobID)
+	require.NoError(t, err)
 	require.Empty(t, demoResp.ErrMsg, demoResp.ErrFileIdx)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7102

### What is changed and how it works?

- Use smaller data size
- Use `require.NoError` to check nil error

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
