### PR TITLE
framework(engine): simplify CreateWorker API

### DIFF
--- a/engine/framework/base_jobmaster.go
+++ b/engine/framework/base_jobmaster.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/tiflow/engine/model"
 	dcontext "github.com/pingcap/tiflow/engine/pkg/context"
 	"github.com/pingcap/tiflow/engine/pkg/errctx"
-	resModel "github.com/pingcap/tiflow/engine/pkg/externalresource/model"
 	metaModel "github.com/pingcap/tiflow/engine/pkg/meta/model"
 	"github.com/pingcap/tiflow/engine/pkg/p2p"
 	"github.com/pingcap/tiflow/engine/pkg/promutil"
@@ -54,13 +53,9 @@ type BaseJobMaster interface {
 	// the method for sending message to specific worker
 	GetWorkers() map[frameModel.WorkerID]WorkerHandle
 
-	// CreateWorker requires the framework to dispatch a new worker.
-	// If the worker needs to access certain file system resources,
-	// their ID's must be passed by `resources`.
-	CreateWorker(workerType WorkerType, config WorkerConfig, cost model.RescUnit, resources ...resModel.ResourceID) (frameModel.WorkerID, error)
-
-	// CreateWorkerV2 is the latest version of CreateWorker, but with
-	// a more flexible way of passing options.
+	// CreateWorkerV2 requires the framework to dispatch a new worker.
+	// If the worker needs to access certain file system resources, it must pass
+	// resource ID via CreateWorkerOpt
 	CreateWorkerV2(
 		workerType frameModel.WorkerType,
 		config WorkerConfig,
@@ -301,16 +296,6 @@ func (d *DefaultBaseJobMaster) NotifyExit(ctx context.Context, errIn error) (ret
 
 	d.Logger().Info("worker start exiting", zap.NamedError("cause", errIn))
 	return d.worker.masterClient.WaitClosed(ctx)
-}
-
-// CreateWorker implements BaseJobMaster.CreateWorker
-func (d *DefaultBaseJobMaster) CreateWorker(
-	workerType WorkerType,
-	config WorkerConfig,
-	cost model.RescUnit,
-	resources ...resModel.ResourceID,
-) (frameModel.WorkerID, error) {
-	return d.master.CreateWorker(workerType, config, cost, resources...)
 }
 
 // CreateWorkerV2 implements BaseJobMaster.CreateWorkerV2

--- a/engine/framework/base_jobmaster.go
+++ b/engine/framework/base_jobmaster.go
@@ -53,10 +53,10 @@ type BaseJobMaster interface {
 	// the method for sending message to specific worker
 	GetWorkers() map[frameModel.WorkerID]WorkerHandle
 
-	// CreateWorkerV2 requires the framework to dispatch a new worker.
+	// CreateWorker requires the framework to dispatch a new worker.
 	// If the worker needs to access certain file system resources, it must pass
 	// resource ID via CreateWorkerOpt
-	CreateWorkerV2(
+	CreateWorker(
 		workerType frameModel.WorkerType,
 		config WorkerConfig,
 		opts ...CreateWorkerOpt,
@@ -298,13 +298,13 @@ func (d *DefaultBaseJobMaster) NotifyExit(ctx context.Context, errIn error) (ret
 	return d.worker.masterClient.WaitClosed(ctx)
 }
 
-// CreateWorkerV2 implements BaseJobMaster.CreateWorkerV2
-func (d *DefaultBaseJobMaster) CreateWorkerV2(
+// CreateWorker implements BaseJobMaster.CreateWorker
+func (d *DefaultBaseJobMaster) CreateWorker(
 	workerType frameModel.WorkerType,
 	config WorkerConfig,
 	opts ...CreateWorkerOpt,
 ) (frameModel.WorkerID, error) {
-	return d.master.CreateWorkerV2(workerType, config, opts...)
+	return d.master.CreateWorker(workerType, config, opts...)
 }
 
 // UpdateStatus delegates the UpdateStatus of inner worker

--- a/engine/framework/fake/fake_master.go
+++ b/engine/framework/fake/fake_master.go
@@ -196,7 +196,7 @@ func (m *Master) InitImpl(ctx context.Context) error {
 
 // This function is not thread safe, it must be called with m.workerListMu locked
 func (m *Master) createWorker(wcfg *WorkerConfig) error {
-	workerID, err := m.CreateWorkerV2(frameModel.FakeTask, wcfg, framework.CreateWorkerWithCost(1))
+	workerID, err := m.CreateWorker(frameModel.FakeTask, wcfg, framework.CreateWorkerWithCost(1))
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/engine/framework/fake/fake_master.go
+++ b/engine/framework/fake/fake_master.go
@@ -196,7 +196,7 @@ func (m *Master) InitImpl(ctx context.Context) error {
 
 // This function is not thread safe, it must be called with m.workerListMu locked
 func (m *Master) createWorker(wcfg *WorkerConfig) error {
-	workerID, err := m.CreateWorker(frameModel.FakeTask, wcfg, 1)
+	workerID, err := m.CreateWorkerV2(frameModel.FakeTask, wcfg, framework.CreateWorkerWithCost(1))
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/engine/framework/master.go
+++ b/engine/framework/master.go
@@ -211,18 +211,10 @@ type BaseMaster interface {
 	// NOTE: Currently, no implement has used this method, but we still keep it to make the interface intact
 	Exit(ctx context.Context, exitReason ExitReason, err error, detail []byte) error
 
-	// CreateWorker requires the framework to dispatch a new worker.
-	// If the worker needs to access certain file system resources,
-	// their ID's must be passed by `resources`.
-	CreateWorker(
-		workerType WorkerType,
-		config WorkerConfig,
-		cost model.RescUnit,
-		resources ...resModel.ResourceID,
-	) (frameModel.WorkerID, error)
-
 	// CreateWorkerV2 is the latest version of CreateWorker, but with
 	// a more flexible way of passing options.
+	// If the worker needs to access certain file system resources, it must pass
+	// resource ID via CreateWorkerOpt
 	CreateWorkerV2(
 		workerType frameModel.WorkerType,
 		config WorkerConfig,
@@ -694,24 +686,6 @@ func (m *DefaultBaseMaster) PrepareWorkerConfig(
 		workerID = m.uuidGen.NewString()
 	}
 	return
-}
-
-// CreateWorker implements BaseMaster.CreateWorker
-func (m *DefaultBaseMaster) CreateWorker(
-	workerType frameModel.WorkerType,
-	config WorkerConfig,
-	cost model.RescUnit,
-	resources ...resModel.ResourceID,
-) (frameModel.WorkerID, error) {
-	m.Logger().Info("CreateWorker",
-		zap.Stringer("worker-type", workerType),
-		zap.Any("worker-config", config),
-		zap.Int("cost", int(cost)),
-		zap.Any("resources", resources),
-		zap.String("master-id", m.id))
-
-	return m.CreateWorkerV2(workerType, config,
-		CreateWorkerWithCost(cost), CreateWorkerWithResourceRequirements(resources...))
 }
 
 // CreateWorkerV2 implements BaseMaster.CreateWorkerV2

--- a/engine/framework/master.go
+++ b/engine/framework/master.go
@@ -211,11 +211,11 @@ type BaseMaster interface {
 	// NOTE: Currently, no implement has used this method, but we still keep it to make the interface intact
 	Exit(ctx context.Context, exitReason ExitReason, err error, detail []byte) error
 
-	// CreateWorkerV2 is the latest version of CreateWorker, but with
+	// CreateWorker is the latest version of CreateWorker, but with
 	// a more flexible way of passing options.
 	// If the worker needs to access certain file system resources, it must pass
 	// resource ID via CreateWorkerOpt
-	CreateWorkerV2(
+	CreateWorker(
 		workerType frameModel.WorkerType,
 		config WorkerConfig,
 		opts ...CreateWorkerOpt,
@@ -688,8 +688,8 @@ func (m *DefaultBaseMaster) PrepareWorkerConfig(
 	return
 }
 
-// CreateWorkerV2 implements BaseMaster.CreateWorkerV2
-func (m *DefaultBaseMaster) CreateWorkerV2(
+// CreateWorker implements BaseMaster.CreateWorker
+func (m *DefaultBaseMaster) CreateWorker(
 	workerType frameModel.WorkerType,
 	config WorkerConfig,
 	opts ...CreateWorkerOpt,

--- a/engine/framework/master_test.go
+++ b/engine/framework/master_test.go
@@ -162,7 +162,7 @@ func TestMasterCreateWorker(t *testing.T) {
 		epoch+3,
 	)
 
-	workerID, err := master.CreateWorkerV2(
+	workerID, err := master.CreateWorker(
 		workerTypePlaceholder,
 		&dummyConfig{param: 1},
 		CreateWorkerWithCost(100),
@@ -275,7 +275,7 @@ func TestMasterCreateWorkerMetError(t *testing.T) {
 			close(done)
 		})
 
-	_, err = master.CreateWorkerV2(workerTypePlaceholder, &dummyConfig{param: 1}, CreateWorkerWithCost(100))
+	_, err = master.CreateWorker(workerTypePlaceholder, &dummyConfig{param: 1}, CreateWorkerWithCost(100))
 	require.NoError(t, err)
 
 	for {

--- a/engine/framework/master_test.go
+++ b/engine/framework/master_test.go
@@ -162,12 +162,12 @@ func TestMasterCreateWorker(t *testing.T) {
 		epoch+3,
 	)
 
-	workerID, err := master.CreateWorker(
+	workerID, err := master.CreateWorkerV2(
 		workerTypePlaceholder,
 		&dummyConfig{param: 1},
-		100,
-		"resource-1",
-		"resource-2")
+		CreateWorkerWithCost(100),
+		CreateWorkerWithResourceRequirements("resource-1", "resource-2"),
+	)
 	require.NoError(t, err)
 	require.Equal(t, workerID1, workerID)
 
@@ -275,7 +275,7 @@ func TestMasterCreateWorkerMetError(t *testing.T) {
 			close(done)
 		})
 
-	_, err = master.CreateWorker(workerTypePlaceholder, &dummyConfig{param: 1}, 100)
+	_, err = master.CreateWorkerV2(workerTypePlaceholder, &dummyConfig{param: 1}, CreateWorkerWithCost(100))
 	require.NoError(t, err)
 
 	for {

--- a/engine/jobmaster/cvsjob/cvs_job_master.go
+++ b/engine/jobmaster/cvsjob/cvs_job_master.go
@@ -162,7 +162,7 @@ func (jm *JobMaster) Tick(ctx context.Context) error {
 	for idx, workerInfo := range jm.syncFilesInfo {
 		// check if need to recreate worker
 		if workerInfo.needCreate.Load() {
-			workerID, err := jm.CreateWorkerV2(frameModel.CvsTask,
+			workerID, err := jm.CreateWorker(frameModel.CvsTask,
 				getTaskConfig(jm.jobStatus, idx), framework.CreateWorkerWithCost(10))
 			if err != nil {
 				log.Warn("create worker failed, try next time", zap.Any("master id", jm.workerID), zap.Error(err))

--- a/engine/jobmaster/cvsjob/cvs_job_master.go
+++ b/engine/jobmaster/cvsjob/cvs_job_master.go
@@ -162,7 +162,8 @@ func (jm *JobMaster) Tick(ctx context.Context) error {
 	for idx, workerInfo := range jm.syncFilesInfo {
 		// check if need to recreate worker
 		if workerInfo.needCreate.Load() {
-			workerID, err := jm.CreateWorker(frameModel.CvsTask, getTaskConfig(jm.jobStatus, idx), 10)
+			workerID, err := jm.CreateWorkerV2(frameModel.CvsTask,
+				getTaskConfig(jm.jobStatus, idx), framework.CreateWorkerWithCost(10))
 			if err != nil {
 				log.Warn("create worker failed, try next time", zap.Any("master id", jm.workerID), zap.Error(err))
 			} else {

--- a/engine/jobmaster/dm/dm_jobmaster_test.go
+++ b/engine/jobmaster/dm/dm_jobmaster_test.go
@@ -45,7 +45,6 @@ import (
 	"github.com/pingcap/tiflow/engine/pkg/deps"
 	dmpkg "github.com/pingcap/tiflow/engine/pkg/dm"
 	"github.com/pingcap/tiflow/engine/pkg/externalresource/broker"
-	resModel "github.com/pingcap/tiflow/engine/pkg/externalresource/model"
 	kvmock "github.com/pingcap/tiflow/engine/pkg/meta/mock"
 	metaModel "github.com/pingcap/tiflow/engine/pkg/meta/model"
 	pkgOrm "github.com/pingcap/tiflow/engine/pkg/orm"
@@ -253,8 +252,8 @@ func (t *testDMJobmasterSuite) TestDMJobmaster() {
 	// tick
 	worker1 := "worker1"
 	worker2 := "worker2"
-	mockBaseJobmaster.On("CreateWorker", mock.Anything, mock.Anything, mock.Anything).Return(worker1, nil).Once()
-	mockBaseJobmaster.On("CreateWorker", mock.Anything, mock.Anything, mock.Anything).Return(worker2, nil).Once()
+	mockBaseJobmaster.On("CreateWorkerV2", mock.Anything, mock.Anything, mock.Anything).Return(worker1, nil).Once()
+	mockBaseJobmaster.On("CreateWorkerV2", mock.Anything, mock.Anything, mock.Anything).Return(worker2, nil).Once()
 	mockCheckpointAgent.On("IsFresh", mock.Anything).Return(true, nil).Times(6)
 	require.NoError(t.T(), jm.Tick(context.Background()))
 	require.NoError(t.T(), jm.Tick(context.Background()))
@@ -300,7 +299,7 @@ func (t *testDMJobmasterSuite) TestDMJobmaster() {
 	jm.OnWorkerOnline(workerHandle1)
 	jm.OnWorkerDispatched(workerHandle2, errors.New("dispatch error"))
 	worker3 := "worker3"
-	mockBaseJobmaster.On("CreateWorker", mock.Anything, mock.Anything, mock.Anything).Return(worker3, nil).Once()
+	mockBaseJobmaster.On("CreateWorkerV2", mock.Anything, mock.Anything, mock.Anything).Return(worker3, nil).Once()
 	mockCheckpointAgent.On("IsFresh", mock.Anything).Return(true, nil).Times(3)
 	require.NoError(t.T(), jm.Tick(context.Background()))
 
@@ -315,7 +314,7 @@ func (t *testDMJobmasterSuite) TestDMJobmaster() {
 	workerHandle1.On("Status").Return(&frameModel.WorkerStatus{ExtBytes: bytes1}).Once()
 	jm.OnWorkerOffline(workerHandle1, errors.New("offline error"))
 	worker4 := "worker4"
-	mockBaseJobmaster.On("CreateWorker", mock.Anything, mock.Anything, mock.Anything).Return(worker4, nil).Once()
+	mockBaseJobmaster.On("CreateWorkerV2", mock.Anything, mock.Anything, mock.Anything).Return(worker4, nil).Once()
 	mockCheckpointAgent.On("IsFresh", mock.Anything).Return(true, nil).Times(3)
 	require.NoError(t.T(), jm.Tick(context.Background()))
 
@@ -333,7 +332,7 @@ func (t *testDMJobmasterSuite) TestDMJobmaster() {
 	require.NoError(t.T(), err)
 	worker5 := "worker5"
 	workerHandle1.On("Status").Return(&frameModel.WorkerStatus{ExtBytes: bytes1}).Once()
-	mockBaseJobmaster.On("CreateWorker", mock.Anything, mock.Anything, mock.Anything).Return(worker5, nil).Once()
+	mockBaseJobmaster.On("CreateWorkerV2", mock.Anything, mock.Anything, mock.Anything).Return(worker5, nil).Once()
 	jm.OnWorkerOffline(workerHandle1, nil)
 	require.NoError(t.T(), jm.Tick(context.Background()))
 	// worker5 online
@@ -517,7 +516,8 @@ func (m *MockBaseJobmaster) MetaKVClient() metaModel.KVClient {
 	return args.Get(0).(metaModel.KVClient)
 }
 
-func (m *MockBaseJobmaster) CreateWorker(workerType framework.WorkerType, config framework.WorkerConfig, cost model.RescUnit, resources ...resModel.ResourceID) (frameModel.WorkerID, error) {
+func (m *MockBaseJobmaster) CreateWorkerV2(workerType framework.WorkerType,
+	config framework.WorkerConfig, opts ...framework.CreateWorkerOpt) (frameModel.WorkerID, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	args := m.Called()

--- a/engine/jobmaster/dm/dm_jobmaster_test.go
+++ b/engine/jobmaster/dm/dm_jobmaster_test.go
@@ -517,7 +517,8 @@ func (m *MockBaseJobmaster) MetaKVClient() metaModel.KVClient {
 }
 
 func (m *MockBaseJobmaster) CreateWorker(workerType framework.WorkerType,
-	config framework.WorkerConfig, opts ...framework.CreateWorkerOpt) (frameModel.WorkerID, error) {
+	config framework.WorkerConfig, opts ...framework.CreateWorkerOpt,
+) (frameModel.WorkerID, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	args := m.Called()

--- a/engine/jobmaster/dm/dm_jobmaster_test.go
+++ b/engine/jobmaster/dm/dm_jobmaster_test.go
@@ -252,8 +252,8 @@ func (t *testDMJobmasterSuite) TestDMJobmaster() {
 	// tick
 	worker1 := "worker1"
 	worker2 := "worker2"
-	mockBaseJobmaster.On("CreateWorkerV2", mock.Anything, mock.Anything, mock.Anything).Return(worker1, nil).Once()
-	mockBaseJobmaster.On("CreateWorkerV2", mock.Anything, mock.Anything, mock.Anything).Return(worker2, nil).Once()
+	mockBaseJobmaster.On("CreateWorker", mock.Anything, mock.Anything, mock.Anything).Return(worker1, nil).Once()
+	mockBaseJobmaster.On("CreateWorker", mock.Anything, mock.Anything, mock.Anything).Return(worker2, nil).Once()
 	mockCheckpointAgent.On("IsFresh", mock.Anything).Return(true, nil).Times(6)
 	require.NoError(t.T(), jm.Tick(context.Background()))
 	require.NoError(t.T(), jm.Tick(context.Background()))
@@ -299,7 +299,7 @@ func (t *testDMJobmasterSuite) TestDMJobmaster() {
 	jm.OnWorkerOnline(workerHandle1)
 	jm.OnWorkerDispatched(workerHandle2, errors.New("dispatch error"))
 	worker3 := "worker3"
-	mockBaseJobmaster.On("CreateWorkerV2", mock.Anything, mock.Anything, mock.Anything).Return(worker3, nil).Once()
+	mockBaseJobmaster.On("CreateWorker", mock.Anything, mock.Anything, mock.Anything).Return(worker3, nil).Once()
 	mockCheckpointAgent.On("IsFresh", mock.Anything).Return(true, nil).Times(3)
 	require.NoError(t.T(), jm.Tick(context.Background()))
 
@@ -314,7 +314,7 @@ func (t *testDMJobmasterSuite) TestDMJobmaster() {
 	workerHandle1.On("Status").Return(&frameModel.WorkerStatus{ExtBytes: bytes1}).Once()
 	jm.OnWorkerOffline(workerHandle1, errors.New("offline error"))
 	worker4 := "worker4"
-	mockBaseJobmaster.On("CreateWorkerV2", mock.Anything, mock.Anything, mock.Anything).Return(worker4, nil).Once()
+	mockBaseJobmaster.On("CreateWorker", mock.Anything, mock.Anything, mock.Anything).Return(worker4, nil).Once()
 	mockCheckpointAgent.On("IsFresh", mock.Anything).Return(true, nil).Times(3)
 	require.NoError(t.T(), jm.Tick(context.Background()))
 
@@ -332,7 +332,7 @@ func (t *testDMJobmasterSuite) TestDMJobmaster() {
 	require.NoError(t.T(), err)
 	worker5 := "worker5"
 	workerHandle1.On("Status").Return(&frameModel.WorkerStatus{ExtBytes: bytes1}).Once()
-	mockBaseJobmaster.On("CreateWorkerV2", mock.Anything, mock.Anything, mock.Anything).Return(worker5, nil).Once()
+	mockBaseJobmaster.On("CreateWorker", mock.Anything, mock.Anything, mock.Anything).Return(worker5, nil).Once()
 	jm.OnWorkerOffline(workerHandle1, nil)
 	require.NoError(t.T(), jm.Tick(context.Background()))
 	// worker5 online
@@ -516,7 +516,7 @@ func (m *MockBaseJobmaster) MetaKVClient() metaModel.KVClient {
 	return args.Get(0).(metaModel.KVClient)
 }
 
-func (m *MockBaseJobmaster) CreateWorkerV2(workerType framework.WorkerType,
+func (m *MockBaseJobmaster) CreateWorker(workerType framework.WorkerType,
 	config framework.WorkerConfig, opts ...framework.CreateWorkerOpt) (frameModel.WorkerID, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/engine/jobmaster/dm/worker_manager.go
+++ b/engine/jobmaster/dm/worker_manager.go
@@ -41,7 +41,7 @@ var (
 // WorkerAgent defines an interface for create worker.
 type WorkerAgent interface {
 	// for create worker
-	CreateWorkerV2(
+	CreateWorker(
 		workerType framework.WorkerType,
 		config framework.WorkerConfig,
 		opts ...framework.CreateWorkerOpt,
@@ -354,7 +354,7 @@ func (wm *WorkerManager) createWorker(
 	resources ...resModel.ResourceID,
 ) error {
 	wm.logger.Info("start to create worker", zap.String("task_id", taskID), zap.Stringer("unit", unit))
-	workerID, err := wm.workerAgent.CreateWorkerV2(unit, taskCfg,
+	workerID, err := wm.workerAgent.CreateWorker(unit, taskCfg,
 		framework.CreateWorkerWithCost(1),
 		framework.CreateWorkerWithResourceRequirements(resources...))
 	if err != nil {

--- a/engine/jobmaster/dm/worker_manager.go
+++ b/engine/jobmaster/dm/worker_manager.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/tiflow/engine/jobmaster/dm/metadata"
 	"github.com/pingcap/tiflow/engine/jobmaster/dm/runtime"
 	"github.com/pingcap/tiflow/engine/jobmaster/dm/ticker"
-	"github.com/pingcap/tiflow/engine/model"
 	dmpkg "github.com/pingcap/tiflow/engine/pkg/dm"
 	resModel "github.com/pingcap/tiflow/engine/pkg/externalresource/model"
 	"go.uber.org/zap"
@@ -42,11 +41,10 @@ var (
 // WorkerAgent defines an interface for create worker.
 type WorkerAgent interface {
 	// for create worker
-	CreateWorker(
+	CreateWorkerV2(
 		workerType framework.WorkerType,
 		config framework.WorkerConfig,
-		cost model.RescUnit,
-		resources ...resModel.ResourceID,
+		opts ...framework.CreateWorkerOpt,
 	) (frameModel.WorkerID, error)
 }
 
@@ -356,7 +354,9 @@ func (wm *WorkerManager) createWorker(
 	resources ...resModel.ResourceID,
 ) error {
 	wm.logger.Info("start to create worker", zap.String("task_id", taskID), zap.Stringer("unit", unit))
-	workerID, err := wm.workerAgent.CreateWorker(unit, taskCfg, 1, resources...)
+	workerID, err := wm.workerAgent.CreateWorkerV2(unit, taskCfg,
+		framework.CreateWorkerWithCost(1),
+		framework.CreateWorkerWithResourceRequirements(resources...))
 	if err != nil {
 		wm.logger.Error("failed to create workers", zap.String("task_id", taskID), zap.Stringer("unit", unit), zap.Error(err))
 	}

--- a/engine/jobmaster/dm/worker_manager_test.go
+++ b/engine/jobmaster/dm/worker_manager_test.go
@@ -230,12 +230,12 @@ func (t *testDMJobmasterSuite) TestCreateWorker() {
 	task1 := jobCfg.Upstreams[0].SourceID
 	worker1 := "worker1"
 	createError := errors.New("create error")
-	mockAgent.On("CreateWorkerV2").Return("", createError).Once()
+	mockAgent.On("CreateWorker").Return("", createError).Once()
 	require.EqualError(t.T(), workerManager.createWorker(context.Background(), task1, frameModel.WorkerDMDump, taskCfgs[task1]), createError.Error())
 	require.Len(t.T(), workerManager.WorkerStatus(), 0)
 
 	workerStatus1 := runtime.InitWorkerStatus(task1, frameModel.WorkerDMDump, worker1)
-	mockAgent.On("CreateWorkerV2").Return(worker1, createError).Once()
+	mockAgent.On("CreateWorker").Return(worker1, createError).Once()
 	require.EqualError(t.T(), workerManager.createWorker(context.Background(), task1, frameModel.WorkerDMDump, taskCfgs[task1]), createError.Error())
 	workerStatusMap := workerManager.WorkerStatus()
 	require.Len(t.T(), workerStatusMap, 1)
@@ -245,7 +245,7 @@ func (t *testDMJobmasterSuite) TestCreateWorker() {
 	task2 := jobCfg.Upstreams[1].SourceID
 	worker2 := "worker2"
 	workerStatus2 := runtime.InitWorkerStatus(task2, frameModel.WorkerDMLoad, worker2)
-	mockAgent.On("CreateWorkerV2").Return(worker2, nil).Once()
+	mockAgent.On("CreateWorker").Return(worker2, nil).Once()
 	require.NoError(t.T(), workerManager.createWorker(context.Background(), task2, frameModel.WorkerDMLoad, taskCfgs[task2]))
 	workerStatusMap = workerManager.WorkerStatus()
 	require.Len(t.T(), workerStatusMap, 2)
@@ -372,7 +372,7 @@ func (t *testDMJobmasterSuite) TestCheckAndScheduleWorkers() {
 
 	checkpointAgent.On("IsFresh", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Times(3)
 	checkpointAgent.On("IsFresh", mock.Anything, mock.Anything, mock.Anything).Return(false, checkpointError).Once()
-	workerAgent.On("CreateWorkerV2").Return(worker1, nil).Once()
+	workerAgent.On("CreateWorker").Return(worker1, nil).Once()
 	require.EqualError(t.T(), workerManager.checkAndScheduleWorkers(context.Background(), job), checkpointError.Error())
 	wokerStatusMap := workerManager.WorkerStatus()
 	require.Len(t.T(), wokerStatusMap, 1)
@@ -385,7 +385,7 @@ func (t *testDMJobmasterSuite) TestCheckAndScheduleWorkers() {
 
 	// check again
 	checkpointAgent.On("IsFresh", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Times(3)
-	workerAgent.On("CreateWorkerV2").Return(worker2, createError).Once()
+	workerAgent.On("CreateWorker").Return(worker2, createError).Once()
 	require.EqualError(t.T(), workerManager.checkAndScheduleWorkers(context.Background(), job), createError.Error())
 	wokerStatusMap = workerManager.WorkerStatus()
 	require.Len(t.T(), wokerStatusMap, 2)
@@ -417,7 +417,7 @@ func (t *testDMJobmasterSuite) TestCheckAndScheduleWorkers() {
 	workerStatus3 := runtime.InitWorkerStatus(source1, frameModel.WorkerDMLoad, worker3)
 	workerManager.UpdateWorkerStatus(workerStatus1)
 	workerStatus1.Stage = runtime.WorkerFinished
-	workerAgent.On("CreateWorkerV2").Return(worker3, nil).Once()
+	workerAgent.On("CreateWorker").Return(worker3, nil).Once()
 	require.NoError(t.T(), workerManager.checkAndScheduleWorkers(context.Background(), job))
 	wokerStatusMap = workerManager.WorkerStatus()
 	require.Len(t.T(), wokerStatusMap, 2)
@@ -435,7 +435,7 @@ func (t *testDMJobmasterSuite) TestCheckAndScheduleWorkers() {
 	workerStatus3.Stage = runtime.WorkerOffline
 	workerStatus4 := runtime.InitWorkerStatus(source1, frameModel.WorkerDMLoad, worker4)
 	workerManager.UpdateWorkerStatus(workerStatus3)
-	workerAgent.On("CreateWorkerV2").Return(worker4, nil).Once()
+	workerAgent.On("CreateWorker").Return(worker4, nil).Once()
 	require.NoError(t.T(), workerManager.checkAndScheduleWorkers(context.Background(), job))
 	wokerStatusMap = workerManager.WorkerStatus()
 	require.Len(t.T(), wokerStatusMap, 2)
@@ -481,9 +481,9 @@ func (t *testDMJobmasterSuite) TestWorkerManager() {
 	checkpointAgent.On("IsFresh", mock.Anything, mock.Anything, mock.Anything).Return(false, checkpointError).Once()
 	checkpointAgent.On("IsFresh", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Times(6)
 	createError := errors.New("create error")
-	workerAgent.On("CreateWorkerV2").Return(worker1, nil).Once()
-	workerAgent.On("CreateWorkerV2").Return("", createError).Once()
-	workerAgent.On("CreateWorkerV2").Return(worker2, nil).Once()
+	workerAgent.On("CreateWorker").Return(worker1, nil).Once()
+	workerAgent.On("CreateWorker").Return("", createError).Once()
+	workerAgent.On("CreateWorker").Return(worker2, nil).Once()
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -532,7 +532,7 @@ func (t *testDMJobmasterSuite) TestWorkerManager() {
 	workerManager.UpdateWorkerStatus(workerStatus2)
 	workerManager.SetNextCheckTime(time.Now())
 	checkpointAgent.On("IsFresh", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Times(3)
-	workerAgent.On("CreateWorkerV2").Return(worker3, nil).Once()
+	workerAgent.On("CreateWorker").Return(worker3, nil).Once()
 
 	// scheduled eventually
 	require.Eventually(t.T(), func() bool {
@@ -561,7 +561,7 @@ func (t *testDMJobmasterSuite) TestWorkerManager() {
 
 	// task1 eventually restarts
 	checkpointAgent.On("IsFresh", mock.Anything, mock.Anything, mock.Anything).Return(true, nil).Times(3)
-	workerAgent.On("CreateWorkerV2").Return(worker1, nil).Once()
+	workerAgent.On("CreateWorker").Return(worker1, nil).Once()
 	workerManager.SetNextCheckTime(time.Now())
 	require.Eventually(t.T(), func() bool {
 		return len(workerManager.WorkerStatus()) == 1
@@ -572,7 +572,7 @@ func (t *testDMJobmasterSuite) TestWorkerManager() {
 	workerStatus := workerManager.WorkerStatus()[source1]
 	workerStatus.Stage = runtime.WorkerFinished
 	workerManager.UpdateWorkerStatus(workerStatus)
-	workerAgent.On("CreateWorkerV2").Return(worker4, nil).Once()
+	workerAgent.On("CreateWorker").Return(worker4, nil).Once()
 	// check by finished
 	workerManager.SetNextCheckTime(time.Now())
 	// scheduled eventually
@@ -615,7 +615,7 @@ type MockWorkerAgent struct {
 	mock.Mock
 }
 
-func (mockAgent *MockWorkerAgent) CreateWorkerV2(
+func (mockAgent *MockWorkerAgent) CreateWorker(
 	workerType framework.WorkerType, taskCfg interface{},
 	opts ...framework.CreateWorkerOpt,
 ) (frameModel.WorkerID, error) {

--- a/engine/jobmaster/example/master_impl.go
+++ b/engine/jobmaster/example/master_impl.go
@@ -51,7 +51,8 @@ type exampleMaster struct {
 func (e *exampleMaster) InitImpl(ctx context.Context) (err error) {
 	log.Info("InitImpl")
 	e.worker.mu.Lock()
-	e.worker.id, err = e.CreateWorker(exampleWorkerType, exampleWorkerCfg, exampleWorkerCost)
+	e.worker.id, err = e.CreateWorkerV2(exampleWorkerType, exampleWorkerCfg,
+		framework.CreateWorkerWithCost(exampleWorkerCost))
 	e.worker.mu.Unlock()
 	return
 }

--- a/engine/jobmaster/example/master_impl.go
+++ b/engine/jobmaster/example/master_impl.go
@@ -51,7 +51,7 @@ type exampleMaster struct {
 func (e *exampleMaster) InitImpl(ctx context.Context) (err error) {
 	log.Info("InitImpl")
 	e.worker.mu.Lock()
-	e.worker.id, err = e.CreateWorkerV2(exampleWorkerType, exampleWorkerCfg,
+	e.worker.id, err = e.CreateWorker(exampleWorkerType, exampleWorkerCfg,
 		framework.CreateWorkerWithCost(exampleWorkerCost))
 	e.worker.mu.Unlock()
 	return

--- a/engine/servermaster/jobmanager.go
+++ b/engine/servermaster/jobmanager.go
@@ -617,8 +617,8 @@ func (jm *JobManagerImpl) Tick(ctx context.Context) error {
 			if !jm.JobBackoffMgr.Allow(job.ID) {
 				return "", errors.ErrMasterCreateWorkerBackoff.FastGenByArgs()
 			}
-			return jm.BaseMaster.CreateWorker(
-				job.Type, job, defaultJobMasterCost)
+			return jm.BaseMaster.CreateWorkerV2(
+				job.Type, job, framework.CreateWorkerWithCost(defaultJobMasterCost))
 		})
 	if _, err = filterQuotaError(err); err != nil {
 		return err
@@ -644,8 +644,8 @@ func (jm *JobManagerImpl) Tick(ctx context.Context) error {
 		}
 		err = jm.JobFsm.IterWaitAckJobs(
 			func(job *frameModel.MasterMeta) (string, error) {
-				return jm.BaseMaster.CreateWorker(
-					job.Type, job, defaultJobMasterCost)
+				return jm.BaseMaster.CreateWorkerV2(
+					job.Type, job, framework.CreateWorkerWithCost(defaultJobMasterCost))
 			})
 		exceedQuota, err := filterQuotaError(err)
 		if err != nil {

--- a/engine/servermaster/jobmanager.go
+++ b/engine/servermaster/jobmanager.go
@@ -300,7 +300,7 @@ func (jm *JobManagerImpl) CreateJob(ctx context.Context, req *pb.CreateJobReques
 
 	// CreateWorker here is to create job master actually
 	// TODO: use correct worker cost
-	workerID, err := jm.BaseMaster.CreateWorkerV2(
+	workerID, err := jm.BaseMaster.CreateWorker(
 		meta.Type, meta,
 		framework.CreateWorkerWithCost(defaultJobMasterCost),
 		framework.CreateWorkerWithSelectors(selectors...))
@@ -617,7 +617,7 @@ func (jm *JobManagerImpl) Tick(ctx context.Context) error {
 			if !jm.JobBackoffMgr.Allow(job.ID) {
 				return "", errors.ErrMasterCreateWorkerBackoff.FastGenByArgs()
 			}
-			return jm.BaseMaster.CreateWorkerV2(
+			return jm.BaseMaster.CreateWorker(
 				job.Type, job, framework.CreateWorkerWithCost(defaultJobMasterCost))
 		})
 	if _, err = filterQuotaError(err); err != nil {
@@ -644,7 +644,7 @@ func (jm *JobManagerImpl) Tick(ctx context.Context) error {
 		}
 		err = jm.JobFsm.IterWaitAckJobs(
 			func(job *frameModel.MasterMeta) (string, error) {
-				return jm.BaseMaster.CreateWorkerV2(
+				return jm.BaseMaster.CreateWorker(
 					job.Type, job, framework.CreateWorkerWithCost(defaultJobMasterCost))
 			})
 		exceedQuota, err := filterQuotaError(err)

--- a/engine/servermaster/jobmanager_test.go
+++ b/engine/servermaster/jobmanager_test.go
@@ -23,11 +23,9 @@ import (
 	"github.com/pingcap/tiflow/engine/framework"
 	"github.com/pingcap/tiflow/engine/framework/metadata"
 	frameModel "github.com/pingcap/tiflow/engine/framework/model"
-	"github.com/pingcap/tiflow/engine/model"
 	"github.com/pingcap/tiflow/engine/pkg/clock"
 	"github.com/pingcap/tiflow/engine/pkg/ctxmu"
 	resManager "github.com/pingcap/tiflow/engine/pkg/externalresource/manager"
-	resModel "github.com/pingcap/tiflow/engine/pkg/externalresource/model"
 	jobMock "github.com/pingcap/tiflow/engine/pkg/httputil/mock"
 	"github.com/pingcap/tiflow/engine/pkg/notifier"
 	pkgOrm "github.com/pingcap/tiflow/engine/pkg/orm"
@@ -122,15 +120,6 @@ func TestJobManagerCreateJob(t *testing.T) {
 
 type mockBaseMasterCreateWorkerFailed struct {
 	*framework.MockMasterImpl
-}
-
-func (m *mockBaseMasterCreateWorkerFailed) CreateWorker(
-	workerType framework.WorkerType,
-	config framework.WorkerConfig,
-	cost model.RescUnit,
-	resources ...resModel.ResourceID,
-) (frameModel.WorkerID, error) {
-	return "", errors.ErrMasterConcurrencyExceeded.FastGenByArgs()
 }
 
 func (m *mockBaseMasterCreateWorkerFailed) CreateWorkerV2(

--- a/engine/servermaster/jobmanager_test.go
+++ b/engine/servermaster/jobmanager_test.go
@@ -122,7 +122,7 @@ type mockBaseMasterCreateWorkerFailed struct {
 	*framework.MockMasterImpl
 }
 
-func (m *mockBaseMasterCreateWorkerFailed) CreateWorkerV2(
+func (m *mockBaseMasterCreateWorkerFailed) CreateWorker(
 	workerType framework.WorkerType,
 	config framework.WorkerConfig,
 	opts ...framework.CreateWorkerOpt,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #5673

### What is changed and how it works?

- `CreateWorkerV2` delegates `CreateWorker`, use one `CreateWorker` instead.
- All options passed in `CreateWorkerOptions` will be printed in `ScheduleTask` request.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
