### PR TITLE
engine(dm): use same enum value as dmpb for engine task stage

### DIFF
--- a/engine/jobmaster/dm/metadata/job.go
+++ b/engine/jobmaster/dm/metadata/job.go
@@ -30,8 +30,9 @@ import (
 
 // TaskStage represents internal stage of a task.
 // TODO: use Stage in lib or move Stage to lib.
-// we need to use same value for same stage in dmpb.Stage in order to make grafana dashboard label correct,
+// we need to use same value for stage with same name in dmpb.Stage in order to make grafana dashboard label correct,
 // since we use the same grafana dashboard for OP and engine.
+// there's no need for them to have same meaning, just for grafana display.
 type TaskStage int
 
 // These stages may be updated in later pr.
@@ -62,7 +63,11 @@ var toTaskStage map[string]TaskStage
 
 func init() {
 	toTaskStage = make(map[string]TaskStage, len(typesStringify))
+	toTaskStage[""] = TaskStage(0)
 	for i, s := range typesStringify {
+		if len(s) == 0 {
+			continue
+		}
 		toTaskStage[s] = TaskStage(i)
 	}
 }

--- a/engine/jobmaster/dm/metadata/job.go
+++ b/engine/jobmaster/dm/metadata/job.go
@@ -28,19 +28,21 @@ import (
 	"go.uber.org/zap"
 )
 
-// TaskStage represents internal stage of a task
+// TaskStage represents internal stage of a task.
 // TODO: use Stage in lib or move Stage to lib.
+// we need to use same value for same stage in dmpb.Stage in order to make grafana dashboard label correct,
+// since we use the same grafana dashboard for OP and engine.
 type TaskStage int
 
 // These stages may be updated in later pr.
 const (
-	StageInit TaskStage = iota + 1
-	StageRunning
-	StagePaused
-	StageFinished
-	StageError
-	StagePausing
-	// UnScheduled means the task is not scheduled.
+	StageInit     TaskStage = iota + 1  // = 1 = dmpb.Stage_New
+	StageRunning                        // = 2 = dmpb.Stage_Running
+	StagePaused                         // = 3 ~= dmpb.Stage_Paused. in engine this stage means paused by user, if it's auto-paused by error, it's StageError
+	StageFinished TaskStage = iota + 2  // = 5 = dmpb.Stage_Finished. skip 4 - Stopped, no such stage in engine, see dm/worker/metrics.go
+	StagePausing                        // = 6 = dmpb.Stage_Pausing
+	StageError    TaskStage = iota + 10 // = 15, leave some value space for extension of dmpb.Stage
+	// StageUnscheduled means the task is not scheduled.
 	// This usually happens when the worker is offline.
 	StageUnscheduled
 )

--- a/engine/jobmaster/dm/metadata/job_test.go
+++ b/engine/jobmaster/dm/metadata/job_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/log"
 	dmconfig "github.com/pingcap/tiflow/dm/config"
 	dmmaster "github.com/pingcap/tiflow/dm/master"
+	dmpb "github.com/pingcap/tiflow/dm/pb"
 	"github.com/pingcap/tiflow/engine/jobmaster/dm/config"
 	"github.com/pingcap/tiflow/engine/pkg/adapter"
 	"github.com/pingcap/tiflow/engine/pkg/meta/mock"
@@ -149,4 +150,17 @@ func TestTaskStage(t *testing.T) {
 	var ts2 TaskStage
 	require.EqualError(t, json.Unmarshal(bs, &ts2), "Unknown TaskStage Unknown TaskStage 1000")
 	require.Equal(t, TaskStage(0), ts2)
+}
+
+func TestTaskStageValue(t *testing.T) {
+	require.Equal(t, int(dmpb.Stage_New), int(StageInit))
+	require.Equal(t, int(dmpb.Stage_Running), int(StageRunning))
+	require.Equal(t, int(dmpb.Stage_Paused), int(StagePaused))
+	require.Equal(t, int(dmpb.Stage_Finished), int(StageFinished))
+	require.Equal(t, int(dmpb.Stage_Pausing), int(StagePausing))
+	require.Greater(t, int(StageError), int(dmpb.Stage_Stopping))
+	require.Greater(t, int(StageUnscheduled), int(dmpb.Stage_Stopping))
+
+	require.Equal(t, 15, int(StageError))
+	require.Equal(t, 16, int(StageUnscheduled))
 }

--- a/engine/jobmaster/dm/metadata/job_test.go
+++ b/engine/jobmaster/dm/metadata/job_test.go
@@ -131,6 +131,9 @@ func TestJobStore(t *testing.T) {
 func TestTaskStage(t *testing.T) {
 	t.Parallel()
 	for i, s := range typesStringify {
+		if len(s) == 0 {
+			continue
+		}
 		ts, ok := toTaskStage[s]
 		require.True(t, ok)
 		bs, err := json.Marshal(ts)
@@ -163,4 +166,6 @@ func TestTaskStageValue(t *testing.T) {
 
 	require.Equal(t, 15, int(StageError))
 	require.Equal(t, 16, int(StageUnscheduled))
+
+	require.Equal(t, 0, int(toTaskStage[""]))
 }

--- a/engine/jobmaster/dm/metadata/job_test.go
+++ b/engine/jobmaster/dm/metadata/job_test.go
@@ -168,4 +168,12 @@ func TestTaskStageValue(t *testing.T) {
 	require.Equal(t, 16, int(StageUnscheduled))
 
 	require.Equal(t, 0, int(toTaskStage[""]))
+
+	require.Equal(t, "Initing", StageInit.String())
+	require.Equal(t, "Running", StageRunning.String())
+	require.Equal(t, "Paused", StagePaused.String())
+	require.Equal(t, "Finished", StageFinished.String())
+	require.Equal(t, "Error", StageError.String())
+	require.Equal(t, "Pausing", StagePausing.String())
+	require.Equal(t, "Unscheduled", StageUnscheduled.String())
 }

--- a/metrics/grafana/DM-Monitor-Professional.json
+++ b/metrics/grafana/DM-Monitor-Professional.json
@@ -137,6 +137,14 @@
               "to": "",
               "type": 1,
               "value": "5"
+            },
+            {
+              "from": "",
+              "id": 7,
+              "text": "Error",
+              "to": "",
+              "type": 1,
+              "value": "15"
             }
           ],
           "min": 0,

--- a/metrics/grafana/DM-Monitor-Standard.json
+++ b/metrics/grafana/DM-Monitor-Standard.json
@@ -222,6 +222,14 @@
                     "to": "",
                     "type": 1,
                     "value": "5"
+                  },
+                  {
+                    "from": "",
+                    "id": 7,
+                    "text": "Error",
+                    "to": "",
+                    "type": 1,
+                    "value": "15"
                   }
                 ]
               }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #7115

### What is changed and how it works?
- now we uses the same grafana dashboard for dm in OP and engine(https://github.com/pingcap/tiflow/pull/7881), so we need to use same enum value as dmpb for engine task stage, to avoid confusion

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
