### PR TITLE
cmd(ticdc): print error msg if an invalid input was read

### DIFF
--- a/pkg/cmd/cli/cli_changefeed_helper.go
+++ b/pkg/cmd/cli/cli_changefeed_helper.go
@@ -29,6 +29,19 @@ const (
 	tsGapWarning = 86400 * 1000
 )
 
+func readInput(cmd *cobra.Command) bool {
+	var yOrN string
+	_, err := fmt.Scan(&yOrN)
+	if err != nil {
+		cmd.Printf("Received invalid input: %s, abort the command.\n", err.Error())
+		return false
+	}
+	if strings.ToLower(strings.TrimSpace(yOrN)) != "y" {
+		return false
+	}
+	return true
+}
+
 // confirmLargeDataGap checks if a large data gap is used.
 func confirmLargeDataGap(cmd *cobra.Command, currentPhysical int64, startTs uint64, command string) error {
 	tsGap := currentPhysical - oracle.ExtractPhysical(startTs)
@@ -38,13 +51,9 @@ func confirmLargeDataGap(cmd *cobra.Command, currentPhysical int64, startTs uint
 			"large data may cause OOM, confirm to continue at your own risk [Y/N]\n",
 			time.Duration(tsGap)*time.Millisecond,
 		)
-		var yOrN string
-		_, err := fmt.Scan(&yOrN)
-		if err != nil {
-			return err
-		}
-		if strings.ToLower(strings.TrimSpace(yOrN)) != "y" {
-			cmd.Printf("abort changefeed %s\n", command)
+		confirmed := readInput(cmd)
+		if !confirmed {
+			cmd.Printf("Abort changefeed %s.\n", command)
 			return cerror.ErrCliAborted.FastGenByArgs(fmt.Sprintf("cli changefeed %s", command))
 		}
 	}
@@ -60,13 +69,9 @@ func confirmOverwriteCheckpointTs(
 	cmd.Printf("You are overwriting the checkpoint of changefeed(%s) to %d,"+
 		" which may lead to data loss or data duplication.\nConfirm that you know"+
 		" what this command will do and use it at your own risk [Y/N]", changefeedID, checkpointTs)
-	var yOrN string
-	_, err := fmt.Scan(&yOrN)
-	if err != nil {
-		return err
-	}
-	if strings.ToLower(strings.TrimSpace(yOrN)) != "y" {
-		cmd.Printf("abort changefeed resume\n")
+	confirmed := readInput(cmd)
+	if !confirmed {
+		cmd.Printf("Abort changefeed resume.\n")
 		return cerror.ErrCliAborted.FastGenByArgs("cli changefeed resume")
 	}
 
@@ -77,12 +82,8 @@ func confirmOverwriteCheckpointTs(
 // If ignore it will return true.
 func confirmIgnoreIneligibleTables(cmd *cobra.Command) (bool, error) {
 	cmd.Printf("Could you agree to ignore those tables, and continue to replicate [Y/N]\n")
-	var yOrN string
-	_, err := fmt.Scan(&yOrN)
-	if err != nil {
-		return false, err
-	}
-	if strings.ToLower(strings.TrimSpace(yOrN)) != "y" {
+	confirmed := readInput(cmd)
+	if !confirmed {
 		cmd.Printf("No changefeed is created because you don't want to ignore some tables.\n")
 		return false, cerror.ErrCliAborted.FastGenByArgs("cli changefeed create")
 	}

--- a/pkg/cmd/cli/cli_changefeed_update.go
+++ b/pkg/cmd/cli/cli_changefeed_update.go
@@ -15,7 +15,6 @@ package cli
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/pingcap/log"
@@ -116,12 +115,8 @@ func (o *updateChangefeedOptions) run(cmd *cobra.Command) error {
 
 	if !o.commonChangefeedOptions.noConfirm {
 		cmd.Printf("Could you agree to apply changes above to changefeed [Y/N]\n")
-		var yOrN string
-		_, err = fmt.Scan(&yOrN)
-		if err != nil {
-			return err
-		}
-		if strings.ToLower(strings.TrimSpace(yOrN)) != "y" {
+		confirmed := readInput(cmd)
+		if !confirmed {
 			cmd.Printf("No update to changefeed.\n")
 			return nil
 		}

--- a/pkg/cmd/cli/cli_unsafe.go
+++ b/pkg/cmd/cli/cli_unsafe.go
@@ -14,9 +14,6 @@
 package cli
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiflow/pkg/cmd/factory"
 	"github.com/spf13/cobra"
@@ -39,14 +36,8 @@ func (o *unsafeCommonOptions) confirmMetaDelete(cmd *cobra.Command) error {
 	}
 
 	cmd.Printf("Confirm that you know what this command will do and use it at your own risk [Y/N]\n")
-
-	var yOrN string
-	_, err := fmt.Scan(&yOrN)
-	if err != nil {
-		return err
-	}
-
-	if strings.ToLower(strings.TrimSpace(yOrN)) != "y" {
+	confirmed := readInput(cmd)
+	if !confirmed {
 		return errors.NewNoStackError("abort meta command")
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7903

### What is changed and how it works?
print error msg if an invalid input was read

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 Manual test (add detailed scripts or steps below)
1. before
```bash
# docker run cdc:test /cdc cli changefeed create --sink-uri="blackhole://" -c storage-perf --server=10.2.6.163:8300 --start-ts=438045762164359180
Error: EOF
Replicate lag (121h36m31.6s) is larger than 1 days, large data may cause OOM, confirm to continue at your own risk [Y/N]
```
2. after
```bash
# docker run cdc:test /cdc cli changefeed create --sink-uri="blackhole://" -c storage-perf --server=10.2.7.167:8301 --start-ts=438045762164359180

Replicate lag (380h54m19.605s) is larger than 1 days, large data may cause OOM, confirm to continue at your own risk [Y/N]
Received invalid input: EOF, abort the command.
Abort changefeed create.
```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
