### PR TITLE
engine: unit status use cached source status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ MAKE_FILES = $(shell find . \( -name 'Makefile' -o -name '*.mk' \) -print)
 
 RELEASE_VERSION =
 ifeq ($(RELEASE_VERSION),)
-	RELEASE_VERSION := v6.4.0-master
+	RELEASE_VERSION := v6.5.0-master
 	release_version_regex := ^v[0-9]\..*$$
 	release_branch_regex := "^release-[0-9]\.[0-9].*$$|^HEAD$$|^.*/*tags/v[0-9]\.[0-9]\..*$$"
 	ifneq ($(shell git rev-parse --abbrev-ref HEAD | grep -E $(release_branch_regex)),)

--- a/engine/executor/dm/unitholder.go
+++ b/engine/executor/dm/unitholder.go
@@ -249,7 +249,7 @@ func (u *unitHolderImpl) updateSourceStatus(ctx context.Context) interface{} {
 		u.logger.Warn("failed to get source status", zap.Error(err))
 	}
 	u.setSourceStatus(sourceStatus)
-	return nil
+	return u.unit.Status(sourceStatus)
 }
 
 func (u *unitHolderImpl) getSourceStatus() *binlog.SourceStatus {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #7343

### What is changed and how it works?
- df-service will call `get job api` which calls `dm status`, but current impl will get source status every time, if the source is down, it won't return after 30s timeout, which will make df-service `get/list job` timeout and fails. so change `unit.Status` to use cached source status.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
