### PR TITLE
sinkmanager(ticdc): release mem quota when remove a table

### DIFF
--- a/cdc/processor/sinkmanager/manager_impl.go
+++ b/cdc/processor/sinkmanager/manager_impl.go
@@ -335,12 +335,13 @@ func (m *ManagerImpl) RemoveTable(tableID model.TableID) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	cleaned := m.memQuota.clean(tableID)
 	log.Debug("MemoryQuotaTracing: Clean up memory quota for table sink task when removing table",
 		zap.String("namespace", m.changefeedID.Namespace),
 		zap.String("changefeed", m.changefeedID.ID),
 		zap.Int64("tableID", tableID),
+		zap.Uint64("memory", cleaned),
 	)
-	m.memQuota.clean(tableID)
 	// NOTICE: It is safe to only remove the table sink from the map.
 	// Because if we found the table sink is closed, we will not add it back to the heap.
 	// Also, no need to GC the SorterEngine. Because the SorterEngine also removes this table.

--- a/cdc/processor/sinkmanager/manager_impl.go
+++ b/cdc/processor/sinkmanager/manager_impl.go
@@ -335,12 +335,12 @@ func (m *ManagerImpl) RemoveTable(tableID model.TableID) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	cleaned := m.memQuota.clean(tableID)
+	cleanedBytes := m.memQuota.clean(tableID)
 	log.Debug("MemoryQuotaTracing: Clean up memory quota for table sink task when removing table",
 		zap.String("namespace", m.changefeedID.Namespace),
 		zap.String("changefeed", m.changefeedID.ID),
 		zap.Int64("tableID", tableID),
-		zap.Uint64("memory", cleaned),
+		zap.Uint64("memory", cleanedBytes),
 	)
 	// NOTICE: It is safe to only remove the table sink from the map.
 	// Because if we found the table sink is closed, we will not add it back to the heap.

--- a/cdc/processor/sinkmanager/manager_impl_test.go
+++ b/cdc/processor/sinkmanager/manager_impl_test.go
@@ -159,6 +159,7 @@ func TestRemoveTable(t *testing.T) {
 	tableSink, ok := manager.tableSinks.Load(tableID)
 	require.True(t, ok)
 	require.NotNil(t, tableSink)
+	manager.StartTable(tableID)
 	addTableAndAddEventsToSorterEngine(t, manager.sortEngine, tableID)
 	manager.UpdateBarrierTs(4)
 	manager.UpdateReceivedSorterResolvedTs(tableID, 5)

--- a/cdc/processor/sinkmanager/mem_quota.go
+++ b/cdc/processor/sinkmanager/mem_quota.go
@@ -183,7 +183,7 @@ func (m *memQuota) clean(tableID model.TableID) {
 		zap.Uint64("cleaned", cleaned),
 	)
 	if m.usedBytes < m.totalBytes {
-		m.blockAcquireCond.Signal()
+		m.blockAcquireCond.Broadcast()
 	}
 }
 

--- a/cdc/processor/sinkmanager/mem_quota_test.go
+++ b/cdc/processor/sinkmanager/mem_quota_test.go
@@ -240,6 +240,7 @@ func TestMemQuotaRecordAndClean(t *testing.T) {
 	require.False(t, m.hasAvailable(1))
 
 	// clean the all memory.
-	m.clean(1)
+	cleaned := m.clean(1)
+	require.Equal(t, uint64(300), cleaned)
 	require.True(t, m.hasAvailable(100))
 }

--- a/cdc/processor/sinkmanager/mem_quota_test.go
+++ b/cdc/processor/sinkmanager/mem_quota_test.go
@@ -240,7 +240,7 @@ func TestMemQuotaRecordAndClean(t *testing.T) {
 	require.False(t, m.hasAvailable(1))
 
 	// clean the all memory.
-	cleaned := m.clean(1)
-	require.Equal(t, uint64(300), cleaned)
+	cleanedBytes := m.clean(1)
+	require.Equal(t, uint64(300), cleanedBytes)
 	require.True(t, m.hasAvailable(100))
 }

