### PR TITLE
pkg/security(ticdc): support online load tls config (#7927)

### DIFF
--- a/engine/pkg/client/executor_client_test.go
+++ b/engine/pkg/client/executor_client_test.go
@@ -14,6 +14,7 @@
 package client
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -34,10 +35,15 @@ func TestNewExecutorClientNotBlocking(t *testing.T) {
 func TestExecutorClientFactoryIllegalCredentials(t *testing.T) {
 	t.Parallel()
 
+	dir := t.TempDir()
+	caPath := dir + "/ca.pem"
+	err := os.WriteFile(caPath, []byte("invalid ca pem"), 0o600)
+	require.NoError(t, err)
+
 	credentials := &security.Credential{
-		CAPath: "/dev/null", // illegal CA path to trigger an error
+		CAPath: caPath, // illegal CA path to trigger an error
 	}
 	factory := newExecutorClientFactory(credentials, nil)
-	_, err := factory.NewExecutorClient("127.0.0.1:1234")
+	_, err = factory.NewExecutorClient("127.0.0.1:1234")
 	require.Error(t, err)
 }

--- a/engine/test/e2e/e2e_dm_test.go
+++ b/engine/test/e2e/e2e_dm_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -384,7 +383,7 @@ func queryStatus(ctx context.Context, client *httputil.Client, jobID string, tas
 		return nil, err
 	}
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -431,7 +430,7 @@ func getJobCfg(ctx context.Context, client *httputil.Client, jobID string) (stri
 		return "", err
 	}
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -472,7 +471,7 @@ func getBinlogOperator(ctx context.Context, client *httputil.Client, jobID strin
 		return nil, err
 	}
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -534,7 +533,7 @@ func getBinlogSchema(ctx context.Context, client *httputil.Client, jobID string,
 		return nil, err
 	}
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/cli/cli_changefeed_list_test.go
+++ b/pkg/cmd/cli/cli_changefeed_list_test.go
@@ -15,7 +15,7 @@ package cli
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -88,7 +88,7 @@ func TestChangefeedListCli(t *testing.T) {
 	// when --all=false, should contains StateNormal, StateError, StateFailed, StateStopped changefeed
 	os.Args = []string{"list", "--all=false"}
 	require.Nil(t, cmd.Execute())
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	require.Nil(t, err)
 	require.Contains(t, string(out), "error-1")
 	require.Contains(t, string(out), "normal-2")
@@ -98,7 +98,7 @@ func TestChangefeedListCli(t *testing.T) {
 	// when --all=true, should contains all changefeed
 	os.Args = []string{"list", "--all=true"}
 	require.Nil(t, cmd.Execute())
-	out, err = ioutil.ReadAll(b)
+	out, err = io.ReadAll(b)
 	require.Nil(t, err)
 	require.Contains(t, string(out), "error-1")
 	require.Contains(t, string(out), "normal-2")

--- a/pkg/cmd/cli/cli_changefeed_query_test.go
+++ b/pkg/cmd/cli/cli_changefeed_query_test.go
@@ -15,7 +15,7 @@ package cli
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -83,7 +83,7 @@ func TestChangefeedQueryCli(t *testing.T) {
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
 	require.Nil(t, o.run(cmd))
-	out, err := ioutil.ReadAll(b)
+	out, err := io.ReadAll(b)
 	require.Nil(t, err)
 	// make sure config is printed
 	require.Contains(t, string(out), "config")

--- a/pkg/fsutil/preallocate_test.go
+++ b/pkg/fsutil/preallocate_test.go
@@ -13,7 +13,6 @@
 package fsutil
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -21,7 +20,7 @@ import (
 )
 
 func TestPreAllocate(t *testing.T) {
-	f, err := ioutil.TempFile("", "preallocate-test")
+	f, err := os.CreateTemp("", "preallocate-test")
 	defer os.Remove(f.Name())
 	require.Nil(t, err)
 

--- a/pkg/security/credential.go
+++ b/pkg/security/credential.go
@@ -18,9 +18,9 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"os"
+	"strings"
 
-	"github.com/pingcap/tidb-tools/pkg/utils"
-	cerror "github.com/pingcap/tiflow/pkg/errors"
+	"github.com/pingcap/tiflow/pkg/errors"
 	pd "github.com/tikv/pd/client"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -64,15 +64,15 @@ func (s *Credential) ToGRPCDialOption() (grpc.DialOption, error) {
 
 // ToTLSConfig generates tls's config from *Security
 func (s *Credential) ToTLSConfig() (*tls.Config, error) {
-	cfg, err := utils.ToTLSConfig(s.CAPath, s.CertPath, s.KeyPath)
-	return cfg, cerror.WrapError(cerror.ErrToTLSConfigFailed, err)
+	cfg, err := ToTLSConfigWithVerify(s.CAPath, s.CertPath, s.KeyPath, nil)
+	return cfg, errors.WrapError(errors.ErrToTLSConfigFailed, err)
 }
 
 // ToTLSConfigWithVerify generates tls's config from *Security and requires
 // the remote common name to be verified.
 func (s *Credential) ToTLSConfigWithVerify() (*tls.Config, error) {
-	cfg, err := utils.ToTLSConfigWithVerify(s.CAPath, s.CertPath, s.KeyPath, s.CertAllowedCN)
-	return cfg, cerror.WrapError(cerror.ErrToTLSConfigFailed, err)
+	cfg, err := ToTLSConfigWithVerify(s.CAPath, s.CertPath, s.KeyPath, s.CertAllowedCN)
+	return cfg, errors.WrapError(errors.ErrToTLSConfigFailed, err)
 }
 
 func (s *Credential) getSelfCommonName() (string, error) {
@@ -81,15 +81,16 @@ func (s *Credential) getSelfCommonName() (string, error) {
 	}
 	data, err := os.ReadFile(s.CertPath)
 	if err != nil {
-		return "", cerror.WrapError(cerror.ErrToTLSConfigFailed, err)
+		return "", errors.WrapError(errors.ErrToTLSConfigFailed, err)
 	}
 	block, _ := pem.Decode(data)
 	if block == nil || block.Type != "CERTIFICATE" {
-		return "", cerror.ErrToTLSConfigFailed.GenWithStack("failed to decode PEM block to certificate")
+		return "", errors.ErrToTLSConfigFailed.
+			GenWithStack("failed to decode PEM block to certificate")
 	}
 	certificate, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		return "", cerror.WrapError(cerror.ErrToTLSConfigFailed, err)
+		return "", errors.WrapError(errors.ErrToTLSConfigFailed, err)
 	}
 	return certificate.Subject.CommonName, nil
 }
@@ -106,4 +107,81 @@ func (s *Credential) AddSelfCommonName() error {
 	}
 	s.CertAllowedCN = append(s.CertAllowedCN, cn)
 	return nil
+}
+
+// ToTLSConfigWithVerify constructs a `*tls.Config` from the CA, certification and key
+// paths, and add verify for CN.
+//
+// If the CA path is empty, returns nil.
+func ToTLSConfigWithVerify(
+	caPath, certPath, keyPath string, verifyCN []string,
+) (*tls.Config, error) {
+	if len(caPath) == 0 {
+		return nil, nil
+	}
+
+	// Create a certificate pool from CA
+	certPool := x509.NewCertPool()
+	ca, err := os.ReadFile(caPath)
+	if err != nil {
+		return nil, errors.Annotate(err, "could not read ca certificate")
+	}
+
+	// Append the certificates from the CA
+	if !certPool.AppendCertsFromPEM(ca) {
+		return nil, errors.New("failed to append ca certs")
+	}
+
+	tlsCfg := &tls.Config{
+		RootCAs:    certPool,
+		ClientCAs:  certPool,
+		NextProtos: []string{"h2", "http/1.1"}, // specify `h2` to let Go use HTTP/2.
+		MinVersion: tls.VersionTLS12,
+	}
+
+	if len(certPath) != 0 && len(keyPath) != 0 {
+		loadCert := func() (*tls.Certificate, error) {
+			cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+			if err != nil {
+				return nil, errors.Annotate(err, "could not load client key pair")
+			}
+			return &cert, nil
+		}
+		tlsCfg.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return loadCert()
+		}
+		tlsCfg.GetCertificate = func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return loadCert()
+		}
+	}
+
+	addVerifyPeerCertificate(tlsCfg, verifyCN)
+	return tlsCfg, nil
+}
+
+func addVerifyPeerCertificate(tlsCfg *tls.Config, verifyCN []string) {
+	if len(verifyCN) != 0 {
+		checkCN := make(map[string]struct{})
+		for _, cn := range verifyCN {
+			cn = strings.TrimSpace(cn)
+			checkCN[cn] = struct{}{}
+		}
+		tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
+		tlsCfg.VerifyPeerCertificate = func(
+			rawCerts [][]byte, verifiedChains [][]*x509.Certificate,
+		) error {
+			cns := make([]string, 0, len(verifiedChains))
+			for _, chains := range verifiedChains {
+				for _, chain := range chains {
+					cns = append(cns, chain.Subject.CommonName)
+					if _, match := checkCN[chain.Subject.CommonName]; match {
+						return nil
+					}
+				}
+			}
+			return errors.Errorf("client certificate authentication failed. "+
+				"The Common Name from the client certificate %v was not found "+
+				"in the configuration cluster-verify-cn with value: %s", cns, verifyCN)
+		}
+	}
 }

--- a/pkg/security/test_util.go
+++ b/pkg/security/test_util.go
@@ -13,120 +13,176 @@
 
 package security
 
-import "os"
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"time"
+)
 
-// All these certificates or keys are use for testing only.
-var certPem = `-----BEGIN CERTIFICATE-----
-MIIDjzCCAnegAwIBAgIUWBTDQm4xOYDxZBTkpCQouREtT8QwDQYJKoZIhvcNAQEL
-BQAwVzELMAkGA1UEBhMCQ04xEDAOBgNVBAgTB0JlaWppbmcxEDAOBgNVBAcTB0Jl
-aWppbmcxEDAOBgNVBAoTB1BpbmdDQVAxEjAQBgNVBAMTCU15IG93biBDQTAgFw0y
-MDAyMTgwOTExMDBaGA8yMTIwMDEyNTA5MTEwMFowFjEUMBIGA1UEAxMLdGlkYi1z
-ZXJ2ZXIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCr2ZxAb+dItEQz
-avuza0IoIT/UolC9XTGaQiCUUPZUMN9hb4KYEwTks1ZthHovTIJUdTwHtpWfDUWx
-uIXhOlRjfD+viY4aXtBsaK8xi9F7o2HbFQ5O9y3AXK/YW+u0FfWtnn/xAtvPUgUc
-61NXtBTMvNard9ICIXW+FWxLcFSaHpC9ZTyr13KWmZRDbai1JFeaKvATMW30r7Dd
-Ur1npppzt7ZdG6tU/FuqBBSrZtuVSGKLwVx0JQDw16eVan4friY3ZPNVoZvkKyvt
-I1LsBYMQ8p+ijtbcftvMqWZFVw95F1+3C2JIjWN9ujGmvJr+dtPIE8T/J8tT9Jif
-9vz16nOLAgMBAAGjgZEwgY4wDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsG
-AQUFBwMBBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBRVB/Bvdzvh
-6WQRWpc9SzcbXLz77zAfBgNVHSMEGDAWgBSdAhKsS8BKSOidoGCUYNeaFma4/zAP
-BgNVHREECDAGhwR/AAABMA0GCSqGSIb3DQEBCwUAA4IBAQAAqg5pgGQqORKRSdlY
-wzVvzKaulpvjZfVMM6YiOUtmlU0CGWq7E3gLFzkvebpU0KsFlbyZ92h/2Fw5Ay2b
-kxkCy18mJ4lGkvF0cU4UD3XheFMvD2QWWRX4WPpAhStofrWOXeyq3Div2+fQjMJd
-kyeWUzPU7T467IWUHOWNsFAjfVHNsmG45qLGt+XQckHTvASX5IvN+5tkRUCW30vO
-b3BdDQUFglGTUFU2epaZGTti0SYiRiY+9R3zFWX4uBcEBYhk9e/0BU8FqdWW5GjI
-pFpH9t64CjKIdRQXpIn4cogK/GwyuRuDPV/RkMjrIqOi7pGejXwyDe9avHFVR6re
-oowA
------END CERTIFICATE-----`
+// WriteFile write content to a temp file
+func WriteFile(fileName string, content []byte) (path string, err error) {
+	cert, err := os.CreateTemp("", fileName)
+	if err != nil {
+		return "", err
+	}
+	_, err = cert.Write(content)
+	return cert.Name(), err
+}
 
-var caPem = `-----BEGIN CERTIFICATE-----
-MIIDgDCCAmigAwIBAgIUHWvlRJydvYTR0ot3b8f6IlSHcGUwDQYJKoZIhvcNAQEL
-BQAwVzELMAkGA1UEBhMCQ04xEDAOBgNVBAgTB0JlaWppbmcxEDAOBgNVBAcTB0Jl
-aWppbmcxEDAOBgNVBAoTB1BpbmdDQVAxEjAQBgNVBAMTCU15IG93biBDQTAgFw0y
-MDAyMTgwNzQxMDBaGA8yMTIwMDEyNTA3NDEwMFowVzELMAkGA1UEBhMCQ04xEDAO
-BgNVBAgTB0JlaWppbmcxEDAOBgNVBAcTB0JlaWppbmcxEDAOBgNVBAoTB1BpbmdD
-QVAxEjAQBgNVBAMTCU15IG93biBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
-AQoCggEBAOAdNtjanFhPaKJHQjr7+h/Cpps5bLc6S1vmgi/EIi9PKv3eyDgtlW1r
-As2sjXRMHjcuZp2hHJ9r9FrMQD1rQQq5vJzQqM+eyWLc2tyZWXNWkZVvpjU4Hy5k
-jZFLXoyHgAvps/LGu81F5Lk5CvLHswWTyGQUCFi1l/cYcQg6AExh2pO/WJu4hQhe
-1mBBIKsJhZ5b5tWruLeI+YIjD1oo1ADMHYLK1BHON2fUmUHRGbrYKu4yCuyip3wn
-rbVlpabn7l1JBMatCUJLHR6VWQ2MNjrOXAEUYm4xGEN+tUYyUOGl5mHFguLl3OIn
-wj+1dT3WOr/NraPYlwVOnAd9GNbPJj0CAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEG
-MA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFJ0CEqxLwEpI6J2gYJRg15oWZrj/
-MA0GCSqGSIb3DQEBCwUAA4IBAQCf8xRf7q1xAaGrc9HCPvN4OFkxDwz1CifrvrLR
-ZgIWGUdCHDW2D1IiWKZQWeJKC1otA5x0hrS5kEGfkLFhADEU4txwp70DQaBArPti
-pSgheIEbaT0H3BUTYSgS3VL2HjxN5OVMN6jNG3rWyxnJpNOCsJhhJXPK50CRZ7fk
-Dcodj6FfEM2bfp2bGkxyVtUch7eepfUVbslXa7jE7Y8M3cr9NoLUcSP6D1RJWkNd
-dBQoUsb6Ckq27ozEKOgwuBVv4BrrbFN//+7WHP8Vy6sSMyd+dJLBi6wehJjQhIz6
-vqLWE81rSJuxZqjLpCkFdeEF+9SRjWegU0ZDM4V+YeX53BPC
------END CERTIFICATE-----
-`
+// NewServerCredential4Test return a Credential for testing
+func NewServerCredential4Test(cn string) (*CA, *Credential, error) {
+	var caPath, certPath, keyPath string
 
-var keyPem = `-----BEGIN RSA PRIVATE KEY-----
-MIIEogIBAAKCAQEAq9mcQG/nSLREM2r7s2tCKCE/1KJQvV0xmkIglFD2VDDfYW+C
-mBME5LNWbYR6L0yCVHU8B7aVnw1FsbiF4TpUY3w/r4mOGl7QbGivMYvRe6Nh2xUO
-TvctwFyv2FvrtBX1rZ5/8QLbz1IFHOtTV7QUzLzWq3fSAiF1vhVsS3BUmh6QvWU8
-q9dylpmUQ22otSRXmirwEzFt9K+w3VK9Z6aac7e2XRurVPxbqgQUq2bblUhii8Fc
-dCUA8NenlWp+H64mN2TzVaGb5Csr7SNS7AWDEPKfoo7W3H7bzKlmRVcPeRdftwti
-SI1jfboxprya/nbTyBPE/yfLU/SYn/b89epziwIDAQABAoIBACPlI08OULgN90Tq
-LsLuP3ZUY5nNgaHcKnU3JMj2FE3Hm5ElkpijOF1w3Dep+T+R8pMjnbNavuvnAMy7
-ZzOBVIknNcI7sDPv5AcQ4q8trkbt/I2fW0rBNIw+j/hYUuZdw+BNABpeZ31pe2nr
-+Y+TLNkLBKfyMiqBxK88mE81mmZKblyvXCawW0A/iDDJ7fPNqoGF+y9ylTYaNRPk
-aJGnaEZobJ4Lm5tSqW4gRX2ft6Hm67RkvVaopPFnlkvfusXUTFUqEVQCURRUqXbf
-1ah2chUHxj22UdY9540H5yVNgEP3oR+uS/hbZqxKcJUTznUW5th3CyQPIKMlGlcB
-p+zWlTECgYEAxlY4zGJw4QQwGYMKLyWCSHUgKYrKu2Ub2JKJFMTdsoj9H7DI+WHf
-lQaO9NCOo2lt0ofYM1MzEpI5Cl/aMrPw+mwquBbxWdMHXK2eSsUQOVo9HtUjgK2t
-J2AYFCfsYndo+hCj3ApMHgiY3sghTCXeycvT52bm11VeNVcs3pKxIYMCgYEA3dAJ
-PwIfAB8t+6JCP2yYH4ExNjoMNYMdXqhz4vt3UGwgskRqTW6qdd9JvrRQ/JPvGpDy
-T375h/+lLw0E4ljsnOPGSzbXNf4bYRHTwPOL+LqVM4Bg90hjclqphElHChxep1di
-WcdArB0oae/l4M96z3GjfnXIUVOp8K6BUQCab1kCgYAFFAQUR5j4SfEpVg+WsXEq
-hcUzCxixv5785pOX8opynctNWmtq5zSgTjCu2AAu8u4a69t/ROwT16aaO2YM0kqj
-Ps3BNOUtFZgkqVVaOL13mnXiKjbkfo3majFzoqoMw13uuSpY4fKc+j9fxOQFXRrd
-M9jTHfFfJhJpbzf44uyiHQKBgFIPwzvyVvG+l05/Ky83x9fv/frn4thxV45LmAQj
-sHKqbjZFpWZcSOgu4aOSJlwrhsw3T84lVcAAzmXn1STAbVll01jEQz6QciSpacP6
-1pAAx240UqtptpD6BbkROxz8ffA/Hf3E/6Itb2QyAsP3PqI8kpYYkTG1WCvZA7Kq
-HHiRAoGAXbUZ25LcrmyuxKWpbty8fck1tjKPvclQB35rOx6vgnfW6pcKMeebYvgq
-nJka/QunEReOH/kGxAd/+ymvUBuFQCfFg3Aus+DtAuh9AkBr+cIyPjJqynnIT87J
-MbkOw4uEhDJAtGUR9o1j83N1f05bnEwssXiXR0LZPylb9Qzc4tg=
------END RSA PRIVATE KEY-----
-`
+	ca, err := NewCA()
+	if err != nil {
+		return nil, nil, err
+	}
+	if caPath, err = WriteFile("ticdc-test-ca", ca.CAPEM); err != nil {
+		return nil, nil, err
+	}
 
-// NewCredential4Test return a Credential for testing
-func NewCredential4Test(cn string) (Credential, error) {
-	res := Credential{}
+	certPEM, keyPEM, err := ca.GenerateCerts(cn)
+	if err != nil {
+		return nil, nil, err
+	}
+	if certPath, err = WriteFile("ticdc-test-cert", certPEM); err != nil {
+		return nil, nil, err
+	}
+	if keyPath, err = WriteFile("ticdc-test-key", keyPEM); err != nil {
+		return nil, nil, err
+	}
+
+	res := &Credential{
+		CAPath:   caPath,
+		CertPath: certPath,
+		KeyPath:  keyPath,
+	}
 	if cn != "" {
 		res.CertAllowedCN = append(res.CertAllowedCN, cn)
 	}
-	cert, err := os.CreateTemp("", "ticdc-test-cert")
+	return ca, res, nil
+}
+
+// CA represents a certificate authority
+type CA struct {
+	privateKey *rsa.PrivateKey
+
+	Cert  *x509.Certificate
+	CAPEM []byte
+}
+
+// NewCA create a new CA
+func NewCA() (*CA, error) {
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		return res, err
-	}
-	_, err = cert.Write([]byte(certPem))
-	if err != nil {
-		return res, err
+		return nil, err
 	}
 
-	ca, err := os.CreateTemp("", "ticdc-test-ca")
-	if err != nil {
-		return res, err
-	}
-	_, err = ca.Write([]byte(caPem))
-	if err != nil {
-		return res, err
-	}
-
-	key, err := os.CreateTemp("", "ticdc-test-key")
-	if err != nil {
-		return res, err
-	}
-	_, err = key.Write([]byte(keyPem))
-	if err != nil {
-		return res, err
+	caCert := &x509.Certificate{
+		SerialNumber: big.NewInt(2019),
+		Subject: pkix.Name{
+			Organization: []string{"test"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().AddDate(10, 0, 0),
+		IsCA:      true,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageClientAuth,
+			x509.ExtKeyUsageServerAuth,
+		},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
 	}
 
-	res.CertPath = cert.Name()
-	res.CAPath = ca.Name()
-	res.KeyPath = key.Name()
+	// self-signed certificate
+	caBytes, err := x509.CreateCertificate(rand.Reader, caCert, caCert,
+		&caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, err
+	}
 
-	return res, nil
+	caPem := new(bytes.Buffer)
+	err = pem.Encode(caPem, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &CA{
+		privateKey: caPrivKey,
+		Cert:       caCert,
+		CAPEM:      caPem.Bytes(),
+	}, err
+}
+
+// GetPrivKeyPEM returns the PEM contents of the private key.
+func (ca *CA) GetPrivKeyPEM() ([]byte, error) {
+	caPrivKeyPEM := new(bytes.Buffer)
+	err := pem.Encode(caPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(ca.privateKey),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return caPrivKeyPEM.Bytes(), nil
+}
+
+// GenerateCerts returns the PEM contents of a CA certificate and some certificates
+// and private keys per Common Name in commonNames.
+// thanks to https://shaneutt.com/blog/golang-ca-and-signed-cert-go/.
+func (ca *CA) GenerateCerts(commonName string) (certPEM, KeyPEM []byte, err error) {
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(1658),
+		Subject: pkix.Name{
+			Organization: []string{"test"},
+			CommonName:   commonName,
+		},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	// signing the certificate with CA
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca.Cert,
+		&certPrivKey.PublicKey, ca.privateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEMBuffer := new(bytes.Buffer)
+	err = pem.Encode(certPEMBuffer, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	keyPEMBuffer := new(bytes.Buffer)
+	err = pem.Encode(keyPEMBuffer, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return certPEMBuffer.Bytes(), keyPEMBuffer.Bytes(), nil
 }


### PR DESCRIPTION

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7908

### What is changed and how it works?
1. use GetClientCertificate and GetCertificate in tls.config


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`support online load tls config in TiCDC`.
```
