### PR TITLE
puller(ticdc): remove GetResolvedTs from Puller interface

### DIFF
--- a/cdc/puller/ddl_puller_test.go
+++ b/cdc/puller/ddl_puller_test.go
@@ -74,10 +74,6 @@ func (m *mockPuller) Run(ctx context.Context) error {
 	}
 }
 
-func (m *mockPuller) GetResolvedTs() uint64 {
-	return atomic.LoadUint64(&m.resolvedTs)
-}
-
 func (m *mockPuller) Output() <-chan *model.RawKVEntry {
 	return m.outCh
 }

--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -55,7 +55,6 @@ type Stats struct {
 type Puller interface {
 	// Run the puller, continually fetch event from TiKV and add event into buffer.
 	Run(ctx context.Context) error
-	GetResolvedTs() uint64
 	Output() <-chan *model.RawKVEntry
 	Stats() Stats
 }
@@ -260,10 +259,6 @@ func (p *pullerImpl) Run(ctx context.Context) error {
 		}
 	})
 	return g.Wait()
-}
-
-func (p *pullerImpl) GetResolvedTs() uint64 {
-	return atomic.LoadUint64(&p.resolvedTs)
 }
 
 func (p *pullerImpl) Output() <-chan *model.RawKVEntry {

--- a/cdc/puller/puller_test.go
+++ b/cdc/puller/puller_test.go
@@ -184,7 +184,7 @@ func TestPullerResolvedForward(t *testing.T) {
 	require.Equal(t, model.OpTypeResolved, ev.OpType)
 	require.Equal(t, uint64(1000), ev.CRTs)
 	err := retry.Do(context.Background(), func() error {
-		ts := plr.GetResolvedTs()
+		ts := plr.Puller.(*pullerImpl).resolvedTs
 		if ts != uint64(1000) {
 			return errors.Errorf("resolved ts %d of puller does not forward to 1000", ts)
 		}

--- a/cdc/puller/puller_test.go
+++ b/cdc/puller/puller_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pingcap/errors"
@@ -184,7 +185,7 @@ func TestPullerResolvedForward(t *testing.T) {
 	require.Equal(t, model.OpTypeResolved, ev.OpType)
 	require.Equal(t, uint64(1000), ev.CRTs)
 	err := retry.Do(context.Background(), func() error {
-		ts := plr.Puller.(*pullerImpl).resolvedTs
+		ts := atomic.LoadUint64(&(plr.Puller.(*pullerImpl).resolvedTs))
 		if ts != uint64(1000) {
 			return errors.Errorf("resolved ts %d of puller does not forward to 1000", ts)
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->
GetResolvedTs is not used, remove it to simplify the Puller interface

Issue Number: close #7956

### What is changed and how it works?
remove GetResolvedTs

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
