### PR TITLE
expression_filter(dm): fix append update filter for non-update item

### DIFF
--- a/dm/syncer/expr_filter_group.go
+++ b/dm/syncer/expr_filter_group.go
@@ -114,6 +114,9 @@ func (g *ExprFilterGroup) GetUpdateExprs(table *filter.Table, ti *model.TableInf
 
 	if _, ok := g.hasUpdateFilter[tableID]; ok {
 		for _, c := range g.configs[tableID] {
+			if c.UpdateOldValueExpr == "" && c.UpdateNewValueExpr == "" {
+				continue
+			}
 			if c.UpdateOldValueExpr != "" {
 				expr, err := getSimpleExprOfTable(g.tidbCtx, c.UpdateOldValueExpr, ti, g.logCtx.L())
 				if err != nil {

--- a/dm/syncer/expr_filter_group_test.go
+++ b/dm/syncer/expr_filter_group_test.go
@@ -497,8 +497,8 @@ create table t (
 	for i, c := range cases {
 		t.Logf("case #%d", i)
 		g := NewExprFilterGroup(tcontext.Background(), sessCtx, []*config.ExpressionFilter{c})
-		oldExprs, newExprs, err := g.GetUpdateExprs(table, tableInfo)
-		require.NoError(t, err)
+		oldExprs, newExprs, err2 := g.GetUpdateExprs(table, tableInfo)
+		require.NoError(t, err2)
 		require.Equal(t, len(oldExprs), len(newExprs))
 	}
 	g := NewExprFilterGroup(tcontext.Background(), sessCtx, cases)

--- a/dm/syncer/expr_filter_group_test.go
+++ b/dm/syncer/expr_filter_group_test.go
@@ -501,4 +501,9 @@ create table t (
 		require.NoError(t, err)
 		require.Equal(t, len(oldExprs), len(newExprs))
 	}
+	g := NewExprFilterGroup(tcontext.Background(), sessCtx, cases)
+	oldExprs, newExprs, err := g.GetUpdateExprs(table, tableInfo)
+	require.NoError(t, err)
+	require.Equal(t, len(oldExprs), len(newExprs))
+	require.Len(t, oldExprs, 3)
 }

--- a/dm/tests/expression_filter/conf/dm-task2.yaml
+++ b/dm/tests/expression_filter/conf/dm-task2.yaml
@@ -13,6 +13,7 @@ mysql-instances:
     black-white-list: "instance"
     expression-filters:
       - "even_c"
+      - "always_false"
       - "future_date"
       - "pythagorean"
       - "update_old_lt_100"
@@ -26,6 +27,11 @@ expression-filter:
     schema: "expr_filter"
     table: "t2"
     insert-value-expr: "c % 2 = 0"
+  always_false:
+    schema: "expr_filter"
+    table: "t2"
+    update-old-value-expr: "1 = 0"
+    update-new-value-expr: "1 = 0"
   future_date:
     schema: "expr_filter"
     table: "t3"

--- a/dm/tests/expression_filter/data/db1.increment2.sql
+++ b/dm/tests/expression_filter/data/db1.increment2.sql
@@ -10,7 +10,8 @@ alter table t2 drop column c;
 insert into t2 (id, should_skip) values (5, 0), (6, 0);
 -- test filter become valid again, and the checking column is a generated column
 alter table t2 add column c int as (id + 1);
-insert into t2 (id, should_skip, d) values (7, 1, 100), (8, 0, 200);
+insert into t2 (id, should_skip, d) values (7, 1, 100), (8, 0, 200), (10, 2, 300);
+update t2 set should_skip = 0 where id = 10;
 
 -- test a new created table
 create table t3 (id int primary key,

--- a/dm/tests/expression_filter/run.sh
+++ b/dm/tests/expression_filter/run.sh
@@ -40,8 +40,10 @@ function complex_behaviour() {
 		"\"result\": true" 2 \
 		"\"synced\": true" 1
 
-	run_sql_tidb "select count(1) from expr_filter.t2"
-	check_contains "count(1): 5"
+	run_sql_tidb "select count(0) from expr_filter.t2"
+	check_contains "count(0): 6"
+	run_sql_tidb "select count(1) from expr_filter.t2 where should_skip = 0"
+	check_contains "count(1): 6"
 	run_sql_tidb "select count(2) from expr_filter.t2 where should_skip = 1"
 	check_contains "count(2): 0"
 


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7831 

### What is changed and how it works?

I forget the case that a table has both insert and update expression filter

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a bug that when both "update" and "non-update" type expression filters are used in one table, all UPDATE row changes are skipped
```
