### PR TITLE
Dockerfile(engine): remove tiflow demo from default dockerfile

### DIFF
--- a/.github/workflows/dataflow_engine_e2e.yaml
+++ b/.github/workflows/dataflow_engine_e2e.yaml
@@ -17,34 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Basic-workflow:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.19
-
-      - name: Build images
-        run: make engine_image
-
-      - name: Run containers
-        run: docker compose -f $GITHUB_WORKSPACE/deployments/engine/docker-compose/3m3e.yaml -f $GITHUB_WORKSPACE/deployments/engine/docker-compose/demo.yaml up -d
-
-      - name: Run tests
-        run: |
-          cd $GITHUB_WORKSPACE/engine/test/e2e
-          go test -count=1 -v -run=TestSubmitTest
-
-      - name: Upload logs to GitHub
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@master
-        with:
-          name: basic-workflow-logs
-          path: /tmp/tiflow_engine_test/*log
-
   Node-failure-workflow:
     runs-on: ubuntu-latest
 

--- a/Makefile
+++ b/Makefile
@@ -484,7 +484,7 @@ failpoint-enable: check_failpoint_ctl
 failpoint-disable: check_failpoint_ctl
 	$(FAILPOINT_DISABLE)
 
-engine: tiflow tiflow-demo
+engine: tiflow
 
 tiflow:
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/tiflow ./cmd/tiflow/main.go

--- a/deployments/engine/docker/Dockerfile
+++ b/deployments/engine/docker/Dockerfile
@@ -18,4 +18,3 @@ RUN make engine
 FROM alpine:3.16
 
 COPY --from=builder /dataflow-engine/bin/tiflow /tiflow
-COPY --from=builder /dataflow-engine/bin/tiflow-demoserver /tiflow-demoserver


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #5668

### What is changed and how it works?

- Dockerfile is used to publish tiflow(engine) image, we remove tiflow-demo-server from the image
- Jenkins integration test contains the engine e2e basic test, so remove it from the github action to be compatible with the new docker image

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
