### PR TITLE
checker(dm): add precheck on upstream/downstream table structure

### DIFF
--- a/dm/pkg/checker/table_structure_test.go
+++ b/dm/pkg/checker/table_structure_test.go
@@ -19,9 +19,12 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-sql-driver/mysql"
 	"github.com/pingcap/tidb/util/filter"
 	"github.com/stretchr/testify/require"
 )
+
+var errNoSuchTable = &mysql.MySQLError{Number: 1146, Message: "Table 'xxx' doesn't exist"}
 
 func TestShardingTablesChecker(t *testing.T) {
 	db, mock, err := sqlmock.New()
@@ -137,69 +140,90 @@ func TestShardingTablesChecker(t *testing.T) {
 func TestTablesChecker(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
+	downDB, downMock, err := sqlmock.New()
+	require.NoError(t, err)
 	ctx := context.Background()
 
+	commonMock := func() {
+		maxConnectionsRow := sqlmock.NewRows([]string{"Variable_name", "Value"}).
+			AddRow("max_connections", "2")
+		mock.ExpectQuery("SHOW VARIABLES LIKE 'max_connections'").WillReturnRows(maxConnectionsRow)
+		sqlModeRow := sqlmock.NewRows([]string{"Variable_name", "Value"}).
+			AddRow("sql_mode", "ANSI_QUOTES")
+		mock.ExpectQuery("SHOW VARIABLES LIKE 'sql_mode'").WillReturnRows(sqlModeRow)
+		sqlModeRow2 := sqlmock.NewRows([]string{"Variable_name", "Value"}).
+			AddRow("sql_mode", "ANSI_QUOTES")
+		downMock.ExpectQuery("SHOW VARIABLES LIKE 'sql_mode'").WillReturnRows(sqlModeRow2)
+	}
+
 	// 1. test a success check
-	maxConnectionsRow := sqlmock.NewRows([]string{"Variable_name", "Value"}).
-		AddRow("max_connections", "2")
-	mock.ExpectQuery("SHOW VARIABLES LIKE 'max_connections'").WillReturnRows(maxConnectionsRow)
-	sqlModeRow := sqlmock.NewRows([]string{"Variable_name", "Value"}).
-		AddRow("sql_mode", "ANSI_QUOTES")
-	mock.ExpectQuery("SHOW VARIABLES LIKE 'sql_mode'").WillReturnRows(sqlModeRow)
+
+	commonMock()
 	createTableRow := sqlmock.NewRows([]string{"Table", "Create Table"}).
 		AddRow("test-table-1", `CREATE TABLE "test-table-1" (
 		  "c" int(11) NOT NULL,
 		  PRIMARY KEY ("c")
 		) ENGINE=InnoDB DEFAULT CHARSET=latin1`)
 	mock.ExpectQuery("SHOW CREATE TABLE `test-db`.`test-table-1`").WillReturnRows(createTableRow)
+	downMock.ExpectQuery("SHOW CREATE TABLE `test-db`.`test-table-1`").WillReturnError(errNoSuchTable)
 
 	checker := NewTablesChecker(
 		map[string]*sql.DB{"test-source": db},
-		map[string][]filter.Table{"test-source": {
-			{Schema: "test-db", Name: "test-table-1"},
-		}},
+		downDB,
+		map[string]map[filter.Table][]filter.Table{
+			"test-source": {
+				{Schema: "test-db", Name: "test-table-1"}: {
+					{Schema: "test-db", Name: "test-table-1"},
+				},
+			},
+		},
 		1)
 	result := checker.Check(ctx)
 	require.Equal(t, StateSuccess, result.State)
 	require.NoError(t, mock.ExpectationsWereMet())
+	require.NoError(t, downMock.ExpectationsWereMet())
 
 	// 2. check many errors
-	maxConnectionsRow = sqlmock.NewRows([]string{"Variable_name", "Value"}).
-		AddRow("max_connections", "2")
-	mock.ExpectQuery("SHOW VARIABLES LIKE 'max_connections'").WillReturnRows(maxConnectionsRow)
-	sqlModeRow = sqlmock.NewRows([]string{"Variable_name", "Value"}).
-		AddRow("sql_mode", "ANSI_QUOTES")
-	mock.ExpectQuery("SHOW VARIABLES LIKE 'sql_mode'").WillReturnRows(sqlModeRow)
+
+	commonMock()
 	createTableRow = sqlmock.NewRows([]string{"Table", "Create Table"}).
 		AddRow("test-table-1", `CREATE TABLE "test-table-1" (
   "c" int(11) NOT NULL,
   CONSTRAINT "fk" FOREIGN KEY ("c") REFERENCES "t" ("c")
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1`)
 	mock.ExpectQuery("SHOW CREATE TABLE `test-db`.`test-table-1`").WillReturnRows(createTableRow)
+	createTableRow2 := sqlmock.NewRows([]string{"Table", "Create Table"}).
+		AddRow("test-table-1", `CREATE TABLE "test-table-1" (
+  "c" int(11) NOT NULL,
+  CONSTRAINT "fk" FOREIGN KEY ("c") REFERENCES "t" ("c")
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+	downMock.ExpectQuery("SHOW CREATE TABLE `test-db`.`test-table-1`").WillReturnRows(createTableRow2)
 
 	checker = NewTablesChecker(
 		map[string]*sql.DB{"test-source": db},
-		map[string][]filter.Table{"test-source": {
-			{Schema: "test-db", Name: "test-table-1"},
-		}},
+		downDB,
+		map[string]map[filter.Table][]filter.Table{
+			"test-source": {
+				{Schema: "test-db", Name: "test-table-1"}: {
+					{Schema: "test-db", Name: "test-table-1"},
+				},
+			},
+		},
 		1)
 	result = checker.Check(ctx)
 	require.Equal(t, StateWarning, result.State)
 	require.Len(t, result.Errors, 2)
 	require.NoError(t, mock.ExpectationsWereMet())
+	require.NoError(t, downMock.ExpectationsWereMet())
 
-	// test #5759
-	maxConnectionsRow = sqlmock.NewRows([]string{"Variable_name", "Value"}).
-		AddRow("max_connections", "2")
-	mock.ExpectQuery("SHOW VARIABLES LIKE 'max_connections'").WillReturnRows(maxConnectionsRow)
-	sqlModeRow = sqlmock.NewRows([]string{"Variable_name", "Value"}).
-		AddRow("sql_mode", "ANSI_QUOTES")
-	mock.ExpectQuery("SHOW VARIABLES LIKE 'sql_mode'").WillReturnRows(sqlModeRow)
+	// 3. test #5759
+
+	commonMock()
 	createTableRow1 := sqlmock.NewRows([]string{"Table", "Create Table"}).
 		AddRow("test-table-1", `CREATE TABLE "test-table-1" (
   "c" int(11) NOT NULL
 ) ENGINE=InnoDB`)
-	createTableRow2 := sqlmock.NewRows([]string{"Table", "Create Table"}).
+	createTableRow2 = sqlmock.NewRows([]string{"Table", "Create Table"}).
 		AddRow("test-table-2", `CREATE TABLE "test-table-2" (
   "c" int(11) NOT NULL
 ) ENGINE=InnoDB`)
@@ -208,20 +232,62 @@ func TestTablesChecker(t *testing.T) {
   "c" int(11) NOT NULL
 ) ENGINE=InnoDB`)
 	mock.ExpectQuery("SHOW CREATE TABLE `test-db`.`test-table-1`").WillReturnRows(createTableRow1)
+	downMock.ExpectQuery("SHOW CREATE TABLE `test-db`.`test-table`").WillReturnError(errNoSuchTable)
 	mock.ExpectQuery("SHOW CREATE TABLE `test-db`.`test-table-2`").WillReturnRows(createTableRow2)
 	mock.ExpectQuery("SHOW CREATE TABLE `test-db`.`test-table-3`").WillReturnRows(createTableRow3)
 
 	checker = NewTablesChecker(
 		map[string]*sql.DB{"test-source": db},
-		map[string][]filter.Table{"test-source": {
-			{Schema: "test-db", Name: "test-table-1"},
-			{Schema: "test-db", Name: "test-table-2"},
-			{Schema: "test-db", Name: "test-table-3"},
-		}},
+		downDB,
+		map[string]map[filter.Table][]filter.Table{
+			"test-source": {
+				{Schema: "test-db", Name: "test-table"}: {
+					{Schema: "test-db", Name: "test-table-1"},
+					{Schema: "test-db", Name: "test-table-2"},
+					{Schema: "test-db", Name: "test-table-3"},
+				},
+			},
+		},
 		1)
 	result = checker.Check(ctx)
 	require.Equal(t, StateWarning, result.State)
 	require.Len(t, result.Errors, 3)
+	require.NoError(t, mock.ExpectationsWereMet())
+	require.NoError(t, downMock.ExpectationsWereMet())
+
+	// 4. check warning from mismatching of upstream/downstream
+	// TODO: check all warnings here!
+	commonMock()
+	createTableRow = sqlmock.NewRows([]string{"Table", "Create Table"}).
+		AddRow("test-table-1", `CREATE TABLE "test-table-1" (
+		  "c" int(11) NOT NULL,
+		  PRIMARY KEY ("c")
+		) ENGINE=InnoDB DEFAULT CHARSET=latin1`)
+	mock.ExpectQuery("SHOW CREATE TABLE `test-db`.`test-table-1`").WillReturnRows(createTableRow)
+	createTableRow2 = sqlmock.NewRows([]string{"Table", "Create Table"}).
+		AddRow("test-table", `CREATE TABLE "test-table" (
+  		  "c" int(11) NOT NULL,
+		  PRIMARY KEY ("c")
+		) ENGINE=InnoDB DEFAULT CHARSET=gbk`)
+	downMock.ExpectQuery("SHOW CREATE TABLE `test-db`.`test-table`").WillReturnRows(createTableRow2)
+
+	checker = NewTablesChecker(
+		map[string]*sql.DB{"test-source": db},
+		downDB,
+		map[string]map[filter.Table][]filter.Table{
+			"test-source": {
+				{Schema: "test-db", Name: "test-table"}: {
+					{Schema: "test-db", Name: "test-table-1"},
+				},
+			},
+		},
+		1)
+	result = checker.Check(ctx)
+	require.Equal(t, StateWarning, result.State)
+	require.Len(t, result.Errors, 1)
+	require.Equal(t, "table `test-db`.`test-table-1` charset is not same, upstream: (test-table-1 latin1), downstream: (test-table gbk)", result.Errors[0].ShortErr)
+	require.NoError(t, mock.ExpectationsWereMet())
+	require.NoError(t, downMock.ExpectationsWereMet())
 }
 
 func TestOptimisticShardingTablesChecker(t *testing.T) {
@@ -342,6 +408,8 @@ func TestOptimisticShardingTablesChecker(t *testing.T) {
 func TestUnknownCharsetCollation(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
+	downDB, downMock, err := sqlmock.New()
+	require.NoError(t, err)
 	ctx := context.Background()
 
 	// 1. test TablesChecker
@@ -358,18 +426,27 @@ func TestUnknownCharsetCollation(t *testing.T) {
 		  PRIMARY KEY ("c")
 		) ENGINE=InnoDB DEFAULT CHARSET=utf32`)
 	mock.ExpectQuery("SHOW CREATE TABLE `test-db`.`test-table-1`").WillReturnRows(createTableRow)
+	sqlModeRow2 := sqlmock.NewRows([]string{"Variable_name", "Value"}).
+		AddRow("sql_mode", "ANSI_QUOTES")
+	downMock.ExpectQuery("SHOW VARIABLES LIKE 'sql_mode'").WillReturnRows(sqlModeRow2)
 
 	checker := NewTablesChecker(
 		map[string]*sql.DB{"test-source": db},
-		map[string][]filter.Table{"test-source": {
-			{Schema: "test-db", Name: "test-table-1"},
-		}},
+		downDB,
+		map[string]map[filter.Table][]filter.Table{
+			"test-source": {
+				{Schema: "test-db", Name: "test-table-1"}: {
+					{Schema: "test-db", Name: "test-table-1"},
+				},
+			},
+		},
 		1)
 	result := checker.Check(ctx)
 	require.Equal(t, StateWarning, result.State)
 	require.Len(t, result.Errors, 1)
 	require.Contains(t, result.Errors[0].ShortErr, "Unknown character set: 'utf32'")
 	require.NoError(t, mock.ExpectationsWereMet())
+	require.NoError(t, downMock.ExpectationsWereMet())
 
 	// 2. test ShardingTablesChecker
 	// 2.1 the first table has unknown charset

--- a/dm/pkg/checker/utils.go
+++ b/dm/pkg/checker/utils.go
@@ -168,3 +168,25 @@ func getCreateTableStmt(p *parser.Parser, statement string) (*ast.CreateTableStm
 	}
 	return ctStmt, nil
 }
+
+func getCharset(stmt *ast.CreateTableStmt) string {
+	if stmt.Options != nil {
+		for _, option := range stmt.Options {
+			if option.Tp == ast.TableOptionCharset {
+				return option.StrValue
+			}
+		}
+	}
+	return ""
+}
+
+func getCollation(stmt *ast.CreateTableStmt) string {
+	if stmt.Options != nil {
+		for _, option := range stmt.Options {
+			if option.Tp == ast.TableOptionCollate {
+				return option.StrValue
+			}
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #4287

### What is changed and how it works?

add precheck when downstream table is created before the task, it will cause warning when
- charset is different and downstream is not utf8mb4
- collation is different
- PK/UK is different
- upstream has more columns
- downstream has more columns and they must specify values when inserting

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Add more precheck about downstream tables that are created before task starts
```
