### PR TITLE
deployment(engine): change restart policy in docker compose files

### DIFF
--- a/deployments/engine/docker-compose/1m1e.yaml
+++ b/deployments/engine/docker-compose/1m1e.yaml
@@ -21,6 +21,8 @@ services:
         condition: service_started
       "mysql-standalone":
         condition: service_healthy
+    restart: unless-stopped
+
   server-executor:
     image: dataflow:test
     container_name: server-executor-0
@@ -45,6 +47,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       - TZ=UTC
+    restart: unless-stopped
+
   etcd-standalone:
     image: quay.io/coreos/etcd
     container_name: etcd-standalone
@@ -54,6 +58,7 @@ services:
       - "--advertise-client-urls=http://etcd-standalone:2379"
     ports:
       - "12479:2379"
+
   mysql-standalone:
     image: mysql:8.0
     container_name: mysql-standalone

--- a/deployments/engine/docker-compose/1m3e.yaml
+++ b/deployments/engine/docker-compose/1m3e.yaml
@@ -21,6 +21,8 @@ services:
         condition: service_started
       "mysql-standalone":
         condition: service_healthy
+    restart: unless-stopped
+
   server-executor-0:
     image: dataflow:test
     container_name: server-executor-0
@@ -41,6 +43,8 @@ services:
     restart: "on-failure"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
   server-executor-1:
     image: dataflow:test
     container_name: server-executor-1
@@ -61,6 +65,8 @@ services:
     restart: "on-failure"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
   server-executor-2:
     image: dataflow:test
     container_name: server-executor-2
@@ -81,6 +87,8 @@ services:
     restart: "on-failure"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
   etcd-standalone:
     image: quay.io/coreos/etcd
     container_name: etcd-standalone
@@ -90,6 +98,7 @@ services:
       - "--advertise-client-urls=http://etcd-standalone:2379"
     ports:
       - "12479:2379"
+
   mysql-standalone:
     image: mysql:8.0
     container_name: mysql-standalone

--- a/deployments/engine/docker-compose/3m3e.yaml
+++ b/deployments/engine/docker-compose/3m3e.yaml
@@ -21,6 +21,8 @@ services:
         condition: service_started
       "mysql-standalone":
         condition: service_healthy
+    restart: unless-stopped
+
   server-master-1:
     image: dataflow:test
     container_name: server-master-1
@@ -42,6 +44,8 @@ services:
         condition: service_started
       "mysql-standalone":
         condition: service_healthy
+    restart: unless-stopped
+
   server-master-2:
     image: dataflow:test
     container_name: server-master-2
@@ -63,6 +67,8 @@ services:
         condition: service_started
       "mysql-standalone":
         condition: service_healthy
+    restart: unless-stopped
+
   server-executor-0:
     image: dataflow:test
     container_name: server-executor-0
@@ -87,6 +93,8 @@ services:
       - "server-master-1"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
   server-executor-1:
     image: dataflow:test
     container_name: server-executor-1
@@ -111,6 +119,8 @@ services:
       - "server-master-1"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
   server-executor-2:
     image: dataflow:test
     container_name: server-executor-2
@@ -135,6 +145,8 @@ services:
       - "server-master-1"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
   etcd-standalone:
     image: quay.io/coreos/etcd
     container_name: etcd-standalone
@@ -144,6 +156,7 @@ services:
       - "--advertise-client-urls=http://etcd-standalone:2379"
     ports:
       - "12479:2379"
+
   mysql-standalone:
     image: mysql:8.0
     container_name: mysql-standalone

--- a/deployments/engine/docker-compose/3m3e_with_tls.yaml
+++ b/deployments/engine/docker-compose/3m3e_with_tls.yaml
@@ -21,6 +21,8 @@ services:
         condition: service_started
       "mysql-standalone":
         condition: service_healthy
+    restart: unless-stopped
+
   server-master-1:
     image: dataflow:test
     container_name: server-master-1
@@ -42,6 +44,8 @@ services:
         condition: service_started
       "mysql-standalone":
         condition: service_healthy
+    restart: unless-stopped
+
   server-master-2:
     image: dataflow:test
     container_name: server-master-2
@@ -63,6 +67,8 @@ services:
         condition: service_started
       "mysql-standalone":
         condition: service_healthy
+    restart: unless-stopped
+
   server-executor-0:
     image: dataflow:test
     container_name: server-executor-0
