### PR TITLE
sink(ticdc): Fix a slice overwriting problem

### DIFF
--- a/cdc/sinkv2/eventsink/cloudstorage/dml_worker.go
+++ b/cdc/sinkv2/eventsink/cloudstorage/dml_worker.go
@@ -132,7 +132,8 @@ func (d *dmlWorker) backgroundFlushMsgs(ctx context.Context) {
 						version:   tableInfo.Version,
 					}
 					d.tableEvents.mu.Lock()
-					events := d.tableEvents.fragments[table]
+					events := make([]eventFragment, len(d.tableEvents.fragments[table]))
+					copy(events, d.tableEvents.fragments[table])
 					d.tableEvents.fragments[table] = d.tableEvents.fragments[table][:0]
 					d.tableEvents.mu.Unlock()
 					if len(events) == 0 {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #6797 

### What is changed and how it works?
- Before this PR:
When iterating `events` in L143:
https://github.com/pingcap/tiflow/blob/e7e2894c18c1a538458c66770bd17a255676b854/cdc/sinkv2/eventsink/cloudstorage/dml_worker.go#L135-L143
some items may have been mistakenly overwritten by L256, so the table checkpoint will not be updated anymore.
https://github.com/pingcap/tiflow/blob/e7e2894c18c1a538458c66770bd17a255676b854/cdc/sinkv2/eventsink/cloudstorage/dml_worker.go#L255-L257

- After this PR:
Clone a new slice to detach with the old one, so as to prevent the slice overwriting problem from happening.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
