### PR TITLE
sink(ticdc): fix eventFragment memory leak in cloud storage sink

### DIFF
--- a/cdc/sinkv2/eventsink/cloudstorage/dml_worker.go
+++ b/cdc/sinkv2/eventsink/cloudstorage/dml_worker.go
@@ -150,7 +150,7 @@ func (d *dmlWorker) backgroundFlushMsgs(ctx context.Context) {
 					d.tableEvents.mu.Lock()
 					events := make([]eventFragment, len(d.tableEvents.fragments[table]))
 					copy(events, d.tableEvents.fragments[table])
-					d.tableEvents.fragments[table] = make([]eventFragment, 0, 16)
+					d.tableEvents.fragments[table] = nil
 					d.tableEvents.mu.Unlock()
 					if len(events) == 0 {
 						continue

--- a/cdc/sinkv2/eventsink/cloudstorage/dml_worker.go
+++ b/cdc/sinkv2/eventsink/cloudstorage/dml_worker.go
@@ -150,7 +150,7 @@ func (d *dmlWorker) backgroundFlushMsgs(ctx context.Context) {
 					d.tableEvents.mu.Lock()
 					events := make([]eventFragment, len(d.tableEvents.fragments[table]))
 					copy(events, d.tableEvents.fragments[table])
-					d.tableEvents.fragments[table] = d.tableEvents.fragments[table][:0]
+					d.tableEvents.fragments[table] = make([]eventFragment, 0, 16)
 					d.tableEvents.mu.Unlock()
 					if len(events) == 0 {
 						continue


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #7886

### What is changed and how it works?

replicate 1000 tables with 40 million old data, no incremental data. After lag equalizes, the heap information is as follows: 

before:
![image](https://user-images.githubusercontent.com/61726649/207278217-f430dc8e-99c7-44fc-9606-6e3d56646a58.png)

after:
![image](https://user-images.githubusercontent.com/61726649/207278378-8fbbfad0-7167-479d-aaf1-0ea0963c674a.png)


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
