### PR TITLE
engine(externalresource): handle cleanBeforeOpen option before getting persisted resource

### DIFF
--- a/engine/pkg/externalresource/broker/broker.go
+++ b/engine/pkg/externalresource/broker/broker.go
@@ -344,6 +344,8 @@ func (b *DefaultBroker) getPersistResource(
 
 	if options.cleanBeforeOpen {
 		err := fm.RemoveResource(ctx, ident)
+		// LocalFileManager may return ErrResourceDoesNotExist, which can be 
+		// ignored because the resource no longer exists.
 		if err != nil && !derrors.ErrResourceDoesNotExist.Equal(err) {
 			return nil, err
 		}

--- a/engine/pkg/externalresource/broker/broker.go
+++ b/engine/pkg/externalresource/broker/broker.go
@@ -344,7 +344,7 @@ func (b *DefaultBroker) getPersistResource(
 
 	if options.cleanBeforeOpen {
 		err := fm.RemoveResource(ctx, ident)
-		// LocalFileManager may return ErrResourceDoesNotExist, which can be 
+		// LocalFileManager may return ErrResourceDoesNotExist, which can be
 		// ignored because the resource no longer exists.
 		if err != nil && !derrors.ErrResourceDoesNotExist.Equal(err) {
 			return nil, err

--- a/engine/pkg/externalresource/broker/broker.go
+++ b/engine/pkg/externalresource/broker/broker.go
@@ -344,7 +344,7 @@ func (b *DefaultBroker) getPersistResource(
 
 	if options.cleanBeforeOpen {
 		err := fm.RemoveResource(ctx, ident)
-		if err != nil {
+		if err != nil && !derrors.ErrResourceDoesNotExist.Equal(err) {
 			return nil, err
 		}
 		desc, err = fm.CreateResource(ctx, ident)

--- a/engine/pkg/externalresource/broker/broker.go
+++ b/engine/pkg/externalresource/broker/broker.go
@@ -340,10 +340,7 @@ func (b *DefaultBroker) getPersistResource(
 			WorkerID:    record.Worker,   /* creator id*/
 		},
 	}
-	desc, err := fm.GetPersistedResource(ctx, ident)
-	if err != nil {
-		return nil, err
-	}
+	var desc internal.ResourceDescriptor
 
 	if options.cleanBeforeOpen {
 		err := fm.RemoveResource(ctx, ident)
@@ -354,6 +351,12 @@ func (b *DefaultBroker) getPersistResource(
 		if err != nil {
 			return nil, err
 		}
+		return desc, nil
+	}
+
+	desc, err := fm.GetPersistedResource(ctx, ident)
+	if err != nil {
+		return nil, err
 	}
 	return desc, nil
 }

--- a/engine/pkg/externalresource/broker/broker_test.go
+++ b/engine/pkg/externalresource/broker/broker_test.go
@@ -21,6 +21,7 @@ import (
 
 	pb "github.com/pingcap/tiflow/engine/enginepb"
 	"github.com/pingcap/tiflow/engine/pkg/externalresource/internal/local"
+	"github.com/pingcap/tiflow/engine/pkg/externalresource/internal/s3"
 	"github.com/pingcap/tiflow/engine/pkg/externalresource/manager"
 	resModel "github.com/pingcap/tiflow/engine/pkg/externalresource/model"
 	"github.com/pingcap/tiflow/engine/pkg/tenant"
@@ -135,6 +136,43 @@ func TestBrokerOpenExistingStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	local.AssertLocalFileExists(t, dir, "worker-2", resName, "1.txt")
+}
+
+func TestBrokerOpenExistingStorageWithOption(t *testing.T) {
+	t.Parallel()
+	fakeProjectInfo := tenant.NewProjectInfo("fakeTenant", "fakeProject")
+	brk, cli, _ := newBroker(t)
+	defer brk.Close()
+	mockS3FileManager, _ := s3.NewFileManagerForUT(t.TempDir(), brk.executorID)
+	brk.fileManagers[resModel.ResourceTypeS3] = mockS3FileManager
+
+	openStorageWithClean := func(resID resModel.ResourceID) {
+		// resource metadata exists
+		cli.On("QueryResource", mock.Anything,
+			&pb.QueryResourceRequest{ResourceKey: &pb.ResourceKey{JobId: "job-1", ResourceId: resID}}, mock.Anything).
+			Return(&pb.QueryResourceResponse{
+				CreatorExecutor: "executor-1",
+				JobId:           "job-1",
+				CreatorWorkerId: "worker-2",
+			}, nil)
+		hdl, err := brk.OpenStorage(
+			context.Background(),
+			fakeProjectInfo,
+			"worker-2",
+			"job-1",
+			resID, WithCleanBeforeOpen())
+		require.NoError(t, err)
+		require.Equal(t, resID, hdl.ID())
+		require.True(t, hdl.(*ResourceHandle).isPersisted.Load())
+	}
+
+	resIDs := []resModel.ResourceID{"/local/test-option", "/s3/test-option"}
+	for _, resID := range resIDs {
+		// resource does not exist, metadata exists
+		openStorageWithClean(resID)
+		// open again, resource exists, metadata exists
+		openStorageWithClean(resID)
+	}
 }
 
 func TestBrokerRemoveResource(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7399

### What is changed and how it works?
> https://github.com/pingcap/tiflow/blob/9abde064c9a50aef77ffd3aa8be609d3265e4ed0/engine/pkg/externalresource/broker/broker.go#L343-L357
> 
L349 and L353 are non-atomic operations. If a worker successfully executes L349 but fails in L353, there will be an inconsistency between the resource and meta data (In this case, the resource does not exist while meta still exists).
And we can avoid this problem by handling the cleanBeforeOpen option before getting persistent resource



### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
