### PR TITLE
owner(ticdc): async close the owner before set the owner to nil to clean up pending jobs and metrics

### DIFF
--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -445,6 +445,7 @@ func (c *captureImpl) campaignOwner(ctx cdcContext.Context) error {
 		err = c.runEtcdWorker(ownerCtx, owner,
 			orchestrator.NewGlobalState(c.EtcdClient.GetClusterID()),
 			ownerFlushInterval, util.RoleOwner.String())
+		c.owner.AsyncStop()
 		c.setOwner(nil)
 
 		// if owner exits, resign the owner key,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7294 

### What is changed and how it works?

when the owner exit, it does not clean up metrics in time before set the owner to nil.

before set the owner to nil, clean up old owner's pending jobs and metrics by call `AsyncStop`



### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
