### PR TITLE
test(chaos): fix duplicate entry due to concurrency delete and insert.

### DIFF
--- a/deployments/engine/helm/minio/minio.yaml
+++ b/deployments/engine/helm/minio/minio.yaml
@@ -67,7 +67,6 @@ spec:
     spec:
       accessModes:
         - ReadWriteOnce
-      storageClassName: standard
       resources:
         requests:
           storage: 10Gi


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7426 

### What is changed and how it works?
we generate insert and delete for different sources.
```
source1 delete key 1
source2 insert key 1
```
If the latency of source1 is greater than source2, than the worker of source2 will report duplicate key 1 error.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - chaos

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
