### PR TITLE
engine(pkg/client): remove infinite retry in RegisterExecutor

### DIFF
--- a/engine/pkg/client/discovery_client.go
+++ b/engine/pkg/client/discovery_client.go
@@ -20,7 +20,6 @@ import (
 	pb "github.com/pingcap/tiflow/engine/enginepb"
 	"github.com/pingcap/tiflow/engine/model"
 	"github.com/pingcap/tiflow/engine/pkg/client/internal"
-	"github.com/pingcap/tiflow/pkg/retry"
 )
 
 // DiscoveryClient is a client to the Discovery service on the server master.
@@ -80,24 +79,18 @@ func (c *discoveryClient) RegisterExecutor(
 	request *pb.RegisterExecutorRequest,
 ) (model.ExecutorID, error) {
 	var ret model.ExecutorID
-	err := retry.Do(ctx, func() error {
-		call := internal.NewCall(
-			c.cli.RegisterExecutor,
-			request,
-			// RegisterExecutor is not idempotent in general
-			// TODO review idempotency
-			// internal.WithForceNoRetry()
-		)
-		executor, err := call.Do(ctx)
-		if err != nil {
-			return err
-		}
-		ret = model.ExecutorID(executor.Id)
-		return nil
-	})
+	call := internal.NewCall(
+		c.cli.RegisterExecutor,
+		request,
+		// RegisterExecutor is not idempotent in general
+		// TODO review idempotency
+		// internal.WithForceNoRetry()
+	)
+	executor, err := call.Do(ctx)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
+	ret = model.ExecutorID(executor.Id)
 	return ret, nil
 }
 

--- a/engine/pkg/client/internal/call.go
+++ b/engine/pkg/client/internal/call.go
@@ -17,10 +17,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/engine/pkg/rpcerror"
 	"github.com/pingcap/tiflow/pkg/retry"
