### PR TITLE
sinkv2(cdc): improve onflict detector slots

### DIFF
--- a/cdc/sinkv2/eventsink/txn/event.go
+++ b/cdc/sinkv2/eventsink/txn/event.go
@@ -47,13 +47,13 @@ func genTxnKeys(txn *model.SingleTableTxn) []uint64 {
 		return nil
 	}
 	hashRes := make(map[uint64]struct{}, len(txn.Rows))
-	hasher := fnv.New64a()
+	hasher := fnv.New32a()
 	for _, row := range txn.Rows {
 		for _, key := range genRowKeys(row) {
 			if n, err := hasher.Write(key); n != len(key) || err != nil {
 				log.Panic("transaction key hash fail")
 			}
-			hashRes[hasher.Sum64()] = struct{}{}
+			hashRes[uint64(hasher.Sum32())] = struct{}{}
 			hasher.Reset()
 		}
 	}

--- a/cdc/sinkv2/eventsink/txn/txn_sink.go
+++ b/cdc/sinkv2/eventsink/txn/txn_sink.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// DefaultConflictDetectorSlots indicates the default slot count of conflict detector.
-	DefaultConflictDetectorSlots uint64 = 8 * 1024 * 1024
+	DefaultConflictDetectorSlots uint64 = 16 * 1024
 )
 
 // Assert EventSink[E event.TableEvent] implementation

--- a/cdc/sinkv2/eventsink/txn/txn_sink_test.go
+++ b/cdc/sinkv2/eventsink/txn/txn_sink_test.go
@@ -15,7 +15,6 @@ package txn
 
 import (
 	"context"
-	"math"
 	"sort"
 	"sync/atomic"
 	"testing"
@@ -230,7 +229,7 @@ func TestGenKeys(t *testing.T) {
 		expected: []uint64{318190470, 2095136920, 2658640457},
 	}}
 	for _, tc := range testCases {
-		keys := genTxnKeys(tc.txn, math.MaxUint64)
+		keys := genTxnKeys(tc.txn)
 		sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
 		require.Equal(t, tc.expected, keys)
 	}

--- a/pkg/causality/internal/slots.go
+++ b/pkg/causality/internal/slots.go
@@ -14,6 +14,7 @@
 package internal
 
 import (
+	"math"
 	"sync"
 )
 
@@ -39,8 +40,12 @@ type Slots[E SlotNode[E]] struct {
 
 // NewSlots creates a new Slots.
 func NewSlots[E SlotNode[E]](numSlots uint64) *Slots[E] {
+	slots := make([]slot[E], numSlots)
+	for i := uint64(0); i < numSlots; i++ {
+		slots[i].nodes = make(map[uint64]E, 8)
+	}
 	return &Slots[E]{
-		slots:    make([]slot[E], numSlots),
+		slots:    slots,
 		numSlots: numSlots,
 	}
 }
@@ -51,37 +56,53 @@ func NewSlots[E SlotNode[E]](numSlots uint64) *Slots[E] {
 // dependee.
 func (s *Slots[E]) Add(elem E, keys []uint64) {
 	dependOnList := make(map[int64]E, len(keys))
+	var lastSlot uint64 = math.MaxUint64
 	for _, key := range keys {
-		s.slots[key].mu.Lock()
-		if s.slots[key].tail == nil {
-			s.slots[key].tail = new(E)
-		} else {
-			prevID := (*s.slots[key].tail).NodeID()
-			dependOnList[prevID] = *s.slots[key].tail
+		slotIdx := key % s.numSlots
+		if lastSlot != slotIdx {
+			s.slots[slotIdx].mu.Lock()
+			lastSlot = slotIdx
 		}
-		*s.slots[key].tail = elem
+		if tail, ok := s.slots[slotIdx].nodes[key]; ok {
+			prevID := tail.NodeID()
+			dependOnList[prevID] = tail
+		}
+		s.slots[slotIdx].nodes[key] = elem
 	}
 	elem.DependOn(dependOnList)
+
 	// Lock those slots one by one and then unlock them one by one, so that
 	// we can avoid 2 transactions get executed interleaved.
+	lastSlot = math.MaxUint64
 	for _, key := range keys {
-		s.slots[key].mu.Unlock()
+		slotIdx := key % s.numSlots
+		if lastSlot != slotIdx {
+			s.slots[slotIdx].mu.Unlock()
+			lastSlot = slotIdx
+		}
 	}
 }
 
 // Free removes an element from the Slots.
 func (s *Slots[E]) Free(elem E, keys []uint64) {
+	var lastSlot uint64 = math.MaxUint64
 	for _, key := range keys {
-		s.slots[key].mu.Lock()
-		if s.slots[key].tail != nil && (*s.slots[key].tail).NodeID() == elem.NodeID() {
-			s.slots[key].tail = nil
+		slotIdx := key % s.numSlots
+		if lastSlot != slotIdx {
+			s.slots[slotIdx].mu.Lock()
 		}
-		s.slots[key].mu.Unlock()
+		if tail, ok := s.slots[slotIdx].nodes[key]; ok && tail.NodeID() == elem.NodeID() {
+			delete(s.slots[slotIdx].nodes, key)
+		}
+		if lastSlot != slotIdx {
+			s.slots[slotIdx].mu.Unlock()
+			lastSlot = slotIdx
+		}
 	}
 	elem.Free()
 }
 
 type slot[E SlotNode[E]] struct {
-	tail *E // `tail` points to the last node in the slot.
-	mu   sync.Mutex
+	nodes map[uint64]E
+	mu    sync.Mutex
 }

--- a/pkg/causality/tests/workload.go
+++ b/pkg/causality/tests/workload.go
@@ -40,7 +40,7 @@ func newUniformGenerator(workingSetSize int64, batchSize int, numSlots uint64) *
 func (g *uniformGenerator) Next() []uint64 {
 	set := make(map[uint64]struct{}, g.batchSize)
 	for i := 0; i < g.batchSize; i++ {
-		key := uint64(rand.Int63n(g.workingSetSize)) % g.numSlots
+		key := uint64(rand.Int63n(g.workingSetSize))
 		set[key] = struct{}{}
 	}
 
@@ -49,6 +49,6 @@ func (g *uniformGenerator) Next() []uint64 {
 		ret = append(ret, key)
 	}
 
-	sort.Slice(ret, func(i, j int) bool { return ret[i] < ret[j] })
+	sort.Slice(ret, func(i, j int) bool { return ret[i]%g.numSlots < ret[j]%g.numSlots })
 	return ret
 }

--- a/pkg/causality/worker.go
+++ b/pkg/causality/worker.go
@@ -18,10 +18,10 @@ type (
 )
 
 type txnEvent interface {
-	// Keys are in range [0, numSlots) and must be deduped.
+	// Keys are in range [0, math.MaxUint64) and must be deduped.
 	//
 	// NOTE: if the conflict detector is accessed by multiple threads concurrently,
-	// ConflictKeys must also be sorted.
+	// ConflictKeys must also be sorted based on `key % numSlots`.
 	ConflictKeys(numSlots uint64) []conflictKey
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #5928 

### What is changed and how it works?

We find that sinkv2 conflict detector works worse than sinkv1 in some cases. The reason is `pkg/causality/internal/slots` increases conflicting ratio.

This PR reduces conflicting ratio.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
