### PR TITLE
lightning(dm): all lightning errors are not auto-resumeable

### DIFF
--- a/dm/_utils/terror_gen/errors_release.txt
+++ b/dm/_utils/terror_gen/errors_release.txt
@@ -280,6 +280,7 @@ ErrLoadUnitDuplicateTableFile,[code=34015:class=load-unit:scope=internal:level=h
 ErrLoadUnitGenBAList,[code=34016:class=load-unit:scope=internal:level=high], "Message: generate block allow list, Workaround: Please check the `block-allow-list` config in task configuration file."
 ErrLoadTaskWorkerNotMatch,[code=34017:class=functional:scope=internal:level=high], "Message: different worker in load stage, previous worker: %s, current worker: %s, Workaround: Please check if the previous worker is online."
 ErrLoadTaskCheckPointNotMatch,[code=34018:class=functional:scope=internal:level=high], "Message: inconsistent checkpoints between loader and target database, Workaround: If you want to redo the whole task, please check that you have not forgotten to add -remove-meta flag for start-task command."
+ErrLoadLightningRuntime,[code=34019:class=load-unit:scope=not-set:level=high]
 ErrSyncerUnitPanic,[code=36001:class=sync-unit:scope=internal:level=high], "Message: panic error: %v"
 ErrSyncUnitInvalidTableName,[code=36002:class=sync-unit:scope=internal:level=high], "Message: extract table name for DML error: %s"
 ErrSyncUnitTableNameQuery,[code=36003:class=sync-unit:scope=internal:level=high], "Message: table name parse error: %s"

--- a/dm/errors.toml
+++ b/dm/errors.toml
@@ -1696,6 +1696,12 @@ description = ""
 workaround = "If you want to redo the whole task, please check that you have not forgotten to add -remove-meta flag for start-task command."
 tags = ["internal", "high"]
 
+[error.DM-load-unit-34019]
+message = ""
+description = ""
+workaround = ""
+tags = ["not-set", "high"]
+
 [error.DM-sync-unit-36001]
 message = "panic error: %v"
 description = ""

--- a/dm/loader/lightning.go
+++ b/dm/loader/lightning.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/lightning/checkpoints"
 	lcfg "github.com/pingcap/tidb/br/pkg/lightning/config"
 	tidbpromutil "github.com/pingcap/tidb/util/promutil"
+	"github.com/pingcap/tiflow/dm/pkg/terror"
 	"github.com/pingcap/tiflow/engine/pkg/promutil"
 	"github.com/prometheus/client_golang/prometheus"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -263,7 +264,7 @@ func (l *LightningLoader) runLightning(ctx context.Context, cfg *lcfg.Config) er
 			}
 		}
 	})
