### PR TITLE
notifier(engine): fix Flush deadloop in closed notifier

### DIFF
--- a/engine/pkg/notifier/notifier.go
+++ b/engine/pkg/notifier/notifier.go
@@ -137,6 +137,8 @@ func (n *Notifier[T]) Flush(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return errors.Trace(ctx.Err())
+		case <-n.closeCh:
+			return nil
 		case <-n.synchronizeCh:
 			// Checks the queue size after each iteration
 			// of run().

--- a/engine/pkg/notifier/notifier_test.go
+++ b/engine/pkg/notifier/notifier_test.go
@@ -120,3 +120,13 @@ func TestReceiverClose(t *testing.T) {
 	}
 	n.Close()
 }
+
+func TestFlushWithClosedNotifier(t *testing.T) {
+	t.Parallel()
+
+	n := NewNotifier[int]()
+	n.Notify(1)
+	n.Close()
+	err := n.Flush(context.Background())
+	require.Nil(t, err)
+}

--- a/engine/servermaster/executor_manager.go
+++ b/engine/servermaster/executor_manager.go
@@ -43,7 +43,6 @@ type ExecutorManager interface {
 	ListExecutors() []*ormModel.Executor
 	GetAddr(executorID model.ExecutorID) (string, bool)
 	Run(ctx context.Context) error
-	Stop()
 
 	// WatchExecutors returns a snapshot of all online executors plus
 	// a stream of events describing changes that happen to the executors
@@ -291,7 +290,7 @@ func (e *ExecutorManagerImpl) Run(ctx context.Context) error {
 	ticker := time.NewTicker(e.keepAliveInterval)
 	defer func() {
 		ticker.Stop()
-		e.Stop()
+		e.notifier.Close()
 		log.Info("executor manager exited")
 	}()
 	for {
@@ -305,11 +304,6 @@ func (e *ExecutorManagerImpl) Run(ctx context.Context) error {
 			}
 		}
 	}
-}
-
-// Stop implements ExecutorManager.Stop
-func (e *ExecutorManagerImpl) Stop() {
-	e.notifier.Close()
 }
 
 func (e *ExecutorManagerImpl) checkAliveImpl() error {

--- a/engine/servermaster/executor_manager_test.go
+++ b/engine/servermaster/executor_manager_test.go
@@ -99,7 +99,6 @@ func TestExecutorManager(t *testing.T) {
 	require.True(t, ErrUnknownExecutor.Is(err))
 
 	cancel()
-	mgr.Stop()
 	wg.Wait()
 }
 
@@ -261,6 +260,5 @@ func TestExecutorManagerWatch(t *testing.T) {
 	}, event)
 
 	cancel()
-	mgr.Stop()
 	mgrWg.Wait()
 }

--- a/engine/servermaster/server.go
+++ b/engine/servermaster/server.go
@@ -436,6 +436,9 @@ func (s *Server) Run(ctx context.Context) error {
 		return errors.Trace(err)
 	}
 
+	// resourceManagerService relies on meta store
+	s.initResourceManagerService()
+
 	if err := broker.PreCheckConfig(s.cfg.Storage); err != nil {
 		return err
 	}
@@ -807,7 +810,6 @@ func (s *Server) runLeaderService(ctx context.Context) (err error) {
 	s.executorManager = NewExecutorManagerImpl(s.frameMetaClient, s.cfg.KeepAliveTTL, s.cfg.KeepAliveInterval)
 
 	// ResourceManagerService should be initialized after registerMetaStore.
-	s.initResourceManagerService()
 	s.scheduler = scheduler.NewScheduler(
 		s.executorManager,
 		s.resourceManagerService)

--- a/engine/servermaster/server.go
+++ b/engine/servermaster/server.go
@@ -847,11 +847,7 @@ func (s *Server) runLeaderService(ctx context.Context) (err error) {
 	})
 
 	errg.Go(func() error {
-		defer func() {
-			s.executorManager.Stop()
-			log.Info("executor manager exited")
-		}()
-		return s.executorManager.Start(errgCtx)
+		return s.executorManager.Run(errgCtx)
 	})
 
 	errg.Go(func() error {

--- a/engine/servermaster/server.go
+++ b/engine/servermaster/server.go
@@ -424,30 +424,6 @@ func (s *Server) ReportExecutorWorkload(
 	return &pb.ExecWorkloadResponse{}, nil
 }
 
-// Stop and clean resources.
-// TODO: implement stop gracefully.
-func (s *Server) Stop() {
-	if s.mockGrpcServer != nil {
-		s.mockGrpcServer.Stop()
-	}
-	// in some tests this fields is not initialized
-	if s.masterCli != nil {
-		s.masterCli.Close()
-	}
-	if s.frameMetaClient != nil {
-		s.frameMetaClient.Close()
-	}
-	if s.frameworkClientConn != nil {
-		s.frameworkClientConn.Close()
-	}
-	if s.businessClientConn != nil {
-		s.businessClientConn.Close()
-	}
-	if s.executorManager != nil {
-		s.executorManager.Stop()
-	}
-}
-
 // Run the server master.
 func (s *Server) Run(ctx context.Context) error {
 	err := s.registerMetaStore(ctx)

--- a/engine/servermaster/server_test.go
+++ b/engine/servermaster/server_test.go
@@ -176,9 +176,6 @@ type mockExecutorManager struct {
 	count      map[model.ExecutorStatus]int
 }
 
-func (m *mockExecutorManager) Stop() {
-}
-
 func (m *mockExecutorManager) ExecutorCount(status model.ExecutorStatus) int {
 	m.executorMu.RLock()
 	defer m.executorMu.RUnlock()
@@ -232,7 +229,6 @@ func TestCollectMetric(t *testing.T) {
 
 	cancel()
 	wg.Wait()
-	s.Stop()
 }
 
 func testCustomedPrometheusMetrics(t *testing.T, addr string) {
@@ -322,5 +318,4 @@ func TestHTTPErrorHandler(t *testing.T) {
 
 	cancel()
 	wg.Wait()
-	s.Stop()
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7506

### What is changed and how it works?

- Flush should return immediately if notifier has been closed.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
