### PR TITLE
engine: fix duration not updated

### DIFF
--- a/engine/jobmaster/dm/api.go
+++ b/engine/jobmaster/dm/api.go
@@ -78,6 +78,12 @@ func (jm *JobMaster) QueryJobStatus(ctx context.Context, tasks []string) (*JobSt
 		existUnitState bool
 	)
 
+	// need to get unit state here, so we calculate duration
+	state, err := jm.metadata.UnitStateStore().Get(ctx)
+	if err != nil && errors.Cause(err) != metadata.ErrStateNotFound {
+		return nil, err
+	}
+	_, existUnitState = state.(*metadata.UnitState)
 	for _, task := range tasks {
 		taskID := task
 		wg.Add(1)
@@ -133,7 +139,7 @@ func (jm *JobMaster) QueryJobStatus(ctx context.Context, tasks []string) (*JobSt
 
 	// should be done after we get current task-status, since some unit status might be missing if
 	// current unit finish between we get finished unit status and get current task-status
-	state, err := jm.metadata.UnitStateStore().Get(ctx)
+	state, err = jm.metadata.UnitStateStore().Get(ctx)
 	if err != nil && errors.Cause(err) != metadata.ErrStateNotFound {
 		return nil, err
 	}

--- a/engine/jobmaster/dm/api.go
+++ b/engine/jobmaster/dm/api.go
@@ -83,7 +83,7 @@ func (jm *JobMaster) QueryJobStatus(ctx context.Context, tasks []string) (*JobSt
 	if err != nil && errors.Cause(err) != metadata.ErrStateNotFound {
 		return nil, err
 	}
-	_, existUnitState = state.(*metadata.UnitState)
+	unitState, existUnitState = state.(*metadata.UnitState)
 	for _, task := range tasks {
 		taskID := task
 		wg.Add(1)

--- a/engine/jobmaster/dm/api_test.go
+++ b/engine/jobmaster/dm/api_test.go
@@ -110,9 +110,9 @@ func TestQueryStatusAPI(t *testing.T) {
 		dumpStatusResp     = &dmpkg.QueryStatusResponse{Unit: frameModel.WorkerDMDump, Stage: metadata.StageRunning, Status: dumpStatusBytes, IoTotalBytes: 0}
 		loadStatusResp     = &dmpkg.QueryStatusResponse{Unit: frameModel.WorkerDMLoad, Stage: metadata.StagePaused, Result: &dmpkg.ProcessResult{IsCanceled: true}, Status: loadStatusBytes, IoTotalBytes: 0}
 		syncStatusResp     = &dmpkg.QueryStatusResponse{Unit: frameModel.WorkerDMSync, Stage: metadata.StageError, Result: &dmpkg.ProcessResult{Errors: []*dmpkg.ProcessError{processError}}, Status: syncStatusBytes, IoTotalBytes: 0}
-		dumpTime, _        = time.Parse(time.RFC3339Nano, "2022-11-04T18:47:57.43382274+08:00")
-		loadTime, _        = time.Parse(time.RFC3339Nano, "2022-11-04T19:47:57.43382274+08:00")
-		syncTime, _        = time.Parse(time.RFC3339Nano, "2022-11-04T20:47:57.43382274+08:00")
+		dumpTime, _        = time.Parse(time.RFC3339Nano, "2020-11-04T18:47:57.43382274+08:00")
+		loadTime, _        = time.Parse(time.RFC3339Nano, "2020-11-04T19:47:57.43382274+08:00")
+		syncTime, _        = time.Parse(time.RFC3339Nano, "2020-11-04T20:47:57.43382274+08:00")
 		dumpDuration       = time.Hour
 		loadDuration       = time.Minute
 		unitState          = &metadata.UnitState{
@@ -214,15 +214,13 @@ func TestQueryStatusAPI(t *testing.T) {
 
 	jobStatus, err = jm.QueryJobStatus(ctx, nil)
 	require.NoError(t, err)
+	require.Len(t, jobStatus.TaskStatus, 7)
 
 	for task, currentStatus := range jobStatus.TaskStatus {
-		switch currentStatus.Status.Unit {
-		case frameModel.WorkerDMDump:
-			require.True(t, currentStatus.Duration-time.Since(dumpTime) < time.Second)
-		case frameModel.WorkerDMLoad:
-			require.True(t, currentStatus.Duration-time.Since(loadTime) < time.Second)
-		case frameModel.WorkerDMSync:
-			require.True(t, currentStatus.Duration-time.Since(syncTime) < time.Second)
+		// start-time is fixed at 2020-11-04 except task1 which is paused and don't have current status,
+		// we just check that it's > 24h （now it's 2022-12-16)
+		if task != "task1" {
+			require.Greater(t, currentStatus.Duration, 24*time.Hour)
 		}
 		// this is for passing follow test, because we can't offer the precise duration in advance
 		currentStatus.Duration = time.Second
@@ -380,7 +378,7 @@ func TestQueryStatusAPI(t *testing.T) {
 				"Task": "task2",
 				"Stage": "Finished",
 				"CfgModRevision": 3,
-				"StageUpdatedTime": "2022-11-04T19:47:57.43382274+08:00",
+				"StageUpdatedTime": "2020-11-04T19:47:57.43382274+08:00",
 				"Result": null,
 				"Status": {
 					"totalTables": 10,
@@ -398,7 +396,7 @@ func TestQueryStatusAPI(t *testing.T) {
 				"Task": "task2",
 				"Stage": "Finished",
 				"CfgModRevision": 3,
-				"StageUpdatedTime": "2022-11-04T20:47:57.43382274+08:00",
+				"StageUpdatedTime": "2020-11-04T20:47:57.43382274+08:00",
 				"Result": null,
 				"Status": {
 					"finishedBytes": 4,
@@ -417,7 +415,7 @@ func TestQueryStatusAPI(t *testing.T) {
 				"Task": "task7",
 				"Stage": "Finished",
 				"CfgModRevision": 4,
-				"StageUpdatedTime": "2022-11-04T19:47:57.43382274+08:00",
+				"StageUpdatedTime": "2020-11-04T19:47:57.43382274+08:00",
 				"Result": null,
 				"Status": {
 					"totalTables": 10,
@@ -435,7 +433,7 @@ func TestQueryStatusAPI(t *testing.T) {
 				"Task": "task7",
 				"Stage": "Finished",
 				"CfgModRevision": 4,
-				"StageUpdatedTime": "2022-11-04T20:47:57.43382274+08:00",
+				"StageUpdatedTime": "2020-11-04T20:47:57.43382274+08:00",
 				"Result": null,
 				"Status": {
 					"finishedBytes": 4,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #7115

### What is changed and how it works?
- introduced by https://github.com/pingcap/tiflow/pull/7711, which cause `existUnitState` not inited, so duration is not calculated

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
