### PR TITLE
pkg(engine): enable orm initialize test

### DIFF
--- a/engine/pkg/orm/util_test.go
+++ b/engine/pkg/orm/util_test.go
@@ -44,9 +44,7 @@ func TestIsNotFoundError(t *testing.T) {
 	require.False(t, b)
 }
 
-// nolint: deadcode
-// TODO: The reason why index sequence is unstable is unknown
-func testInitialize(t *testing.T) {
+func TestInitialize(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.Nil(t, err)
 	defer db.Close()
@@ -71,17 +69,37 @@ func testInitialize(t *testing.T) {
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT SCHEMA_NAME from Information_schema.SCHEMATA where SCHEMA_NAME LIKE ? ORDER BY SCHEMA_NAME=? DESC limit 1")).WillReturnRows(
 		sqlmock.NewRows([]string{"SCHEMA_NAME"}))
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE `master_meta` (`seq_id` bigint unsigned AUTO_INCREMENT,`created_at` datetime(3) NULL," +
-		"`updated_at` datetime(3) NULL,`project_id` varchar(128) not null,`id` varchar(128) not null,`type` smallint not null COMMENT 'JobManager(1),CvsJobMaster(2),FakeJobMaster(3),DMJobMaster(4),CDCJobMaster(5)'," +
-		"`state` tinyint not null COMMENT 'Uninit(1),Init(2),Finished(3),Stopped(4)',`node_id` varchar(128) not null,`address` varchar(256) not null,`epoch` bigint not null," +
-		"`config` blob,`detail` blob,`deleted` datetime(3) NULL,PRIMARY KEY (`seq_id`),INDEX `idx_mst` (`project_id`,`state`),UNIQUE INDEX `uidx_mid` (`id`))")).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(regexp.QuoteMeta(
+		"CREATE TABLE `master_meta` (`seq_id` bigint unsigned AUTO_INCREMENT,"+
+			"`created_at` datetime(3) NULL,`updated_at` datetime(3) NULL,"+
+			"`project_id` varchar(128) not null,`id` varchar(128) not null,"+
+			"`type` smallint not null COMMENT "+
+			"'JobManager(1),CvsJobMaster(2),FakeJobMaster(3),DMJobMaster(4),CDCJobMaster(5)',"+
+			"`state` tinyint not null COMMENT "+
+			"'Uninit(1),Init(2),Finished(3),Stopped(4),Failed(5)',"+
+			"`node_id` varchar(128) not null,`address` varchar(256) not null,"+
+			"`epoch` bigint not null,`config` blob,`error_message` text,"+
+			"`detail` blob,`ext` JSON,`deleted` datetime(3) NULL,"+
+			"PRIMARY KEY (`seq_id`)") +
+		".*", // sequence of indexes are nondeterministic
+	).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT SCHEMA_NAME from Information_schema.SCHEMATA where SCHEMA_NAME LIKE ? ORDER BY SCHEMA_NAME=? DESC limit 1")).WillReturnRows(
 		sqlmock.NewRows([]string{"SCHEMA_NAME"}))
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE `worker_statuses` (`seq_id` bigint unsigned AUTO_INCREMENT,`created_at` datetime(3) NULL," +
-		"`updated_at` datetime(3) NULL,`project_id` varchar(128) not null,`job_id` varchar(128) not null,`id` varchar(128) not null,`type` smallint not null COMMENT 'JobManager(1),CvsJobMaster(2),FakeJobMaster(3),DMJobMaster(4)," +
-		"CDCJobMaster(5),CvsTask(6),FakeTask(7),DMTask(8),CDCTask(9),WorkerDMDump(10),WorkerDMLoad(11),WorkerDMSync(12)',`state` tinyint not null COMMENT 'Normal(1),Created(2),Init(3),Error(4),Finished(5),Stopped(6)'," +
-		"`epoch` bigint not null,`errmsg` text,`extend_bytes` blob,PRIMARY KEY (`seq_id`),UNIQUE INDEX `uidx_wid` (`job_id`,`id`),INDEX `idx_wst` (`job_id`,`state`))")).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(regexp.QuoteMeta(
+		"CREATE TABLE `worker_statuses` (`seq_id` bigint unsigned AUTO_INCREMENT,"+
+			"`created_at` datetime(3) NULL,`updated_at` datetime(3) NULL,"+
+			"`project_id` varchar(128) not null,`job_id` varchar(128) not null,"+
+			"`id` varchar(128) not null,`type` smallint not null COMMENT "+
+			"'JobManager(1),CvsJobMaster(2),FakeJobMaster(3),DMJobMaster(4),"+
+			"CDCJobMaster(5),CvsTask(6),FakeTask(7),DMTask(8),CDCTask(9),"+
+			"WorkerDMDump(10),WorkerDMLoad(11),WorkerDMSync(12)',"+
+			"`state` tinyint not null COMMENT "+
+			"'Normal(1),Created(2),Init(3),Error(4),Finished(5),Stopped(6)',"+
+			"`epoch` bigint not null,`error_message` text,`extend_bytes` blob,"+
+			"PRIMARY KEY (`seq_id`)") +
+		".*", // sequence of indexes are nondeterministic
+	).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT SCHEMA_NAME from Information_schema.SCHEMATA where SCHEMA_NAME LIKE ? ORDER BY SCHEMA_NAME=? DESC limit 1")).WillReturnRows(
 		sqlmock.NewRows([]string{"SCHEMA_NAME"}))
