### PR TITLE
processor/sourcemanager(ticdc): move mounted iter into sourceManager

### DIFF
--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -846,9 +846,9 @@ func (p *processor) lazyInitImpl(ctx cdcContext.Context) error {
 				zap.Duration("duration", time.Since(start)))
 			return errors.Trace(err)
 		}
-		p.sourceManager = sourcemanager.New(p.changefeedID, p.upstream, sortEngine, p.errCh)
+		p.sourceManager = sourcemanager.New(p.changefeedID, p.upstream, p.mg, sortEngine, p.errCh)
 		sinkManager, err := sinkmanager.New(stdCtx, p.changefeedID, p.changefeed.Info, p.upstream, p.redoManager,
-			sortEngine, p.mg, p.errCh, p.metricsTableSinkTotalRows)
+			p.sourceManager, p.errCh, p.metricsTableSinkTotalRows)
 		// Bind them so that sourceManager can notify sinkManager.
 		p.sourceManager.OnResolve(sinkManager.UpdateReceivedSorterResolvedTs)
 		if err != nil {

--- a/cdc/processor/sinkmanager/redo_log_worker.go
+++ b/cdc/processor/sinkmanager/redo_log_worker.go
@@ -18,8 +18,8 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
-	"github.com/pingcap/tiflow/cdc/entry"
 	"github.com/pingcap/tiflow/cdc/model"
+	"github.com/pingcap/tiflow/cdc/processor/sourcemanager"
 	"github.com/pingcap/tiflow/cdc/processor/sourcemanager/engine"
 	"github.com/pingcap/tiflow/cdc/redo"
 	"go.uber.org/zap"
@@ -27,8 +27,7 @@ import (
 
 type redoWorker struct {
 	changefeedID   model.ChangeFeedID
-	mg             entry.MounterGroup
-	sortEngine     engine.SortEngine
+	sourceManager  *sourcemanager.SourceManager
 	memQuota       *memQuota
 	redoManager    redo.LogManager
 	eventCache     *redoEventCache
@@ -38,8 +37,7 @@ type redoWorker struct {
 
 func newRedoWorker(
 	changefeedID model.ChangeFeedID,
-	mg entry.MounterGroup,
-	sortEngine engine.SortEngine,
+	sourceManager *sourcemanager.SourceManager,
 	quota *memQuota,
 	redoManager redo.LogManager,
 	eventCache *redoEventCache,
@@ -48,8 +46,7 @@ func newRedoWorker(
 ) *redoWorker {
 	return &redoWorker{
 		changefeedID:   changefeedID,
-		mg:             mg,
-		sortEngine:     sortEngine,
+		sourceManager:  sourceManager,
 		memQuota:       quota,
 		redoManager:    redoManager,
 		eventCache:     eventCache,
@@ -164,10 +161,7 @@ func (w *redoWorker) handleTask(ctx context.Context, task *redoTask) error {
 	}
 
 	upperBound := task.getUpperBound()
-	iter := engine.NewMountedEventIter(
-		w.sortEngine.FetchByTable(task.tableID, task.lowerBound, upperBound),
-		w.mg, 256)
-
+	iter := w.sourceManager.FetchByTable(task.tableID, task.lowerBound, upperBound)
 	defer func() {
 		if err := iter.Close(); err != nil {
 			log.Error("sink redo worker fails to close iterator",

--- a/cdc/processor/sourcemanager/manager.go
+++ b/cdc/processor/sourcemanager/manager.go
@@ -102,11 +102,6 @@ func (m *SourceManager) GetTableResolvedTs(tableID model.TableID) model.Ts {
 	return m.engine.GetResolvedTs(tableID)
 }
 
-// CleanAllTables just wrap the engine's CleanAllTables method.
-func (m *SourceManager) CleanAllTables(upperBound engine.Position) error {
-	return m.engine.CleanAllTables(upperBound)
-}
-
 // GetTablePullerStats returns the puller stats of the table.
 func (m *SourceManager) GetTablePullerStats(tableID model.TableID) puller.Stats {
 	p, ok := m.pullers.Load(tableID)

--- a/cdc/processor/sourcemanager/manager.go
+++ b/cdc/processor/sourcemanager/manager.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 
 	"github.com/pingcap/log"
+	"github.com/pingcap/tiflow/cdc/entry"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/processor/sourcemanager/engine"
 	pullerwrapper "github.com/pingcap/tiflow/cdc/processor/sourcemanager/puller"
@@ -27,6 +28,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const defaultMaxBatchSize = 256
+
 // SourceManager is the manager of the source engine and puller.
 type SourceManager struct {
 	// changefeedID is the changefeed ID.
@@ -34,6 +37,8 @@ type SourceManager struct {
 	changefeedID model.ChangeFeedID
 	// up is the upstream of the puller.
 	up *upstream.Upstream
+	// mg is the mounter group for mount the raw kv entry.
+	mg entry.MounterGroup
 	// engine is the source engine.
 	engine engine.SortEngine
 	// pullers is the puller wrapper map.
@@ -46,12 +51,14 @@ type SourceManager struct {
 func New(
 	changefeedID model.ChangeFeedID,
 	up *upstream.Upstream,
+	mg entry.MounterGroup,
 	engine engine.SortEngine,
 	errChan chan error,
 ) *SourceManager {
 	return &SourceManager{
 		changefeedID: changefeedID,
 		up:           up,
+		mg:           mg,
 		engine:       engine,
 		errChan:      errChan,
 	}
@@ -80,13 +87,24 @@ func (m *SourceManager) OnResolve(action func(model.TableID, model.Ts)) {
 }
 
 // FetchByTable just wrap the engine's FetchByTable method.
-func (m *SourceManager) FetchByTable(tableID model.TableID, lowerBound, upperBound engine.Position) engine.EventIterator {
-	return m.engine.FetchByTable(tableID, lowerBound, upperBound)
+func (m *SourceManager) FetchByTable(tableID model.TableID, lowerBound, upperBound engine.Position) *engine.MountedEventIter {
+	iter := m.engine.FetchByTable(tableID, lowerBound, upperBound)
+	return engine.NewMountedEventIter(iter, m.mg, defaultMaxBatchSize)
 }
 
 // CleanByTable just wrap the engine's CleanByTable method.
 func (m *SourceManager) CleanByTable(tableID model.TableID, upperBound engine.Position) error {
 	return m.engine.CleanByTable(tableID, upperBound)
+}
+
+// GetTableResolvedTs returns the resolved ts of the table.
+func (m *SourceManager) GetTableResolvedTs(tableID model.TableID) model.Ts {
+	return m.engine.GetResolvedTs(tableID)
+}
+
+// CleanAllTables just wrap the engine's CleanAllTables method.
+func (m *SourceManager) CleanAllTables(upperBound engine.Position) error {
+	return m.engine.CleanAllTables(upperBound)
 }
 
 // GetTablePullerStats returns the puller stats of the table.


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref https://github.com/pingcap/tiflow/issues/5928

See: https://github.com/pingcap/tiflow/issues/5928#issuecomment-1318253453

### What is changed and how it works?

move mounted iter into sourceManager.
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
