### PR TITLE
sorter/db,processor: replace table ID with Span 

### DIFF
--- a/cdc/processor/pipeline/sorter.go
+++ b/cdc/processor/pipeline/sorter.go
@@ -121,7 +121,9 @@ func newSorterNode(
 	}
 }
 
-func createSorter(ctx pipeline.NodeContext, tableName string, span tablepb.Span) (sorter.EventSorter, error) {
+func createSorter(
+	ctx pipeline.NodeContext, tableName string, span tablepb.Span,
+) (sorter.EventSorter, error) {
 	sortEngine := ctx.ChangefeedVars().Info.Engine
 	switch sortEngine {
 	// `file` and `memory` become aliases of `unified` for backward compatibility.
@@ -162,7 +164,8 @@ func createSorter(ctx pipeline.NodeContext, tableName string, span tablepb.Span)
 		// Sorter dir has been set and checked when server starts.
 		// See https://github.com/pingcap/tiflow/blob/9dad09/cdc/server.go#L275
 		sortDir := config.GetGlobalServerConfig().Sorter.SortDir
-		unifiedSorter, err := unified.NewUnifiedSorter(sortDir, ctx.ChangefeedVars().ID, tableName, span.TableID)
+		unifiedSorter, err := unified.NewUnifiedSorter(
+			sortDir, ctx.ChangefeedVars().ID, tableName, span.TableID)
 		if err != nil {
 			return nil, err
 		}

--- a/cdc/processor/pipeline/sorter.go
+++ b/cdc/processor/pipeline/sorter.go
@@ -121,7 +121,7 @@ func newSorterNode(
 	}
 }
 
-func createSorter(ctx pipeline.NodeContext, tableName string, tableID model.TableID) (sorter.EventSorter, error) {
+func createSorter(ctx pipeline.NodeContext, tableName string, span tablepb.Span) (sorter.EventSorter, error) {
 	sortEngine := ctx.ChangefeedVars().Info.Engine
 	switch sortEngine {
 	// `file` and `memory` become aliases of `unified` for backward compatibility.
@@ -147,10 +147,10 @@ func createSorter(ctx pipeline.NodeContext, tableName string, tableID model.Tabl
 			}
 			startTs := ctx.ChangefeedVars().Info.StartTs
 			ssystem := ctx.GlobalVars().SorterSystem
-			dbActorID := ssystem.DBActorID(uint64(tableID))
+			dbActorID := ssystem.DBActorID(span)
 			compactScheduler := ctx.GlobalVars().SorterSystem.CompactScheduler()
 			levelSorter, err := db.NewSorter(
-				ctx, ctx.ChangefeedVars().ID, tableID, startTs, ssystem.DBRouter, dbActorID,
+				ctx, ctx.ChangefeedVars().ID, span, startTs, ssystem.DBRouter, dbActorID,
 				ssystem.WriterSystem, ssystem.WriterRouter,
 				ssystem.ReaderSystem, ssystem.ReaderRouter,
 				compactScheduler, config.GetGlobalServerConfig().Debug.DB)
@@ -162,7 +162,7 @@ func createSorter(ctx pipeline.NodeContext, tableName string, tableID model.Tabl
 		// Sorter dir has been set and checked when server starts.
 		// See https://github.com/pingcap/tiflow/blob/9dad09/cdc/server.go#L275
 		sortDir := config.GetGlobalServerConfig().Sorter.SortDir
-		unifiedSorter, err := unified.NewUnifiedSorter(sortDir, ctx.ChangefeedVars().ID, tableName, tableID)
+		unifiedSorter, err := unified.NewUnifiedSorter(sortDir, ctx.ChangefeedVars().ID, tableName, span.TableID)
 		if err != nil {
 			return nil, err
 		}

--- a/cdc/processor/pipeline/sorter_test.go
+++ b/cdc/processor/pipeline/sorter_test.go
@@ -30,6 +30,7 @@ import (
 	cdcContext "github.com/pingcap/tiflow/pkg/context"
 	"github.com/pingcap/tiflow/pkg/pipeline"
 	pmessage "github.com/pingcap/tiflow/pkg/pipeline/message"
+	"github.com/pingcap/tiflow/pkg/spanz"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/oracle"
 	pd "github.com/tikv/pd/client"
@@ -57,7 +58,7 @@ func TestUnifiedSorterFileLockConflict(t *testing.T) {
 	ctx.ChangefeedVars().Info.Engine = model.SortUnified
 	ctx.ChangefeedVars().Info.SortDir = dir
 	nodeCtx := pipeline.MockNodeContext4Test(ctx, pmessage.Message{}, nil)
-	_, err = createSorter(nodeCtx, "", 0)
+	_, err = createSorter(nodeCtx, "", spanz.TableIDToComparableSpan(0))
 	require.True(t, strings.Contains(err.Error(), "file lock conflict"))
 }
 

--- a/cdc/processor/pipeline/table_actor.go
+++ b/cdc/processor/pipeline/table_actor.go
@@ -556,7 +556,7 @@ var startPuller = func(t *tableActor, ctx *actorNodeContext) error {
 }
 
 var startSorter = func(t *tableActor, ctx *actorNodeContext) error {
-	eventSorter, err := createSorter(ctx, t.tableName, t.span.TableID)
+	eventSorter, err := createSorter(ctx, t.tableName, t.span)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -1163,6 +1163,7 @@ func (p *processor) createTablePipelineImpl(
 	})
 
 	if p.redoManager.Enabled() {
+		// FIXME: make span-level replication compatible with redo log.
 		p.redoManager.AddTable(span.TableID, replicaInfo.StartTs)
 	}
 

--- a/cdc/sorter/db/db.go
+++ b/cdc/sorter/db/db.go
@@ -227,19 +227,19 @@ func (ldb *Actor) Poll(ctx context.Context, tasks []actormsg.Message[message.Tas
 				// Force write pending write batch before delete range.
 				if err := ldb.maybeWrite(true); err != nil {
 					log.Panic("db error",
-						zap.Error(err), zap.Uint64("tableID", task.TableID))
+						zap.Error(err), zap.Stringer("span", task.Span))
 				}
 				start, end := task.DeleteReq.Range[0], task.DeleteReq.Range[1]
 				if err := ldb.db.DeleteRange(start, end); err != nil {
 					log.Panic("db error",
-						zap.Error(err), zap.Uint64("tableID", task.TableID))
+						zap.Error(err), zap.Stringer("span", task.Span))
 				}
 				ldb.tryScheduleCompact()
 			}
 		}
 		if task.IterReq != nil {
 			// Append to slice for later batch acquiring iterators.
-			ldb.iterQ.push(task.UID, task.TableID, task.IterReq)
+			ldb.iterQ.push(task.UID, uint64(task.Span.TableID), task.IterReq)
 			requireIter = true
 		}
 		if task.Test != nil {

--- a/cdc/sorter/db/message/task.go
+++ b/cdc/sorter/db/message/task.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiflow/cdc/model"
+	"github.com/pingcap/tiflow/cdc/processor/tablepb"
 	"github.com/pingcap/tiflow/cdc/sorter/encoding"
 	"github.com/pingcap/tiflow/pkg/db"
 	"golang.org/x/sync/semaphore"
@@ -26,8 +27,8 @@ import (
 
 // Task is a db actor task. It carries write and read request.
 type Task struct {
-	UID     uint32
-	TableID uint64
+	UID  uint32
+	Span *tablepb.Span
 
 	// Input unsorted event for writers.
 	// Sorter.AddEntry -> writer.

--- a/cdc/sorter/db/reader_test.go
+++ b/cdc/sorter/db/reader_test.go
@@ -339,6 +339,7 @@ func TestReaderOutputIterEvents(t *testing.T) {
 
 	capacity := 4
 	r := newTestReader()
+	tableID := r.span.TableID
 
 	// Prepare data, 3 txns, 3 events for each.
 	// CRTs 3, StartTs 1, keys (0|1|2)
@@ -377,9 +378,9 @@ func TestReaderOutputIterEvents(t *testing.T) {
 
 			expectEvents: []*model.PolymorphicEvent{},
 			expectDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(3, 1, 0))),
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(3, 1, 1))),
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(3, 1, 2))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(3, 1, 0))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(3, 1, 1))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(3, 1, 2))),
 			},
 			expectOutputs: []*model.PolymorphicEvent{
 				newTestEvent(3, 1, 0),
@@ -396,8 +397,8 @@ func TestReaderOutputIterEvents(t *testing.T) {
 
 			expectEvents: []*model.PolymorphicEvent{newTestEvent(4, 2, 2)},
 			expectDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(4, 2, 0))),
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(4, 2, 1))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(4, 2, 0))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(4, 2, 1))),
 			},
 			expectOutputs: []*model.PolymorphicEvent{
 				newTestEvent(4, 2, 0),
@@ -414,7 +415,7 @@ func TestReaderOutputIterEvents(t *testing.T) {
 
 			expectEvents: []*model.PolymorphicEvent{},
 			expectDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(4, 2, 2))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(4, 2, 2))),
 			},
 			expectOutputs: []*model.PolymorphicEvent{
 				newTestEvent(4, 2, 2),
@@ -434,10 +435,10 @@ func TestReaderOutputIterEvents(t *testing.T) {
 				newTestEvent(6, 4, 2),
 			},
 			expectDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(5, 3, 0))),
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(5, 3, 1))),
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(5, 3, 2))),
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(6, 4, 0))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(5, 3, 0))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(5, 3, 1))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(5, 3, 2))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(6, 4, 0))),
 			},
 			expectOutputs: []*model.PolymorphicEvent{
 				newTestEvent(5, 3, 0),
@@ -458,11 +459,11 @@ func TestReaderOutputIterEvents(t *testing.T) {
 
 			expectEvents: []*model.PolymorphicEvent{},
 			expectDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(6, 4, 1))),
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(6, 4, 2))),
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(7, 5, 0))),
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(7, 5, 1))),
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(7, 5, 2))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(6, 4, 1))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(6, 4, 2))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(7, 5, 0))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(7, 5, 1))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(7, 5, 2))),
 			},
 			expectOutputs: []*model.PolymorphicEvent{
 				newTestEvent(6, 4, 1),
@@ -495,8 +496,8 @@ func TestReaderOutputIterEvents(t *testing.T) {
 		buf := newOutputBuffer(capacity)
 
 		iter := db.Iterator(
-			encoding.EncodeTsKey(r.uid, uint64(r.span.TableID), 0),
-			encoding.EncodeTsKey(r.uid, uint64(r.span.TableID), cs.maxResolvedTs+1),
+			encoding.EncodeTsKey(r.uid, uint64(tableID), 0),
+			encoding.EncodeTsKey(r.uid, uint64(tableID), cs.maxResolvedTs+1),
 			0, math.MaxUint64)
 		iter.Seek([]byte{})
 		require.Nil(t, iter.Error(), "case #%d, %v", i, cs)
@@ -642,6 +643,7 @@ func TestReaderPoll(t *testing.T) {
 	r.common.dbRouter = router
 	r.common.dbActorID = dbMb.ID()
 	r.outputCh = make(chan *model.PolymorphicEvent, sorterOutputCap)
+	tableID := r.span.TableID
 
 	// Prepare data, 3 txns, 3 events for each.
 	// CRTs 3, StartTs 1, keys (0|1|2)
@@ -739,9 +741,9 @@ func TestReaderPoll(t *testing.T) {
 
 			expectEvents: []*model.PolymorphicEvent{},
 			expectDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(3, 1, 0))),
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(3, 1, 1))),
-				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(3, 1, 2))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(3, 1, 0))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(3, 1, 1))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(tableID), newTestEvent(3, 1, 2))),
 			},
 			expectOutputs: []*model.PolymorphicEvent{
 				newTestEvent(3, 1, 0),

--- a/cdc/sorter/db/reader_test.go
+++ b/cdc/sorter/db/reader_test.go
@@ -29,6 +29,7 @@ import (
 	actormsg "github.com/pingcap/tiflow/pkg/actor/message"
 	"github.com/pingcap/tiflow/pkg/config"
 	"github.com/pingcap/tiflow/pkg/db"
+	"github.com/pingcap/tiflow/pkg/spanz"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/semaphore"
@@ -49,9 +50,9 @@ func newTestReader() *reader {
 		common: common{
 			dbActorID: 1,
 			// dbRouter:  dbRouter,
-			uid:     2,
-			tableID: uint64(3),
-			serde:   &encoding.MsgPackGenSerde{},
+			uid:   2,
+			span:  spanz.TableIDToComparableSpan(3),
+			serde: &encoding.MsgPackGenSerde{},
 		},
 		state: pollState{
 			metricIterRequest: metricIterDuration.WithLabelValues("request"),
@@ -86,21 +87,21 @@ func TestReaderSetTaskDelete(t *testing.T) {
 		// 1 delete key does not set delete.
 		{
 			deleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, r.tableID,
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID),
 					model.NewPolymorphicEvent(&model.RawKVEntry{CRTs: 2}))),
 			},
 		},
 		// One more delete key sets delete.
 		{
 			deleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, r.tableID,
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID),
 					model.NewPolymorphicEvent(&model.RawKVEntry{CRTs: 1}))),
 			},
 			expectDelete: &message.DeleteRequest{
 				Count: 2,
 				Range: [2][]byte{
-					encoding.EncodeTsKey(r.uid, r.tableID, 0),
-					encoding.EncodeKey(r.uid, r.tableID,
+					encoding.EncodeTsKey(r.uid, uint64(r.span.TableID), 0),
+					encoding.EncodeKey(r.uid, uint64(r.span.TableID),
 						model.NewPolymorphicEvent(&model.RawKVEntry{CRTs: 1})),
 				},
 			},
@@ -108,15 +109,15 @@ func TestReaderSetTaskDelete(t *testing.T) {
 		// Waiting long period sets delete.
 		{
 			deleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, r.tableID,
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID),
 					model.NewPolymorphicEvent(&model.RawKVEntry{CRTs: 3}))),
 			},
 			sleep: 4 * time.Second,
 			expectDelete: &message.DeleteRequest{
 				Count: 1,
 				Range: [2][]byte{
-					encoding.EncodeTsKey(r.uid, r.tableID, 0),
-					encoding.EncodeKey(r.uid, r.tableID,
+					encoding.EncodeTsKey(r.uid, uint64(r.span.TableID), 0),
+					encoding.EncodeKey(r.uid, uint64(r.span.TableID),
 						model.NewPolymorphicEvent(&model.RawKVEntry{CRTs: 3})),
 				},
 			},
@@ -196,7 +197,7 @@ func TestReaderOutputBufferedResolvedEvents(t *testing.T) {
 
 			expectEvents: []*model.PolymorphicEvent{},
 			expectDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, r.tableID,
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID),
 					model.NewPolymorphicEvent(&model.RawKVEntry{CRTs: 1}))),
 			},
 			expectOutputs: []*model.PolymorphicEvent{
@@ -210,13 +211,13 @@ func TestReaderOutputBufferedResolvedEvents(t *testing.T) {
 			outputChCap: 2,
 			inputEvents: []*model.PolymorphicEvent{},
 			inputDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, r.tableID,
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID),
 					model.NewPolymorphicEvent(&model.RawKVEntry{CRTs: 1}))),
 			},
 
 			expectEvents: []*model.PolymorphicEvent{},
 			expectDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, r.tableID,
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID),
 					model.NewPolymorphicEvent(&model.RawKVEntry{CRTs: 1}))),
 			},
 			expectOutputs: []*model.PolymorphicEvent{},
