### PR TITLE
test(dm): update python2 to python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -442,7 +442,7 @@ dm_integration_test_build_ctl: check_failpoint_ctl
 
 install_test_python_dep:
 	@echo "install python requirments for test"
-	pip install --user -q -r ./dm/tests/requirements.txt
+	pip3 install --user -q -r ./dm/tests/requirements.txt
 
 check_third_party_binary_for_dm:
 	@which bin/tidb-server

--- a/dm/tests/README.md
+++ b/dm/tests/README.md
@@ -20,7 +20,7 @@
 2. The following programs must be installed:
 
     * `mysql` (the CLI client, currently [not supported for mysql client 8.0](https://github.com/pingcap/tidb/issues/14021))
-    * `python2.7` or `python3.x`
+    * `python3.x`
 
 3. The user executing the tests must have permission to create the folder `/tmp/dm_test`. All test artifacts will be written into this folder.
 

--- a/dm/tests/_utils/check_grafana_dashboard_datasource
+++ b/dm/tests/_utils/check_grafana_dashboard_datasource
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import json
 

--- a/dm/tests/_utils/check_port
+++ b/dm/tests/_utils/check_port
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #coding: utf-8
 
 import sys

--- a/dm/tests/_utils/check_ticker_interval
+++ b/dm/tests/_utils/check_ticker_interval
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 import sys
 
 

--- a/dm/tests/openapi/client/openapi_cluster_check
+++ b/dm/tests/openapi/client/openapi_cluster_check
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import time
 import requests

--- a/dm/tests/openapi/client/openapi_source_check
+++ b/dm/tests/openapi/client/openapi_source_check
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import requests
 import ssl

--- a/dm/tests/openapi/client/openapi_task_check
+++ b/dm/tests/openapi/client/openapi_task_check
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import sys
 import requests


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #4159

### What is changed and how it works?

CI base image does not pre-install requests library, and this library does not support python2 now. We might always use python3 for integration tests

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
