### PR TITLE
engien(dm, externalstorage): generate resource id by storage config

### DIFF
--- a/engine/executor/dm/worker.go
+++ b/engine/executor/dm/worker.go
@@ -192,7 +192,7 @@ func (w *dmWorker) CloseImpl(ctx context.Context) {
 
 // setupStorage opens and configs external storage
 func (w *dmWorker) setupStorage(ctx context.Context) error {
-	rid := dm.NewDMResourceID(w.cfg.Name, w.cfg.SourceID)
+	rid := dm.NewDMResourceID(w.cfg.Name, w.cfg.SourceID, w.IsS3StorageEnabled())
 	opts := []broker.OpenStorageOption{}
 	if w.workerType == frameModel.WorkerDMDump {
 		// always use an empty storage for dumpling task

--- a/engine/framework/base_jobmaster.go
+++ b/engine/framework/base_jobmaster.go
@@ -90,6 +90,9 @@ type BaseJobMaster interface {
 	// IsBaseJobMaster is an empty function used to prevent accidental implementation
 	// of this interface.
 	IsBaseJobMaster()
+
+	// IsS3StorageEnabled returns whether the s3 storage is enabled
+	IsS3StorageEnabled() bool
 }
 
 // BaseJobMasterExt extends BaseJobMaster with some extra methods.
@@ -353,6 +356,11 @@ func (d *DefaultBaseJobMaster) CurrentEpoch() frameModel.Epoch {
 
 // IsBaseJobMaster implements BaseJobMaster.IsBaseJobMaster
 func (d *DefaultBaseJobMaster) IsBaseJobMaster() {
+}
+
+// IsS3StorageEnabled implements BaseJobMaster.IsS3StorageEnabled
+func (d *DefaultBaseJobMaster) IsS3StorageEnabled() bool {
+	return d.worker.IsS3StorageEnabled()
 }
 
 // SendMessage delegates the SendMessage or inner worker

--- a/engine/framework/worker.go
+++ b/engine/framework/worker.go
@@ -126,6 +126,9 @@ type BaseWorker interface {
 		ctx context.Context, resourcePath resModel.ResourceID, opts ...broker.OpenStorageOption,
 	) (broker.Handle, error)
 
+	// IsS3StorageEnabled returns whether the s3 storage is enabled
+	IsS3StorageEnabled() bool
+
 	// Exit should be called when worker (in user logic) wants to exit.
 	// exitReason: ExitReasonFinished/ExitReasonCanceled/ExitReasonFailed
 	Exit(ctx context.Context, exitReason ExitReason, err error, extBytes []byte) error
@@ -513,6 +516,11 @@ func (w *DefaultBaseWorker) OpenStorage(
 	ctx, cancel := w.errCenter.WithCancelOnFirstError(ctx)
 	defer cancel()
 	return w.resourceBroker.OpenStorage(ctx, w.projectInfo, w.id, w.masterID, resourcePath, opts...)
+}
+
+// IsS3StorageEnabled implements BaseWorker.IsS3StorageEnabled
+func (w *DefaultBaseWorker) IsS3StorageEnabled() bool {
+	return w.resourceBroker.IsS3StorageEnabled()
 }
 
 // Exit implements BaseWorker.Exit

--- a/engine/jobmaster/dm/api_test.go
+++ b/engine/jobmaster/dm/api_test.go
@@ -119,7 +119,7 @@ func TestQueryStatusAPI(t *testing.T) {
 	)
 	messageAgent := &dmpkg.MockMessageAgent{}
 	jm.messageAgent = messageAgent
-	jm.workerManager = NewWorkerManager(mockBaseJobmaster.ID(), nil, jm.metadata.JobStore(), nil, nil, nil, jm.Logger())
+	jm.workerManager = NewWorkerManager(mockBaseJobmaster.ID(), nil, jm.metadata.JobStore(), nil, nil, nil, jm.Logger(), false)
 	jm.taskManager = NewTaskManager(nil, nil, nil, jm.Logger())
 	jm.workerManager.UpdateWorkerStatus(runtime.NewWorkerStatus("task2", frameModel.WorkerDMLoad, "worker2", runtime.WorkerFinished, 3))
 	jm.workerManager.UpdateWorkerStatus(runtime.NewWorkerStatus("task3", frameModel.WorkerDMDump, "worker3", runtime.WorkerOnline, 4))
@@ -332,7 +332,7 @@ func TestUpdateJobCfg(t *testing.T) {
 		}
 	)
 	jm.taskManager = NewTaskManager(nil, jobStore, messageAgent, jm.Logger())
-	jm.workerManager = NewWorkerManager(mockBaseJobmaster.ID(), nil, jobStore, jm, messageAgent, mockCheckpointAgent, jm.Logger())
+	jm.workerManager = NewWorkerManager(mockBaseJobmaster.ID(), nil, jobStore, jm, messageAgent, mockCheckpointAgent, jm.Logger(), false)
 	funcBackup := master.CheckAndAdjustSourceConfigFunc
 	master.CheckAndAdjustSourceConfigFunc = func(ctx context.Context, cfg *dmconfig.SourceConfig) error { return nil }
 	defer func() {

--- a/engine/jobmaster/dm/dm_jobmaster.go
+++ b/engine/jobmaster/dm/dm_jobmaster.go
@@ -113,7 +113,8 @@ func (jm *JobMaster) initComponents() error {
 	jm.messageAgent = dmpkg.NewMessageAgent(jm.ID(), jm, jm.messageHandlerManager, jm.Logger())
 	jm.checkpointAgent = checkpoint.NewCheckpointAgent(jm.ID(), jm.Logger())
 	jm.taskManager = NewTaskManager(taskStatus, jm.metadata.JobStore(), jm.messageAgent, jm.Logger())
-	jm.workerManager = NewWorkerManager(jm.ID(), workerStatus, jm.metadata.JobStore(), jm, jm.messageAgent, jm.checkpointAgent, jm.Logger())
+	jm.workerManager = NewWorkerManager(jm.ID(), workerStatus, jm.metadata.JobStore(),
+		jm, jm.messageAgent, jm.checkpointAgent, jm.Logger(), jm.IsS3StorageEnabled())
 	return err
 }
 

--- a/engine/jobmaster/dm/dm_jobmaster_test.go
+++ b/engine/jobmaster/dm/dm_jobmaster_test.go
@@ -108,6 +108,8 @@ func (t *testDMJobmasterSuite) TestRunDMJobMaster() {
 	require.NoError(t.T(), err)
 	mockServerMasterClient := client.NewMockServerMasterClient(gomock.NewController(t.T()))
 	mockExecutorGroup := client.NewMockExecutorGroup()
+	broker := broker.NewBrokerForTesting("test-executor-id")
+	defer broker.Close()
 	depsForTest := masterParamListForTest{
 		MessageHandlerManager: p2p.NewMockMessageHandlerManager(),
 		MessageSender:         p2p.NewMockMessageSender(),
@@ -115,7 +117,7 @@ func (t *testDMJobmasterSuite) TestRunDMJobMaster() {
 		BusinessClientConn:    kvmock.NewMockClientConn(),
 		ExecutorGroup:         mockExecutorGroup,
 		ServerMasterClient:    mockServerMasterClient,
-		ResourceBroker:        nil,
+		ResourceBroker:        broker,
 	}
 
 	RegisterWorker()
@@ -452,6 +454,10 @@ func (m *MockBaseJobmaster) Exit(ctx context.Context, exitReason framework.ExitR
 	defer m.mu.Unlock()
 	args := m.Called()
 	return args.Error(0)
+}
+
+func (m *MockBaseJobmaster) IsS3StorageEnabled() bool {
+	return false
 }
 
 type MockCheckpointAgent struct {

--- a/engine/jobmaster/dm/openapi_test.go
+++ b/engine/jobmaster/dm/openapi_test.go
@@ -69,7 +69,7 @@ func (t *testDMOpenAPISuite) SetupSuite() {
 		}
 	)
 	jm.taskManager = NewTaskManager(nil, jm.metadata.JobStore(), jm.messageAgent, jm.Logger())
-	jm.workerManager = NewWorkerManager(mockBaseJobmaster.ID(), nil, jm.metadata.JobStore(), nil, jm.messageAgent, nil, jm.Logger())
+	jm.workerManager = NewWorkerManager(mockBaseJobmaster.ID(), nil, jm.metadata.JobStore(), nil, jm.messageAgent, nil, jm.Logger(), false)
 
 	engine := gin.New()
 	apiGroup := engine.Group(baseURL)

--- a/engine/jobmaster/dm/utils.go
+++ b/engine/jobmaster/dm/utils.go
@@ -18,6 +18,10 @@ import (
 )
 
 // NewDMResourceID returns a ResourceID in DM's style. Currently only support s3 resource.
-func NewDMResourceID(taskName, sourceName string) resModel.ResourceID {
-	return "/" + string(resModel.ResourceTypeS3) + "/" + taskName + "-" + sourceName
+func NewDMResourceID(taskName, sourceName string, isS3Enabled bool) resModel.ResourceID {
+	resType := resModel.ResourceTypeLocalFile
+	if isS3Enabled {
+		resType = resModel.ResourceTypeS3
+	}
+	return "/" + string(resType) + "/" + taskName + "-" + sourceName
 }

--- a/engine/jobmaster/dm/worker_manager_test.go
+++ b/engine/jobmaster/dm/worker_manager_test.go
@@ -40,7 +40,7 @@ func (t *testDMJobmasterSuite) TestUpdateWorkerStatus() {
 	job := metadata.NewJob(jobCfg)
 	jobStore := metadata.NewJobStore(kvmock.NewMetaMock(), log.L())
 	require.NoError(t.T(), jobStore.Put(context.Background(), job))
-	workerManager := NewWorkerManager("job_id", nil, jobStore, nil, nil, nil, log.L())
+	workerManager := NewWorkerManager("job_id", nil, jobStore, nil, nil, nil, log.L(), false)
 
 	require.Len(t.T(), workerManager.WorkerStatus(), 0)
 
@@ -100,7 +100,7 @@ func (t *testDMJobmasterSuite) TestUpdateWorkerStatus() {
 	workerStatus1.Stage = runtime.WorkerOnline
 	workerStatus2.Stage = runtime.WorkerOnline
 	workerStatusList := []runtime.WorkerStatus{workerStatus1, workerStatus2}
-	workerManager = NewWorkerManager("job_id", workerStatusList, jobStore, nil, nil, nil, log.L())
+	workerManager = NewWorkerManager("job_id", workerStatusList, jobStore, nil, nil, nil, log.L(), false)
 	workerStatusMap = workerManager.WorkerStatus()
 	require.Len(t.T(), workerStatusMap, 2)
 	require.Contains(t.T(), workerStatusMap, source1)
@@ -138,7 +138,7 @@ func (t *testDMJobmasterSuite) TestClearWorkerStatus() {
 	workerStatus1 := runtime.InitWorkerStatus(source1, frameModel.WorkerDMDump, "worker-id-1")
 	workerStatus2 := runtime.InitWorkerStatus(source2, frameModel.WorkerDMDump, "worker-id-2")
 
-	workerManager := NewWorkerManager("job_id", []runtime.WorkerStatus{workerStatus1, workerStatus2}, nil, nil, messageAgent, nil, log.L())
+	workerManager := NewWorkerManager("job_id", []runtime.WorkerStatus{workerStatus1, workerStatus2}, nil, nil, messageAgent, nil, log.L(), false)
 	require.Len(t.T(), workerManager.WorkerStatus(), 2)
 
 	workerManager.removeOfflineWorkers()
@@ -222,7 +222,7 @@ func (t *testDMJobmasterSuite) TestClearWorkerStatus() {
 
 func (t *testDMJobmasterSuite) TestCreateWorker() {
 	mockAgent := &MockWorkerAgent{}
-	workerManager := NewWorkerManager("job_id", nil, nil, mockAgent, nil, nil, log.L())
+	workerManager := NewWorkerManager("job_id", nil, nil, mockAgent, nil, nil, log.L(), false)
 
 	jobCfg := &config.JobCfg{}
 	require.NoError(t.T(), jobCfg.DecodeFile(jobTemplatePath))
@@ -261,7 +261,7 @@ func (t *testDMJobmasterSuite) TestGetUnit() {
 	mockAgent := &MockCheckpointAgent{}
 	task := &metadata.Task{Cfg: &config.TaskCfg{}}
 	task.Cfg.TaskMode = dmconfig.ModeFull
-	workerManager := NewWorkerManager("job_id", nil, nil, nil, nil, mockAgent, log.L())
+	workerManager := NewWorkerManager("job_id", nil, nil, nil, nil, mockAgent, log.L(), false)
 
 	workerStatus := runtime.NewWorkerStatus("source", frameModel.WorkerDMDump, "worker-id-1", runtime.WorkerOnline, 0)
 	require.Equal(t.T(), getNextUnit(task, workerStatus), frameModel.WorkerDMDump)
@@ -340,7 +340,7 @@ func (t *testDMJobmasterSuite) TestCheckAndScheduleWorkers() {
 	job := metadata.NewJob(jobCfg)
 	checkpointAgent := &MockCheckpointAgent{}
 	workerAgent := &MockWorkerAgent{}
-	workerManager := NewWorkerManager("job_id", nil, nil, workerAgent, nil, checkpointAgent, log.L())
+	workerManager := NewWorkerManager("job_id", nil, nil, workerAgent, nil, checkpointAgent, log.L(), false)
 
 	// new tasks
 	worker1 := "worker1"
@@ -431,7 +431,7 @@ func (t *testDMJobmasterSuite) TestWorkerManager() {
 	checkpointAgent := &MockCheckpointAgent{}
 	workerAgent := &MockWorkerAgent{}
 	messageAgent := &dmpkg.MockMessageAgent{}
-	workerManager := NewWorkerManager("job_id", nil, jobStore, workerAgent, messageAgent, checkpointAgent, log.L())
+	workerManager := NewWorkerManager("job_id", nil, jobStore, workerAgent, messageAgent, checkpointAgent, log.L(), false)
 	source1 := jobCfg.Upstreams[0].SourceID
 	source2 := jobCfg.Upstreams[1].SourceID
 

--- a/engine/pkg/externalresource/broker/broker.go
+++ b/engine/pkg/externalresource/broker/broker.go
@@ -418,6 +418,11 @@ func (b *DefaultBroker) Close() {
 	}
 }
 
+func (b *DefaultBroker) IsS3StorageEnabled() bool {
+	_, ok := b.fileManagers[resModel.ResourceTypeS3]
+	return ok
+}
+
 // PreCheckConfig checks the configuration of external storage.
 func PreCheckConfig(config resModel.Config) error {
 	if config.LocalEnabled() {

--- a/engine/pkg/externalresource/broker/broker.go
+++ b/engine/pkg/externalresource/broker/broker.go
@@ -418,6 +418,7 @@ func (b *DefaultBroker) Close() {
 	}
 }
 
+// IsS3StorageEnabled returns true if s3 storage is enabled.
 func (b *DefaultBroker) IsS3StorageEnabled() bool {
 	_, ok := b.fileManagers[resModel.ResourceTypeS3]
 	return ok

--- a/engine/pkg/externalresource/broker/broker_test.go
+++ b/engine/pkg/externalresource/broker/broker_test.go
@@ -143,8 +143,10 @@ func TestBrokerOpenExistingStorageWithOption(t *testing.T) {
 	fakeProjectInfo := tenant.NewProjectInfo("fakeTenant", "fakeProject")
 	brk, cli, _ := newBroker(t)
 	defer brk.Close()
+	require.False(t, brk.IsS3StorageEnabled())
 	mockS3FileManager, _ := s3.NewFileManagerForUT(t.TempDir(), brk.executorID)
 	brk.fileManagers[resModel.ResourceTypeS3] = mockS3FileManager
+	require.True(t, brk.IsS3StorageEnabled())
 
 	openStorageWithClean := func(resID resModel.ResourceID) {
 		// resource metadata exists

--- a/engine/pkg/externalresource/broker/interfaces.go
+++ b/engine/pkg/externalresource/broker/interfaces.go
@@ -45,6 +45,8 @@ type Broker interface {
 		jobID resModel.JobID,
 	)
 
+	IsS3StorageEnabled() bool
+
 	Close()
 }
 

--- a/engine/test/integration_tests/dm_many_tables_local/conf/diff_config.toml
+++ b/engine/test/integration_tests/dm_many_tables_local/conf/diff_config.toml
@@ -1,0 +1,29 @@
+# diff Configuration.
+
+check-thread-count = 4
+
+export-fix-sql = true
+
+check-struct-only = false
+
+[task]
+    output-dir = "/tmp/tiflow_engine_test/dm_many_tables/output"
+
+    source-instances = ["mysql1"]
+
+    target-instance = "tidb0"
+
+    target-check-tables = ["dm_many_tables.?*"]
+
+[data-sources]
+[data-sources.mysql1]
+host = "127.0.0.1"
+port = 3306
+user = "root"
+password = ""
+
+[data-sources.tidb0]
+host = "127.0.0.1"
+port = 4000
+user = "root"
+password = ""

--- a/engine/test/integration_tests/dm_many_tables_local/conf/job.yaml
+++ b/engine/test/integration_tests/dm_many_tables_local/conf/job.yaml
@@ -1,0 +1,19 @@
+task-mode: full
+target-database:
+  host: host.docker.internal
+  port: 4000
+  user: root
+  password: ''
+upstreams:
+  - db-config:
+      host: host.docker.internal
+      port: 3306
+      user: root
+      password: ''
+    source-id: mysql-01
+    block-allow-list: balist-01
+    loader-thread: 1
+block-allow-list:
+  balist-01:
+    do-dbs:
+      - dm_many_tables

--- a/engine/test/integration_tests/dm_many_tables_local/run.sh
+++ b/engine/test/integration_tests/dm_many_tables_local/run.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -eu
+
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+CONFIG="$DOCKER_COMPOSE_DIR/3m3e.yaml $DOCKER_COMPOSE_DIR/dm_databases.yaml"
+CONFIG=$(adjust_config $OUT_DIR $TEST_NAME $CONFIG)
+echo "using adjusted configs to deploy cluster: $CONFIG"
+TABLE_NUM=500
+
+function run() {
+	start_engine_cluster $CONFIG
+	wait_mysql_online.sh --port 3306
+	wait_mysql_online.sh --port 4000
+
+	# prepare data
+	run_sql 'DROP DATABASE IF EXISTS dm_many_tables'
+	run_sql 'CREATE DATABASE dm_many_tables;'
+	for i in $(seq $TABLE_NUM); do
+		run_sql --quiet "CREATE TABLE dm_many_tables.t$i(i TINYINT, j INT UNIQUE KEY);"
+		for j in $(seq 2); do
+			run_sql --quiet "INSERT INTO dm_many_tables.t$i VALUES ($j,${j}000$j),($j,${j}001$j);"
+		done
+		# to make the tables have odd number of lines before 'ALTER TABLE' command, for check_sync_diff to work correctly
+		run_sql --quiet "INSERT INTO dm_many_tables.t$i VALUES (9, 90009);"
+	done
+
+	# create job & wait for job finished
+	job_id=$(create_job "DM" "$CUR_DIR/conf/job.yaml" "dm_many_tables")
+	# check progress is forwarded gradually, not jump to "finished"
+	exec_with_retry --count 500 "curl \"http://127.0.0.1:10245/api/v1/jobs/$job_id/status\" | tee /dev/stderr | jq -e '.task_status.\"mysql-01\".status.status | .finishedBytes > 0 and .finishedBytes < .totalBytes'"
+	exec_with_retry --count 100 "curl \"http://127.0.0.1:10245/api/v1/jobs/$job_id\" | tee /dev/stderr | jq -e '.state == \"Finished\"'"
+
+	# check data
+	check_sync_diff $WORK_DIR $CUR_DIR/conf/diff_config.toml 1
+}
+
+trap "stop_engine_cluster $WORK_DIR $CONFIG" EXIT
+run $*
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #7114

### What is changed and how it works?
1. Add IsS3StorageEnabled to BaseWorker and BaseMaster.
2. Generate resource id by storage config.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
