### PR TITLE
worker(engine): start heartbeat after init impl

### DIFF
--- a/engine/framework/worker.go
+++ b/engine/framework/worker.go
@@ -343,8 +343,6 @@ func (w *DefaultBaseWorker) doPreInit(ctx context.Context) (retErr error) {
 		},
 	)
 
-	w.startBackgroundTasks()
-
 	if err := w.initMessageHandlers(ctx); err != nil {
 		return errors.Trace(err)
 	}
@@ -357,6 +355,8 @@ func (w *DefaultBaseWorker) doPreInit(ctx context.Context) (retErr error) {
 }
 
 func (w *DefaultBaseWorker) doPostInit(ctx context.Context) error {
+	w.startBackgroundTasks()
+
 	// Upsert the worker to ensure we have created the worker info
 	if err := w.frameMetaClient.UpsertWorker(ctx, w.workerStatus); err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #7555

### What is changed and how it works?

- Start worker heartbeat goroutine in `doPostInit`, which comes after `InitImpl`, in this way job master is available before job manager knows it is online.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
