### PR TITLE
engine(dm): use new ctx rather than ctx of tick to get source status

### DIFF
--- a/engine/executor/dm/unitholder_test.go
+++ b/engine/executor/dm/unitholder_test.go
@@ -176,7 +176,6 @@ func TestUnitHolderCheckAndUpdateStatus(t *testing.T) {
 	db, mock, err := conn.InitMockDBFull()
 	require.NoError(t, err)
 	unitHolder.upstreamDB = conn.NewBaseDB(db)
-	ctx := context.Background()
 
 	u.On("Status").Return(&pb.DumpStatus{})
 	mock.ExpectQuery("SHOW MASTER STATUS").WillReturnRows(
@@ -186,7 +185,7 @@ func TestUnitHolderCheckAndUpdateStatus(t *testing.T) {
 	mock.ExpectQuery("SHOW BINARY LOGS").WillReturnRows(
 		sqlmock.NewRows([]string{"File", "Position"}).AddRow("mysql-bin.000001", "2345"),
 	)
-	unitHolder.CheckAndUpdateStatus(ctx)
+	unitHolder.CheckAndUpdateStatus()
 	unitHolder.bgWg.Wait()
 	u.AssertExpectations(t)
 	require.NotNil(t, unitHolder.sourceStatus)
@@ -194,7 +193,7 @@ func TestUnitHolderCheckAndUpdateStatus(t *testing.T) {
 
 	// the second time CheckAndUpdateStatus, will not query upstreamDB
 	unitHolder.upstreamDB = nil
-	unitHolder.CheckAndUpdateStatus(ctx)
+	unitHolder.CheckAndUpdateStatus()
 	unitHolder.bgWg.Wait()
 	u.AssertExpectations(t)
 
@@ -215,7 +214,7 @@ func TestUnitHolderCheckAndUpdateStatus(t *testing.T) {
 		sqlmock.NewRows([]string{"File", "Position"}).AddRow("mysql-bin.000001", "2345"),
 	)
 	u.On("Status").Return(&pb.DumpStatus{})
-	unitHolder.CheckAndUpdateStatus(ctx)
+	unitHolder.CheckAndUpdateStatus()
 	unitHolder.bgWg.Wait()
 	u.AssertExpectations(t)
 	require.NoError(t, mock.ExpectationsWereMet())
@@ -330,7 +329,7 @@ func (m *mockUnitHolder) Status(ctx context.Context) interface{} {
 }
 
 // CheckAndUpdateStatus implement Holder.CheckAndUpdateStatus
-func (m *mockUnitHolder) CheckAndUpdateStatus(ctx context.Context) {
+func (m *mockUnitHolder) CheckAndUpdateStatus() {
 	m.Lock()
 	defer m.Unlock()
 	m.Called()

--- a/engine/executor/dm/worker.go
+++ b/engine/executor/dm/worker.go
@@ -164,7 +164,7 @@ func (w *dmWorker) Tick(ctx context.Context) error {
 		return err
 	}
 	// update unit status periodically to update metrics
-	w.unitHolder.CheckAndUpdateStatus(ctx)
+	w.unitHolder.CheckAndUpdateStatus()
 	w.discardResource4Syncer(ctx)
 	return w.messageAgent.Tick(ctx)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #5504 

### What is changed and how it works?
- create new ctx to get source status

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
