### PR TITLE
capture(ticdc): fix cdc panic when async close capture 

### DIFF
--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -209,6 +209,11 @@ func (c *captureImpl) reset(ctx context.Context) error {
 
 	c.captureMu.Lock()
 	defer c.captureMu.Unlock()
+	c.info = &model.CaptureInfo{
+		ID:            uuid.New().String(),
+		AdvertiseAddr: c.config.AdvertiseAddr,
+		Version:       version.ReleaseVersion,
+	}
 	c.EtcdClient = etcdClient
 	c.migrator = migrate.NewMigrator(c.EtcdClient, c.pdEndpoints, c.config)
 
@@ -222,12 +227,6 @@ func (c *captureImpl) reset(ctx context.Context) error {
 		concurrency.WithLease(lease.ID))
 	if err != nil {
 		return cerror.WrapError(cerror.ErrNewCaptureFailed, err)
-	}
-
-	c.info = &model.CaptureInfo{
-		ID:            uuid.New().String(),
-		AdvertiseAddr: c.config.AdvertiseAddr,
-		Version:       version.ReleaseVersion,
 	}
 
 	if c.upstreamManager != nil {

--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -574,6 +574,9 @@ func (c *captureImpl) resign(ctx context.Context) error {
 	failpoint.Inject("capture-resign-failed", func() {
 		failpoint.Return(errors.New("capture resign failed"))
 	})
+	if c.election == nil {
+		return nil
+	}
 	return cerror.WrapError(cerror.ErrCaptureResignOwner, c.election.resign(ctx))
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7918

### What is changed and how it works?
if c.reset() meet error between [L204 and L246](https://github.com/pingcap/tiflow/pull/7921/files#diff-4f24fb50f8768cd676f96ed676da601c83670784c3af3fac055361e7b035efd9R206-R246), capture will panic. So, we should check if c.election is nil before close it.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