-	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )
@@ -94,7 +92,6 @@ func (c *Call[ReqT, RespT, F]) callOnce(ctx context.Context) (RespT, error) {
 }
 
 func (c *Call[ReqT, RespT, F]) isRetryable(errIn error) bool {
-	log.Error("call rpc returns error", zap.Any("request", c.request), zap.Error(errIn))
 	if rpcerror.IsManagedError(errIn) {
 		return rpcerror.IsRetryable(errIn)
 	}

--- a/engine/pkg/client/internal/call.go
+++ b/engine/pkg/client/internal/call.go
@@ -17,8 +17,10 @@ import (
 	"context"
 	"time"
 
+	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/engine/pkg/rpcerror"
 	"github.com/pingcap/tiflow/pkg/retry"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )
@@ -92,6 +94,7 @@ func (c *Call[ReqT, RespT, F]) callOnce(ctx context.Context) (RespT, error) {
 }
 
 func (c *Call[ReqT, RespT, F]) isRetryable(errIn error) bool {
+	log.Error("call rpc returns error", zap.Any("request", c.request), zap.Error(errIn))
 	if rpcerror.IsManagedError(errIn) {
 		return rpcerror.IsRetryable(errIn)
 	}

--- a/engine/pkg/externalresource/internal/s3/file_manager.go
+++ b/engine/pkg/externalresource/internal/s3/file_manager.go
@@ -310,7 +310,7 @@ func createPlaceholderFile(ctx context.Context, storage brStorage.ExternalStorag
 // PreCheckConfig does a preflight check on the executor's storage configurations.
 func PreCheckConfig(config resModel.S3Config) error {
 	// TODO: use customized retry policy.
-	log.Debug("pre-checking broker config", zap.Any("config", config))
+	log.Debug("pre-checking s3Storage config", zap.Any("config", config))
 	factory := NewExternalStorageFactory(config.Bucket,
 		config.Prefix, &config.S3BackendOptions)
 	_, err := factory.newS3ExternalStorageForScope(context.Background(), internal.ResourceScope{})

--- a/engine/pkg/externalresource/model/config.go
+++ b/engine/pkg/externalresource/model/config.go
@@ -46,15 +46,7 @@ func (c *Config) LocalEnabled() bool {
 
 // S3Enabled returns true if the S3 storage is enabled
 func (c *Config) S3Enabled() bool {
-	if c.S3.Bucket == "" {
-		return false
-	}
-	if c.S3.Endpoint == "" {
-		// If endpoint is empty, s3 will be accessed through environment variables
-		return true
-	}
-	// If endpoint is not empty, s3 will be accessed through AccessKey and SecretAccessKey
-	return c.S3.AccessKey != "" && c.S3.SecretAccessKey != ""
+	return c.S3.Bucket != ""
 }
 
 // ValidateAndAdjust validates and adjusts the configuration

--- a/engine/pkg/externalresource/model/config.go
+++ b/engine/pkg/externalresource/model/config.go
@@ -49,8 +49,11 @@ func (c *Config) S3Enabled() bool {
 	if c.S3.Bucket == "" {
 		return false
 	}
-	return c.S3.RoleARN != "" || (c.S3.Endpoint != "" &&
-		c.S3.AccessKey != "" && c.S3.SecretAccessKey != "")
+	if c.S3.Endpoint == "" {
+		// s3 will be accessed through environment variables
+		return true
+	}
+	return c.S3.AccessKey != "" && c.S3.SecretAccessKey != ""
 }
 
 // ValidateAndAdjust validates and adjusts the configuration

--- a/engine/pkg/externalresource/model/config.go
+++ b/engine/pkg/externalresource/model/config.go
@@ -50,9 +50,10 @@ func (c *Config) S3Enabled() bool {
 		return false
 	}
 	if c.S3.Endpoint == "" {
-		// s3 will be accessed through environment variables
+		// If endpoint is empty, s3 will be accessed through environment variables
 		return true
 	}
+	// If endpoint is not empty, s3 will be accessed through AccessKey and SecretAccessKey
 	return c.S3.AccessKey != "" && c.S3.SecretAccessKey != ""
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7442

### What is changed and how it works?
1. Remove infinite retry in RegisterExecutor.
2. Remove unused c.S3.RoleARN check in external storage.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 ```shell
# ./bin/tiflow executor                                                                                               root@tiflow
2022/10/25 17:53:15.546 +08:00] [INFO] [version.go:47] ["Welcome to TiFlow Executor"] [release-version=v6.3.0-master] [git-hash=38662c76239b6e0237ad9f389a0ca128d24c5bc4] [git-branch=fix_executor_stuck] [utc-build-time="2022-10-25 09:52:51"] [go-version="go version go1.19.2 linux/amd64"] [failpoint-build=false]
[2022/10/25 17:53:15.546 +08:00] [INFO] [server.go:98] ["creating executor"] [config="{\"name\":\"executor-127.0.0.1:10340\",\"log\":{\"level\":\"info\",\"file\":\"\",\"max-size\":0,\"max-days\":0,\"max-backups\":0,\"error-output\":\"\"},\"join\":\"127.0.0.1:10240\",\"addr\":\"127.0.0.1:10340\",\"advertise-addr\":\"127.0.0.1:10340\",\"labels\":null,\"keepalive-ttl\":\"20s\",\"keepalive-interval\":\"500ms\",\"rpc-timeout\":\"3s\",\"security\":null}"]
[2022/10/25 17:53:15.547 +08:00] [INFO] [registry.go:68] ["register worker"] [worker-type=CVSTask]
[2022/10/25 17:53:15.547 +08:00] [INFO] [registry.go:68] ["register worker"] [worker-type=CVSJobMaster]
[2022/10/25 17:53:15.547 +08:00] [INFO] [registry.go:68] ["register worker"] [worker-type=DMJobMaster]
[2022/10/25 17:53:15.547 +08:00] [INFO] [registry.go:68] ["register worker"] [worker-type=DMDumpTask]
[2022/10/25 17:53:15.547 +08:00] [INFO] [registry.go:68] ["register worker"] [worker-type=DMLoadTask]
[2022/10/25 17:53:15.547 +08:00] [INFO] [registry.go:68] ["register worker"] [worker-type=DMSyncTask]
[2022/10/25 17:53:15.547 +08:00] [INFO] [registry.go:68] ["register worker"] [worker-type=FakeJobMaster]
[2022/10/25 17:53:15.547 +08:00] [INFO] [registry.go:68] ["register worker"] [worker-type=FakeTask]
[2022/10/25 17:53:15.548 +08:00] [INFO] [server.go:595] ["master client init successful"] [server-addrs=127.0.0.1:10240]
[2022/10/25 17:53:15.549 +08:00] [ERROR] [call.go:97] ["call rpc returns error"] [request="executor:{name:\"executor-127.0.0.1:10340\" address:\"127.0.0.1:10340\" capability:100}"] [error="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 127.0.0.1:10240: connect: connection refused\""] [errorVerbose="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 127.0.0.1:10240: connect: connection refused\"\ngithub.com/pingcap/errors.AddStack\n\tgithub.com/pingcap/errors@v0.11.5-0.20220729040631-518f63d66278/errors.go:174\ngithub.com/pingcap/errors.Trace\n\tgithub.com/pingcap/errors@v0.11.5-0.20220729040631-518f63d66278/juju_adaptor.go:15\ngithub.com/pingcap/tiflow/engine/pkg/rpcerror.FromGRPCError\n\tgithub.com/pingcap/tiflow/engine/pkg/rpcerror/grpc.go:71\ngithub.com/pingcap/tiflow/engine/pkg/client/internal.(*Call[...]).callOnce\n\tgithub.com/pingcap/tiflow/engine/pkg/client/internal/call.go:90\ngithub.com/pingcap/tiflow/engine/pkg/client/internal.(*Call[...]).Do.func1\n\tgithub.com/pingcap/tiflow/engine/pkg/client/internal/call.go:76\ngithub.com/pingcap/tiflow/pkg/retry.run\n\tgithub.com/pingcap/tiflow/pkg/retry/retry_with_opt.go:57\ngithub.com/pingcap/tiflow/pkg/retry.Do\n\tgithub.com/pingcap/tiflow/pkg/retry/retry_with_opt.go:34\ngithub.com/pingcap/tiflow/engine/pkg/client/internal.(*Call[...]).Do\n\tgithub.com/pingcap/tiflow/engine/pkg/client/internal/call.go:74\ngithub.com/pingcap/tiflow/engine/pkg/client.(*discoveryClient).RegisterExecutor\n\tgithub.com/pingcap/tiflow/engine/pkg/client/discovery_client.go:89\ngithub.com/pingcap/tiflow/engine/executor.(*Server).selfRegister\n\tgithub.com/pingcap/tiflow/engine/executor/server.go:611\ngithub.com/pingcap/tiflow/engine/executor.(*Server).Run\n\tgithub.com/pingcap/tiflow/engine/executor/server.go:414\ngithub.com/pingcap/tiflow/engine/pkg/cmd/executor.(*options).run\n\tgithub.com/pingcap/tiflow/engine/pkg/cmd/executor/executor.go:81\ngithub.com/pingcap/tiflow/engine/pkg/cmd/executor.NewCmdExecutor.func1\n\tgithub.com/pingcap/tiflow/engine/pkg/cmd/executor/executor.go:147\ngithub.com/spf13/cobra.(*Command).execute\n\tgithub.com/spf13/cobra@v1.5.0/command.go:872\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\tgithub.com/spf13/cobra@v1.5.0/command.go:990\ngithub.com/spf13/cobra.(*Command).Execute\n\tgithub.com/spf13/cobra@v1.5.0/command.go:918\ngithub.com/pingcap/tiflow/engine/pkg/cmd.Run\n\tgithub.com/pingcap/tiflow/engine/pkg/cmd/cmd.go:50\nmain.main\n\t./main.go:21\nruntime.main\n\truntime/proc.go:250\nruntime.goexit\n\truntime/asm_amd64.s:1594"]
......
[2022/10/25 17:53:26.320 +08:00] [ERROR] [executor.go:83] ["run dataflow executor with error"] [error="[CDC:ErrReachMaxTry]reach maximum try: 10s, error: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp 127.0.0.1:10240: connect: connection refused\":...
```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`None`.
```
