### PR TITLE
config(engine): remove deprecated session-ttl config from executor

### DIFF
--- a/deployments/engine/docker-compose/config/executor.toml
+++ b/deployments/engine/docker-compose/config/executor.toml
@@ -1,6 +1,5 @@
 keepalive-ttl = "20s"
 keepalive-interval = "500ms"
-session-ttl = 20
 
 [log] 
 level = "debug"

--- a/deployments/engine/docker-compose/config/template_executor.toml
+++ b/deployments/engine/docker-compose/config/template_executor.toml
@@ -6,7 +6,6 @@ join = ["127.0.0.1:10240"]          # Corresponding command line:  --join
 
 keepalive-ttl = "20s"
 keepalive-interval = "500ms"
-session-ttl = 20
 
 [log] 
 level = "info"              # Corresponding command line:  --log-level

--- a/deployments/engine/helm/tiflow/values.yaml
+++ b/deployments/engine/helm/tiflow/values.yaml
@@ -43,7 +43,6 @@ executor:
   config: |
     keepalive-ttl = "20s"
     keepalive-interval = "500ms"
-    session-ttl = 20
 
 metastore:
   frameworkStorage: 5Gi

--- a/engine/executor/config.go
+++ b/engine/executor/config.go
@@ -30,7 +30,6 @@ import (
 
 var (
 	defaultJoinAddr          = "127.0.0.1:10240"
-	defaultSessionTTL        = 20
 	defaultKeepAliveTTL      = "20s"
 	defaultKeepAliveInterval = "500ms"
 	defaultRPCTimeout        = "3s"
@@ -51,8 +50,6 @@ type Config struct {
 	AdvertiseAddr string `toml:"advertise-addr" json:"advertise-addr"`
 
 	Labels map[string]string `toml:"labels" json:"labels"`
-
-	SessionTTL int `toml:"session-ttl" json:"session-ttl"`
 
 	// TODO: in the future executors should share a same ttl from server-master
 	KeepAliveTTLStr      string `toml:"keepalive-ttl" json:"keepalive-ttl"`
@@ -147,7 +144,6 @@ func GetDefaultExecutorConfig() *Config {
 		Join:                 defaultJoinAddr,
 		Addr:                 defaultExecutorAddr,
 		AdvertiseAddr:        "",
-		SessionTTL:           defaultSessionTTL,
 		KeepAliveTTLStr:      defaultKeepAliveTTL,
 		KeepAliveIntervalStr: defaultKeepAliveInterval,
 		RPCTimeoutStr:        defaultRPCTimeout,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #6849

### What is changed and how it works?

`session-ttl` is used in etcd based session, it is no longer used after #6949

Since it is break compatibility, we also need to update template in tiflow-operator.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
