### PR TITLE
jobmanager(engine): insert job directly when handling create API

### DIFF
--- a/dm/pkg/utils/db.go
+++ b/dm/pkg/utils/db.go
@@ -343,6 +343,11 @@ func IsMySQLError(err error, code uint16) bool {
 	return ok && e.Number == code
 }
 
+// IsErrDuplicateEntry checks whether err is DuplicateEntry error.
+func IsErrDuplicateEntry(err error) bool {
+	return IsMySQLError(err, tmysql.ErrDupEntry)
+}
+
 // IsErrBinlogPurged checks whether err is BinlogPurged error.
 func IsErrBinlogPurged(err error) bool {
 	return IsMySQLError(err, tmysql.ErrMasterFatalErrorReadingBinlog)

--- a/dm/pkg/utils/db_test.go
+++ b/dm/pkg/utils/db_test.go
@@ -194,6 +194,9 @@ func (t *testDBSuite) TestMySQLError(c *C) {
 
 	err = newMysqlErr(tmysql.ErrMasterFatalErrorReadingBinlog, "binlog purged error")
 	c.Assert(IsErrBinlogPurged(err), Equals, true)
+
+	err = newMysqlErr(tmysql.ErrDupEntry, "Duplicate entry '123456' for key 'index'")
+	c.Assert(IsErrDuplicateEntry(err), Equals, true)
 }
 
 func (t *testDBSuite) TestGetAllServerID(c *C) {

--- a/engine/framework/metadata/metadata.go
+++ b/engine/framework/metadata/metadata.go
@@ -65,6 +65,11 @@ func (c *MasterMetadataClient) Load(ctx context.Context) (*frameModel.MasterMeta
 	return masterMeta, nil
 }
 
+// Insert inserts the metadata
+func (c *MasterMetadataClient) Insert(ctx context.Context, data *frameModel.MasterMeta) error {
+	return errors.Trace(c.metaClient.InsertJob(ctx, data))
+}
+
 // Store upsert the data
 func (c *MasterMetadataClient) Store(ctx context.Context, data *frameModel.MasterMeta) error {
 	return errors.Trace(c.metaClient.UpsertJob(ctx, data))

--- a/engine/pkg/orm/client.go
+++ b/engine/pkg/orm/client.go
@@ -96,6 +96,7 @@ type ProjectOperationClient interface {
 
 // JobClient defines interface that manages job in metastore
 type JobClient interface {
+	InsertJob(ctx context.Context, job *frameModel.MasterMeta) error
 	UpsertJob(ctx context.Context, job *frameModel.MasterMeta) error
 	UpdateJob(ctx context.Context, jobID string, values model.KeyValueMap) error
 	DeleteJob(ctx context.Context, jobID string) (Result, error)
@@ -292,6 +293,19 @@ func (c *metaOpsClient) QueryProjectOperationsByTimeRange(ctx context.Context,
 }
 
 // ///////////////////////////// Job Operation
+// InsertJob insert the jobInfo
+func (c *metaOpsClient) InsertJob(ctx context.Context, job *frameModel.MasterMeta) error {
+	if job == nil {
+		return errors.ErrMetaParamsInvalid.GenWithStackByArgs("input master meta is nil")
+	}
+
+	if err := c.db.WithContext(ctx).Create(job).Error; err != nil {
+		return errors.ErrMetaOpFail.Wrap(err)
+	}
+
+	return nil
+}
+
 // UpsertJob upsert the jobInfo
 func (c *metaOpsClient) UpsertJob(ctx context.Context, job *frameModel.MasterMeta) error {
 	if job == nil {

--- a/engine/pkg/orm/client_test.go
+++ b/engine/pkg/orm/client_test.go
@@ -374,6 +374,64 @@ func TestJob(t *testing.T) {
 
 	testCases := []tCase{
 		{
+			fn: "InsertJob",
+			inputs: []interface{}{
+				&frameModel.MasterMeta{
+					Model: model.Model{
+						CreatedAt: createdAt,
+						UpdatedAt: updatedAt,
+					},
+					ProjectID: "p111",
+					ID:        "j111",
+					Type:      1,
+					NodeID:    "n111",
+					Epoch:     1,
+					State:     1,
+					Addr:      "127.0.0.1",
+					Config:    []byte{0x11, 0x22},
+					Ext:       extForTest,
+				},
+			},
+			mockExpectResFn: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("INSERT INTO `master_meta` [(]`created_at`,"+
+					"`updated_at`,`project_id`,`id`,`type`,`state`,`node_id`,"+
+					"`address`,`epoch`,`config`,`error_message`,`detail`,"+
+					"`ext`,`deleted`[)]").
+					WithArgs(createdAt, updatedAt, "p111", "j111", 1, 1, "n111",
+						"127.0.0.1", 1, []byte{0x11, 0x22}, sqlmock.AnyArg(),
+						sqlmock.AnyArg(), extForTest, nil).
+					WillReturnResult(sqlmock.NewResult(1, 1))
+			},
+		},
+		{
+			fn: "InsertJob",
+			inputs: []interface{}{
+				&frameModel.MasterMeta{
+					Model: model.Model{
+						CreatedAt: createdAt,
+						UpdatedAt: updatedAt,
+					},
+					ProjectID: "p111",
+					ID:        "j111",
+					Type:      1,
+					NodeID:    "n111",
+					Epoch:     1,
+					State:     1,
+					Addr:      "127.0.0.1",
+					Config:    []byte{0x11, 0x22},
+					Ext:       extForTest,
+				},
+			},
+			err: derror.ErrMetaOpFail.GenWithStackByArgs(),
+			mockExpectResFn: func(mock sqlmock.Sqlmock) {
+				mock.ExpectExec("INSERT INTO `master_meta` [(]`created_at`," +
+					"`updated_at`,`project_id`,`id`,`type`,`state`,`node_id`," +
+					"`address`,`epoch`,`config`,`error_message`,`detail`," +
+					"`ext`,`deleted`[)]").
+					WillReturnError(&mysql.MySQLError{Number: 1062, Message: "Duplicate entry '123456' for key 'uidx_mid'"})
+			},
+		},
+		{
 			fn: "UpsertJob",
 			inputs: []interface{}{
 				&frameModel.MasterMeta{

--- a/engine/pkg/orm/mock/client_mock.go
+++ b/engine/pkg/orm/mock/client_mock.go
@@ -264,6 +264,20 @@ func (mr *MockClientMockRecorder) GetWorkerByID(arg0, arg1, arg2 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkerByID", reflect.TypeOf((*MockClient)(nil).GetWorkerByID), arg0, arg1, arg2)
 }
 
+// InsertJob mocks base method.
+func (m *MockClient) InsertJob(arg0 context.Context, arg1 *model.MasterMeta) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertJob", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InsertJob indicates an expected call of InsertJob.
+func (mr *MockClientMockRecorder) InsertJob(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertJob", reflect.TypeOf((*MockClient)(nil).InsertJob), arg0, arg1)
+}
+
 // QueryJobOp mocks base method.
 func (m *MockClient) QueryJobOp(arg0 context.Context, arg1 string) (*model2.JobOp, error) {
 	m.ctrl.T.Helper()

--- a/engine/pkg/orm/util.go
+++ b/engine/pkg/orm/util.go
@@ -24,6 +24,7 @@ import (
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 
+	dmutils "github.com/pingcap/tiflow/dm/pkg/utils" // TODO: move it to pkg
 	"github.com/pingcap/tiflow/engine/pkg/meta/model"
 	metaModel "github.com/pingcap/tiflow/engine/pkg/meta/model"
 	ormModel "github.com/pingcap/tiflow/engine/pkg/orm/model"
@@ -127,4 +128,14 @@ func NewGormDB(sqlDB *sql.DB, storeType metaModel.StoreType) (*gorm.DB, error) {
 	}
 
 	return db, nil
+}
+
+// IsDuplicateEntryError checks whether error contains DuplicateEntry(MySQL) error
+// or UNIQUE constraint failed(SQLite) error underlying.
+func IsDuplicateEntryError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return dmutils.IsErrDuplicateEntry(err) ||
+		strings.Contains(err.Error(), "UNIQUE constraint failed")
 }

--- a/engine/servermaster/jobmanager.go
+++ b/engine/servermaster/jobmanager.go
@@ -272,13 +272,11 @@ func (jm *JobManagerImpl) CreateJob(ctx context.Context, req *pb.CreateJobReques
 		return nil, status.Errorf(codes.InvalidArgument, "job type %v is not supported", job.Type)
 	}
 
-	// Store job master metadata before creating it.
-	// FIXME: note the following two operations are not atomic. We should use
-	//  a transaction or an insert statement to avoid inconsistent result.
-	if _, err := jm.frameMetaClient.GetJobByID(ctx, job.Id); err == nil {
-		return nil, ErrJobAlreadyExists.GenWithStack(&JobAlreadyExistsError{JobID: job.Id})
-	}
-	if err := metadata.StoreMasterMeta(ctx, jm.frameMetaClient, meta); err != nil {
+	// create job master metadata before creating it.
+	if err := jm.frameMetaClient.InsertJob(ctx, meta); err != nil {
+		if pkgOrm.IsDuplicateEntryError(err) {
+			return nil, ErrJobAlreadyExists.GenWithStack(&JobAlreadyExistsError{JobID: job.Id})
+		}
 		return nil, err
 	}
 

--- a/engine/servermaster/jobmanager_test.go
+++ b/engine/servermaster/jobmanager_test.go
@@ -110,6 +110,18 @@ func TestJobManagerCreateJob(t *testing.T) {
 	}
 	_, err = mgr.CreateJob(ctx, req)
 	require.True(t, ErrJobAlreadyExists.Is(err))
+
+	// delete a finished job, re-create job with the same id will meet error
+	err = mockMaster.GetFrameMetaClient().UpdateJob(ctx, job.Id,
+		map[string]interface{}{
+			"state": frameModel.MasterStateFinished,
+		},
+	)
+	require.NoError(t, err)
+	_, err = mgr.DeleteJob(ctx, &pb.DeleteJobRequest{Id: job.Id})
+	require.NoError(t, err)
+	_, err = mgr.CreateJob(ctx, req)
+	require.True(t, ErrJobAlreadyExists.Is(err))
 }
 
 type mockBaseMasterCreateWorkerFailed struct {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7322

### What is changed and how it works?

- Insert into job master meta directly instead of the old check and upsert way.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
