### PR TITLE
test(dm): set clustered index behaviour to old version

### DIFF
--- a/dm/tests/_utils/run_tidb_server
+++ b/dm/tests/_utils/run_tidb_server
@@ -47,3 +47,4 @@ done
 # if user test is already exist, add || true to avoid exit with 2
 mysql -uroot -h127.0.0.1 -P${PORT} --default-character-set utf8 -e "CREATE USER 'test'@'%' IDENTIFIED BY '$PASSWORD';" || true
 mysql -uroot -h127.0.0.1 -P${PORT} --default-character-set utf8 -e "GRANT ALL PRIVILEGES ON *.* TO 'test'@'%' WITH GRANT OPTION;" || true
+mysql -uroot -h127.0.0.1 -P${PORT} --default-character-set utf8 -e "SET @@global.tidb_enable_clustered_index = 'INT_ONLY'"

--- a/dm/tests/shardddl3/run.sh
+++ b/dm/tests/shardddl3/run.sh
@@ -126,7 +126,7 @@ function DM_079_CASE() {
 
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"query-status test" \
-		"Unsupported drop primary key when the table's pkIsHandle is true" 1
+		"Unsupported drop primary key" 1
 }
 
 function DM_079() {


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #4159

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
 `None`.
```
