### PR TITLE
sinkmanager(ticdc): consider table state when generate tasks

### DIFF
--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -29,6 +29,8 @@ type Manager interface {
 	// AddTable adds a table(TableSink) to the sink manager.
 	// Sink manager will create a new table sink and start it.
 	AddTable(tableID model.TableID, startTs model.Ts, targetTs model.Ts)
+	// StartTable starts a table sin. Make it replicating data to downstream.
+	StartTable(tableID model.TableID)
 	// RemoveTable removes a table(TableSink) from the sink manager.
 	// Sink manager will stop the table sink and remove it.
 	RemoveTable(tableID model.TableID) error

--- a/cdc/processor/sinkmanager/manager_impl.go
+++ b/cdc/processor/sinkmanager/manager_impl.go
@@ -282,6 +282,7 @@ func (m *ManagerImpl) AddTable(tableID model.TableID, startTs model.Ts, targetTs
 		tableID,
 		m.sinkFactory.CreateTableSink(m.changefeedID, tableID, m.metricsTableSinkTotalRows),
 		tablepb.TableStatePreparing,
+		startTs,
 		targetTs,
 	)
 	m.tableSinks.Store(tableID, sinkWrapper)

--- a/cdc/processor/sinkmanager/manager_impl.go
+++ b/cdc/processor/sinkmanager/manager_impl.go
@@ -293,6 +293,7 @@ func (m *ManagerImpl) AddTable(tableID model.TableID, startTs model.Ts, targetTs
 	m.progressHeap.push(initProgress)
 }
 
+// StartTable sets the table(TableSink) state to replicating.
 func (m *ManagerImpl) StartTable(tableID model.TableID) {
 	tableSink, ok := m.tableSinks.Load(tableID)
 	if !ok {

--- a/cdc/processor/sinkmanager/manager_impl_test.go
+++ b/cdc/processor/sinkmanager/manager_impl_test.go
@@ -251,6 +251,27 @@ func TestGetTableStatsToReleaseMemQuota(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond)
 }
 
+func TestDoNotGenerateTableSinkTaskWhenTableIsNotReplicating(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	changefeedInfo := getChangefeedInfo()
+	manager := createManager(t, ctx, model.DefaultChangeFeedID("1"), changefeedInfo, make(chan error, 1))
+	tableID := model.TableID(1)
+	manager.AddTable(tableID, 1, 100)
+	addTableAndAddEventsToSorterEngine(t, manager.sortEngine, tableID)
+	manager.UpdateBarrierTs(4)
+	manager.UpdateReceivedSorterResolvedTs(tableID, 5)
+
+	require.Equal(t, uint64(0), manager.memQuota.getUsedBytes())
+	tableSink, ok := manager.tableSinks.Load(tableID)
+	require.True(t, ok)
+	require.NotNil(t, tableSink)
+	require.Equal(t, uint64(0), tableSink.(*tableSinkWrapper).getCheckpointTs().Ts)
+}
+
 func TestClose(t *testing.T) {
 	t.Parallel()
 

--- a/cdc/processor/sinkmanager/table_progress_heap.go
+++ b/cdc/processor/sinkmanager/table_progress_heap.go
@@ -18,7 +18,6 @@ import (
 	"sync"
 
 	"github.com/pingcap/tiflow/cdc/model"
-	"github.com/pingcap/tiflow/cdc/processor/tablepb"
 	"github.com/pingcap/tiflow/pkg/sorter"
 )
 
@@ -26,7 +25,6 @@ import (
 type progress struct {
 	tableID           model.TableID
 	nextLowerBoundPos sorter.Position
-	tableState        *tablepb.TableState
 }
 
 // Assert progressHeap implements heap.Interface
@@ -49,11 +47,6 @@ func (p *progressHeap) Len() int {
 func (p *progressHeap) Less(i, j int) bool {
 	a := p.heap[i]
 	b := p.heap[j]
-
-	// Prefer tables with replication state.
-	if a.tableState.Load() == tablepb.TableStateReplicating && b.tableState.Load() != tablepb.TableStateReplicating {
-		return true
-	}
 	return a.nextLowerBoundPos.Compare(b.nextLowerBoundPos) == -1
 }
 

--- a/cdc/processor/sinkmanager/table_progress_heap_test.go
+++ b/cdc/processor/sinkmanager/table_progress_heap_test.go
@@ -16,15 +16,12 @@ package sinkmanager
 import (
 	"testing"
 
-	"github.com/pingcap/tiflow/cdc/processor/tablepb"
 	"github.com/pingcap/tiflow/pkg/sorter"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTableProgresses(t *testing.T) {
 	t.Parallel()
-
-	tableState := tablepb.TableStateReplicating
 
 	p := newTableProgresses()
 	p.push(&progress{
@@ -33,7 +30,6 @@ func TestTableProgresses(t *testing.T) {
 			StartTs:  1,
 			CommitTs: 2,
 		},
-		tableState: &tableState,
 	})
 	p.push(&progress{
 		tableID: 3,
@@ -41,7 +37,6 @@ func TestTableProgresses(t *testing.T) {
 			StartTs:  2,
 			CommitTs: 2,
 		},
-		tableState: &tableState,
 	})
 	p.push(&progress{
 		tableID: 2,
@@ -49,7 +44,6 @@ func TestTableProgresses(t *testing.T) {
 			StartTs:  2,
 			CommitTs: 3,
 		},
-		tableState: &tableState,
 	})
 
 	require.Equal(t, p.len(), 3)
@@ -60,50 +54,6 @@ func TestTableProgresses(t *testing.T) {
 	require.Equal(t, int64(3), pg.tableID, "table2 is the slowest table")
 	pg = p.pop()
 	require.Equal(t, int64(2), pg.tableID, "table3 is the slowest table")
-
-	require.Equal(t, p.len(), 0, "all tables are popped")
-}
-
-func TestHeapWithState(t *testing.T) {
-	t.Parallel()
-	replicatingState := tablepb.TableStateReplicating
-	stoppingState := tablepb.TableStateStopping
-	preparingState := tablepb.TableStatePreparing
-
-	p := newTableProgresses()
-	p.push(&progress{
-		tableID: 1,
-		nextLowerBoundPos: sorter.Position{
-			StartTs:  1,
-			CommitTs: 2,
-		},
-		tableState: &stoppingState,
-	})
-	p.push(&progress{
-		tableID: 3,
-		nextLowerBoundPos: sorter.Position{
-			StartTs:  2,
-			CommitTs: 2,
-		},
-		tableState: &replicatingState,
-	})
-	p.push(&progress{
-		tableID: 2,
-		nextLowerBoundPos: sorter.Position{
-			StartTs:  2,
-			CommitTs: 3,
-		},
-		tableState: &preparingState,
-	})
-
-	require.Equal(t, p.len(), 3)
-
-	pg := p.pop()
-	require.Equal(t, int64(3), pg.tableID, "table3 is replicating, so it comes first")
-	pg = p.pop()
-	require.Equal(t, int64(1), pg.tableID, "other states are equal, so table1 comes first")
-	pg = p.pop()
-	require.Equal(t, int64(2), pg.tableID, "table2 is last")
 
 	require.Equal(t, p.len(), 0, "all tables are popped")
 }

--- a/cdc/processor/sinkmanager/table_progress_heap_test.go
+++ b/cdc/processor/sinkmanager/table_progress_heap_test.go
@@ -16,12 +16,15 @@ package sinkmanager
 import (
 	"testing"
 
+	"github.com/pingcap/tiflow/cdc/processor/tablepb"
 	"github.com/pingcap/tiflow/pkg/sorter"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTableProgresses(t *testing.T) {
 	t.Parallel()
+
+	tableState := tablepb.TableStateReplicating
 
 	p := newTableProgresses()
 	p.push(&progress{
@@ -30,6 +33,7 @@ func TestTableProgresses(t *testing.T) {
 			StartTs:  1,
 			CommitTs: 2,
 		},
+		tableState: &tableState,
 	})
 	p.push(&progress{
 		tableID: 3,
@@ -37,6 +41,7 @@ func TestTableProgresses(t *testing.T) {
 			StartTs:  2,
 			CommitTs: 2,
 		},
+		tableState: &tableState,
 	})
 	p.push(&progress{
 		tableID: 2,
@@ -44,6 +49,7 @@ func TestTableProgresses(t *testing.T) {
 			StartTs:  2,
 			CommitTs: 3,
 		},
+		tableState: &tableState,
 	})
 
 	require.Equal(t, p.len(), 3)
@@ -54,6 +60,50 @@ func TestTableProgresses(t *testing.T) {
 	require.Equal(t, int64(3), pg.tableID, "table2 is the slowest table")
 	pg = p.pop()
 	require.Equal(t, int64(2), pg.tableID, "table3 is the slowest table")
+
+	require.Equal(t, p.len(), 0, "all tables are popped")
+}
+
+func TestHeapWithState(t *testing.T) {
+	t.Parallel()
+	replicatingState := tablepb.TableStateReplicating
+	stoppingState := tablepb.TableStateStopping
+	preparingState := tablepb.TableStatePreparing
+
+	p := newTableProgresses()
+	p.push(&progress{
+		tableID: 1,
+		nextLowerBoundPos: sorter.Position{
+			StartTs:  1,
+			CommitTs: 2,
+		},
+		tableState: &stoppingState,
+	})
+	p.push(&progress{
+		tableID: 3,
+		nextLowerBoundPos: sorter.Position{
+			StartTs:  2,
+			CommitTs: 2,
+		},
+		tableState: &replicatingState,
+	})
+	p.push(&progress{
+		tableID: 2,
+		nextLowerBoundPos: sorter.Position{
+			StartTs:  2,
+			CommitTs: 3,
+		},
+		tableState: &preparingState,
+	})
+
+	require.Equal(t, p.len(), 3)
+
+	pg := p.pop()
+	require.Equal(t, int64(3), pg.tableID, "table3 is replicating, so it comes first")
+	pg = p.pop()
+	require.Equal(t, int64(1), pg.tableID, "other states are equal, so table1 comes first")
+	pg = p.pop()
+	require.Equal(t, int64(2), pg.tableID, "table2 is last")
 
 	require.Equal(t, p.len(), 0, "all tables are popped")
 }

--- a/cdc/processor/sinkmanager/table_sink_wrapper.go
+++ b/cdc/processor/sinkmanager/table_sink_wrapper.go
@@ -62,6 +62,10 @@ func newTableSinkWrapper(
 	}
 }
 
+func (t *tableSinkWrapper) start() {
+	t.state.Store(tablepb.TableStateReplicating)
+}
+
 func (t *tableSinkWrapper) appendRowChangedEvents(events ...*model.RowChangedEvent) {
 	t.tableSink.AppendRowChangedEvents(events...)
 }

--- a/cdc/processor/sinkmanager/table_sink_wrapper.go
+++ b/cdc/processor/sinkmanager/table_sink_wrapper.go
@@ -39,6 +39,8 @@ type tableSinkWrapper struct {
 	tableSink sinkv2.TableSink
 	// state used to control the lifecycle of the table.
 	state *tablepb.TableState
+	// startTs is the start ts of the table.
+	startTs model.Ts
 	// targetTs is the upper bound of the table sink.
 	targetTs model.Ts
 	// receivedSorterResolvedTs is the resolved ts received from the sorter.
@@ -51,6 +53,7 @@ func newTableSinkWrapper(
 	tableID model.TableID,
 	tableSink sinkv2.TableSink,
 	state tablepb.TableState,
+	startTs model.Ts,
 	targetTs model.Ts,
 ) *tableSinkWrapper {
 	return &tableSinkWrapper{
@@ -58,6 +61,7 @@ func newTableSinkWrapper(
 		tableID:    tableID,
 		tableSink:  tableSink,
 		state:      &state,
+		startTs:    startTs,
 		targetTs:   targetTs,
 	}
 }
@@ -71,6 +75,9 @@ func (t *tableSinkWrapper) appendRowChangedEvents(events ...*model.RowChangedEve
 }
 
 func (t *tableSinkWrapper) updateReceivedSorterResolvedTs(ts model.Ts) {
+	if t.state.Load() == tablepb.TableStatePreparing && ts > t.startTs {
+		t.state.Store(tablepb.TableStatePrepared)
+	}
 	t.receivedSorterResolvedTs.Store(ts)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref https://github.com/pingcap/tiflow/issues/5928

### What is changed and how it works?
Consider the table state when generating tasks. If the table sink state is not replicating, then skip it.
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