-	return err
+	return terror.ErrLoadLightningRuntime.Delegate(err)
 }
 
 func (l *LightningLoader) getLightningConfig() (*lcfg.Config, error) {

--- a/dm/pkg/retry/errors.go
+++ b/dm/pkg/retry/errors.go
@@ -69,6 +69,7 @@ var (
 		int32(terror.ErrDumpUnitRuntime.Code()):             {},
 		int32(terror.ErrSyncerUnitDMLColumnNotMatch.Code()): {},
 		int32(terror.ErrSyncerCancelledDDL.Code()):          {},
+		int32(terror.ErrLoadLightningRuntime.Code()):        {},
 	}
 
 	// UnresumableRelayErrCodes is a set of unresumeable relay unit err codes.

--- a/dm/pkg/terror/error_list.go
+++ b/dm/pkg/terror/error_list.go
@@ -378,6 +378,7 @@ const (
 	codeLoadUnitGenBAList
 	codeLoadTaskWorkerNotMatch
 	codeLoadCheckPointNotMatch
+	codeLoadLightningRuntime
 )
 
 // Sync unit error code.
@@ -1067,6 +1068,7 @@ var (
 	ErrLoadUnitGenBAList           = New(codeLoadUnitGenBAList, ClassLoadUnit, ScopeInternal, LevelHigh, "generate block allow list", "Please check the `block-allow-list` config in task configuration file.")
 	ErrLoadTaskWorkerNotMatch      = New(codeLoadTaskWorkerNotMatch, ClassFunctional, ScopeInternal, LevelHigh, "different worker in load stage, previous worker: %s, current worker: %s", "Please check if the previous worker is online.")
 	ErrLoadTaskCheckPointNotMatch  = New(codeLoadCheckPointNotMatch, ClassFunctional, ScopeInternal, LevelHigh, "inconsistent checkpoints between loader and target database", "If you want to redo the whole task, please check that you have not forgotten to add -remove-meta flag for start-task command.")
+	ErrLoadLightningRuntime        = New(codeLoadLightningRuntime, ClassLoadUnit, ScopeNotSet, LevelHigh, "", "")
 
 	// Sync unit error.
 	ErrSyncerUnitPanic                   = New(codeSyncerUnitPanic, ClassSyncUnit, ScopeInternal, LevelHigh, "panic error: %v", "")

--- a/dm/worker/server_test.go
+++ b/dm/worker/server_test.go
@@ -734,6 +734,8 @@ func loadSourceConfigWithoutPassword(c *C) *config.SourceConfig {
 }
 
 func loadSourceConfigWithoutPassword2(t *testing.T) *config.SourceConfig {
+	t.Helper()
+
 	sourceCfg, err := config.ParseYamlAndVerify(config.SampleSourceConfig)
 	require.NoError(t, err)
 	sourceCfg.From.Password = "" // no password set

--- a/dm/worker/server_test.go
+++ b/dm/worker/server_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	"github.com/stretchr/testify/require"
 	"github.com/tikv/pd/pkg/tempurl"
 	v3rpc "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -728,6 +729,13 @@ func checkRelayStatus(cli pb.WorkerClient, expect pb.Stage) bool {
 func loadSourceConfigWithoutPassword(c *C) *config.SourceConfig {
 	sourceCfg, err := config.ParseYamlAndVerify(config.SampleSourceConfig)
 	c.Assert(err, IsNil)
+	sourceCfg.From.Password = "" // no password set
+	return sourceCfg
+}
+
+func loadSourceConfigWithoutPassword2(t *testing.T) *config.SourceConfig {
+	sourceCfg, err := config.ParseYamlAndVerify(config.SampleSourceConfig)
+	require.NoError(t, err)
 	sourceCfg.From.Password = "" // no password set
 	return sourceCfg
 }

--- a/dm/worker/task_checker_test.go
+++ b/dm/worker/task_checker_test.go
@@ -14,11 +14,13 @@
 package worker
 
 import (
+	"testing"
 	"time"
 
-	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/br/pkg/lightning/common"
 	tmysql "github.com/pingcap/tidb/parser/mysql"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/pingcap/tiflow/dm/config"
@@ -29,18 +31,14 @@ import (
 	"github.com/pingcap/tiflow/dm/unit"
 )
 
-var _ = check.Suite(&testTaskCheckerSuite{})
-
-type testTaskCheckerSuite struct{}
-
 var (
 	unsupportedModifyColumnError = unit.NewProcessError(terror.ErrDBExecuteFailed.Delegate(&tmysql.SQLError{Code: 1105, Message: "unsupported modify column length 20 is less than origin 40", State: tmysql.DefaultMySQLState}))
 	unknownProcessError          = unit.NewProcessError(errors.New("error message"))
 )
 
-func (s *testTaskCheckerSuite) TestResumeStrategy(c *check.C) {
-	c.Assert(ResumeSkip.String(), check.Equals, resumeStrategy2Str[ResumeSkip])
-	c.Assert(ResumeStrategy(10000).String(), check.Equals, "unsupported resume strategy: 10000")
+func TestResumeStrategy(t *testing.T) {
+	require.Equal(t, resumeStrategy2Str[ResumeSkip], ResumeSkip.String())
+	require.Equal(t, "unsupported resume strategy: 10000", ResumeStrategy(10000).String())
 
 	taskName := "test-task"
 	now := func(addition time.Duration) time.Time { return time.Now().Add(addition) }
@@ -70,7 +68,7 @@ func (s *testTaskCheckerSuite) TestResumeStrategy(c *check.C) {
 	}, nil)
 	for _, tc := range testCases {
 		rtsc, ok := tsc.(*realTaskStatusChecker)
-		c.Assert(ok, check.IsTrue)
+		require.True(t, ok)
 		bf, _ := backoff.NewBackoff(
 			1,
 			false,
@@ -81,11 +79,11 @@ func (s *testTaskCheckerSuite) TestResumeStrategy(c *check.C) {
 			LatestResumeTime: tc.latestResumeFn(tc.addition),
 		}
 		strategy := rtsc.subtaskAutoResume[taskName].CheckResumeSubtask(tc.status, config.DefaultBackoffRollback)
-		c.Assert(strategy, check.Equals, tc.expected)
+		require.Equal(t, tc.expected, strategy)
 	}
 }
 
-func (s *testTaskCheckerSuite) TestCheck(c *check.C) {
+func TestCheck(t *testing.T) {
 	var (
 		latestResumeTime time.Time
 		latestPausedTime time.Time
@@ -94,12 +92,12 @@ func (s *testTaskCheckerSuite) TestCheck(c *check.C) {
 	)
 
 	NewRelayHolder = NewDummyRelayHolder
-	dir := c.MkDir()
-	cfg := loadSourceConfigWithoutPassword(c)
+	dir := t.TempDir()
+	cfg := loadSourceConfigWithoutPassword2(t)
 	cfg.RelayDir = dir
 	cfg.MetaDir = dir
 	w, err := NewSourceWorker(cfg, nil, "", "")
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	w.closed.Store(false)
 
 	tsc := NewRealTaskStatusChecker(config.CheckerConfig{
@@ -110,9 +108,9 @@ func (s *testTaskCheckerSuite) TestCheck(c *check.C) {
 		BackoffMax:      config.Duration{Duration: 1 * time.Second},
 		BackoffFactor:   config.DefaultBackoffFactor,
 	}, nil)
-	c.Assert(tsc.Init(), check.IsNil)
+	require.NoError(t, tsc.Init())
 	rtsc, ok := tsc.(*realTaskStatusChecker)
-	c.Assert(ok, check.IsTrue)
+	require.True(t, ok)
 	rtsc.w = w
 
 	st := &SubTask{
@@ -120,7 +118,7 @@ func (s *testTaskCheckerSuite) TestCheck(c *check.C) {
 		stage: pb.Stage_Running,
 		l:     log.With(zap.String("subtask", taskName)),
 	}
-	c.Assert(st.cfg.Adjust(false), check.IsNil)
+	require.NoError(t, st.cfg.Adjust(false))
 	rtsc.w.subTaskHolder.recordSubTask(st)
 	rtsc.check()
 	bf := rtsc.subtaskAutoResume[taskName].Backoff
@@ -137,13 +135,13 @@ func (s *testTaskCheckerSuite) TestCheck(c *check.C) {
 	rtsc.check()
 	time.Sleep(4 * time.Millisecond)
 	rtsc.check()
-	c.Assert(bf.Current(), check.Equals, 8*time.Millisecond)
+	require.Equal(t, 8*time.Millisecond, bf.Current())
 
 	// test backoff rollback at least once, as well as resume ignore strategy
 	st.result = &pb.ProcessResult{IsCanceled: true}
 	time.Sleep(200 * time.Millisecond)
 	rtsc.check()
-	c.Assert(bf.Current() <= 4*time.Millisecond, check.IsTrue)
+	require.True(t, bf.Current() <= 4*time.Millisecond)
 	current := bf.Current()
 
 	// test no sense strategy
@@ -152,12 +150,12 @@ func (s *testTaskCheckerSuite) TestCheck(c *check.C) {
 		Errors:     []*pb.ProcessError{unsupportedModifyColumnError},
 	}
 	rtsc.check()
-	c.Assert(latestPausedTime.Before(rtsc.subtaskAutoResume[taskName].LatestPausedTime), check.IsTrue)
+	require.True(t, latestPausedTime.Before(rtsc.subtaskAutoResume[taskName].LatestPausedTime))
 	latestBlockTime = rtsc.subtaskAutoResume[taskName].LatestBlockTime
 	time.Sleep(200 * time.Millisecond)
 	rtsc.check()
-	c.Assert(rtsc.subtaskAutoResume[taskName].LatestBlockTime, check.Equals, latestBlockTime)
-	c.Assert(bf.Current(), check.Equals, current)
+	require.Equal(t, latestBlockTime, rtsc.subtaskAutoResume[taskName].LatestBlockTime)
+	require.Equal(t, current, bf.Current())
 
 	// test resume skip strategy
 	tsc = NewRealTaskStatusChecker(config.CheckerConfig{
@@ -168,9 +166,9 @@ func (s *testTaskCheckerSuite) TestCheck(c *check.C) {
 		BackoffMax:      config.Duration{Duration: 100 * time.Second},
 		BackoffFactor:   config.DefaultBackoffFactor,
 	}, w)
-	c.Assert(tsc.Init(), check.IsNil)
+	require.NoError(t, tsc.Init())
 	rtsc, ok = tsc.(*realTaskStatusChecker)
-	c.Assert(ok, check.IsTrue)
+	require.True(t, ok)
 
 	st = &SubTask{
 		cfg:   &config.SubTaskConfig{Name: taskName},
@@ -189,16 +187,16 @@ func (s *testTaskCheckerSuite) TestCheck(c *check.C) {
 	rtsc.check()
 	latestResumeTime = rtsc.subtaskAutoResume[taskName].LatestResumeTime
 	latestPausedTime = rtsc.subtaskAutoResume[taskName].LatestPausedTime
-	c.Assert(bf.Current(), check.Equals, 10*time.Second)
+	require.Equal(t, 10*time.Second, bf.Current())
 	for i := 0; i < 10; i++ {
 		rtsc.check()
-		c.Assert(latestResumeTime, check.Equals, rtsc.subtaskAutoResume[taskName].LatestResumeTime)
-		c.Assert(latestPausedTime.Before(rtsc.subtaskAutoResume[taskName].LatestPausedTime), check.IsTrue)
+		require.Equal(t, latestResumeTime, rtsc.subtaskAutoResume[taskName].LatestResumeTime)
+		require.True(t, latestPausedTime.Before(rtsc.subtaskAutoResume[taskName].LatestPausedTime))
 		latestPausedTime = rtsc.subtaskAutoResume[taskName].LatestPausedTime
 	}
 }
 
-func (s *testTaskCheckerSuite) TestCheckTaskIndependent(c *check.C) {
+func TestCheckTaskIndependent(t *testing.T) {
 	var (
 		task1                 = "task1"
 		task2                 = "tesk2"
@@ -208,12 +206,12 @@ func (s *testTaskCheckerSuite) TestCheckTaskIndependent(c *check.C) {
 	)
 
 	NewRelayHolder = NewDummyRelayHolder
-	dir := c.MkDir()
-	cfg := loadSourceConfigWithoutPassword(c)
+	dir := t.TempDir()
+	cfg := loadSourceConfigWithoutPassword2(t)
 	cfg.RelayDir = dir
 	cfg.MetaDir = dir
 	w, err := NewSourceWorker(cfg, nil, "", "")
-	c.Assert(err, check.IsNil)
+	require.NoError(t, err)
 	w.closed.Store(false)
 
 	tsc := NewRealTaskStatusChecker(config.CheckerConfig{
@@ -224,9 +222,9 @@ func (s *testTaskCheckerSuite) TestCheckTaskIndependent(c *check.C) {
 		BackoffMax:      config.Duration{Duration: 10 * time.Second},
 		BackoffFactor:   1.0,
 	}, nil)
-	c.Assert(tsc.Init(), check.IsNil)
+	require.NoError(t, tsc.Init())
 	rtsc, ok := tsc.(*realTaskStatusChecker)
-	c.Assert(ok, check.IsTrue)
+	require.True(t, ok)
 	rtsc.w = w
 
 	st1 := &SubTask{
@@ -242,9 +240,9 @@ func (s *testTaskCheckerSuite) TestCheckTaskIndependent(c *check.C) {
 	}
 	rtsc.w.subTaskHolder.recordSubTask(st2)
 	rtsc.check()
-	c.Assert(len(rtsc.subtaskAutoResume), check.Equals, 2)
+	require.Len(t, rtsc.subtaskAutoResume, 2)
 	for _, times := range rtsc.subtaskAutoResume {
-		c.Assert(times.LatestBlockTime.IsZero(), check.IsTrue)
+		require.True(t, times.LatestBlockTime.IsZero())
 	}
 
 	// test backoff strategies of different tasks do not affect each other
@@ -257,7 +255,7 @@ func (s *testTaskCheckerSuite) TestCheckTaskIndependent(c *check.C) {
 		},
 		l: log.With(zap.String("subtask", task1)),
 	}
-	c.Assert(st1.cfg.Adjust(false), check.IsNil)
+	require.NoError(t, st1.cfg.Adjust(false))
 	rtsc.w.subTaskHolder.recordSubTask(st1)
 	st2 = &SubTask{
 		cfg:   &config.SubTaskConfig{SourceID: "source", Name: task2},
@@ -268,7 +266,7 @@ func (s *testTaskCheckerSuite) TestCheckTaskIndependent(c *check.C) {
 		},
 		l: log.With(zap.String("subtask", task2)),
 	}
-	c.Assert(st2.cfg.Adjust(false), check.IsNil)
+	require.NoError(t, st2.cfg.Adjust(false))
 	rtsc.w.subTaskHolder.recordSubTask(st2)
 
 	task1LatestResumeTime = rtsc.subtaskAutoResume[task1].LatestResumeTime
@@ -276,10 +274,10 @@ func (s *testTaskCheckerSuite) TestCheckTaskIndependent(c *check.C) {
 	for i := 0; i < 10; i++ {
 		time.Sleep(backoffMin)
 		rtsc.check()
-		c.Assert(task1LatestResumeTime, check.Equals, rtsc.subtaskAutoResume[task1].LatestResumeTime)
-		c.Assert(task2LatestResumeTime.Before(rtsc.subtaskAutoResume[task2].LatestResumeTime), check.IsTrue)
-		c.Assert(rtsc.subtaskAutoResume[task1].LatestBlockTime.IsZero(), check.IsFalse)
-		c.Assert(rtsc.subtaskAutoResume[task2].LatestBlockTime.IsZero(), check.IsTrue)
+		require.Equal(t, task1LatestResumeTime, rtsc.subtaskAutoResume[task1].LatestResumeTime)
+		require.True(t, task2LatestResumeTime.Before(rtsc.subtaskAutoResume[task2].LatestResumeTime))
+		require.False(t, rtsc.subtaskAutoResume[task1].LatestBlockTime.IsZero())
+		require.True(t, rtsc.subtaskAutoResume[task2].LatestBlockTime.IsZero())
 
 		task2LatestResumeTime = rtsc.subtaskAutoResume[task2].LatestResumeTime
 	}
@@ -288,12 +286,12 @@ func (s *testTaskCheckerSuite) TestCheckTaskIndependent(c *check.C) {
 	rtsc.w.subTaskHolder.removeSubTask(task1)
 	time.Sleep(backoffMin)
 	rtsc.check()
-	c.Assert(task2LatestResumeTime.Before(rtsc.subtaskAutoResume[task2].LatestResumeTime), check.IsTrue)
-	c.Assert(len(rtsc.subtaskAutoResume), check.Equals, 1)
-	c.Assert(rtsc.subtaskAutoResume[task2].LatestBlockTime.IsZero(), check.IsTrue)
+	require.True(t, task2LatestResumeTime.Before(rtsc.subtaskAutoResume[task2].LatestResumeTime))
+	require.Len(t, rtsc.subtaskAutoResume, 1)
+	require.True(t, rtsc.subtaskAutoResume[task2].LatestBlockTime.IsZero())
 }
 
-func (s *testTaskCheckerSuite) TestIsResumableError(c *check.C) {
+func TestIsResumableError(t *testing.T) {
 	testCases := []struct {
 		err       error
 		resumable bool
@@ -318,10 +316,11 @@ func (s *testTaskCheckerSuite) TestIsResumableError(c *check.C) {
 		{errors.New("unknown error"), true},
 		{terror.ErrNotSet.Delegate(&tmysql.SQLError{Code: 1236, Message: "Could not find first log file name in binary log index file", State: tmysql.DefaultMySQLState}), false},
 		{terror.ErrNotSet.Delegate(&tmysql.SQLError{Code: 1236, Message: "The slave is connecting using CHANGE MASTER TO MASTER_AUTO_POSITION = 1, but the master has purged binary logs containing GTIDs that the slave requires", State: tmysql.DefaultMySQLState}), false},
+		{terror.ErrLoadLightningRuntime.Delegate(common.ErrDBConnect), false},
 	}
 
 	for _, tc := range testCases {
 		err := unit.NewProcessError(tc.err)
-		c.Assert(isResumableError(err), check.Equals, tc.resumable)
+		require.Equal(t, tc.resumable, isResumableError(err))
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #7068

### What is changed and how it works?

lightning itself is a long time runnning import job, so it already has handled retry. It's no need to let DM add retry mechanism.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
