### PR TITLE
processor(ticdc): cancel the context before closing the processor

### DIFF
--- a/cdc/processor/manager.go
+++ b/cdc/processor/manager.go
@@ -150,9 +150,6 @@ func (m *managerImpl) Tick(stdCtx context.Context, state orchestrator.ReactorSta
 func (m *managerImpl) closeProcessor(changefeedID model.ChangeFeedID, ctx cdcContext.Context) {
 	processor, exist := m.processors[changefeedID]
 	if exist {
-		log.Info("Try to close processor",
-			zap.String("namespace", changefeedID.Namespace),
-			zap.String("changefeed", changefeedID.ID))
 		startTime := time.Now()
 		err := processor.Close(ctx)
 		costTime := time.Since(startTime)

--- a/cdc/processor/manager.go
+++ b/cdc/processor/manager.go
@@ -149,12 +149,10 @@ func (m *managerImpl) Tick(stdCtx context.Context, state orchestrator.ReactorSta
 
 func (m *managerImpl) closeProcessor(changefeedID model.ChangeFeedID, ctx cdcContext.Context) {
 	processor, exist := m.processors[changefeedID]
-	log.Info("Try to close processor",
-		zap.String("namespace", changefeedID.Namespace),
-		zap.String("changefeed", changefeedID.ID),
-		zap.Bool("exist", exist))
-
 	if exist {
+		log.Info("Try to close processor",
+			zap.String("namespace", changefeedID.Namespace),
+			zap.String("changefeed", changefeedID.ID))
 		startTime := time.Now()
 		err := processor.Close(ctx)
 		costTime := time.Since(startTime)

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -1281,6 +1281,9 @@ func (p *processor) Close(ctx cdcContext.Context) error {
 		zap.String("changefeed", p.changefeedID.ID))
 	if p.pullBasedSinking {
 		if p.sourceManager != nil {
+			log.Info("Processor try to close source manager",
+				zap.String("namespace", p.changefeedID.Namespace),
+				zap.String("changefeed", p.changefeedID.ID))
 			if err := p.sourceManager.Close(); err != nil {
 				log.Error("Failed to close source manager",
 					zap.String("namespace", p.changefeedID.Namespace),
@@ -1288,9 +1291,15 @@ func (p *processor) Close(ctx cdcContext.Context) error {
 					zap.Error(err))
 				return errors.Trace(err)
 			}
+			log.Info("Processor closed source manager successfully",
+				zap.String("namespace", p.changefeedID.Namespace),
+				zap.String("changefeed", p.changefeedID.ID))
 			p.sourceManager = nil
 		}
 		if p.sinkManager != nil {
+			log.Info("Processor try to close sink manager",
+				zap.String("namespace", p.changefeedID.Namespace),
+				zap.String("changefeed", p.changefeedID.ID))
 			if err := p.sinkManager.Close(); err != nil {
 				log.Error("Failed to close sink manager",
 					zap.String("namespace", p.changefeedID.Namespace),
@@ -1298,6 +1307,9 @@ func (p *processor) Close(ctx cdcContext.Context) error {
 					zap.Error(err))
 				return errors.Trace(err)
 			}
+			log.Info("Processor closed sink manager successfully",
+				zap.String("namespace", p.changefeedID.Namespace),
+				zap.String("changefeed", p.changefeedID.ID))
 			p.sinkManager = nil
 		}
 		engineFactory := ctx.GlobalVars().SortEngineFactory

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -1335,9 +1335,15 @@ func (p *processor) Close(ctx cdcContext.Context) error {
 	p.wg.Wait()
 
 	if p.agent != nil {
+		log.Info("Processor try to close agent",
+			zap.String("namespace", p.changefeedID.Namespace),
+			zap.String("changefeed", p.changefeedID.ID))
 		if err := p.agent.Close(); err != nil {
 			log.Warn("close agent meet error", zap.Error(err))
 		}
+		log.Info("Processor closed agent successfully",
+			zap.String("namespace", p.changefeedID.Namespace),
+			zap.String("changefeed", p.changefeedID.ID))
 		p.agent = nil
 	}
 

--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -581,6 +581,11 @@ func (m *SinkManager) AsyncStopTable(tableID model.TableID) {
 	m.wg.Add(1)
 	go func() {
 		defer m.wg.Done()
+		log.Info("Async stop table sink",
+			zap.String("namespace", m.changefeedID.Namespace),
+			zap.String("changefeed", m.changefeedID.ID),
+			zap.Int64("tableID", tableID),
+		)
 		tableSink, ok := m.tableSinks.Load(tableID)
 		if !ok {
 			log.Panic("Table sink not found when removing table",
@@ -595,6 +600,11 @@ func (m *SinkManager) AsyncStopTable(tableID model.TableID) {
 			zap.String("changefeed", m.changefeedID.ID),
 			zap.Int64("tableID", tableID),
 			zap.Uint64("memory", cleanedBytes),
+		)
+		log.Info("Table sink closed asynchronously",
+			zap.String("namespace", m.changefeedID.Namespace),
+			zap.String("changefeed", m.changefeedID.ID),
+			zap.Int64("tableID", tableID),
 		)
 	}()
 }
@@ -690,6 +700,10 @@ func (m *SinkManager) ReceivedEvents() int64 {
 
 // Close closes all workers.
 func (m *SinkManager) Close() error {
+	log.Info("Closing sink manager",
+		zap.String("namespace", m.changefeedID.Namespace),
+		zap.String("changefeed", m.changefeedID.ID))
+	start := time.Now()
 	if m.cancel != nil {
 		m.cancel()
 		m.cancel = nil
@@ -703,6 +717,14 @@ func (m *SinkManager) Close() error {
 		value.(*tableSinkWrapper).close(m.ctx)
 		return true
 	})
+	log.Info("All table sinks closed",
+		zap.String("namespace", m.changefeedID.Namespace),
+		zap.String("changefeed", m.changefeedID.ID),
+		zap.Duration("cost", time.Since(start)))
 	m.wg.Wait()
+	log.Info("Closed sink manager",
+		zap.String("namespace", m.changefeedID.Namespace),
+		zap.String("changefeed", m.changefeedID.ID),
+		zap.Duration("cost", time.Since(start)))
 	return nil
 }

--- a/cdc/sinkv2/eventsink/txn/worker.go
+++ b/cdc/sinkv2/eventsink/txn/worker.go
@@ -92,9 +92,17 @@ func (w *worker) Add(txn *txnEvent, unlock func()) {
 }
 
 func (w *worker) Close() {
+	log.Info("Closing txn worker",
+		zap.String("changefeed", w.changefeed),
+		zap.Int("worker", w.ID))
+	start := time.Now()
 	close(w.stopped)
 	w.wg.Wait()
 	w.txnCh.Close()
+	log.Info("Closed txn worker",
+		zap.String("changefeed", w.changefeed),
+		zap.Int("worker", w.ID),
+		zap.Duration("elapsed", time.Since(start)))
 }
 
 // Run a background loop.


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/7780 

### What is changed and how it works?

Cancel the context before we close the processor. Otherwise, we might be stuck when closing the sink.

Add some logs when closing the processor.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