--- a/cdc/processor/sinkmanager/mem_quota_test.go
+++ b/cdc/processor/sinkmanager/mem_quota_test.go
@@ -26,6 +26,8 @@ func TestMemQuotaTryAcquire(t *testing.T) {
 	t.Parallel()
 
 	m := newMemQuota(model.DefaultChangeFeedID("1"), 100)
+	defer m.close()
+
 	require.True(t, m.tryAcquire(50))
 	require.True(t, m.tryAcquire(50))
 	require.False(t, m.tryAcquire(1))
@@ -35,19 +37,21 @@ func TestMemQuotaForceAcquire(t *testing.T) {
 	t.Parallel()
 
 	m := newMemQuota(model.DefaultChangeFeedID("1"), 100)
+	defer m.close()
+
 	require.True(t, m.tryAcquire(100))
 	require.False(t, m.tryAcquire(1))
 	m.forceAcquire(1)
-	m.mu.Lock()
-	require.Equal(t, uint64(101), m.usedBytes)
-	m.mu.Unlock()
+	require.Equal(t, uint64(101), m.getUsedBytes())
 }
 
 func TestMemQuotaBlockAcquire(t *testing.T) {
 	t.Parallel()
 
 	m := newMemQuota(model.DefaultChangeFeedID("1"), 100)
-	require.Nil(t, m.blockAcquire(100))
+	defer m.close()
+	err := m.blockAcquire(100)
+	require.Nil(t, err)
 	m.record(1, model.NewResolvedTs(1), 50)
 	m.record(1, model.NewResolvedTs(2), 50)
 
@@ -55,12 +59,14 @@ func TestMemQuotaBlockAcquire(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		require.Nil(t, m.blockAcquire(50))
+		err := m.blockAcquire(50)
+		require.Nil(t, err)
 	}()
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		require.Nil(t, m.blockAcquire(50))
+		err := m.blockAcquire(50)
+		require.Nil(t, err)
 	}()
 	m.release(1, model.NewResolvedTs(1))
 	m.release(1, model.NewResolvedTs(2))
@@ -71,7 +77,9 @@ func TestMemQuotaClose(t *testing.T) {
 	t.Parallel()
 
 	m := newMemQuota(model.DefaultChangeFeedID("1"), 100)
-	require.Nil(t, m.blockAcquire(100))
+
+	err := m.blockAcquire(100)
+	require.Nil(t, err)
 	m.record(1, model.NewResolvedTs(2), 100)
 
 	var wg sync.WaitGroup
@@ -114,6 +122,8 @@ func TestMemQuotaRefund(t *testing.T) {
 	t.Parallel()
 
 	m := newMemQuota(model.DefaultChangeFeedID("1"), 100)
+	defer m.close()
+
 	require.True(t, m.tryAcquire(50))
 	require.True(t, m.tryAcquire(50))
 	m.refund(50)
@@ -125,7 +135,8 @@ func TestMemQuotaRefund(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		require.Nil(t, m.blockAcquire(50))
+		err := m.blockAcquire(50)
+		require.Nil(t, err)
 	}()
 	m.refund(50)
 	wg.Wait()
@@ -135,6 +146,8 @@ func TestMemQuotaHasAvailable(t *testing.T) {
 	t.Parallel()
 
 	m := newMemQuota(model.DefaultChangeFeedID("1"), 100)
+	defer m.close()
+
 	require.True(t, m.hasAvailable(100))
 	require.True(t, m.tryAcquire(100))
 	require.False(t, m.hasAvailable(1))
@@ -144,6 +157,8 @@ func TestMemQuotaRecordAndRelease(t *testing.T) {
 	t.Parallel()
 
 	m := newMemQuota(model.DefaultChangeFeedID("1"), 300)
+	defer m.close()
+
 	require.True(t, m.tryAcquire(100))
 	m.record(1, model.NewResolvedTs(100), 100)
 	require.True(t, m.tryAcquire(100))
@@ -170,6 +185,8 @@ func TestMemQuotaRecordAndReleaseWithBatchID(t *testing.T) {
 	t.Parallel()
 
 	m := newMemQuota(model.DefaultChangeFeedID("1"), 300)
+	defer m.close()
+
 	require.True(t, m.tryAcquire(100))
 	resolvedTs := model.ResolvedTs{
 		Mode:    model.BatchResolvedMode,
@@ -205,4 +222,24 @@ func TestMemQuotaRecordAndReleaseWithBatchID(t *testing.T) {
 	// release the memory of resolvedTs 101
 	m.release(1, model.NewResolvedTs(101))
 	require.True(t, m.hasAvailable(300))
+}
+
+func TestMemQuotaRecordAndClean(t *testing.T) {
+	t.Parallel()
+
+	m := newMemQuota(model.DefaultChangeFeedID("1"), 300)
+	defer m.close()
+
+	require.True(t, m.tryAcquire(100))
+	m.record(1, model.NewResolvedTs(100), 100)
+	require.True(t, m.tryAcquire(100))
+	m.record(1, model.NewResolvedTs(200), 100)
+	require.True(t, m.tryAcquire(100))
+	m.record(1, model.NewResolvedTs(300), 100)
+	require.False(t, m.tryAcquire(1))
+	require.False(t, m.hasAvailable(1))
+
+	// clean the all memory.
+	m.clean(1)
+	require.True(t, m.hasAvailable(100))
 }

--- a/cdc/processor/sinkmanager/table_sink_wrapper.go
+++ b/cdc/processor/sinkmanager/table_sink_wrapper.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/tiflow/cdc/processor/pipeline"
 	"github.com/pingcap/tiflow/cdc/processor/tablepb"
 	sinkv2 "github.com/pingcap/tiflow/cdc/sinkv2/tablesink"
-	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 )
@@ -112,7 +111,7 @@ func (t *tableSinkWrapper) close(ctx context.Context) error {
 		zap.Int64("tableID", t.tableID),
 		zap.String("namespace", t.changefeed.Namespace),
 		zap.String("changefeed", t.changefeed.ID))
-	return cerror.ErrTableProcessorStoppedSafely.GenWithStackByArgs()
+	return nil
 }
 
 // convertRowChangedEvents uses to convert RowChangedEvents to TableSinkRowChangedEvents.

--- a/cdc/processor/sinkmanager/table_sink_wrapper_test.go
+++ b/cdc/processor/sinkmanager/table_sink_wrapper_test.go
@@ -17,12 +17,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/processor/tablepb"
 	"github.com/pingcap/tiflow/cdc/sinkv2/eventsink"
 	"github.com/pingcap/tiflow/cdc/sinkv2/tablesink"
-	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
@@ -70,7 +68,7 @@ func TestTableSinkWrapperClose(t *testing.T) {
 
 	wrapper, _ := createTableSinkWrapper(model.DefaultChangeFeedID("1"), 1)
 	require.Equal(t, tablepb.TableStatePreparing, wrapper.getState())
-	require.ErrorIs(t, cerror.ErrTableProcessorStoppedSafely, errors.Cause(wrapper.close(context.Background())))
+	require.Nil(t, wrapper.close(context.Background()))
 	require.Equal(t, tablepb.TableStateStopped, wrapper.getState(), "table sink state should be stopped")
 }
 

--- a/cdc/processor/sinkmanager/worker.go
+++ b/cdc/processor/sinkmanager/worker.go
@@ -23,6 +23,9 @@ import (
 // Used to record the progress of the table.
 type writeSuccessCallback func(lastWrittenPos sorter.Position)
 
+// Used to abort the task processing of the table.
+type isCanceled func() bool
+
 // Used to get the upper bound of the table task.
 type tableTaskUpperBoundGetter func() sorter.Position
 
@@ -39,6 +42,7 @@ type tableSinkTask struct {
 	upperBarrierTsGetter tableTaskUpperBoundGetter
 	tableSink            *tableSinkWrapper
 	callback             writeSuccessCallback
+	isCanceled           isCanceled
 }
 
 type worker interface {

--- a/cdc/processor/sinkmanager/worker_impl.go
+++ b/cdc/processor/sinkmanager/worker_impl.go
@@ -228,12 +228,12 @@ func (w *workerImpl) receiveTableSinkTask(ctx context.Context, taskChan <-chan *
 				// But the table sink task is still processing the data.
 				// If the last time we advance the table sink, then we generate a record in the memory quota.
 				// So we need to clean up it.
-				cleaned := w.memQuota.clean(task.tableID)
+				cleanedBytes := w.memQuota.clean(task.tableID)
 				log.Debug("MemoryQuotaTracing: Clean up memory quota for table sink task when canceling",
 					zap.String("namespace", w.changefeedID.Namespace),
 					zap.String("changefeed", w.changefeedID.ID),
 					zap.Int64("tableID", task.tableID),
-					zap.Uint64("memory", cleaned),
+					zap.Uint64("memory", cleanedBytes),
 				)
 
 			} else {

--- a/cdc/processor/sinkmanager/worker_impl.go
+++ b/cdc/processor/sinkmanager/worker_impl.go
@@ -223,17 +223,19 @@ func (w *workerImpl) receiveTableSinkTask(ctx context.Context, taskChan <-chan *
 						zap.Uint64("memory", currentTotalSize),
 					)
 				}
-				log.Debug("MemoryQuotaTracing: Clean up memory quota for table sink task when canceling",
-					zap.String("namespace", w.changefeedID.Namespace),
-					zap.String("changefeed", w.changefeedID.ID),
-					zap.Int64("tableID", task.tableID),
-				)
 				// Clean up the memory quota.
 				// This could happen when the table sink is closed.
 				// But the table sink task is still processing the data.
 				// If the last time we advance the table sink, then we generate a record in the memory quota.
 				// So we need to clean up it.
-				w.memQuota.clean(task.tableID)
+				cleaned := w.memQuota.clean(task.tableID)
+				log.Debug("MemoryQuotaTracing: Clean up memory quota for table sink task when canceling",
+					zap.String("namespace", w.changefeedID.Namespace),
+					zap.String("changefeed", w.changefeedID.ID),
+					zap.Int64("tableID", task.tableID),
+					zap.Uint64("memory", cleaned),
+				)
+
 			} else {
 				// This means that we append all the events to the table sink.
 				// But we have not updated the resolved ts.

--- a/cdc/processor/sinkmanager/worker_impl_test.go
+++ b/cdc/processor/sinkmanager/worker_impl_test.go
@@ -182,6 +182,9 @@ func (suite *workerSuite) TestReceiveTableSinkTaskWithSplitTxnAndAbortWhenNoMemA
 		upperBarrierTsGetter: upperBoundGetter,
 		tableSink:            wrapper,
 		callback:             callback,
+		isCanceled: func() bool {
+			return false
+		},
 	}
 	wg.Wait()
 	require.Len(suite.T(), sink.events, 3)
@@ -296,6 +299,9 @@ func (suite *workerSuite) TestReceiveTableSinkTaskWithSplitTxnAndAbortWhenNoMemA
 		upperBarrierTsGetter: upperBoundGetter,
 		tableSink:            wrapper,
 		callback:             callback,
+		isCanceled: func() bool {
+			return false
+		},
 	}
 	// Abort the task when no memory quota and blocked.
 	w.(*workerImpl).memQuota.close()
@@ -422,6 +428,9 @@ func (suite *workerSuite) TestReceiveTableSinkTaskWithSplitTxnAndOnlyAdvanceTabl
 		upperBarrierTsGetter: upperBoundGetter,
 		tableSink:            wrapper,
 		callback:             callback,
+		isCanceled: func() bool {
+			return false
+		},
 	}
 	wg.Wait()
 	require.Len(suite.T(), sink.events, 5, "All events should be sent to sink")
@@ -547,6 +556,9 @@ func (suite *workerSuite) TestReceiveTableSinkTaskWithoutSplitTxnAndAbortWhenNoM
 		upperBarrierTsGetter: upperBoundGetter,
 		tableSink:            wrapper,
 		callback:             callback,
+		isCanceled: func() bool {
+			return false
+		},
 	}
 	wg.Wait()
 	require.Len(suite.T(), sink.events, 5, "All events should be sent to sink")
@@ -671,6 +683,9 @@ func (suite *workerSuite) TestReceiveTableSinkTaskWithoutSplitTxnOnlyAdvanceTabl
 		upperBarrierTsGetter: upperBoundGetter,
 		tableSink:            wrapper,
 		callback:             callback,
+		isCanceled: func() bool {
+			return false
+		},
 	}
 	wg.Wait()
 	require.Len(suite.T(), sink.events, 5, "All events should be sent to sink")


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref https://github.com/pingcap/tiflow/issues/5928

### What is changed and how it works?

Release mem quota when removing a table.

Abort the task and refund the unused memory quota. Also, do not put the progress back into the heap.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - [x] Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
