### PR TITLE
jobmaster(engine/dm): fix empty worker status for OnWorkerOnline/OnWorkerOffline

### DIFF
--- a/engine/jobmaster/dm/dm_jobmaster.go
+++ b/engine/jobmaster/dm/dm_jobmaster.go
@@ -183,11 +183,12 @@ func (jm *JobMaster) OnWorkerDispatched(worker framework.WorkerHandle, result er
 
 // OnWorkerOnline implements JobMasterImpl.OnWorkerOnline
 func (jm *JobMaster) OnWorkerOnline(worker framework.WorkerHandle) error {
-	jm.Logger().Debug("on worker online", zap.String(logutil.ConstFieldWorkerKey, worker.ID()))
-	return jm.handleOnlineStatus(worker)
+	// because DM needs business online message with worker bound information, plain framework online is no use
+	jm.Logger().Info("on worker online", zap.String(logutil.ConstFieldWorkerKey, worker.ID()))
+	return nil
 }
 
-// handleOnlineStatus is used by OnWorkerOnline and OnWorkerStatusUpdated.
+// handleOnlineStatus is used by OnWorkerStatusUpdated.
 func (jm *JobMaster) handleOnlineStatus(worker framework.WorkerHandle) error {
 	extBytes := worker.Status().ExtBytes
 	if len(extBytes) == 0 {

--- a/engine/jobmaster/dm/dm_jobmaster.go
+++ b/engine/jobmaster/dm/dm_jobmaster.go
@@ -355,8 +355,7 @@ func (jm *JobMaster) getInitStatus() ([]runtime.TaskStatus, []runtime.WorkerStat
 		var taskStatus runtime.TaskStatus
 		extBytes := workerHandle.Status().ExtBytes
 		if len(extBytes) == 0 {
-			jm.Logger().Warn("worker status extBytes is empty", zap.String(logutil.ConstFieldWorkerKey, workerHandle.ID()))
-			continue
+			return nil, nil, errors.Errorf("extBytes of %d is empty", workerHandle.ID())
 		}
 		err := json.Unmarshal(extBytes, &taskStatus)
 		if err != nil {

--- a/engine/jobmaster/dm/dm_jobmaster.go
+++ b/engine/jobmaster/dm/dm_jobmaster.go
@@ -208,7 +208,8 @@ func (jm *JobMaster) handleOnlineStatus(worker framework.WorkerHandle) error {
 func (jm *JobMaster) OnWorkerOffline(worker framework.WorkerHandle, reason error) error {
 	extBytes := worker.Status().ExtBytes
 	if len(extBytes) == 0 {
-		return errors.New("worker status extBytes is empty")
+		jm.Logger().Warn("worker status extBytes is empty", zap.String(logutil.ConstFieldWorkerKey, worker.ID()))
+		return nil
 	}
 	jm.Logger().Info("on worker offline", zap.String(logutil.ConstFieldWorkerKey, worker.ID()))
 	var taskStatus runtime.TaskStatus

--- a/engine/jobmaster/dm/dm_jobmaster.go
+++ b/engine/jobmaster/dm/dm_jobmaster.go
@@ -117,26 +117,26 @@ func (jm *JobMaster) initComponents() error {
 	jm.taskManager = NewTaskManager(taskStatus, jm.metadata.JobStore(), jm.messageAgent, jm.Logger(), jm.MetricFactory())
 	jm.workerManager = NewWorkerManager(jm.ID(), workerStatus, jm.metadata.JobStore(), jm.metadata.UnitStateStore(),
 		jm, jm.messageAgent, jm.checkpointAgent, jm.Logger(), jm.IsS3StorageEnabled())
-	return err
+	return errors.Trace(err)
 }
 
 // InitImpl implements JobMasterImpl.InitImpl
 func (jm *JobMaster) InitImpl(ctx context.Context) error {
 	jm.Logger().Info("initializing the dm jobmaster")
 	if err := jm.initComponents(); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	if err := jm.preCheck(ctx, jm.initJobCfg); err != nil {
 		return jm.Exit(ctx, framework.ExitReasonFailed, err, nil)
 	}
 	if err := jm.bootstrap(ctx); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	if err := jm.checkpointAgent.Create(ctx, jm.initJobCfg); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	if err := jm.taskManager.OperateTask(ctx, dmpkg.Create, jm.initJobCfg, nil); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	jm.initialized.Store(true)
 	return nil
@@ -147,10 +147,10 @@ func (jm *JobMaster) InitImpl(ctx context.Context) error {
 func (jm *JobMaster) OnMasterRecovered(ctx context.Context) error {
 	jm.Logger().Info("recovering the dm jobmaster")
 	if err := jm.initComponents(); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	if err := jm.bootstrap(ctx); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	jm.initialized.Store(true)
 	return nil
@@ -162,7 +162,7 @@ func (jm *JobMaster) Tick(ctx context.Context) error {
 	jm.workerManager.Tick(ctx)
 	jm.taskManager.Tick(ctx)
 	if err := jm.messageAgent.Tick(ctx); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	if jm.isFinished(ctx) {
 		return jm.cancel(ctx, frameModel.WorkerStateFinished)
@@ -189,9 +189,14 @@ func (jm *JobMaster) OnWorkerOnline(worker framework.WorkerHandle) error {
 
 // handleOnlineStatus is used by OnWorkerOnline and OnWorkerStatusUpdated.
 func (jm *JobMaster) handleOnlineStatus(worker framework.WorkerHandle) error {
+	extBytes := worker.Status().ExtBytes
+	if len(extBytes) == 0 {
+		jm.Logger().Warn("worker status extBytes is empty", zap.String(logutil.ConstFieldWorkerKey, worker.ID()))
+		return nil
+	}
 	var taskStatus runtime.TaskStatus
-	if err := json.Unmarshal(worker.Status().ExtBytes, &taskStatus); err != nil {
-		return err
+	if err := json.Unmarshal(extBytes, &taskStatus); err != nil {
+		return errors.Trace(err)
 	}
 
 	jm.taskManager.UpdateTaskStatus(taskStatus)
@@ -201,24 +206,27 @@ func (jm *JobMaster) handleOnlineStatus(worker framework.WorkerHandle) error {
 
 // OnWorkerOffline implements JobMasterImpl.OnWorkerOffline
 func (jm *JobMaster) OnWorkerOffline(worker framework.WorkerHandle, reason error) error {
+	extBytes := worker.Status().ExtBytes
+	if len(extBytes) == 0 {
+		return errors.New("worker status extBytes is empty")
+	}
 	jm.Logger().Info("on worker offline", zap.String(logutil.ConstFieldWorkerKey, worker.ID()))
-	workerStatus := worker.Status()
 	var taskStatus runtime.TaskStatus
-	if err := json.Unmarshal(workerStatus.ExtBytes, &taskStatus); err != nil {
-		return err
+	if err := json.Unmarshal(extBytes, &taskStatus); err != nil {
+		return errors.Trace(err)
 	}
 
 	if taskStatus.Stage == metadata.StageFinished {
 		var finishedTaskStatus runtime.FinishedTaskStatus
-		if err := json.Unmarshal(workerStatus.ExtBytes, &finishedTaskStatus); err != nil {
-			return err
+		if err := json.Unmarshal(extBytes, &finishedTaskStatus); err != nil {
+			return errors.Trace(err)
 		}
 		return jm.onWorkerFinished(finishedTaskStatus, worker)
 	}
 	jm.taskManager.UpdateTaskStatus(runtime.NewOfflineStatus(taskStatus.Task))
 	jm.workerManager.UpdateWorkerStatus(runtime.NewWorkerStatus(taskStatus.Task, taskStatus.Unit, worker.ID(), runtime.WorkerOffline, taskStatus.CfgModRevision))
 	if err := jm.messageAgent.UpdateClient(taskStatus.Task, nil); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	jm.workerManager.SetNextCheckTime(time.Now())
 	return nil
@@ -246,13 +254,13 @@ func (jm *JobMaster) onWorkerFinished(finishedTaskStatus runtime.FinishedTaskSta
 		return nil
 	})
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	jm.taskManager.UpdateTaskStatus(taskStatus)
 	jm.workerManager.UpdateWorkerStatus(runtime.NewWorkerStatus(taskStatus.Task, taskStatus.Unit, worker.ID(), runtime.WorkerFinished, taskStatus.CfgModRevision))
 	if err := jm.messageAgent.RemoveClient(taskStatus.Task); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	jm.workerManager.SetNextCheckTime(time.Now())
 	return nil
@@ -266,7 +274,7 @@ func (jm *JobMaster) OnWorkerStatusUpdated(worker framework.WorkerHandle, newSta
 	}
 	jm.Logger().Info("on worker status updated", zap.String(logutil.ConstFieldWorkerKey, worker.ID()), zap.String("extra bytes", string(newStatus.ExtBytes)))
 	if err := jm.handleOnlineStatus(worker); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	// run task manager tick when worker status changed to operate task.
 	jm.taskManager.SetNextCheckTime(time.Now())
@@ -366,7 +374,7 @@ func (jm *JobMaster) preCheck(ctx context.Context, cfg *config.JobCfg) error {
 	}
 
 	if err := master.AdjustTargetDB(ctx, cfg.TargetDB); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	if cfg.TaskMode == dmconfig.ModeIncrement {
@@ -374,7 +382,7 @@ func (jm *JobMaster) preCheck(ctx context.Context, cfg *config.JobCfg) error {
 			if inst.Meta == nil {
 				meta, err2 := master.GetLatestMeta(ctx, inst.Flavor, inst.DBCfg)
 				if err2 != nil {
-					return err2
+					return errors.Trace(err2)
 				}
 				inst.Meta = meta
 			}
@@ -390,7 +398,7 @@ func (jm *JobMaster) preCheck(ctx context.Context, cfg *config.JobCfg) error {
 	msg, err := checker.CheckSyncConfigFunc(ctx, dmSubtaskCfgs, ctlcommon.DefaultErrorCnt, ctlcommon.DefaultWarnCnt)
 	if err != nil {
 		jm.Logger().Error("error when pre-checking", zap.Error(err))
-		return err
+		return errors.Trace(err)
 	}
 	jm.Logger().Info("finish pre-checking job config", zap.String("result", msg))
 	return nil
@@ -450,7 +458,7 @@ func (jm *JobMaster) cancel(ctx context.Context, code frameModel.WorkerState) er
 func (jm *JobMaster) removeCheckpoint(ctx context.Context) error {
 	state, err := jm.metadata.JobStore().Get(ctx)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	job := state.(*metadata.Job)
 	for _, task := range job.Tasks {
@@ -474,16 +482,16 @@ func (jm *JobMaster) bootstrap(ctx context.Context) error {
 			return clusterInfoStore.Put(ctx, metadata.NewClusterInfo(*internalVersion))
 		}
 		jm.Logger().Info("get cluster info error", zap.Error(err))
-		return err
+		return errors.Trace(err)
 	}
 	clusterInfo := state.(*metadata.ClusterInfo)
 	jm.Logger().Info("get cluster info for job", zap.Any("cluster_info", clusterInfo))
 
 	if err := jm.metadata.Upgrade(ctx, clusterInfo.Version); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	if err := jm.checkpointAgent.Upgrade(ctx, clusterInfo.Version); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	// only update for new version

--- a/engine/jobmaster/dm/dm_jobmaster.go
+++ b/engine/jobmaster/dm/dm_jobmaster.go
@@ -353,7 +353,12 @@ func (jm *JobMaster) getInitStatus() ([]runtime.TaskStatus, []runtime.WorkerStat
 			continue
 		}
 		var taskStatus runtime.TaskStatus
-		err := json.Unmarshal(workerHandle.Status().ExtBytes, &taskStatus)
+		extBytes := workerHandle.Status().ExtBytes
+		if len(extBytes) == 0 {
+			jm.Logger().Warn("worker status extBytes is empty", zap.String(logutil.ConstFieldWorkerKey, workerHandle.ID()))
+			continue
+		}
+		err := json.Unmarshal(extBytes, &taskStatus)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}

--- a/engine/jobmaster/dm/dm_jobmaster_test.go
+++ b/engine/jobmaster/dm/dm_jobmaster_test.go
@@ -294,11 +294,10 @@ func (t *testDMJobmasterSuite) TestDMJobmaster() {
 	// worker1 online, worker2 dispatch error
 	bytes1, err := json.Marshal(taskStatus1)
 	require.NoError(t.T(), err)
-	workerHandle1.On("Status").Return(&frameModel.WorkerStatus{ExtBytes: nil}).Once()
 	require.NoError(t.T(), jm.OnWorkerOnline(workerHandle1))
 	workerHandle1.On("Status").Return(&frameModel.WorkerStatus{ExtBytes: bytes1}).Once()
 	workerHandle1.On("IsTombStone").Return(false).Once()
-	require.NoError(t.T(), jm.OnWorkerOnline(workerHandle1))
+	require.NoError(t.T(), jm.OnWorkerStatusUpdated(workerHandle1, &frameModel.WorkerStatus{State: frameModel.WorkerStateNormal, ExtBytes: bytes1}))
 	jm.OnWorkerDispatched(workerHandle2, errors.New("dispatch error"))
 	worker3 := "worker3"
 	mockBaseJobmaster.On("CreateWorker", mock.Anything, mock.Anything, mock.Anything).Return(worker3, nil).Once()
@@ -312,7 +311,7 @@ func (t *testDMJobmasterSuite) TestDMJobmaster() {
 	require.NoError(t.T(), err)
 	workerHandle2.On("Status").Return(&frameModel.WorkerStatus{ExtBytes: bytes2}).Once()
 	workerHandle2.On("IsTombStone").Return(false).Once()
-	jm.OnWorkerOnline(workerHandle2)
+	jm.OnWorkerStatusUpdated(workerHandle2, &frameModel.WorkerStatus{State: frameModel.WorkerStateNormal, ExtBytes: bytes2})
 	workerHandle1.On("Status").Return(&frameModel.WorkerStatus{ExtBytes: bytes1}).Once()
 	jm.OnWorkerOffline(workerHandle1, errors.New("offline error"))
 	worker4 := "worker4"
@@ -324,7 +323,7 @@ func (t *testDMJobmasterSuite) TestDMJobmaster() {
 	workerHandle1.WorkerID = worker4
 	workerHandle1.On("Status").Return(&frameModel.WorkerStatus{ExtBytes: bytes1}).Once()
 	workerHandle1.On("IsTombStone").Return(false).Once()
-	jm.OnWorkerOnline(workerHandle1)
+	jm.OnWorkerStatusUpdated(workerHandle1, &frameModel.WorkerStatus{State: frameModel.WorkerStateNormal, ExtBytes: bytes1})
 	require.NoError(t.T(), jm.Tick(context.Background()))
 
 	// worker1 finished
@@ -344,7 +343,7 @@ func (t *testDMJobmasterSuite) TestDMJobmaster() {
 	require.NoError(t.T(), err)
 	workerHandle1.On("Status").Return(&frameModel.WorkerStatus{ExtBytes: bytes1}).Once()
 	workerHandle1.On("IsTombStone").Return(false).Once()
-	jm.OnWorkerOnline(workerHandle1)
+	jm.OnWorkerStatusUpdated(workerHandle1, &frameModel.WorkerStatus{State: frameModel.WorkerStateNormal, ExtBytes: bytes1})
 	require.NoError(t.T(), jm.Tick(context.Background()))
 
 	// master failover

--- a/engine/jobmaster/dm/dm_jobmaster_test.go
+++ b/engine/jobmaster/dm/dm_jobmaster_test.go
@@ -294,9 +294,11 @@ func (t *testDMJobmasterSuite) TestDMJobmaster() {
 	// worker1 online, worker2 dispatch error
 	bytes1, err := json.Marshal(taskStatus1)
 	require.NoError(t.T(), err)
+	workerHandle1.On("Status").Return(&frameModel.WorkerStatus{ExtBytes: nil}).Once()
+	require.NoError(t.T(), jm.OnWorkerOnline(workerHandle1))
 	workerHandle1.On("Status").Return(&frameModel.WorkerStatus{ExtBytes: bytes1}).Once()
 	workerHandle1.On("IsTombStone").Return(false).Once()
-	jm.OnWorkerOnline(workerHandle1)
+	require.NoError(t.T(), jm.OnWorkerOnline(workerHandle1))
 	jm.OnWorkerDispatched(workerHandle2, errors.New("dispatch error"))
 	worker3 := "worker3"
 	mockBaseJobmaster.On("CreateWorker", mock.Anything, mock.Anything, mock.Anything).Return(worker3, nil).Once()


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7691

### What is changed and how it works?
- ignore nil extra status bytes for OnWorkerOnline

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
