### PR TITLE
test(engine): increase timeout in e2e test

### DIFF
--- a/cmd/tiflow-demoserver/kvdatamake.go
+++ b/cmd/tiflow-demoserver/kvdatamake.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/pingcap/log"
 	pb "github.com/pingcap/tiflow/engine/enginepb"
@@ -126,6 +127,7 @@ func (s *DataRWServer) GenerateData(ctx context.Context, req *pb.GenerateDataReq
 	s.dbMap = make(map[string]dbBuckets)
 	s.mu.Unlock()
 	log.Info("Start to generate data ...")
+	start := time.Now()
 
 	fileNum := int(req.FileNum)
 	batches := make([]db.Batch, 0, fileNum)
@@ -159,7 +161,8 @@ func (s *DataRWServer) GenerateData(ctx context.Context, req *pb.GenerateDataReq
 	s.dbMap[demoDir] = bucket
 	s.mu.Unlock()
 
-	log.Info("files have been created", zap.Any("filenumber", fileNum))
+	log.Info("files have been created", zap.Any("filenumber", fileNum),
+		zap.Duration("duration", time.Since(start)))
 	close(ready)
 	return &pb.GenerateDataResponse{}, nil
 }

--- a/engine/test/e2e/e2e_test.go
+++ b/engine/test/e2e/e2e_test.go
@@ -78,7 +78,7 @@ func TestSubmitTest(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, demoAddr := range config.DemoAddrs {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		democlient, err := NewDemoClient(ctx, demoAddr)
 		require.NoError(t, err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7102

### What is changed and how it works?

- Add timeout for `GenerateData` rpc call

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
