### PR TITLE
pkg(dm): modify the type of pos returned by function GetMasterStatus

### DIFF
--- a/dm/pkg/conn/utils.go
+++ b/dm/pkg/conn/utils.go
@@ -100,11 +100,11 @@ func getVariable(ctx *tcontext.Context, conn *BaseConn, variable string, isGloba
 // GetMasterStatus gets status from master.
 // When the returned error is nil, the gtid must be not nil.
 func GetMasterStatus(ctx *tcontext.Context, db *BaseDB, flavor string) (
-	string, uint32, string, string, string, error,
+	string, uint64, string, string, string, error,
 ) {
 	var (
 		binlogName     string
-		pos            uint32
+		pos            uint64
 		binlogDoDB     string
 		binlogIgnoreDB string
 		gtidStr        string
@@ -166,7 +166,7 @@ func GetMasterStatus(ctx *tcontext.Context, db *BaseDB, flavor string) (
 				err = terror.DBErrorAdapt(err, terror.ErrDBDriverError)
 				return binlogName, pos, binlogDoDB, binlogIgnoreDB, gtidStr, err
 			}
-			pos = uint32(posInt)
+			pos = uint64(posInt)
 			binlogDoDB = rowsResult[0][2]
 			binlogIgnoreDB = rowsResult[0][3]
 			gtidStr = rowsResult[0][4]
@@ -194,7 +194,7 @@ func GetMasterStatus(ctx *tcontext.Context, db *BaseDB, flavor string) (
 				err = terror.DBErrorAdapt(err, terror.ErrDBDriverError)
 				return binlogName, pos, binlogDoDB, binlogIgnoreDB, gtidStr, err
 			}
-			pos = uint32(posInt)
+			pos = uint64(posInt)
 			binlogDoDB = rowsResult[0][2]
 			binlogIgnoreDB = rowsResult[0][3]
 		}
@@ -234,7 +234,7 @@ func GetPosAndGs(ctx *tcontext.Context, db *BaseDB, flavor string) (
 	}
 	binlogPos = gmysql.Position{
 		Name: binlogName,
-		Pos:  pos,
+		Pos:  uint32(pos),
 	}
 
 	gs, err = gtid.ParserGTID(flavor, gtidStr)

--- a/dm/pkg/conn/utils_test.go
+++ b/dm/pkg/conn/utils_test.go
@@ -72,7 +72,7 @@ func TestGetMasterStatus(t *testing.T) {
 	cases := []struct {
 		rows           *sqlmock.Rows
 		binlogName     string
-		pos            uint32
+		pos            uint64
 		binlogDoDB     string
 		binlogIgnoreDB string
 		gtidStr        string


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7483

### What is changed and how it works?
Returned pos of function GetMasterStatus should be `uint64` instead of `uint32`
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
