### PR TITLE
[DNM] codec(ticdc): canal-json reuse map to hold all message fields to reduce make map cost

### DIFF
--- a/cdc/sink/codec/canal/canal_json_encoder.go
+++ b/cdc/sink/codec/canal/canal_json_encoder.go
@@ -38,17 +38,25 @@ type JSONBatchEncoder struct {
 
 	// messageHolder is used to hold each message and will be reset after each message is encoded.
 	messageHolder canalJSONMessageInterface
-	messages      []*common.Message
+	// oldDataHolder is only used for `update` event
+	oldDataHolder map[string]interface{}
+
+	messages []*common.Message
 }
 
 // newJSONBatchEncoder creates a new JSONBatchEncoder
 func newJSONBatchEncoder(enableTiDBExtension bool) codec.EventBatchEncoder {
+	messageHolder := &canalJSONMessage{
+		// for Data field, no matter event type, always be filled with only one item.
+		Data: make([]map[string]interface{}, 1),
+	}
+	messageHolder.Data[0] = make(map[string]interface{})
+	messageHolder.SQLType = make(map[string]int32)
+	messageHolder.MySQLType = make(map[string]string)
+
 	encoder := &JSONBatchEncoder{
-		builder: newCanalEntryBuilder(),
-		messageHolder: &canalJSONMessage{
-			// for Data field, no matter event type, always be filled with only one item.
-			Data: make([]map[string]interface{}, 1),
-		},
+		builder:             newCanalEntryBuilder(),
+		messageHolder:       messageHolder,
 		enableTiDBExtension: enableTiDBExtension,
 		messages:            make([]*common.Message, 0, 1),
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
