### PR TITLE
causality(ticdc): fix slot could not be locked during free

### DIFF
--- a/pkg/causality/internal/slots.go
+++ b/pkg/causality/internal/slots.go
@@ -91,27 +91,14 @@ func (s *Slots[E]) Add(elem E, keys []uint64) {
 
 // Free removes an element from the Slots.
 func (s *Slots[E]) Free(elem E, keys []uint64) {
-	var lastSlot uint64 = math.MaxUint64
 	for _, key := range keys {
 		slotIdx := getSlot(key, s.numSlots)
-		if lastSlot != slotIdx {
-			s.slots[slotIdx].mu.Lock()
-			lastSlot = slotIdx
-		}
+		s.slots[slotIdx].mu.Lock()
 		if tail, ok := s.slots[slotIdx].nodes[key]; ok && tail.NodeID() == elem.NodeID() {
 			delete(s.slots[slotIdx].nodes, key)
 		}
+		s.slots[slotIdx].mu.Unlock()
 	}
-
-	lastSlot = math.MaxUint64
-	for _, key := range keys {
-		slotIdx := getSlot(key, s.numSlots)
-		if lastSlot != slotIdx {
-			s.slots[slotIdx].mu.Unlock()
-			lastSlot = slotIdx
-		}
-	}
-
 	elem.Free()
 }
 

--- a/pkg/causality/internal/slots.go
+++ b/pkg/causality/internal/slots.go
@@ -96,15 +96,22 @@ func (s *Slots[E]) Free(elem E, keys []uint64) {
 		slotIdx := getSlot(key, s.numSlots)
 		if lastSlot != slotIdx {
 			s.slots[slotIdx].mu.Lock()
+			lastSlot = slotIdx
 		}
 		if tail, ok := s.slots[slotIdx].nodes[key]; ok && tail.NodeID() == elem.NodeID() {
 			delete(s.slots[slotIdx].nodes, key)
 		}
+	}
+
+	lastSlot = math.MaxUint64
+	for _, key := range keys {
+		slotIdx := getSlot(key, s.numSlots)
 		if lastSlot != slotIdx {
 			s.slots[slotIdx].mu.Unlock()
 			lastSlot = slotIdx
 		}
 	}
+
 	elem.Free()
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7974

### What is changed and how it works?

- In original `Free` implement, if `keys` contain two or more successive key that have the same slot index, only the first key can be locked when accessing slots.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
