### PR TITLE
test(DM): add check log contain to `safe-mode` integration test

### DIFF
--- a/dm/tests/safe_mode/run.sh
+++ b/dm/tests/safe_mode/run.sh
@@ -212,7 +212,7 @@ function safe_mode_duration() {
 	run_sql_file $cur/data/db2.increment.sql $MYSQL_HOST2 $MYSQL_PORT2 $MYSQL_PASSWORD2
 
 	# make sure worker1 enter to sync status, and complete one dml
-	check_log_contain_with_retry "alter table t1 add column age int" $WORK_DIR/worker1/log/dm-worker.log
+	check_log_contain_with_retry "event=XID" $WORK_DIR/worker1/log/dm-worker.log
 	# restart workers
 	kill_dm_worker
 
@@ -345,7 +345,8 @@ function run() {
 cleanup_data safe_mode_target
 # also cleanup dm processes in case of last run failed
 cleanup_process $*
-run $*
+# run $*
+safe_mode_duration
 cleanup_process $*
 
 echo "[$(date)] <<<<<< test case $TEST_NAME success! >>>>>>"

--- a/dm/tests/safe_mode/run.sh
+++ b/dm/tests/safe_mode/run.sh
@@ -206,14 +206,13 @@ function safe_mode_duration() {
 	dmctl_operate_source create $WORK_DIR/source2.yaml $SOURCE_ID2
 
 	dmctl_start_task "$cur/conf/dm-task-safe-mode-duration.yaml" "--remove-meta"
-	# Worker1 need to start relay, so it is slow.
-	# It is possible that worker1 has not loaded before check diff.
-	sleep 3
 	check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
 
 	run_sql_file $cur/data/db1.increment.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1
 	run_sql_file $cur/data/db2.increment.sql $MYSQL_HOST2 $MYSQL_PORT2 $MYSQL_PASSWORD2
 
+	# make sure worker1 enter to sync status, and complete one dml
+	check_log_contain_with_retry "alter table t1 add column age int" $WORK_DIR/worker1/log/dm-worker.log
 	# restart workers
 	kill_dm_worker
 

--- a/dm/tests/safe_mode/run.sh
+++ b/dm/tests/safe_mode/run.sh
@@ -206,6 +206,9 @@ function safe_mode_duration() {
 	dmctl_operate_source create $WORK_DIR/source2.yaml $SOURCE_ID2
 
 	dmctl_start_task "$cur/conf/dm-task-safe-mode-duration.yaml" "--remove-meta"
+	# Worker1 need to start relay, so it is slow.
+	# It is possible that worker1 has not loaded before check diff.
+	sleep 3
 	check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
 
 	run_sql_file $cur/data/db1.increment.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1

--- a/dm/tests/safe_mode/run.sh
+++ b/dm/tests/safe_mode/run.sh
@@ -345,8 +345,7 @@ function run() {
 cleanup_data safe_mode_target
 # also cleanup dm processes in case of last run failed
 cleanup_process $*
-# run $*
-safe_mode_duration
+run $*
 cleanup_process $*
 
 echo "[$(date)] <<<<<< test case $TEST_NAME success! >>>>>>"


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #4159, close #7099



### What is changed and how it works?

- the worker1 didn't enter sync status and execute dml, after check_diff before kill_worker, so its SafeModeExitPoint is yet same as its GlobalCheckpoint(beginPosition). This is the unstable reason.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`
```