@@ -95,6 +113,30 @@ func testInitialize(t *testing.T) {
 	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE `logic_epoches` (`seq_id` bigint unsigned AUTO_INCREMENT,`created_at` datetime(3) NULL," +
 		"`updated_at` datetime(3) NULL,`job_id` varchar(128) not null,`epoch` bigint not null default 1,PRIMARY KEY (`seq_id`),UNIQUE INDEX `uidx_jk` (`job_id`))")).
 		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"SELECT SCHEMA_NAME from Information_schema.SCHEMATA " +
+			"where SCHEMA_NAME LIKE ? ORDER BY SCHEMA_NAME=? DESC limit 1"),
+	).WillReturnRows(sqlmock.NewRows([]string{"SCHEMA_NAME"}))
+	mock.ExpectExec(regexp.QuoteMeta(
+		"CREATE TABLE `job_ops` (`seq_id` bigint unsigned AUTO_INCREMENT,"+
+			"`created_at` datetime(3) NULL,`updated_at` datetime(3) NULL,"+
+			"`op` tinyint not null COMMENT 'Canceling(1),Canceled(2)',"+
+			"`job_id` varchar(128) not null,PRIMARY KEY (`seq_id`),") +
+		".*", // sequence of indexes are nondeterministic
+	).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"SELECT SCHEMA_NAME from Information_schema.SCHEMATA " +
+			"where SCHEMA_NAME LIKE ? ORDER BY SCHEMA_NAME=? DESC limit 1"),
+	).WillReturnRows(sqlmock.NewRows([]string{"SCHEMA_NAME"}))
+	mock.ExpectExec(regexp.QuoteMeta(
+		"CREATE TABLE `executors` (`seq_id` bigint unsigned AUTO_INCREMENT," +
+			"`created_at` datetime(3) NULL,`updated_at` datetime(3) NULL," +
+			"`id` varchar(256) not null,`name` varchar(256) not null," +
+			"`address` varchar(256) not null,`capability` int not null," +
+			"`labels` json,PRIMARY KEY (`seq_id`),UNIQUE INDEX `uni_id` (`id`))"),
+	).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT SCHEMA_NAME from Information_schema.SCHEMATA " +
 		"where SCHEMA_NAME LIKE ? ORDER BY SCHEMA_NAME=? DESC limit 1")).WillReturnRows(


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #7271

### What is changed and how it works?

- enable one more unit test in engine orm pkg
- Since the index sequence of generated create table DDL are nondeterministic, we use regex `.*` to match the index part. 

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
