### PR TITLE
sorter(ticdc): split large txn (#7889)

### DIFF
--- a/cdc/sorter/db/reader.go
+++ b/cdc/sorter/db/reader.go
@@ -136,7 +136,7 @@ func (r *reader) outputBufferedResolvedEvents(buffer *outputBuffer) {
 	buffer.shiftResolvedEvents(remainIdx)
 
 	// If all buffered resolved events are sent, send its resolved ts too.
-	if lastCommitTs != 0 && !hasRemainEvents {
+	if lastCommitTs != 0 && !hasRemainEvents && !buffer.partialReadTxn {
 		r.outputResolvedTs(lastCommitTs)
 	}
 }
@@ -155,8 +155,8 @@ func (r *reader) outputBufferedResolvedEvents(buffer *outputBuffer) {
 //
 // Note: outputBuffer must be empty.
 func (r *reader) outputIterEvents(
-	iter db.Iterator, hasReadLastNext bool, buffer *outputBuffer, resolvedTs uint64,
-) (bool, uint64, error) {
+	iter db.Iterator, position readPosition, buffer *outputBuffer, resolvedTs uint64,
+) (readPosition, error) {
 	lenResolvedEvents, lenDeleteKeys := buffer.len()
 	if lenDeleteKeys > 0 || lenResolvedEvents > 0 {
 		log.Panic("buffer is not empty",
@@ -168,7 +168,7 @@ func (r *reader) outputIterEvents(
 	commitTs := uint64(0)
 	start := time.Now()
 	lastNext := start
-	if hasReadLastNext {
+	if position.iterHasRead {
 		// We have read the last key/value, move the Next.
 		iter.Next()
 		r.metricIterNextDuration.Observe(time.Since(start).Seconds())
@@ -181,12 +181,12 @@ func (r *reader) outputIterEvents(
 		lastNext = now
 
 		if iter.Error() != nil {
-			return false, 0, errors.Trace(iter.Error())
+			return readPosition{}, errors.Trace(iter.Error())
 		}
 		event := new(model.PolymorphicEvent)
 		_, err := r.serde.Unmarshal(event, iter.Value())
 		if err != nil {
-			return false, 0, errors.Trace(err)
+			return readPosition{}, errors.Trace(err)
 		}
 		if commitTs > event.CRTs || commitTs > resolvedTs {
 			log.Panic("event commit ts regression",
@@ -199,7 +199,14 @@ func (r *reader) outputIterEvents(
 		}
 		// Read all resolved events that have the same commit ts.
 		if commitTs == event.CRTs {
-			buffer.appendResolvedEvent(event)
+			ok := buffer.tryAppendResolvedEvent(event)
+			if !ok {
+				// append fails and buffer is full, we need to flush buffer to
+				// prevent OOM.
+				// It means we have not read value in to buffer after calling Next.
+				hasReadNext = false
+				break
+			}
 			continue
 		}
 
@@ -209,14 +216,14 @@ func (r *reader) outputIterEvents(
 		lenResolvedEvents, _ = buffer.len()
 		if lenResolvedEvents > 0 {
 			// Output blocked, skip append new event.
-			// This means we have not read Next.
+			// It means we have not read value in to buffer after calling Next.
 			hasReadNext = false
 			break
 		}
 
 		// Append new event to the buffer.
 		commitTs = event.CRTs
-		buffer.appendResolvedEvent(event)
+		buffer.tryAppendResolvedEvent(event)
 	}
 	elapsed := time.Since(start)
 	r.metricIterReadDuration.Observe(elapsed.Seconds())
@@ -228,30 +235,55 @@ func (r *reader) outputIterEvents(
 	// Try shrink buffer to release memory.
 	buffer.maybeShrink()
 
-	// All resolved events whose commit ts are less or equal to the commitTs
-	// have read into buffer.
-	exhaustedResolvedTs := commitTs
-	if !hasNext {
-		// Iter is exhausted, it means resolved events whose commit ts are
-		// less or equal to the commitTs have read into buffer.
-		if resolvedTs != 0 {
-			exhaustedResolvedTs = resolvedTs
+	newPos := readPosition{
+		iterHasRead: hasReadNext,
+	}
+	if !buffer.partialReadTxn {
+		// All resolved events whose commit ts are less or equal to the commitTs
+		// have read into buffer.
+		newPos.exhaustedResolvedTs = commitTs
+		if !hasNext {
+			// Iter is exhausted, it means resolved events whose commit ts are
+			// less or equal to the commitTs have read into buffer.
+			if resolvedTs != 0 {
+				newPos.exhaustedResolvedTs = resolvedTs
+			}
 		}
+	} else {
+		// Copy current iter key to position.
+		newPos.partialTxnKey = append([]byte{}, iter.Key()...)
 	}
 
-	return hasReadNext, exhaustedResolvedTs, nil
+	return newPos, nil
 }
 
-// TODO: inline the struct to reader.
+type readPosition struct {
+	// A flag to mark whether the current position has been read.
+	iterHasRead bool
+	// partialTxnKey is set when a transaction is partially read.
+	partialTxnKey []byte
+	// All resolved events before the resolved ts are read into buffer.
+	exhaustedResolvedTs uint64
+}
+
+func (r *readPosition) update(position readPosition) {
+	if position.exhaustedResolvedTs > r.exhaustedResolvedTs {
+		r.exhaustedResolvedTs = position.exhaustedResolvedTs
+	}
+	r.iterHasRead = position.iterHasRead
+	r.partialTxnKey = position.partialTxnKey
+}
+
 type pollState struct {
 	// Buffer for resolved events and to-be-deleted events.
 	outputBuf *outputBuffer
+	// The position of a reader.
+	position readPosition
+
 	// The maximum commit ts for all events.
 	maxCommitTs uint64
 	// The maximum commit ts for all resolved ts events.
 	maxResolvedTs uint64
-	// All resolved events before the resolved ts are read into buffer.
-	exhaustedResolvedTs uint64
 
 	// read data after `startTs`
 	startTs uint64
@@ -277,8 +309,6 @@ type pollState struct {
 	// An iterator for reading resolved events, up to the `iterResolvedTs`.
 	iter           *message.LimitedIterator
 	iterResolvedTs uint64
-	// A flag to mark whether the current position has been read.
-	iterHasRead bool
 
 	metricIterRequest prometheus.Observer
 	metricIterFirst   prometheus.Observer
@@ -300,8 +330,8 @@ func (state *pollState) hasResolvedEvents() bool {
 	// exhaustedResolvedTs
 	//                     maxResolvedTs
 	//                                   maxCommitTs
-	if state.exhaustedResolvedTs < state.maxCommitTs &&
-		state.exhaustedResolvedTs < state.maxResolvedTs {
+	if state.position.exhaustedResolvedTs < state.maxCommitTs &&
+		state.position.exhaustedResolvedTs < state.maxResolvedTs {
 		return true
 	}
 
@@ -346,8 +376,8 @@ func (state *pollState) tryGetIterator(uid uint32, tableID uint64) (*message.Ite
 		readerRouter := state.readerRouter
 		readerID := state.readerID
 		lowerBoundTs := atomic.LoadUint64(&state.startTs)
-		if lowerBoundTs < state.exhaustedResolvedTs {
-			lowerBoundTs = state.exhaustedResolvedTs
+		if lowerBoundTs < state.position.exhaustedResolvedTs {
+			lowerBoundTs = state.position.exhaustedResolvedTs
 		}
 		return &message.IterRequest{
 			Range: [2][]byte{
@@ -355,7 +385,7 @@ func (state *pollState) tryGetIterator(uid uint32, tableID uint64) (*message.Ite
 				encoding.EncodeTsKey(uid, tableID, state.maxResolvedTs+1),
 			},
 			ResolvedTs: state.maxResolvedTs,
-			CRTsFilter: [2]uint64{state.exhaustedResolvedTs + 1, state.maxResolvedTs},
+			CRTsFilter: [2]uint64{state.position.exhaustedResolvedTs + 1, state.maxResolvedTs},
 			IterCallback: func(iter *message.LimitedIterator) {
 				iterCh <- iter
 				close(iterCh)
@@ -381,8 +411,8 @@ func (state *pollState) tryGetIterator(uid uint32, tableID uint64) (*message.Ite
 		state.metricIterRequest.Observe(requestDuration.Seconds())
 		state.iterAliveTime = start
 		state.iterResolvedTs = iter.ResolvedTs
-		state.iterHasRead = false
-		state.iter.Seek(encoding.EncodeTsKey(uid, tableID, 0))
+		state.position.iterHasRead = false
+		state.iter.Seek(state.position.partialTxnKey)
 		duration := time.Since(start)
 		state.metricIterFirst.Observe(duration.Seconds())
 		if duration >= state.iterFirstSlowDuration {
@@ -396,19 +426,19 @@ func (state *pollState) tryGetIterator(uid uint32, tableID uint64) (*message.Ite
 	}
 }
 
-func (state *pollState) tryReleaseIterator() error {
+func (state *pollState) tryReleaseIterator(force bool) error {
 	if state.iter == nil {
 		return nil
 	}
 	now := time.Now()
-	if !state.iter.Valid() || now.Sub(state.iterAliveTime) > state.iterMaxAliveDuration {
+	if !state.iter.Valid() || now.Sub(state.iterAliveTime) > state.iterMaxAliveDuration || force {
 		err := state.iter.Release()
 		if err != nil {
 			return errors.Trace(err)
 		}
 		state.metricIterRelease.Observe(time.Since(now).Seconds())
 		state.iter = nil
-		state.iterHasRead = true
+		state.position.iterHasRead = true
 
 		if state.iterCh != nil {
 			log.Panic("there must not be iterCh", zap.Any("iter", state.iter))
@@ -474,7 +504,7 @@ func (r *reader) Poll(ctx context.Context, msgs []actormsg.Message[message.Task]
 			}
 		}
 		// Release iterator as we do not need to read.
-		err := r.state.tryReleaseIterator()
+		err := r.state.tryReleaseIterator(false)
 		if err != nil {
 			r.reportError("failed to release iterator", err)
 			return false
@@ -504,17 +534,14 @@ func (r *reader) Poll(ctx context.Context, msgs []actormsg.Message[message.Task]
 	}
 
 	// Read and send resolved events from iterator.
-	hasReadNext, exhaustedResolvedTs, err := r.outputIterEvents(
-		r.state.iter, r.state.iterHasRead, r.state.outputBuf, r.state.iterResolvedTs)
+	position, err := r.outputIterEvents(
+		r.state.iter, r.state.position, r.state.outputBuf, r.state.iterResolvedTs)
 	if err != nil {
 		r.reportError("failed to read iterator", err)
 		return false
 	}
-	if exhaustedResolvedTs > r.state.exhaustedResolvedTs {
-		r.state.exhaustedResolvedTs = exhaustedResolvedTs
-	}
-	r.state.iterHasRead = hasReadNext
-	err = r.state.tryReleaseIterator()
+	r.state.position.update(position)
+	err = r.state.tryReleaseIterator(false)
 	if err != nil {
 		r.reportError("failed to release iterator", err)
 		return false
@@ -529,6 +556,6 @@ func (r *reader) OnClose() {
 	}
 	r.stopped = true
 	// Must release iterator before stopping, otherwise it leaks iterator.
-	_ = r.state.tryReleaseIterator()
+	_ = r.state.tryReleaseIterator(true)
 	r.common.closedWg.Done()
 }

--- a/cdc/sorter/db/reader.go
+++ b/cdc/sorter/db/reader.go
@@ -147,11 +147,7 @@ func (r *reader) outputBufferedResolvedEvents(buffer *outputBuffer) {
 // later, and appends resolved events to outputBuffer resolvedEvents to send
 // them later.
 //
-// It returns:
-//   - a bool to indicate whether it has read the last Next or not.
-//   - an uint64, if it is not 0, it means all resolved events before the ts
-//     are outputted.
-//   - an error if it occurs.
+// It returns a new read position.
 //
 // Note: outputBuffer must be empty.
 func (r *reader) outputIterEvents(

--- a/cdc/sorter/db/reader_test.go
+++ b/cdc/sorter/db/reader_test.go
@@ -499,16 +499,17 @@ func TestReaderOutputIterEvents(t *testing.T) {
 			0, math.MaxUint64)
 		iter.Seek([]byte{})
 		require.Nil(t, iter.Error(), "case #%d, %v", i, cs)
-		hasReadLastNext, exhaustedRTs, err := r.outputIterEvents(
-			iter, cs.hasReadNext, buf, cs.maxResolvedTs)
+		pos, err := r.outputIterEvents(
+			iter, readPosition{iterHasRead: cs.hasReadNext}, buf, cs.maxResolvedTs)
 		require.Nil(t, err, "case #%d, %v", i, cs)
-		require.EqualValues(t, cs.expectExhaustedRTs, exhaustedRTs, "case #%d, %v", i, cs)
+		require.EqualValues(
+			t, cs.expectExhaustedRTs, pos.exhaustedResolvedTs, "case #%d, %v", i, cs)
 		for _, k := range buf.deleteKeys {
 			fmt.Printf("%s\n", k)
 		}
 		require.EqualValues(t, cs.expectDeleteKeys, buf.deleteKeys, "case #%d, %v", i, cs)
 		require.EqualValues(t, cs.expectEvents, buf.resolvedEvents, "case #%d, %v", i, cs)
-		require.EqualValues(t, cs.expectHasReadNext, hasReadLastNext, "case #%d, %v", i, cs)
+		require.EqualValues(t, cs.expectHasReadNext, pos.iterHasRead, "case #%d, %v", i, cs)
 		outputEvents := receiveOutputEvents(r.outputCh)
 		require.EqualValues(t, cs.expectOutputs, outputEvents, "case #%d, %v", i, cs)
 
@@ -575,7 +576,7 @@ func TestReaderStateIterator(t *testing.T) {
 
 	// Release an invalid iterator.
 	require.False(t, state.iter.Valid())
-	require.Nil(t, state.tryReleaseIterator())
+	require.Nil(t, state.tryReleaseIterator(false))
 	require.Nil(t, state.iter)
 
 	// Release an outdated iterator.
@@ -587,11 +588,11 @@ func TestReaderStateIterator(t *testing.T) {
 	require.True(t, state.iter.Seek([]byte{}))
 	state.iterAliveTime = time.Now()
 	time.Sleep(2 * state.iterMaxAliveDuration)
-	require.Nil(t, state.tryReleaseIterator())
+	require.Nil(t, state.tryReleaseIterator(false))
 	require.Nil(t, state.iter)
 
 	// Release empty iterator.
-	require.Nil(t, state.tryReleaseIterator())
+	require.Nil(t, state.tryReleaseIterator(false))
 
 	// Slow first must send a compaction task.
 	req3, ok := state.tryGetIterator(1, 1)
@@ -618,7 +619,7 @@ func TestReaderStateIterator(t *testing.T) {
 	require.True(t, ok)
 	// Release iterator.
 	time.Sleep(2 * state.iterMaxAliveDuration)
-	require.Nil(t, state.tryReleaseIterator())
+	require.Nil(t, state.tryReleaseIterator(false))
 	require.Nil(t, state.iter)
 
 	require.Nil(t, db.Close())
@@ -716,12 +717,45 @@ func TestReaderPoll(t *testing.T) {
 			// exhaustedResolvedTs must advance if there is no resolved event.
 			expectExhaustedRTs: 2,
 		}},
+		// exhaustedResolvedTs must not advance if a txn is partially read.
+		// Output: CRTs 3, StartTs 1, keys (0|1|2)
+		{{ // The first poll
+			inputReadTs: message.ReadTs{MaxResolvedTs: 3, MaxCommitTs: 3},
+			state: pollState{
+				// A smaller buffer so that it can not hold all txn events.
+				outputBuf: newOutputBuffer(1),
+			},
+			inputIter: newIterator(ctx, t, db, sema),
+
+			expectEvents:        []*model.PolymorphicEvent{},
+			expectDeleteKeys:    []message.Key{},
+			expectOutputs:       []*model.PolymorphicEvent{},
+			expectMaxCommitTs:   3,
+			expectMaxResolvedTs: 3,
+			expectExhaustedRTs:  0,
+		}, { // The second poll
+			inputReadTs: message.ReadTs{MaxResolvedTs: 3},
+			// state is inherited from the first poll.
+			inputIter: nil, // no need to make an iterator.
+
+			expectEvents: []*model.PolymorphicEvent{},
+			expectDeleteKeys: []message.Key{
+				message.Key(encoding.EncodeKey(r.uid, r.tableID, newTestEvent(3, 1, 0))),
+			},
+			expectOutputs: []*model.PolymorphicEvent{
+				newTestEvent(3, 1, 0),
+			},
+			expectMaxCommitTs:   3,
+			expectMaxResolvedTs: 3,
+			// exhaustedResolvedTs must not advance if a txn is partially read.
+			expectExhaustedRTs: 0,
+		}},
 		// exhaustedResolvedTs must advance if all resolved events are outputted.
 		// Output: CRTs 3, StartTs 1, keys (0|1|2)
 		{{ // The first poll
 			inputReadTs: message.ReadTs{MaxResolvedTs: 3, MaxCommitTs: 3},
 			state: pollState{
-				outputBuf: newOutputBuffer(1),
+				outputBuf: newOutputBuffer(3),
 			},
 			inputIter: newIterator(ctx, t, db, sema),
 
@@ -820,7 +854,7 @@ func TestReaderPoll(t *testing.T) {
 			require.EqualValues(t, cs.expectDeleteKeys, r.state.outputBuf.deleteKeys, "case #%d[%d], %v", i, j, cs)
 			require.EqualValues(t, cs.expectMaxCommitTs, r.state.maxCommitTs, "case #%d[%d], %v", i, j, cs)
 			require.EqualValues(t, cs.expectMaxResolvedTs, r.state.maxResolvedTs, "case #%d[%d], %v", i, j, cs)
-			require.EqualValues(t, cs.expectExhaustedRTs, r.state.exhaustedResolvedTs, "case #%d[%d], %v", i, j, cs)
+			require.EqualValues(t, cs.expectExhaustedRTs, r.state.position.exhaustedResolvedTs, "case #%d[%d], %v", i, j, cs)
 			outputEvents := receiveOutputEvents(r.outputCh)
 			require.EqualValues(t, cs.expectOutputs, outputEvents, "case #%d[%d], %v", i, j, cs)
 

--- a/cdc/sorter/db/reader_test.go
+++ b/cdc/sorter/db/reader_test.go
@@ -904,14 +904,28 @@ func TestReaderPoll(t *testing.T) {
 			}
 			msg := actormsg.ValueMessage(message.Task{ReadTs: cs.inputReadTs})
 			require.True(t, r.Poll(ctx, []actormsg.Message[message.Task]{msg}))
-			require.EqualValues(t, cs.expectEvents, r.state.outputBuf.resolvedEvents, "case #%d[%d], %v", i, j, cs)
-			require.EqualValues(t, cs.expectDeleteKeys, r.state.outputBuf.deleteKeys, "case #%d[%d], %v", i, j, cs)
-			require.EqualValues(t, cs.expectMaxCommitTs, r.state.maxCommitTs, "case #%d[%d], %v", i, j, cs)
-			require.EqualValues(t, cs.expectMaxResolvedTs, r.state.maxResolvedTs, "case #%d[%d], %v", i, j, cs)
-			require.EqualValues(t, cs.expectExhaustedRTs, r.state.position.exhaustedResolvedTs, "case #%d[%d], %v", i, j, cs)
-			require.EqualValues(t, cs.expectPartialTxnKey, r.state.position.partialTxnKey, "case #%d[%d], %v", i, j, cs)
+			require.EqualValues(
+				t, cs.expectEvents, r.state.outputBuf.resolvedEvents,
+				"case #%d[%d], %v", i, j, cs)
+			require.EqualValues(
+				t, cs.expectDeleteKeys, r.state.outputBuf.deleteKeys,
+				"case #%d[%d], %v", i, j, cs)
+			require.EqualValues(
+				t, cs.expectMaxCommitTs, r.state.maxCommitTs,
+				"case #%d[%d], %v", i, j, cs)
+			require.EqualValues(
+				t, cs.expectMaxResolvedTs, r.state.maxResolvedTs,
+				"case #%d[%d], %v", i, j, cs)
+			require.EqualValues(
+				t, cs.expectExhaustedRTs, r.state.position.exhaustedResolvedTs,
+				"case #%d[%d], %v", i, j, cs)
+			require.EqualValues(
+				t, cs.expectPartialTxnKey, r.state.position.partialTxnKey,
+				"case #%d[%d], %v", i, j, cs)
 			outputEvents := receiveOutputEvents(r.outputCh)
-			require.EqualValues(t, cs.expectOutputs, outputEvents, "case #%d[%d], %v", i, j, cs)
+			require.EqualValues(
+				t, cs.expectOutputs, outputEvents,
+				"case #%d[%d], %v", i, j, cs)
 
 			select {
 			case err := <-r.errCh:

--- a/cdc/sorter/db/sorter.go
+++ b/cdc/sorter/db/sorter.go
@@ -141,10 +141,9 @@ func NewSorter(
 		state: pollState{
 			outputBuf: newOutputBuffer(batchReceiveEventSize),
 
-			maxCommitTs:         uint64(0),
-			maxResolvedTs:       uint64(0),
-			exhaustedResolvedTs: uint64(0),
-			startTs:             uint64(0),
+			maxCommitTs:   uint64(0),
+			maxResolvedTs: uint64(0),
+			startTs:       uint64(0),
 
 			readerID:     actorID,
 			readerRouter: readerRouter,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tidb/issues/39819

### What is changed and how it works?

Split large txn during sorter read.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

Yes, it might cause performance regression.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix an OOM issue when TiCDC replicates big transactions
```
