### PR TITLE
codec(ticdc): add unit test to cover maxwell message encode binary data

### DIFF
--- a/cdc/sink/codec/maxwell/maxwell_message_test.go
+++ b/cdc/sink/codec/maxwell/maxwell_message_test.go
@@ -16,6 +16,8 @@ package maxwell
 import (
 	"testing"
 
+	"github.com/pingcap/tidb/parser/mysql"
+	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,4 +39,22 @@ func TestMaxwellFormatCol(t *testing.T) {
 	rowEncode, err := row.encode()
 	require.Nil(t, err)
 	require.NotNil(t, rowEncode)
+}
+
+func TestEncodeBinaryToMaxwell(t *testing.T) {
+	t.Parallel()
+
+	column := &model.Column{
+		Name: "varbinary", Type: mysql.TypeVarchar, Value: []uint8("测试varbinary"),
+		Flag: model.BinaryFlag,
+	}
+
+	e := &model.RowChangedEvent{
+		Table:   &model.TableName{Schema: "a", Table: "b"},
+		Columns: []*model.Column{column},
+	}
+
+	key, msg := rowChangeToMaxwellMsg(e)
+	require.NotNil(t, key)
+	require.NotNil(t, msg)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #5069 

### What is changed and how it works?

add a unit test to verify that binary `[]uint8` can be correctly encoded.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
