### PR TITLE
checker: infoschema does not need privilege to access

### DIFF
--- a/dm/pkg/checker/privilege.go
+++ b/dm/pkg/checker/privilege.go
@@ -355,11 +355,6 @@ func genExpectPriv(privileges map[mysql.PrivilegeType]struct{}, checkTables []*f
 			}
 			lackPriv[p][table.Schema][table.Name] = struct{}{}
 		}
-		if p == mysql.SelectPriv {
-			if _, ok := lackPriv[p]["INFORMATION_SCHEMA"]; !ok {
-				lackPriv[p]["INFORMATION_SCHEMA"] = make(map[string]struct{})
-			}
-		}
 	}
 	return lackPriv
 }

--- a/dm/pkg/checker/privilege_test.go
+++ b/dm/pkg/checker/privilege_test.go
@@ -66,7 +66,7 @@ func TestVerifyDumpPrivileges(t *testing.T) {
 			checkTables: []*filter.Table{
 				{Schema: "db1", Name: "anomaly_score"},
 			},
-			// `db1`.`anomaly_score`; `INFORMATION_SCHEMA`
+			// `db1`.`anomaly_score`
 			// can't guarantee the order
 			errMatch: "lack of Select privilege: {.*}; ",
 		},

--- a/dm/pkg/checker/privilege_test.go
+++ b/dm/pkg/checker/privilege_test.go
@@ -52,7 +52,10 @@ func TestVerifyDumpPrivileges(t *testing.T) {
 		{
 			grants:    []string{"GRANT RELOAD ON *.* TO 'user'@'%'"}, // lack SELECT privilege
 			dumpState: StateFailure,
-			errMatch:  "lack of Select privilege: {`INFORMATION_SCHEMA`}; ",
+			checkTables: []*filter.Table{
+				{Schema: "db1", Name: "tb1"},
+			},
+			errMatch: "lack of Select privilege: {`db1`.`tb1`}; ",
 		},
 		{
 			grants: []string{ // lack optional privilege
@@ -65,7 +68,7 @@ func TestVerifyDumpPrivileges(t *testing.T) {
 			},
 			// `db1`.`anomaly_score`; `INFORMATION_SCHEMA`
 			// can't guarantee the order
-			errMatch: "lack of Select privilege: {.*; .*}; ",
+			errMatch: "lack of Select privilege: {.*}; ",
 		},
 		{
 			grants: []string{ // have privileges
@@ -124,7 +127,6 @@ func TestVerifyDumpPrivileges(t *testing.T) {
 		},
 		{
 			grants: []string{ // lack db/table level privilege
-				"GRANT ALL PRIVILEGES ON `INFORMATION_SCHEMA`.* TO `zhangsan`@`10.8.1.9` WITH GRANT OPTION",
 				"GRANT ALL PRIVILEGES ON `medz`.* TO `zhangsan`@`10.8.1.9` WITH GRANT OPTION",
 			},
 			dumpState: StateFailure,
@@ -136,7 +138,6 @@ func TestVerifyDumpPrivileges(t *testing.T) {
 		{
 			grants: []string{ // privilege on db/table level is not enough to execute SHOW MASTER STATUS
 				"GRANT ALL PRIVILEGES ON `medz`.* TO `zhangsan`@`10.8.1.9` WITH GRANT OPTION",
-				"GRANT ALL PRIVILEGES ON `INFORMATION_SCHEMA`.* TO `zhangsan`@`10.8.1.9` WITH GRANT OPTION",
 			},
 			dumpState: StateFailure,
 			checkTables: []*filter.Table{
@@ -148,7 +149,6 @@ func TestVerifyDumpPrivileges(t *testing.T) {
 			grants: []string{ // privilege on column level is not enough to execute SHOW CREATE TABLE
 				"GRANT RELOAD ON *.* TO 'user'@'%'",
 				"GRANT SELECT (c) ON `lance`.`t` TO 'user'@'%'",
-				"GRANT SELECT ON `INFORMATION_SCHEMA`.* TO 'user'@'%'",
 			},
 			dumpState: StateFailure,
 			checkTables: []*filter.Table{
@@ -160,7 +160,6 @@ func TestVerifyDumpPrivileges(t *testing.T) {
 			grants: []string{
 				"GRANT RELOAD ON *.* TO `u1`@`localhost`",
 				"GRANT SELECT ON `db1`.* TO `u1`@`localhost`",
-				"GRANT SELECT ON `INFORMATION_SCHEMA`.* TO `u1`@`localhost`",
 				"GRANT `r1`@`%`,`r2`@`%` TO `u1`@`localhost`",
 			},
 			dumpState: StateSuccess,
@@ -187,9 +186,11 @@ func TestVerifyDumpPrivileges(t *testing.T) {
 		}
 		dumpLackGrants := genDumpPriv(dumpPrivileges, cs.checkTables)
 		err := verifyPrivilegesWithResult(result, cs.grants, dumpLackGrants)
-		require.Equal(t, err == nil, cs.dumpState == StateSuccess)
-		if err != nil && len(cs.errMatch) != 0 {
-			require.Regexp(t, cs.errMatch, err.ShortErr)
+		if cs.dumpState == StateSuccess {
+			require.Nil(t, err, "grants: %v", cs.grants)
+		} else {
+			require.NotNil(t, err, "grants: %v", cs.grants)
+			require.Regexp(t, cs.errMatch, err.ShortErr, "grants: %v", cs.grants)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7317 

### What is changed and how it works?

so no need to let checker require this privilege

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
DM precheck no longer reports lacking privileges of INFORMATION_SCHEMA
```
