### PR TITLE
binlog_filter: use table name instead of table id as cache key

### DIFF
--- a/dm/syncer/util.go
+++ b/dm/syncer/util.go
@@ -160,36 +160,36 @@ func subtaskCfg2BinlogSyncerCfg(cfg *config.SubTaskConfig, timezone *time.Locati
 	if baList != nil {
 		// we don't track delete table events, so simply reset the cache if it's full
 		// TODO: use LRU or CLOCK cache if needed.
-		allowListCache := make(map[uint64]struct{}, maxCapacity)
-		blockListCache := make(map[uint64]struct{}, maxCapacity)
+		allowListCache := make(map[filter.Table]struct{}, maxCapacity)
+		blockListCache := make(map[filter.Table]struct{}, maxCapacity)
 
 		rowsEventDecodeFunc = func(re *replication.RowsEvent, data []byte) error {
 			pos, err := re.DecodeHeader(data)
 			if err != nil {
 				return err
 			}
-			if _, ok := blockListCache[re.TableID]; ok {
-				return nil
-			} else if _, ok := allowListCache[re.TableID]; ok {
-				return re.DecodeData(pos, data)
-			}
-
-			tb := &filter.Table{
+			tb := filter.Table{
 				Schema: string(re.Table.Schema),
 				Name:   string(re.Table.Table),
 			}
-			if skipByTable(baList, tb) {
+			if _, ok := blockListCache[tb]; ok {
+				return nil
+			} else if _, ok := allowListCache[tb]; ok {
+				return re.DecodeData(pos, data)
+			}
+
+			if skipByTable(baList, &tb) {
 				if len(blockListCache) >= maxCapacity {
-					blockListCache = make(map[uint64]struct{}, maxCapacity)
+					blockListCache = make(map[filter.Table]struct{}, maxCapacity)
 				}
-				blockListCache[re.TableID] = struct{}{}
+				blockListCache[tb] = struct{}{}
 				return nil
 			}
 
 			if len(allowListCache) >= maxCapacity {
-				allowListCache = make(map[uint64]struct{}, maxCapacity)
+				allowListCache = make(map[filter.Table]struct{}, maxCapacity)
 			}
-			allowListCache[re.TableID] = struct{}{}
+			allowListCache[tb] = struct{}{}
 			return re.DecodeData(pos, data)
 		}
 	}

--- a/dm/syncer/util.go
+++ b/dm/syncer/util.go
@@ -160,6 +160,8 @@ func subtaskCfg2BinlogSyncerCfg(cfg *config.SubTaskConfig, timezone *time.Locati
 	if baList != nil {
 		// we don't track delete table events, so simply reset the cache if it's full
 		// TODO: use LRU or CLOCK cache if needed.
+		// NOTE: use Table as Key rather than TableID
+		// because TableID may change when upstream switches master, and also RenameTable will not change TableID.
 		allowListCache := make(map[filter.Table]struct{}, maxCapacity)
 		blockListCache := make(map[filter.Table]struct{}, maxCapacity)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #4287 

### What is changed and how it works?
- use schema/table name as cache key to filter binlog

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