@@ -228,15 +229,15 @@ func TestReaderOutputBufferedResolvedEvents(t *testing.T) {
 				model.NewPolymorphicEvent(&model.RawKVEntry{CRTs: 2}),
 			},
 			inputDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, r.tableID,
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID),
 					model.NewPolymorphicEvent(&model.RawKVEntry{CRTs: 1}))),
 			},
 
 			expectEvents: []*model.PolymorphicEvent{},
 			expectDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, r.tableID,
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID),
 					model.NewPolymorphicEvent(&model.RawKVEntry{CRTs: 1}))),
-				message.Key(encoding.EncodeKey(r.uid, r.tableID,
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID),
 					model.NewPolymorphicEvent(&model.RawKVEntry{CRTs: 2}))),
 			},
 			expectOutputs: []*model.PolymorphicEvent{
@@ -259,9 +260,9 @@ func TestReaderOutputBufferedResolvedEvents(t *testing.T) {
 				model.NewPolymorphicEvent(&model.RawKVEntry{CRTs: 3, RegionID: 3}),
 			},
 			expectDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, r.tableID,
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID),
 					model.NewPolymorphicEvent(&model.RawKVEntry{CRTs: 3, RegionID: 1}))),
-				message.Key(encoding.EncodeKey(r.uid, r.tableID,
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID),
 					model.NewPolymorphicEvent(&model.RawKVEntry{CRTs: 3, RegionID: 2}))),
 			},
 			expectOutputs: []*model.PolymorphicEvent{
@@ -322,7 +323,7 @@ func prepareTxnData(
 	for i := 1; i < txnCount+1; i++ { // txns.
 		for j := 0; j < txnSize; j++ { // events.
 			event := newTestEvent(uint64(i)+2, uint64(i), j)
-			key := encoding.EncodeKey(r.uid, r.tableID, event)
+			key := encoding.EncodeKey(r.uid, uint64(r.span.TableID), event)
 			value, err := r.serde.Marshal(event, []byte{})
 			require.Nil(t, err)
 			t.Logf("key: %s, value: %s\n", message.Key(key), hex.EncodeToString(value))
@@ -376,9 +377,9 @@ func TestReaderOutputIterEvents(t *testing.T) {
 
 			expectEvents: []*model.PolymorphicEvent{},
 			expectDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(3, 1, 0))),
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(3, 1, 1))),
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(3, 1, 2))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(3, 1, 0))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(3, 1, 1))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(3, 1, 2))),
 			},
 			expectOutputs: []*model.PolymorphicEvent{
 				newTestEvent(3, 1, 0),
@@ -395,8 +396,8 @@ func TestReaderOutputIterEvents(t *testing.T) {
 
 			expectEvents: []*model.PolymorphicEvent{newTestEvent(4, 2, 2)},
 			expectDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(4, 2, 0))),
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(4, 2, 1))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(4, 2, 0))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(4, 2, 1))),
 			},
 			expectOutputs: []*model.PolymorphicEvent{
 				newTestEvent(4, 2, 0),
@@ -413,7 +414,7 @@ func TestReaderOutputIterEvents(t *testing.T) {
 
 			expectEvents: []*model.PolymorphicEvent{},
 			expectDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(4, 2, 2))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(4, 2, 2))),
 			},
 			expectOutputs: []*model.PolymorphicEvent{
 				newTestEvent(4, 2, 2),
@@ -433,10 +434,10 @@ func TestReaderOutputIterEvents(t *testing.T) {
 				newTestEvent(6, 4, 2),
 			},
 			expectDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(5, 3, 0))),
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(5, 3, 1))),
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(5, 3, 2))),
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(6, 4, 0))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(5, 3, 0))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(5, 3, 1))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(5, 3, 2))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(6, 4, 0))),
 			},
 			expectOutputs: []*model.PolymorphicEvent{
 				newTestEvent(5, 3, 0),
@@ -457,11 +458,11 @@ func TestReaderOutputIterEvents(t *testing.T) {
 
 			expectEvents: []*model.PolymorphicEvent{},
 			expectDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(6, 4, 1))),
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(6, 4, 2))),
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(7, 5, 0))),
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(7, 5, 1))),
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(7, 5, 2))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(6, 4, 1))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(6, 4, 2))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(7, 5, 0))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(7, 5, 1))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(7, 5, 2))),
 			},
 			expectOutputs: []*model.PolymorphicEvent{
 				newTestEvent(6, 4, 1),
@@ -494,8 +495,8 @@ func TestReaderOutputIterEvents(t *testing.T) {
 		buf := newOutputBuffer(capacity)
 
 		iter := db.Iterator(
-			encoding.EncodeTsKey(r.uid, r.tableID, 0),
-			encoding.EncodeTsKey(r.uid, r.tableID, cs.maxResolvedTs+1),
+			encoding.EncodeTsKey(r.uid, uint64(r.span.TableID), 0),
+			encoding.EncodeTsKey(r.uid, uint64(r.span.TableID), cs.maxResolvedTs+1),
 			0, math.MaxUint64)
 		iter.Seek([]byte{})
 		require.Nil(t, iter.Error(), "case #%d, %v", i, cs)
@@ -738,9 +739,9 @@ func TestReaderPoll(t *testing.T) {
 
 			expectEvents: []*model.PolymorphicEvent{},
 			expectDeleteKeys: []message.Key{
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(3, 1, 0))),
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(3, 1, 1))),
-				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(3, 1, 2))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(3, 1, 0))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(3, 1, 1))),
+				message.Key(encoding.EncodeKey(r.uid, uint64(r.span.TableID), newTestEvent(3, 1, 2))),
 			},
 			expectOutputs: []*model.PolymorphicEvent{
 				newTestEvent(3, 1, 0),

--- a/cdc/sorter/db/sorter.go
+++ b/cdc/sorter/db/sorter.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/cdc/model"
+	"github.com/pingcap/tiflow/cdc/processor/tablepb"
 	"github.com/pingcap/tiflow/cdc/sorter"
 	"github.com/pingcap/tiflow/cdc/sorter/db/message"
 	"github.com/pingcap/tiflow/cdc/sorter/encoding"
@@ -50,7 +51,7 @@ type common struct {
 	dbRouter  *actor.Router[message.Task]
 
 	uid      uint32
-	tableID  uint64
+	span     tablepb.Span
 	serde    *encoding.MsgPackGenSerde
 	errCh    chan error
 	closedWg *sync.WaitGroup
@@ -60,7 +61,7 @@ type common struct {
 func (c *common) reportError(msg string, err error) {
 	if errors.Cause(err) != context.Canceled {
 		log.L().WithOptions(zap.AddCallerSkip(1)).
-			Warn(msg, zap.Uint64("tableID", c.tableID), zap.Error(err))
+			Warn(msg, zap.Stringer("span", &c.span), zap.Error(err))
 	}
 	select {
 	case c.errCh <- err:
@@ -87,7 +88,7 @@ type Sorter struct {
 
 // NewSorter creates a new Sorter
 func NewSorter(
-	ctx context.Context, changefeedID model.ChangeFeedID, tableID int64, startTs uint64,
+	ctx context.Context, changefeedID model.ChangeFeedID, span tablepb.Span, startTs uint64,
 	dbRouter *actor.Router[message.Task], dbActorID actor.ID,
 	writerSystem *actor.System[message.Task], writerRouter *actor.Router[message.Task],
 	readerSystem *actor.System[message.Task], readerRouter *actor.Router[message.Task],
@@ -114,7 +115,7 @@ func NewSorter(
 		dbActorID: dbActorID,
 		dbRouter:  dbRouter,
 		uid:       uid,
-		tableID:   uint64(tableID),
+		span:      span,
 		serde:     &encoding.MsgPackGenSerde{},
 		errCh:     make(chan error, 1),
 		closedWg:  &sync.WaitGroup{},
@@ -220,7 +221,7 @@ func (ls *Sorter) AddEntry(ctx context.Context, event *model.PolymorphicEvent) {
 	}
 	msg := actormsg.ValueMessage(message.Task{
 		UID:        ls.uid,
-		TableID:    ls.tableID,
+		Span:       &ls.span,
 		InputEvent: event,
 	})
 	_ = ls.writerRouter.SendB(ctx, ls.writerActorID, msg)
@@ -230,9 +231,9 @@ func (ls *Sorter) AddEntry(ctx context.Context, event *model.PolymorphicEvent) {
 func (ls *Sorter) Output() <-chan *model.PolymorphicEvent {
 	// Notify reader to read sorted events
 	msg := actormsg.ValueMessage(message.Task{
-		UID:     ls.uid,
-		TableID: ls.tableID,
-		ReadTs:  message.ReadTs{},
+		UID:    ls.uid,
+		Span:   &ls.span,
+		ReadTs: message.ReadTs{},
 	})
 	// It's ok to ignore error, as reader is either channel full or stopped.
 	// If it's channel full, it has been notified by others, and caller will
@@ -246,13 +247,13 @@ func (ls *Sorter) Output() <-chan *model.PolymorphicEvent {
 
 // cleanup cleans up sorter's data.
 func (ls *Sorter) cleanup(ctx context.Context) error {
-	task := message.Task{UID: ls.uid, TableID: ls.tableID}
+	task := message.Task{UID: ls.uid, Span: &ls.span}
 	task.DeleteReq = &message.DeleteRequest{
 		// We do not set task.Delete.Count, because we don't know
 		// how many key-value pairs in the range.
 		Range: [2][]byte{
-			encoding.EncodeTsKey(ls.uid, ls.tableID, 0),
-			encoding.EncodeTsKey(ls.uid, ls.tableID+1, 0),
+			encoding.EncodeTsKey(ls.uid, uint64(ls.span.TableID), 0),
+			encoding.EncodeTsKey(ls.uid, uint64(ls.span.TableID)+1, 0),
 		},
 	}
 	return ls.dbRouter.SendB(ctx, ls.dbActorID, actormsg.ValueMessage(task))
@@ -262,7 +263,7 @@ func (ls *Sorter) cleanup(ctx context.Context) error {
 func (ls *Sorter) EmitStartTs(ctx context.Context, ts uint64) {
 	msg := actormsg.ValueMessage(message.Task{
 		UID:     ls.uid,
-		TableID: ls.tableID,
+		Span:    &ls.span,
 		StartTs: ts,
 	})
 	_ = ls.readerRouter.SendB(ctx, ls.ReaderActorID, msg)

--- a/cdc/sorter/db/sorter_test.go
+++ b/cdc/sorter/db/sorter_test.go
@@ -60,7 +60,7 @@ func TestAddEntry(t *testing.T) {
 	require.EqualValues(t,
 		message.Task{
 			UID:        s.uid,
-			TableID:    s.tableID,
+			Span:       &s.span,
 			InputEvent: event,
 		}, task.Value)
 }
@@ -75,9 +75,9 @@ func TestOutput(t *testing.T) {
 	require.True(t, ok)
 	require.EqualValues(t,
 		message.Task{
-			UID:     s.uid,
-			TableID: s.tableID,
-			ReadTs:  message.ReadTs{},
+			UID:    s.uid,
+			Span:   &s.span,
+			ReadTs: message.ReadTs{},
 		}, task.Value)
 }
 
@@ -106,12 +106,12 @@ func TestRunAndReportError(t *testing.T) {
 	require.True(t, ok)
 	require.EqualValues(t,
 		message.Task{
-			UID:     s.uid,
-			TableID: s.tableID,
+			UID:  s.uid,
+			Span: &s.span,
 			DeleteReq: &message.DeleteRequest{
 				Range: [2][]byte{
-					encoding.EncodeTsKey(s.uid, s.tableID, 0),
-					encoding.EncodeTsKey(s.uid, s.tableID+1, 0),
+					encoding.EncodeTsKey(s.uid, uint64(s.span.TableID), 0),
+					encoding.EncodeTsKey(s.uid, uint64(s.span.TableID)+1, 0),
 				},
 			},
 		}, msg.Value)

--- a/cdc/sorter/db/system/system.go
+++ b/cdc/sorter/db/system/system.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/util/memory"
+	"github.com/pingcap/tiflow/cdc/processor/tablepb"
 	dbsorter "github.com/pingcap/tiflow/cdc/sorter/db"
 	"github.com/pingcap/tiflow/cdc/sorter/db/message"
 	"github.com/pingcap/tiflow/pkg/actor"
@@ -102,11 +103,13 @@ func NewSystem(dir string, memPercentage float64, cfg *config.DBConfig) *System 
 }
 
 // DBActorID returns an DBActorID correspond with tableID.
-func (s *System) DBActorID(tableID uint64) actor.ID {
+func (s *System) DBActorID(span tablepb.Span) actor.ID {
 	h := fnv.New64()
 	b := [8]byte{}
-	binary.LittleEndian.PutUint64(b[:], tableID)
+	binary.LittleEndian.PutUint64(b[:], uint64(span.TableID))
 	h.Write(b[:])
+	h.Write(span.StartKey)
+	h.Write(span.EndKey)
 	return actor.ID(h.Sum64() % uint64(s.cfg.Count))
 }
 

--- a/cdc/sorter/db/writer.go
+++ b/cdc/sorter/db/writer.go
@@ -71,7 +71,7 @@ func (w *writer) Poll(ctx context.Context, msgs []actormsg.Message[message.Task]
 		}
 		kvEventCount++
 
-		key := encoding.EncodeKey(w.uid, w.tableID, ev)
+		key := encoding.EncodeKey(w.uid, uint64(w.span.TableID), ev)
 		value := []byte{}
 		var err error
 		value, err = w.serde.Marshal(ev, value)
@@ -91,7 +91,7 @@ func (w *writer) Poll(ctx context.Context, msgs []actormsg.Message[message.Task]
 
 	if len(writes) != 0 {
 		// Send write task to db.
-		task := message.Task{UID: w.uid, TableID: w.tableID, WriteReq: writes}
+		task := message.Task{UID: w.uid, Span: &w.span, WriteReq: writes}
 		err := w.dbRouter.SendB(ctx, w.dbActorID, actormsg.ValueMessage(task))
 		if err != nil {
 			w.reportError("failed to send write request", err)
@@ -112,8 +112,8 @@ func (w *writer) Poll(ctx context.Context, msgs []actormsg.Message[message.Task]
 	//      it happens after writer send writes to db.
 	//   3. Before db takes iterator, it flushes all buffered writes.
 	msg := actormsg.ValueMessage(message.Task{
-		UID:     w.uid,
-		TableID: w.tableID,
+		UID:  w.uid,
+		Span: &w.span,
 		ReadTs: message.ReadTs{
 			// The maxCommitTs and maxResolvedTs must be sent together,
 			// otherwise reader may output resolved ts wrongly.

--- a/cdc/sorter/db/writer_test.go
+++ b/cdc/sorter/db/writer_test.go
@@ -109,8 +109,8 @@ func TestWriterPoll(t *testing.T) {
 		},
 
 		expectWrites: [][]byte{
-			encoding.EncodeKey(c.uid, c.tableID, newTestEvent(3, 1, 0)),
-			encoding.EncodeKey(c.uid, c.tableID, newTestEvent(3, 1, 1)),
+			encoding.EncodeKey(c.uid, uint64(c.span.TableID), newTestEvent(3, 1, 0)),
+			encoding.EncodeKey(c.uid, uint64(c.span.TableID), newTestEvent(3, 1, 1)),
 		},
 		expectMaxCommitTs:   3,
 		expectMaxResolvedTs: 2,
@@ -124,8 +124,8 @@ func TestWriterPoll(t *testing.T) {
 		},
 
 		expectWrites: [][]byte{
-			encoding.EncodeKey(c.uid, c.tableID, newTestEvent(4, 2, 0)),
-			encoding.EncodeKey(c.uid, c.tableID, newTestEvent(6, 3, 0)),
+			encoding.EncodeKey(c.uid, uint64(c.span.TableID), newTestEvent(4, 2, 0)),
+			encoding.EncodeKey(c.uid, uint64(c.span.TableID), newTestEvent(6, 3, 0)),
 		},
 		expectMaxCommitTs:   6,
 		expectMaxResolvedTs: 3,
@@ -137,7 +137,7 @@ func TestWriterPoll(t *testing.T) {
 		},
 
 		expectWrites: [][]byte{
-			encoding.EncodeKey(c.uid, c.tableID, newTestEvent(6, 3, 0)),
+			encoding.EncodeKey(c.uid, uint64(c.span.TableID), newTestEvent(6, 3, 0)),
 		},
 		expectMaxCommitTs:   6,
 		expectMaxResolvedTs: 3,
@@ -150,9 +150,9 @@ func TestWriterPoll(t *testing.T) {
 		},
 
 		expectWrites: [][]byte{
-			encoding.EncodeKey(c.uid, c.tableID, newTestEvent(4, 3, 0)),
-			encoding.EncodeKey(c.uid, c.tableID, newTestEvent(5, 3, 0)),
-			encoding.EncodeKey(c.uid, c.tableID, newTestEvent(4, 2, 0)),
+			encoding.EncodeKey(c.uid, uint64(c.span.TableID), newTestEvent(4, 3, 0)),
+			encoding.EncodeKey(c.uid, uint64(c.span.TableID), newTestEvent(5, 3, 0)),
+			encoding.EncodeKey(c.uid, uint64(c.span.TableID), newTestEvent(4, 2, 0)),
 		},
 		expectMaxCommitTs:   6,
 		expectMaxResolvedTs: 3,


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #7720 

### What is changed and how it works?

* Replace TableID with tablepb.Span in sorter

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No

##### Do you need to update user documentation, design documentation or monitoring documentation?

No

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
