### PR TITLE
test(eninge): fix unstable index sequence in orm generated sql

### DIFF
--- a/engine/pkg/orm/util_test.go
+++ b/engine/pkg/orm/util_test.go
@@ -103,10 +103,15 @@ func TestInitialize(t *testing.T) {
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT SCHEMA_NAME from Information_schema.SCHEMATA where SCHEMA_NAME LIKE ? ORDER BY SCHEMA_NAME=? DESC limit 1")).WillReturnRows(
 		sqlmock.NewRows([]string{"SCHEMA_NAME"}))
-	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE `resource_meta` (`seq_id` bigint unsigned AUTO_INCREMENT,`created_at` datetime(3) NULL,`updated_at` datetime(3) NULL," +
-		"`project_id` varchar(128) not null,`id` varchar(128) not null,`job_id` varchar(128) not null,`worker_id` varchar(128) not null,`executor_id` varchar(128) not null," +
-		"`gc_pending` BOOLEAN,`deleted` BOOLEAN,PRIMARY KEY (`seq_id`),UNIQUE INDEX `uidx_rid` (`job_id`,`id`),INDEX `idx_rei` (`executor_id`,`id`))")).
-		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(regexp.QuoteMeta(
+		"CREATE TABLE `resource_meta` (`seq_id` bigint unsigned AUTO_INCREMENT,"+
+			"`created_at` datetime(3) NULL,`updated_at` datetime(3) NULL,"+
+			"`project_id` varchar(128) not null,`id` varchar(128) not null,"+
+			"`job_id` varchar(128) not null,`worker_id` varchar(128) not null,"+
+			"`executor_id` varchar(128) not null,`gc_pending` BOOLEAN,"+
+			"`deleted` BOOLEAN,PRIMARY KEY (`seq_id`),") +
+		".*", // sequence of indexes are nondeterministic
+	).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT SCHEMA_NAME from Information_schema.SCHEMATA where SCHEMA_NAME LIKE ? ORDER BY SCHEMA_NAME=? DESC limit 1")).
 		WillReturnRows(sqlmock.NewRows([]string{"SCHEMA_NAME"}))


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7271

#7287

ref: https://ci.pingcap.net/blue/organizations/jenkins/ut-check/detail/ut-check/37767/pipeline/

```go

[2022-10-08T07:27:02.392Z] === Failed
[2022-10-08T07:27:02.392Z] === FAIL: engine/pkg/orm TestInitialize (0.04s)
[2022-10-08T07:27:02.392Z] [2022/10/08 15:26:34.536 +08:00] [ERROR] [callbacks.go:134] ["trace log"] [component=gorm] [elapsed=4.594175ms] [sql="CREATE TABLE `resource_meta` (`seq_id` bigint unsigned AUTO_INCREMENT,`created_at` datetime(3) NULL,`updated_at` datetime(3) NULL,`project_id` varchar(128) not null,`id` varchar(128) not null,`job_id` varchar(128) not null,`worker_id` varchar(128) not null,`executor_id` varchar(128) not null,`gc_pending` BOOLEAN,`deleted` BOOLEAN,PRIMARY KEY (`seq_id`),INDEX `idx_rei` (`executor_id`,`id`),UNIQUE INDEX `uidx_rid` (`job_id`,`id`))"] [affected-rows=0] [error="ExecQuery: could not match actual sql: \"CREATE TABLE `resource_meta` (`seq_id` bigint unsigned AUTO_INCREMENT,`created_at` datetime(3) NULL,`updated_at` datetime(3) NULL,`project_id` varchar(128) not null,`id` varchar(128) not null,`job_id` varchar(128) not null,`worker_id` varchar(128) not null,`executor_id` varchar(128) not null,`gc_pending` BOOLEAN,`deleted` BOOLEAN,PRIMARY KEY (`seq_id`),INDEX `idx_rei` (`executor_id`,`id`),UNIQUE INDEX `uidx_rid` (`job_id`,`id`))\" with expected regexp \"CREATE TABLE `resource_meta` \\(`seq_id` bigint unsigned AUTO_INCREMENT,`created_at` datetime\\(3\\) NULL,`updated_at` datetime\\(3\\) NULL,`project_id` varchar\\(128\\) not null,`id` varchar\\(128\\) not null,`job_id` varchar\\(128\\) not null,`worker_id` varchar\\(128\\) not null,`executor_id` varchar\\(128\\) not null,`gc_pending` BOOLEAN,`deleted` BOOLEAN,PRIMARY KEY \\(`seq_id`\\),UNIQUE INDEX `uidx_rid` \\(`job_id`,`id`\\),INDEX `idx_rei` \\(`executor_id`,`id`\\)\\)\""] [stack="gorm.io/gorm.(*processor).Execute\n\t/go/pkg/mod/gorm.io/gorm@v1.23.8/callbacks.go:134\ngorm.io/gorm.(*DB).Exec\n\t/go/pkg/mod/gorm.io/gorm@v1.23.8/finisher_api.go:696\ngorm.io/gorm/migrator.Migrator.CreateTable.func1\n\t/go/pkg/mod/gorm.io/gorm@v1.23.8/migrator/migrator.go:255\ngorm.io/gorm/migrator.Migrator.RunWithValue\n\t/go/pkg/mod/gorm.io/gorm@v1.23.8/migrator/migrator.go:52\ngorm.io/gorm/migrator.Migrator.CreateTable\n\t/go/pkg/mod/gorm.io/gorm@v1.23.8/migrator/migrator.go:177\ngorm.io/gorm/migrator.Migrator.AutoMigrate\n\t/go/pkg/mod/gorm.io/gorm@v1.23.8/migrator/migrator.go:97\ngorm.io/gorm.(*DB).AutoMigrate\n\t/go/pkg/mod/gorm.io/gorm@v1.23.8/migrator.go:28\ngithub.com/pingcap/tiflow/engine/pkg/orm.InitAllFrameworkModels\n\t/home/jenkins/agent/workspace/ut-check/tiflow/engine/pkg/orm/util.go:57\ngithub.com/pingcap/tiflow/engine/pkg/orm.TestInitialize\n\t/home/jenkins/agent/workspace/ut-check/tiflow/engine/pkg/orm/util_test.go:153\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1446"]
[2022-10-08T07:27:02.393Z]     util_test.go:154: 
[2022-10-08T07:27:02.393Z]         	Error Trace:	/home/jenkins/agent/workspace/ut-check/tiflow/engine/pkg/orm/util_test.go:154
[2022-10-08T07:27:02.393Z]         	Error:      	Expected nil, but got: &errors.Error{code:0, codeText:"DFLOW:ErrMetaOpFail", message:"meta operation fail", redactArgsPos:[]int(nil), cause:(*errors.errorString)(0xc00185c060), args:[]interface {}(nil), file:"", line:0}
[2022-10-08T07:27:02.393Z]         	Test:       	TestInitialize
```

### What is changed and how it works?

- Fix a remaining `index` and `unique index` sequence in gorm generated SQL

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