@@ -87,6 +93,8 @@ services:
       - "server-master-1"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
   server-executor-1:
     image: dataflow:test
     container_name: server-executor-1
@@ -111,6 +119,8 @@ services:
       - "server-master-1"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
   server-executor-2:
     image: dataflow:test
     container_name: server-executor-2
@@ -135,6 +145,8 @@ services:
       - "server-master-1"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
   etcd-standalone:
     image: quay.io/coreos/etcd
     container_name: etcd-standalone
@@ -144,6 +156,7 @@ services:
       - "--advertise-client-urls=http://etcd-standalone:2379"
     ports:
       - "12479:2379"
+
   mysql-standalone:
     image: mysql:8.0
     container_name: mysql-standalone


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #7300

### What is changed and how it works?

We often meet the following error when server master starts up

```go
[2022/10/11 02:28:05.783 +00:00] [INFO] [version.go:47] ["Welcome to TiFlow Master"] [release-version=v6.4.0-alpha-25-gebd5c64f3] [git-hash=ebd5c64f32db7e9cce0e7f75dbd79feea9739d38] [git-branch=HEAD] [utc-build-time="2022-10-11 02:23:55"] [go-version="go version go1.19.1 linux/amd64"] [failpoint-build=false]
[2022/10/11 02:28:05.783 +00:00] [INFO] [server.go:160] ["creating server master"] [config="{\"log\":{\"level\":\"debug\",\"file\":\"/log/server-master-0.log\",\"max-size\":0,\"max-days\":0,\"max-backups\":0,\"error-output\":\"\"},\"name\":\"server-master-0\",\"addr\":\"0.0.0.0:10240\",\"advertise-addr\":\"server-master-0:10240\",\"framework-meta\":{\"store-id\":\"_root\",\"store-type\":\"mysql\",\"endpoints\":[\"mysql-standalone:3306\"],\"user\":\"root\",\"password\":\"\",\"schema\":\"test_framework\",\"read-timeout\":\"3s\",\"write-timeout\":\"3s\",\"dial-timeout\":\"3s\",\"dbconfs\":{\"conn-max-idle-time\":60000000000,\"conn-max-life-time\":43200000000000,\"max-idle-conns\":3,\"max-open-conns\":7},\"security\":null},\"business-meta\":{\"store-id\":\"_default\",\"store-type\":\"mysql\",\"endpoints\":[\"mysql-standalone:3306\"],\"user\":\"root\",\"password\":\"\",\"schema\":\"test_business\",\"read-timeout\":\"3s\",\"write-timeout\":\"3s\",\"dial-timeout\":\"3s\",\"dbconfs\":{\"conn-max-idle-time\":60000000000,\"conn-max-life-time\":43200000000000,\"max-idle-conns\":3,\"max-open-conns\":7},\"security\":null},\"keepalive-ttl\":\"20s\",\"keepalive-interval\":\"500ms\",\"rpc-timeout\":\"3s\",\"storage\":{\"local\":{\"base-dir\":\"\"},\"s3\":{\"endpoint\":\"\",\"region\":\"\",\"storage-class\":\"\",\"sse\":\"\",\"sse-kms-key-id\":\"\",\"acl\":\"\",\"access-key\":\"\",\"secret-access-key\":\"\",\"provider\":\"\",\"force-path-style\":false,\"use-accelerate-endpoint\":false,\"role-arn\":\"\",\"external-id\":\"\",\"object-lock-enabled\":false,\"bucket\":\"\",\"prefix\":\"\"}},\"security\":null,\"job-backoff\":{\"reset-interval\":2000000000,\"initial-interval\":1000000000,\"max-interval\":15000000000,\"multiplier\":2,\"max-try-time\":100}}"]
[2022/10/11 02:28:08.786 +00:00] [ERROR] [server.go:551] ["create schema for framework metastore fail"] [schema=test_framework] [error="[DFLOW:ErrMetaOpFail]meta operation fail: context deadline exceeded"]
[2022/10/11 02:28:08.786 +00:00] [ERROR] [master.go:87] ["run dataflow server master with error"] [error="[DFLOW:ErrMetaOpFail]meta operation fail: context deadline exceeded"]
```

The default restart policy in docker compose is `no` (https://docs.docker.com/compose/compose-file/#restart), change it to `unless-stopped`

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
