### PR TITLE
log(all): replace deprecated log.With

### DIFF
--- a/cdc/scheduler/internal/v2/agent.go
+++ b/cdc/scheduler/internal/v2/agent.go
@@ -114,7 +114,7 @@ func NewBaseAgent(
 	messenger ProcessorMessenger,
 	config *AgentConfig,
 ) *Agent {
-	logger := log.With(
+	logger := log.L().With(
 		zap.String("namespace", changeFeedID.Namespace),
 		zap.String("changefeed", changeFeedID.ID))
 	ret := &Agent{

--- a/cdc/scheduler/internal/v2/schedule_dispatcher.go
+++ b/cdc/scheduler/internal/v2/schedule_dispatcher.go
@@ -86,7 +86,7 @@ func NewBaseScheduleDispatcher(
 	checkpointTs model.Ts,
 ) *ScheduleDispatcher {
 	// logger is just the global logger with the `changefeed-id` field attached.
-	logger := log.With(
+	logger := log.L().With(
 		zap.String("namespace", changeFeedID.Namespace),
 		zap.String("changefeed", changeFeedID.ID))
 

--- a/engine/pkg/externalresource/manager/service.go
+++ b/engine/pkg/externalresource/manager/service.go
@@ -159,7 +159,7 @@ func (s *Service) GetPlacementConstraint(
 	ctx context.Context,
 	resourceKey resModel.ResourceKey,
 ) (resModel.ExecutorID, bool, error) {
-	logger := log.With(
+	logger := log.L().With(
 		zap.String("job-id", resourceKey.JobID),
 		zap.String("resource-id", resourceKey.ID))
 

--- a/engine/pkg/rpcutil/middleware.go
+++ b/engine/pkg/rpcutil/middleware.go
@@ -101,7 +101,7 @@ func UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.Una
 	if err != nil {
 		errOut := ToGRPCError(err)
 		s, _ := status.FromError(errOut)
-		logger := log.With(zap.String("method", info.FullMethod), zap.Error(err), zap.Any("request", req))
+		logger := log.L().With(zap.String("method", info.FullMethod), zap.Error(err), zap.Any("request", req))
 		switch s.Code() {
 		case codes.Unknown:
 			logger.Warn("request handled with an unknown error")
@@ -113,10 +113,6 @@ func UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.Una
 		return nil, errOut
 	}
 
-	log.With(
-		zap.String("method", info.FullMethod),
-		zap.Any("request", req),
-		zap.Any("response", resp),
-	).Debug("request handled successfully")
+	log.Debug("request handled successfully", zap.String("method", info.FullMethod), zap.Any("request", req), zap.Any("response", resp))
 	return resp, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20220729040631-518f63d66278
 	github.com/pingcap/failpoint v0.0.0-20220423142525-ae43b7f4e5c3
 	github.com/pingcap/kvproto v0.0.0-20221026112947-f8d61344b172
-	github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3
+	github.com/pingcap/log v1.1.1-0.20221110065318-21a4942860b3
 	github.com/pingcap/tidb v1.1.0-beta.0.20221101122759-863d35290cc4
 	github.com/pingcap/tidb-tools v6.1.1-0.20220715000306-1d2f00da8c3e+incompatible
 	github.com/pingcap/tidb/parser v0.0.0-20221101122759-863d35290cc4

--- a/go.sum
+++ b/go.sum
@@ -994,8 +994,6 @@ github.com/pingcap/log v0.0.0-20210906054005-afc726e70354/go.mod h1:DWQW5jICDR7U
 github.com/pingcap/log v0.0.0-20211215031037-e024ba4eb0ee/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/log v1.1.0/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/log v1.1.1-0.20221015072633-39906604fb81/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
-github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
-github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/log v1.1.1-0.20221110065318-21a4942860b3 h1:T7e5Low0BU2ZazI2dz2mh3W1qv+w8wtvq1YR8DneA0c=
 github.com/pingcap/log v1.1.1-0.20221110065318-21a4942860b3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/parser v0.0.0-20210415081931-48e7f467fd74/go.mod h1:xZC8I7bug4GJ5KtHhgAikjTfU4kBv1Sbo3Pf1MZ6lVw=

--- a/go.sum
+++ b/go.sum
@@ -996,6 +996,8 @@ github.com/pingcap/log v1.1.0/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoO
 github.com/pingcap/log v1.1.1-0.20221015072633-39906604fb81/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3 h1:HR/ylkkLmGdSSDaD8IDP+SZrdhV1Kibl9KrHxJ9eciw=
 github.com/pingcap/log v1.1.1-0.20221110025148-ca232912c9f3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
+github.com/pingcap/log v1.1.1-0.20221110065318-21a4942860b3 h1:T7e5Low0BU2ZazI2dz2mh3W1qv+w8wtvq1YR8DneA0c=
+github.com/pingcap/log v1.1.1-0.20221110065318-21a4942860b3/go.mod h1:DWQW5jICDR7UJh4HtxXSM20Churx4CQL0fwL/SoOSA4=
 github.com/pingcap/parser v0.0.0-20210415081931-48e7f467fd74/go.mod h1:xZC8I7bug4GJ5KtHhgAikjTfU4kBv1Sbo3Pf1MZ6lVw=
 github.com/pingcap/sysutil v0.0.0-20211208032423-041a72e5860d/go.mod h1:7j18ezaWTao2LHOyMlsc2Dg1vW+mDY9dEbPzVyOlaeM=
 github.com/pingcap/sysutil v0.0.0-20220114020952-ea68d2dbf5b4 h1:HYbcxtnkN3s5tqrZ/z3eJS4j3Db8wMphEm1q10lY/TM=

--- a/pkg/logutil/log.go
+++ b/pkg/logutil/log.go
@@ -300,5 +300,5 @@ func ShortError(err error) zap.Field {
 
 // WithComponent return a logger with specified component scope
 func WithComponent(component string) *zap.Logger {
-	return log.With(zap.String("component", component))
+	return log.L().With(zap.String("component", component))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/7573

### What is changed and how it works?

Replace deprecated `log.With` with `log.L().With`. See https://github.com/pingcap/log/issues/32.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
