### PR TITLE
engine: make sure get-job-status can see unit status either in task_status or finished_unit_status

### DIFF
--- a/engine/jobmaster/dm/api.go
+++ b/engine/jobmaster/dm/api.go
@@ -78,15 +78,6 @@ func (jm *JobMaster) QueryJobStatus(ctx context.Context, tasks []string) (*JobSt
 		existUnitState bool
 	)
 
-	state, err := jm.metadata.UnitStateStore().Get(ctx)
-	if err != nil && errors.Cause(err) != metadata.ErrStateNotFound {
-		return nil, err
-	}
-	unitState, existUnitState = state.(*metadata.UnitState)
-	if existUnitState {
-		jobStatus.FinishedUnitStatus = unitState.FinishedUnitStatus
-	}
-
 	for _, task := range tasks {
 		taskID := task
 		wg.Add(1)
@@ -139,6 +130,15 @@ func (jm *JobMaster) QueryJobStatus(ctx context.Context, tasks []string) (*JobSt
 		}()
 	}
 	wg.Wait()
+
+	state, err := jm.metadata.UnitStateStore().Get(ctx)
+	if err != nil && errors.Cause(err) != metadata.ErrStateNotFound {
+		return nil, err
+	}
+	unitState, existUnitState = state.(*metadata.UnitState)
+	if existUnitState {
+		jobStatus.FinishedUnitStatus = unitState.FinishedUnitStatus
+	}
 
 	return jobStatus, nil
 }

--- a/engine/jobmaster/dm/api.go
+++ b/engine/jobmaster/dm/api.go
@@ -131,6 +131,8 @@ func (jm *JobMaster) QueryJobStatus(ctx context.Context, tasks []string) (*JobSt
 	}
 	wg.Wait()
 
+	// should be done after we get current task-status, since some unit status might be missing if
+	// current unit finish between we get finished unit status and get current task-status
 	state, err := jm.metadata.UnitStateStore().Get(ctx)
 	if err != nil && errors.Cause(err) != metadata.ErrStateNotFound {
 		return nil, err

--- a/engine/jobmaster/dm/dm_jobmaster.go
+++ b/engine/jobmaster/dm/dm_jobmaster.go
@@ -261,6 +261,10 @@ func (jm *JobMaster) onWorkerFinished(finishedTaskStatus runtime.FinishedTaskSta
 
 	jm.taskManager.UpdateTaskStatus(taskStatus)
 	jm.workerManager.UpdateWorkerStatus(runtime.NewWorkerStatus(taskStatus.Task, taskStatus.Unit, worker.ID(), runtime.WorkerFinished, taskStatus.CfgModRevision))
+
+	// we should call this after we set "state.FinishedUnitStatus" to make sure finished-unit-status is persisted
+	// before client is removed. else in status of get-job-api, status of current unit might be missing, since
+	// query-status might not get status of current unit status and the status is not in "state.FinishedUnitStatus"
 	if err := jm.messageAgent.RemoveClient(taskStatus.Task); err != nil {
 		return errors.Trace(err)
 	}

--- a/engine/pkg/dm/message_agent.go
+++ b/engine/pkg/dm/message_agent.go
@@ -124,6 +124,7 @@ func (m *messageMatcher) sendRequest(
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case <-clientCtx.Done():
+		// todo: it's quite normal to see worker finished during the request, should we return nil, nil here?
 		return nil, errors.New("client is finished before receiving response")
 	case resp := <-respCh:
 		return resp, nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7710

### What is changed and how it works?
- get `finished_unit_status` after query worker to avoid finished_unit_status hasn't set and worker finished in the middle of the request, and cause unit status(such as load) is missing

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
