### PR TITLE
syncer(dm): remove placement rule table option for tracker

### DIFF
--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -799,6 +799,14 @@ func (s *Syncer) trackTableInfoFromDownstream(tctx *tcontext.Context, sourceTabl
 			}
 		}
 	}
+	for i, opt := range createStmt.Options {
+		if opt.Tp == ast.TableOptionPlacementPolicy {
+			// createStmt.Options is unordered
+			createStmt.Options[i] = createStmt.Options[len(createStmt.Options)-1]
+			createStmt.Options = createStmt.Options[:len(createStmt.Options)-1]
+			break
+		}
+	}
 
 	var newCreateSQLBuilder strings.Builder
 	restoreCtx := format.NewRestoreCtx(format.DefaultRestoreFlags, &newCreateSQLBuilder)


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7493

### What is changed and how it works?

as title

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix sometime DM task is stopped with error "Unknown placement policy"
```
