### PR TITLE
changefeed (ticdc): extract a method and add some comments

### DIFF
--- a/cdc/owner/barrier.go
+++ b/cdc/owner/barrier.go
@@ -48,7 +48,7 @@ func newBarriers() *barriers {
 
 func (b *barriers) Update(tp barrierType, barrierTs model.Ts) {
 	// the barriers structure was given the ability to handle a fallback barrierTs by design.
-	// but the barrierTs should never fallback in owner replication model
+	// but the barrierTs should never fall back in owner replication model
 	if !b.dirty && (tp == b.min || barrierTs <= b.inner[b.min]) {
 		b.dirty = true
 	}

--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -88,9 +88,9 @@ type changefeed struct {
 	// isRemoved is true if the changefeed is removed,
 	// which means it will be removed from memory forever
 	isRemoved bool
-	// isReleased is true if the changefeed's resource is released
-	// but it will still be kept in the memory and it will be check
-	// in every tick
+	// isReleased is true if the changefeed's resources were released,
+	// but it will still be kept in the memory, and it will be check
+	// in every tick. Such as the changefeed that is stopped or encountered an error.
 	isReleased bool
 
 	// only used for asyncExecDDL function
@@ -180,20 +180,14 @@ func newChangefeed4Test(
 
 func (c *changefeed) Tick(ctx cdcContext.Context, captures map[model.CaptureID]*model.CaptureInfo) {
 	startTime := time.Now()
-	if err := c.upstream.Error(); err != nil {
-		c.handleErr(ctx, err)
+
+	if skip, err := c.checkUpstream(); skip {
+		if err != nil {
+			c.handleErr(ctx, err)
+		}
 		return
 	}
-	if c.upstream.IsClosed() {
-		log.Panic("upstream is closed",
-			zap.Uint64("upstreamID", c.upstream.ID),
-			zap.String("namespace", c.id.Namespace),
-			zap.String("changefeed", c.id.ID))
-	}
-	// skip this tick
-	if !c.upstream.IsNormal() {
-		return
-	}
+
 	ctx = cdcContext.WithErrorHandler(ctx, func(err error) error {
 		c.errCh <- errors.Trace(err)
 		return nil
@@ -252,8 +246,8 @@ func (c *changefeed) checkStaleCheckpointTs(ctx cdcContext.Context, checkpointTs
 func (c *changefeed) tick(ctx cdcContext.Context, captures map[model.CaptureID]*model.CaptureInfo) error {
 	adminJobPending := c.feedStateManager.Tick(c.state)
 	checkpointTs := c.state.Info.GetCheckpointTs(c.state.Status)
-	// check stale checkPointTs must be called before `feedStateManager.ShouldRunning()`
-	// to ensure an error or stopped changefeed also be checked
+	// checkStaleCheckpointTs must be called before `feedStateManager.ShouldRunning()`
+	// to ensure all changefeeds, no matter whether they are running or not, will be checked.
 	if err := c.checkStaleCheckpointTs(ctx, checkpointTs); err != nil {
 		return errors.Trace(err)
 	}
@@ -271,6 +265,7 @@ func (c *changefeed) tick(ctx cdcContext.Context, captures map[model.CaptureID]*
 	if !c.preflightCheck(captures) {
 		return nil
 	}
+
 	if err := c.initialize(ctx); err != nil {
 		return errors.Trace(err)
 	}
@@ -280,8 +275,8 @@ func (c *changefeed) tick(ctx cdcContext.Context, captures map[model.CaptureID]*
 		return errors.Trace(err)
 	default:
 	}
-	// we need to wait sink to be ready before we do the other things
-	// otherwise, we may cause a nil pointer panic
+	// we need to wait ddl sink to be ready before we do the other things
+	// otherwise, we may cause a nil pointer panic when we try to write to the ddl sink.
 	if !c.sink.isInitialized() {
 		return nil
 	}
@@ -332,66 +327,71 @@ func (c *changefeed) tick(ctx cdcContext.Context, captures map[model.CaptureID]*
 
 	// CheckpointCannotProceed implies that not all tables are being replicated normally,
 	// so in that case there is no need to advance the global watermarks.
-	if newCheckpointTs != scheduler.CheckpointCannotProceed {
-		// If the owner is just initialized, barrierTs can be `checkpoint-1`. To avoid
-		// global resolvedTs and checkpointTs regression, we need to handle the case.
-		if newResolvedTs > barrierTs {
-			newResolvedTs = barrierTs
+	if newCheckpointTs == scheduler.CheckpointCannotProceed {
+		if c.state.Status != nil {
+			// We should keep the metrics updated even if the scheduler cannot
+			// advance the watermarks for now.
+			c.updateMetrics(currentTs, c.state.Status.CheckpointTs, c.state.Status.ResolvedTs)
 		}
-		if newCheckpointTs > barrierTs {
-			newCheckpointTs = barrierTs
-		}
-		prevResolvedTs := c.state.Status.ResolvedTs
-		if c.redoManager.Enabled() {
-			var flushedCheckpointTs, flushedResolvedTs model.Ts
-			// newResolvedTs can never exceed the barrier timestamp boundary. If redo is enabled,
-			// we can only upload it to etcd after it has been flushed into redo meta.
-			// NOTE: `UpdateMeta` handles regressed checkpointTs and resolvedTs internally.
-			c.redoManager.UpdateMeta(newCheckpointTs, newResolvedTs)
-			c.redoManager.GetFlushedMeta(&flushedCheckpointTs, &flushedResolvedTs)
-			log.Debug("owner gets flushed meta",
-				zap.Uint64("flushedResolvedTs", flushedResolvedTs),
-				zap.Uint64("flushedCheckpointTs", flushedCheckpointTs),
-				zap.Uint64("newResolvedTs", newResolvedTs),
-				zap.Uint64("newCheckpointTs", newCheckpointTs),
-				zap.String("namespace", c.id.Namespace),
-				zap.String("changefeed", c.id.ID))
-			if flushedResolvedTs != 0 {
-				// It's not necessary to replace newCheckpointTs with flushedResolvedTs,
-				// as cdc can ensure newCheckpointTs can never exceed prevResolvedTs.
-				newResolvedTs = flushedResolvedTs
-			} else {
-				newResolvedTs = prevResolvedTs
-			}
-		}
-		log.Debug("owner prepares to update status",
-			zap.Uint64("prevResolvedTs", prevResolvedTs),
+		return nil
+	}
+
+	// If the owner is just initialized, barrierTs can be `checkpoint-1`. To avoid
+	// global resolvedTs and checkpointTs regression, we need to handle the case.
+	if newResolvedTs > barrierTs {
+		newResolvedTs = barrierTs
+	}
+	if newCheckpointTs > barrierTs {
+		newCheckpointTs = barrierTs
+	}
+	prevResolvedTs := c.state.Status.ResolvedTs
+	if c.redoManager.Enabled() {
+		var flushedCheckpointTs, flushedResolvedTs model.Ts
+		// newResolvedTs can never exceed the barrier timestamp boundary. If redo is enabled,
+		// we can only upload it to etcd after it has been flushed into redo meta.
+		// NOTE: `UpdateMeta` handles regressed checkpointTs and resolvedTs internally.
+		c.redoManager.UpdateMeta(newCheckpointTs, newResolvedTs)
+		c.redoManager.GetFlushedMeta(&flushedCheckpointTs, &flushedResolvedTs)
+		log.Debug("owner gets flushed meta",
+			zap.Uint64("flushedResolvedTs", flushedResolvedTs),
+			zap.Uint64("flushedCheckpointTs", flushedCheckpointTs),
 			zap.Uint64("newResolvedTs", newResolvedTs),
 			zap.Uint64("newCheckpointTs", newCheckpointTs),
 			zap.String("namespace", c.id.Namespace),
 			zap.String("changefeed", c.id.ID))
-		// resolvedTs should never regress but checkpointTs can, as checkpointTs has already
-		// been decreased when the owner is initialized.
-		if newResolvedTs < prevResolvedTs {
+		if flushedResolvedTs != 0 {
+			// It's not necessary to replace newCheckpointTs with flushedResolvedTs,
+			// as cdc can ensure newCheckpointTs can never exceed prevResolvedTs.
+			newResolvedTs = flushedResolvedTs
+		} else {
 			newResolvedTs = prevResolvedTs
 		}
-		failpoint.Inject("ChangefeedOwnerDontUpdateCheckpoint", func() {
-			if c.lastDDLTs != 0 && c.state.Status.CheckpointTs >= c.lastDDLTs {
-				log.Info("owner won't update checkpoint because of failpoint",
-					zap.String("namespace", c.id.Namespace),
-					zap.String("changefeed", c.id.ID),
-					zap.Uint64("keepCheckpoint", c.state.Status.CheckpointTs),
-					zap.Uint64("skipCheckpoint", newCheckpointTs))
-				newCheckpointTs = c.state.Status.CheckpointTs
-			}
-		})
-		c.updateStatus(newCheckpointTs, newResolvedTs)
-		c.updateMetrics(currentTs, newCheckpointTs, newResolvedTs)
-	} else if c.state.Status != nil {
-		// We should keep the metrics updated even if the scheduler cannot
-		// advance the watermarks for now.
-		c.updateMetrics(currentTs, c.state.Status.CheckpointTs, c.state.Status.ResolvedTs)
 	}
+	log.Debug("owner prepares to update status",
+		zap.Uint64("prevResolvedTs", prevResolvedTs),
+		zap.Uint64("newResolvedTs", newResolvedTs),
+		zap.Uint64("newCheckpointTs", newCheckpointTs),
+		zap.String("namespace", c.id.Namespace),
+		zap.String("changefeed", c.id.ID))
+	// resolvedTs should never regress but checkpointTs can, as checkpointTs has already
+	// been decreased when the owner is initialized.
+	if newResolvedTs < prevResolvedTs {
+		newResolvedTs = prevResolvedTs
+	}
+	failpoint.Inject("ChangefeedOwnerDontUpdateCheckpoint", func() {
+		if c.lastDDLTs != 0 && c.state.Status.CheckpointTs >= c.lastDDLTs {
+			log.Info("owner won't update checkpoint because of failpoint",
+				zap.String("namespace", c.id.Namespace),
+				zap.String("changefeed", c.id.ID),
+				zap.Uint64("keepCheckpoint", c.state.Status.CheckpointTs),
+				zap.Uint64("skipCheckpoint", newCheckpointTs))
+			newCheckpointTs = c.state.Status.CheckpointTs
+		}
+	})
+
+	c.updateStatus(newCheckpointTs, newResolvedTs)
+	c.updateMetrics(currentTs, newCheckpointTs, newResolvedTs)
+
 	return nil
 }
 
@@ -692,7 +692,7 @@ func (c *changefeed) preflightCheck(captures map[model.CaptureID]*model.CaptureI
 		c.state.PatchStatus(func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
 			if status == nil {
 				status = &model.ChangeFeedStatus{
-					// the changefeed status is nil when the changefeed is just created.
+					// changefeed status is nil when the changefeed has just created.
 					ResolvedTs:   c.state.Info.StartTs,
 					CheckpointTs: c.state.Info.StartTs,
 					AdminJobType: model.AdminNone,
@@ -715,27 +715,58 @@ func (c *changefeed) preflightCheck(captures map[model.CaptureID]*model.CaptureI
 	return
 }
 
+// handleBarrier calculates the barrierTs of the changefeed.
+// barrierTs is used to control the data that can be flush to downstream.
 func (c *changefeed) handleBarrier(ctx cdcContext.Context) (uint64, error) {
 	barrierTp, barrierTs := c.barriers.Min()
-	phyBarrierTs := oracle.ExtractPhysical(barrierTs)
-	c.metricsChangefeedBarrierTsGauge.Set(float64(phyBarrierTs))
-	ddlBlocked := barrierTs == c.state.Status.CheckpointTs
-	blocked := ddlBlocked && barrierTs == c.state.Status.ResolvedTs
+
+	c.metricsChangefeedBarrierTsGauge.Set(float64(oracle.ExtractPhysical(barrierTs)))
+
+	// It means:
+	//   1. All data before the barrierTs was sent to downstream.
+	//   2. No more data after barrierTs was sent to downstream.
+	// So we can execute the DDL job at the barrierTs.
+	checkpointReachBarrier := barrierTs == c.state.Status.CheckpointTs
+
+	// TODO: To check if we can remove the `barrierTs == c.state.Status.ResolvedTs` condition.
+	fullyBlocked := checkpointReachBarrier && barrierTs == c.state.Status.ResolvedTs
+
 	switch barrierTp {
 	case ddlJobBarrier:
 		ddlResolvedTs, ddlJob := c.ddlPuller.FrontDDL()
+		// ddlJob is nil means there is no ddl job in the queue
+		// and the ddlResolvedTs is updated by resolvedTs event.
 		if ddlJob == nil || ddlResolvedTs != barrierTs {
+			// This situation should only happen when the changefeed release
+			// but the `c.barriers` is not cleaned.
+			// In this case, ddlPuller would restart at `checkpointTs - 1`,
+			// so ddlResolvedTs would be less than barrierTs for a short time.
+			// TODO: To check if we can remove it, since the `c.barriers` is cleaned now.
 			if ddlResolvedTs < barrierTs {
 				return barrierTs, nil
 			}
+			// If the ddlResolvedTs is greater than barrierTs, we should not execute
+			// the DDL job, because the changefeed is not blocked by the DDL job yet,
+			// which also means not all data before the DDL job is sent to downstream.
+			// For example, let say barrierTs(ts=10) and there are some ddl jobs in
+			// the queue: [ddl-1(ts=11), ddl-2(ts=12), ddl-3(ts=13)] => ddlResolvedTs(ts=11)
+			// If ddlResolvedTs(ts=11) > barrierTs(ts=10), it means the last barrier was sent
+			// to sink is barrierTs(ts=10), so the data have been sent ware at most ts=10 not ts=11.
 			c.barriers.Update(ddlJobBarrier, ddlResolvedTs)
 			return barrierTs, nil
 		}
-		if !ddlBlocked {
-			// DDL shouldn't be blocked by resolvedTs because DDL puller is created
-			// with checkpointTs instead of resolvedTs.
+
+		// TiCDC guarantees all dml(s) that happen before a ddl was sent to
+		// downstream when this ddl is sent. So, we need to wait checkpointTs is
+		// fullyBlocked at ddl resolvedTs (equivalent to ddl barrierTs here) before we
+		// execute the next ddl.
+		// For example, let say there are some events are replicated by cdc:
+		// [dml-1(ts=5), dml-2(ts=8), ddl-1(ts=11), ddl-2(ts=12)].
+		// We need to wait `checkpointTs == ddlResolvedTs(ts=11)` before execute ddl-1.
+		if !checkpointReachBarrier {
 			return barrierTs, nil
 		}
+
 		done, err := c.asyncExecDDLJob(ctx, ddlJob)
 		if err != nil {
 			return 0, errors.Trace(err)
@@ -743,12 +774,15 @@ func (c *changefeed) handleBarrier(ctx cdcContext.Context) (uint64, error) {
 		if !done {
 			return barrierTs, nil
 		}
+
+		// If the last ddl was executed successfully, we can pop it
+		// from ddlPuller and update the ddl barrierTs.
 		c.lastDDLTs = ddlResolvedTs
 		c.ddlPuller.PopFrontDDL()
 		newDDLResolvedTs, _ := c.ddlPuller.FrontDDL()
 		c.barriers.Update(ddlJobBarrier, newDDLResolvedTs)
 	case syncPointBarrier:
-		if !blocked {
+		if !fullyBlocked {
 			return barrierTs, nil
 		}
 		nextSyncPointTs := oracle.GoTimeToTS(oracle.GetTimeFromTS(barrierTs).Add(c.state.Info.Config.SyncPointInterval))
@@ -757,7 +791,7 @@ func (c *changefeed) handleBarrier(ctx cdcContext.Context) (uint64, error) {
 		}
 		c.barriers.Update(syncPointBarrier, nextSyncPointTs)
 	case finishBarrier:
-		if blocked {
+		if fullyBlocked {
 			c.feedStateManager.MarkFinished()
 		}
 		return barrierTs, nil
@@ -908,6 +942,29 @@ func (c *changefeed) GetInfoProvider() scheduler.InfoProvider {
 		return provider
 	}
 	return nil
+}
+
+// checkUpstream returns skip = true if the upstream is still in initializing phase,
+// and returns an error if the upstream is unavailable.
+func (c *changefeed) checkUpstream() (skip bool, err error) {
+	if err = c.upstream.Error(); err != nil {
+		return true, err
+	}
+	if c.upstream.IsClosed() {
+		log.Warn("upstream is closed",
+			zap.Uint64("upstreamID", c.upstream.ID),
+			zap.String("namespace", c.id.Namespace),
+			zap.String("changefeed", c.id.ID))
+		return true, cerror.
+			WrapChangefeedUnretryableErr(
+				cerror.ErrUpstreamClosed.GenWithStackByArgs())
+	}
+	// upstream is still in initializing phase
+	// skip this changefeed tick
+	if !c.upstream.IsNormal() {
+		return true, nil
+	}
+	return
 }
 
 // addSpecialComment translate tidb feature to comment

--- a/cdc/owner/owner.go
+++ b/cdc/owner/owner.go
@@ -712,6 +712,9 @@ func (o *ownerImpl) updateGCSafepoint(
 }
 
 // calculateGCSafepoint calculates GCSafepoint for different upstream.
+// Note: we need to maintain a TiCDC service GC safepoint for each upstream TiDB cluster
+// to prevent upstream TiDB GC from removing data that is still needed by TiCDC.
+// GcSafepoint is the minimum checkpointTs of all changefeeds that replicating a same upstream TiDB cluster.
 func (o *ownerImpl) calculateGCSafepoint(state *orchestrator.GlobalReactorState) (
 	map[uint64]uint64, map[uint64]interface{},
 ) {

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -858,7 +858,10 @@ func (p *processor) sendError(err error) {
 	}
 }
 
-// handlePosition calculates the local resolved ts and local checkpoint ts
+// handlePosition calculates the local resolved ts and local checkpoint ts.
+// resolvedTs = min(schemaStorage's resolvedTs, all table's resolvedTs).
+// table's resolvedTs = redo's resolvedTs if redo enable, else sorter's resolvedTs.
+// checkpointTs = min(resolvedTs, all table's checkpointTs).
 func (p *processor) handlePosition(currentTs int64) {
 	minResolvedTs := uint64(math.MaxUint64)
 	minResolvedTableID := int64(0)

--- a/errors.toml
+++ b/errors.toml
@@ -1196,6 +1196,11 @@ error = '''
 updating service safepoint failed
 '''
 
+["CDC:ErrUpstreamClosed"]
+error = '''
+upstream has been closed
+'''
+
 ["CDC:ErrUpstreamManagerNotReady"]
 error = '''
 upstream manager not ready

--- a/pkg/errors/cdc_errors.go
+++ b/pkg/errors/cdc_errors.go
@@ -1043,10 +1043,13 @@ var (
 		"upstream not found, cluster-id: %d",
 		errors.RFCCodeText("CDC:ErrUpstreamNotFound"),
 	)
-
 	ErrUpstreamManagerNotReady = errors.Normalize(
 		"upstream manager not ready",
 		errors.RFCCodeText("CDC:ErrUpstreamManagerNotReady"),
+	)
+	ErrUpstreamClosed = errors.Normalize(
+		"upstream has been closed",
+		errors.RFCCodeText("CDC:ErrUpstreamClosed"),
 	)
 
 	// ReplicationSet error

--- a/pkg/upstream/manager.go
+++ b/pkg/upstream/manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tiflow/pkg/orchestrator"
 	"github.com/pingcap/tiflow/pkg/security"
 	pd "github.com/tikv/pd/client"
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 )
 
@@ -51,7 +52,7 @@ type Manager struct {
 
 	defaultUpstream *Upstream
 
-	lastTickTime time.Time
+	lastTickTime atomic.Time
 
 	initUpstreamFunc func(ctx context.Context, up *Upstream, gcID string) error
 }
@@ -185,10 +186,11 @@ func (m *Manager) Visit(visitor func(up *Upstream) error) error {
 
 // Tick checks and frees upstream that have not been used
 // for a long time to save resources.
+// It's a thread-safe method.
 func (m *Manager) Tick(ctx context.Context,
 	globalState *orchestrator.GlobalReactorState,
 ) error {
-	if time.Since(m.lastTickTime) < tickInterval {
+	if time.Since(m.lastTickTime.Load()) < tickInterval {
 		return nil
 	}
 
@@ -238,6 +240,6 @@ func (m *Manager) Tick(ctx context.Context,
 		}
 		return true
 	})
-	m.lastTickTime = time.Now()
+	m.lastTickTime.Store(time.Now())
 	return err
 }

--- a/pkg/upstream/manager_test.go
+++ b/pkg/upstream/manager_test.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/benbjohnson/clock"
 	"github.com/pingcap/errors"
@@ -26,6 +25,7 @@ import (
 	"github.com/pingcap/tiflow/pkg/security"
 	"github.com/pingcap/tiflow/pkg/txnutil/gc"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 func TestUpstream(t *testing.T) {
@@ -57,12 +57,12 @@ func TestUpstream(t *testing.T) {
 	// test Tick
 	_ = manager.Tick(context.Background(), &orchestrator.GlobalReactorState{})
 	mockClock.Add(maxIdleDuration * 2)
-	manager.lastTickTime = time.Time{}
+	manager.lastTickTime = atomic.Time{}
 	_ = manager.Tick(context.Background(), &orchestrator.GlobalReactorState{})
 	// wait until up2 is closed
 	for !up2.IsClosed() {
 	}
-	manager.lastTickTime = time.Time{}
+	manager.lastTickTime = atomic.Time{}
 	_ = manager.Tick(context.Background(), &orchestrator.GlobalReactorState{})
 	_ = manager.Tick(context.Background(), &orchestrator.GlobalReactorState{})
 	up, ok = manager.Get(testID)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7291 

### What is changed and how it works?
1. Extract a func to check the state of `upstream` of changefeed when it ticks, which simplifies the code of `Tick` method.
2. Add some comments in the `handleBarrier` method of changefeed to make the logic more easier to understand.
3. Make `upstremManager`'s  `Tick` method thread-safe, since it is called by `Owner` and `processorManager` in a same capture.
 
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
