### PR TITLE
puller, sorter (ticdc): fix a panic due to resolvedTs regression in sorter

### DIFF
--- a/cdc/processor/pipeline/sorter.go
+++ b/cdc/processor/pipeline/sorter.go
@@ -437,7 +437,8 @@ func (n *sorterNode) handleRawEvent(ctx context.Context, event *model.Polymorphi
 			log.Panic("resolved ts regression",
 				zap.Int64("tableID", n.tableID),
 				zap.Uint64("resolvedTs", resolvedTs),
-				zap.Uint64("oldResolvedTs", oldResolvedTs))
+				zap.Uint64("oldResolvedTs", oldResolvedTs),
+				zap.Any("rawKV", rawKV))
 		}
 		if resolvedTs > n.BarrierTs() && !n.redoLogEnabled {
 			// Do not send resolved ts events that is larger than

--- a/cdc/puller/puller_test.go
+++ b/cdc/puller/puller_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/pingcap/errors"
 	tidbkv "github.com/pingcap/tidb/kv"
@@ -185,8 +186,21 @@ func TestPullerResolvedForward(t *testing.T) {
 		}
 		return nil
 	}, retry.WithBackoffBaseDelay(10), retry.WithMaxTries(10), retry.WithIsRetryableErr(cerrors.IsRetryableError))
-
 	require.Nil(t, err)
+
+	// make sure p.resolvedTs does not fall back
+	plr.cli.Returns(model.RegionFeedEvent{
+		Resolved: &model.ResolvedSpans{
+			Spans: []model.RegionComparableSpan{{
+				Span: regionspan.ToComparableSpan(regionspan.Span{Start: []byte("t_d"), End: []byte("t_e")}),
+			}}, ResolvedTs: uint64(999),
+		},
+	})
+	checkTime := 10
+	for i := 0; i < checkTime; i++ {
+		require.Equal(t, uint64(1000), plr.GetResolvedTs())
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	store.Close()
 	cancel()


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7672 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
