### PR TITLE
api,config(ticdc): support update transaction-atomicity and protocol via config file

### DIFF
--- a/cdc/api/v2/api_helpers.go
+++ b/cdc/api/v2/api_helpers.go
@@ -294,12 +294,13 @@ func (APIV2HelpersImpl) verifyUpdateChangefeedConfig(
 	kvStorage tidbkv.Storage,
 	checkpointTs uint64,
 ) (*model.ChangeFeedInfo, *model.UpstreamInfo, error) {
+	// update changefeed info
 	newInfo, err := oldInfo.Clone()
 	if err != nil {
 		return nil, nil, cerror.ErrChangefeedUpdateRefused.GenWithStackByArgs(err.Error())
 	}
 
-	// verify TargetTs
+	var configUpdated, sinkURIUpdated bool
 	if cfg.TargetTs != 0 {
 		if cfg.TargetTs <= newInfo.StartTs {
 			return nil, nil, cerror.ErrChangefeedUpdateRefused.GenWithStack(
@@ -308,43 +309,52 @@ func (APIV2HelpersImpl) verifyUpdateChangefeedConfig(
 		}
 		newInfo.TargetTs = cfg.TargetTs
 	}
-
-	// verify replica config
+	if cfg.Engine != "" {
+		newInfo.Engine = cfg.Engine
+	}
 	if cfg.ReplicaConfig != nil {
+		configUpdated = true
 		newInfo.Config = cfg.ReplicaConfig.ToInternalReplicaConfig()
-		err = newInfo.Config.ValidateAndAdjust(nil)
-		if err != nil {
-			return nil, nil, err
-		}
+	}
+	if cfg.SinkURI != "" {
+		sinkURIUpdated = true
+		newInfo.SinkURI = cfg.SinkURI
 	}
 
+	// verify changefeed info
 	f, err := filter.NewFilter(newInfo.Config, "")
 	if err != nil {
 		return nil, nil, cerror.ErrChangefeedUpdateRefused.
 			GenWithStackByArgs(errors.Cause(err).Error())
 	}
-
 	tableInfos, _, _, err := entry.VerifyTables(f, kvStorage, checkpointTs)
 	if err != nil {
 		return nil, nil, cerror.ErrChangefeedUpdateRefused.GenWithStackByCause(err)
 	}
-
 	err = f.Verify(tableInfos)
 	if err != nil {
 		return nil, nil, cerror.ErrChangefeedUpdateRefused.
 			GenWithStackByArgs(errors.Cause(err).Error())
 	}
 
-	// verify SinkURI
-	if cfg.SinkURI != "" {
-		newInfo.SinkURI = cfg.SinkURI
+	if configUpdated || sinkURIUpdated {
+		log.Info("config or sink uri updated, check the compatibility",
+			zap.Bool("configUpdated", configUpdated),
+			zap.Bool("sinkURIUpdated", sinkURIUpdated))
+		// check sink config is compatible with sinkURI
+		newCfg := newInfo.Config.Sink
+		oldCfg := oldInfo.Config.Sink
+		err := newCfg.CheckCompatibilityWithSinkURI(oldCfg, newInfo.SinkURI)
+		if err != nil {
+			return nil, nil, cerror.ErrChangefeedUpdateRefused.GenWithStackByCause(err)
+		}
+
 		if err := sink.Validate(ctx, newInfo.SinkURI, newInfo.Config); err != nil {
 			return nil, nil, cerror.ErrChangefeedUpdateRefused.GenWithStackByCause(err)
 		}
 	}
-	if cfg.Engine != "" {
-		newInfo.Engine = cfg.Engine
-	}
+
+	// update and verify up info
 	newUpInfo, err := oldUpInfo.Clone()
 	if err != nil {
 		return nil, nil, cerror.ErrChangefeedUpdateRefused.GenWithStackByArgs(err.Error())
@@ -364,9 +374,9 @@ func (APIV2HelpersImpl) verifyUpdateChangefeedConfig(
 	if cfg.CertAllowedCN != nil {
 		newUpInfo.CertAllowedCN = cfg.CertAllowedCN
 	}
+
 	changefeedInfoChanged := diff.Changed(oldInfo, newInfo)
 	upstreamInfoChanged := diff.Changed(oldUpInfo, newUpInfo)
-
 	if !changefeedInfoChanged && !upstreamInfoChanged {
 		return nil, nil, cerror.ErrChangefeedUpdateRefused.
 			GenWithStackByArgs("changefeed config is the same with the old one, do nothing")

--- a/cdc/api/v2/api_helpers_test.go
+++ b/cdc/api/v2/api_helpers_test.go
@@ -126,7 +126,6 @@ func TestVerifyUpdateChangefeedConfig(t *testing.T) {
 	newCfInfo, newUpInfo, err = h.verifyUpdateChangefeedConfig(ctx, cfg, oldInfo, oldUpInfo, storage, 0)
 	require.Nil(t, err)
 	// startTs can not be updated
-	require.Equal(t, "none", string(newCfInfo.Config.Sink.TxnAtomicity))
 	newCfInfo.Config.Sink.TxnAtomicity = ""
 	require.Equal(t, uint64(0), newCfInfo.StartTs)
 	require.Equal(t, uint64(10), newCfInfo.TargetTs)

--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -211,12 +211,12 @@ func (h *OpenAPIV2) updateChangefeed(c *gin.Context) {
 		return
 	}
 
-	cfInfo, err := h.capture.StatusProvider().GetChangeFeedInfo(ctx, changefeedID)
+	oldCfInfo, err := h.capture.StatusProvider().GetChangeFeedInfo(ctx, changefeedID)
 	if err != nil {
 		_ = c.Error(err)
 		return
 	}
-	if cfInfo.State != model.StateStopped {
+	if oldCfInfo.State != model.StateStopped {
 		_ = c.Error(cerror.ErrChangefeedUpdateRefused.
 			GenWithStackByArgs("can only update changefeed config when it is stopped"))
 		return
@@ -232,40 +232,39 @@ func (h *OpenAPIV2) updateChangefeed(c *gin.Context) {
 		_ = c.Error(err)
 		return
 	}
-	cfInfo.Namespace = changefeedID.Namespace
-	cfInfo.ID = changefeedID.ID
-	upInfo, err := etcdClient.GetUpstreamInfo(ctx, cfInfo.UpstreamID,
-		cfInfo.Namespace)
+	oldCfInfo.Namespace = changefeedID.Namespace
+	oldCfInfo.ID = changefeedID.ID
+	OldUpInfo, err := etcdClient.GetUpstreamInfo(ctx, oldCfInfo.UpstreamID,
+		oldCfInfo.Namespace)
 	if err != nil {
 		_ = c.Error(err)
 		return
 	}
 
 	updateCfConfig := &ChangefeedConfig{}
-	updateCfConfig.ReplicaConfig = ToAPIReplicaConfig(cfInfo.Config)
 	if err = c.BindJSON(updateCfConfig); err != nil {
 		_ = c.Error(cerror.WrapError(cerror.ErrAPIInvalidParam, err))
 		return
 	}
 
-	if err = h.helpers.verifyUpstream(ctx, updateCfConfig, cfInfo); err != nil {
+	if err = h.helpers.verifyUpstream(ctx, updateCfConfig, oldCfInfo); err != nil {
 		_ = c.Error(errors.Trace(err))
 		return
 	}
 
 	log.Info("Old ChangeFeed and Upstream Info",
-		zap.String("changefeedInfo", cfInfo.String()),
-		zap.Any("upstreamInfo", upInfo))
+		zap.String("changefeedInfo", oldCfInfo.String()),
+		zap.Any("upstreamInfo", OldUpInfo))
 
 	var pdAddrs []string
 	var credentials *security.Credential
-	if upInfo != nil {
-		pdAddrs = strings.Split(upInfo.PDEndpoints, ",")
+	if OldUpInfo != nil {
+		pdAddrs = strings.Split(OldUpInfo.PDEndpoints, ",")
 		credentials = &security.Credential{
-			CAPath:        upInfo.CAPath,
-			CertPath:      upInfo.CertPath,
-			KeyPath:       upInfo.KeyPath,
-			CertAllowedCN: upInfo.CertAllowedCN,
+			CAPath:        OldUpInfo.CAPath,
+			CertPath:      OldUpInfo.CertPath,
+			KeyPath:       OldUpInfo.KeyPath,
+			CertAllowedCN: OldUpInfo.CertAllowedCN,
 		}
 	}
 	if len(updateCfConfig.PDAddrs) != 0 {
@@ -277,8 +276,8 @@ func (h *OpenAPIV2) updateChangefeed(c *gin.Context) {
 	if err != nil {
 		_ = c.Error(errors.Trace(err))
 	}
-	newCfInfo, newUpInfo, err := h.helpers.
-		verifyUpdateChangefeedConfig(ctx, updateCfConfig, cfInfo, upInfo, storage, cfStatus.CheckpointTs)
+	newCfInfo, newUpInfo, err := h.helpers.verifyUpdateChangefeedConfig(ctx,
+		updateCfConfig, oldCfInfo, OldUpInfo, storage, cfStatus.CheckpointTs)
 	if err != nil {
 		_ = c.Error(errors.Trace(err))
 		return

--- a/errors.toml
+++ b/errors.toml
@@ -441,6 +441,11 @@ error = '''
 illegal parameter for sorter: %s
 '''
 
+["CDC:ErrIncompatibleSinkConfig"]
+error = '''
+incompatible configuration in sink uri(%s) and config file(%s)
+'''
+
 ["CDC:ErrIndexKeyTableNotFound"]
 error = '''
 table not found with index ID %d in index kv

--- a/errors.toml
+++ b/errors.toml
@@ -443,7 +443,7 @@ illegal parameter for sorter: %s
 
 ["CDC:ErrIncompatibleSinkConfig"]
 error = '''
-incompatible configuration in sink uri(%s) and config file(%s)
+incompatible configuration in sink uri(%s) and config file(%s), please try to update the configuration only through sink uri
 '''
 
 ["CDC:ErrIndexKeyTableNotFound"]

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -28,25 +28,19 @@ import (
 // DefaultMaxMessageBytes sets the default value for max-message-bytes.
 const DefaultMaxMessageBytes = 10 * 1024 * 1024 // 10M
 
-// AtomicityLevel represents the atomicity level of a changefeed.
-type AtomicityLevel string
-
 const (
-	// unknownTxnAtomicity is the default atomicity level, which is invalid and will
-	// be set to a valid value when initializing sink in processor.
-	unknownTxnAtomicity AtomicityLevel = ""
+	// TxnAtomicityKey specifies the key of the transaction-atomicity in the SinkURI.
+	TxnAtomicityKey = "transaction-atomicity"
+	// defaultTxnAtomicity is the default atomicity level.
+	defaultTxnAtomicity = noneTxnAtomicity
 
+	// unknownTxnAtomicity is an invalid atomicity level and will be treated as
+	// defaultTxnAtomicity when initializing sink in processor.
+	unknownTxnAtomicity AtomicityLevel = ""
 	// noneTxnAtomicity means atomicity of transactions is not guaranteed
 	noneTxnAtomicity AtomicityLevel = "none"
-
 	// tableTxnAtomicity means atomicity of single table transactions is guaranteed.
 	tableTxnAtomicity AtomicityLevel = "table"
-
-	defaultMqTxnAtomicity = noneTxnAtomicity
-	// Note(dongmen): We change this default value to `noneTxnAtomicity` in v6.4.0.
-	// TODO(dongmen): If everything goes well, we can remove this default value in v6.5.0,
-	// and keep a defaultTxnAtomicity is enough.
-	defaultMysqlTxnAtomicity = noneTxnAtomicity
 )
 
 const (
@@ -66,9 +60,33 @@ const (
 	NULL = "\\N"
 )
 
+// AtomicityLevel represents the atomicity level of a changefeed.
+type AtomicityLevel string
+
 // ShouldSplitTxn returns whether the sink should split txn.
 func (l AtomicityLevel) ShouldSplitTxn() bool {
+	if l == unknownTxnAtomicity {
+		l = defaultTxnAtomicity
+	}
 	return l == noneTxnAtomicity
+}
+
+func (l AtomicityLevel) validate(scheme string) error {
+	switch l {
+	case unknownTxnAtomicity:
+	case noneTxnAtomicity:
+		// Do nothing here to avoid modifying the persistence parameters.
+	case tableTxnAtomicity:
+		// MqSink only support `noneTxnAtomicity`.
+		if sink.IsMQScheme(scheme) {
+			errMsg := fmt.Sprintf("%s level atomicity is not supported by %s scheme", l, scheme)
+			return cerror.ErrSinkURIInvalid.GenWithStackByArgs(errMsg)
+		}
+	default:
+		errMsg := fmt.Sprintf("%s level atomicity is not supported by %s scheme", l, scheme)
+		return cerror.ErrSinkURIInvalid.GenWithStackByArgs(errMsg)
+	}
+	return nil
 }
 
 // ForceEnableOldValueProtocols specifies which protocols need to be forced to enable old value.
@@ -80,12 +98,13 @@ var ForceEnableOldValueProtocols = []string{
 
 // SinkConfig represents sink config for a changefeed
 type SinkConfig struct {
+	TxnAtomicity AtomicityLevel `toml:"transaction-atomicity" json:"transaction-atomicity"`
+	Protocol     string         `toml:"protocol" json:"protocol"`
+
 	DispatchRules            []*DispatchRule   `toml:"dispatchers" json:"dispatchers"`
 	CSVConfig                *CSVConfig        `toml:"csv" json:"csv"`
-	Protocol                 string            `toml:"protocol" json:"protocol"`
 	ColumnSelectors          []*ColumnSelector `toml:"column-selectors" json:"column-selectors"`
 	SchemaRegistry           string            `toml:"schema-registry" json:"schema-registry"`
-	TxnAtomicity             AtomicityLevel    `toml:"transaction-atomicity" json:"transaction-atomicity"`
 	EncoderConcurrency       int               `toml:"encoder-concurrency" json:"encoder-concurrency"`
 	Terminator               string            `toml:"terminator" json:"terminator"`
 	DateSeparator            string            `toml:"date-separator" json:"date-separator"`
@@ -170,7 +189,7 @@ type ColumnSelector struct {
 }
 
 func (s *SinkConfig) validateAndAdjust(sinkURI *url.URL, enableOldValue bool) error {
-	if err := s.applyParameter(sinkURI); err != nil {
+	if err := s.validateAndAdjustSinkURI(sinkURI); err != nil {
 		return err
 	}
 
@@ -257,60 +276,36 @@ func (s *SinkConfig) validateAndAdjustCSVConfig() error {
 	return nil
 }
 
-// applyParameter fill the `ReplicaConfig` and `TxnAtomicity` by sinkURI.
-func (s *SinkConfig) applyParameter(sinkURI *url.URL) error {
+// validateAndAdjustSinkURI validate and adjust `Protocol` and `TxnAtomicity` by sinkURI.
+func (s *SinkConfig) validateAndAdjustSinkURI(sinkURI *url.URL) error {
 	if sinkURI == nil {
 		return nil
 	}
-	params := sinkURI.Query()
 
-	txnAtomicity := params.Get("transaction-atomicity")
-	switch AtomicityLevel(txnAtomicity) {
-	case unknownTxnAtomicity:
-		// Set default value according to scheme.
-		if sink.IsMQScheme(sinkURI.Scheme) {
-			s.TxnAtomicity = defaultMqTxnAtomicity
-		} else {
-			s.TxnAtomicity = defaultMysqlTxnAtomicity
+	if err := s.applyParameterBySinkURI(sinkURI); err != nil {
+		if !cerror.ErrIncompatibleSinkConfig.Equal(err) {
+			return err
 		}
-	case noneTxnAtomicity:
-		s.TxnAtomicity = noneTxnAtomicity
-	case tableTxnAtomicity:
-		// MqSink only support `noneTxnAtomicity`.
-		if sink.IsMQScheme(sinkURI.Scheme) {
-			log.Warn("The configuration of transaction-atomicity is incompatible with scheme",
-				zap.Any("txnAtomicity", s.TxnAtomicity),
-				zap.String("scheme", sinkURI.Scheme),
-				zap.String("protocol", s.Protocol))
-			s.TxnAtomicity = defaultMqTxnAtomicity
-		} else {
-			s.TxnAtomicity = tableTxnAtomicity
-		}
-	default:
-		errMsg := fmt.Sprintf("%s level atomicity is not supported by %s scheme",
-			txnAtomicity, sinkURI.Scheme)
-		return cerror.ErrSinkURIInvalid.GenWithStackByArgs(errMsg)
+		// Ignore `ErrIncompatibleSinkConfig` here to:
+		// 1. Keep compatibility with old version.
+		// 2. Avoid throwing error when create changefeed.
+		log.Warn("sink-uri is not compatible with the sink config, "+
+			"the configuration in sink URI will be used", zap.Error(err))
 	}
 
-	protocolFromURI := params.Get(ProtocolKey)
-	if protocolFromURI != "" {
-		if s.Protocol != "" {
-			log.Warn(
-				fmt.Sprintf("protocol is specified in both sink URI and config file "+
-					"the value in sink URI will be used "+
-					"protocol in sink URI:%s, protocol in config file:%s",
-					protocolFromURI, s.Protocol))
-		}
-		s.Protocol = protocolFromURI
+	// validate that TxnAtomicity is valid and compatible with the scheme.
+	if err := s.TxnAtomicity.validate(sinkURI.Scheme); err != nil {
+		return err
 	}
 
-	// validate that protocol is compatible with the scheme
+	// Validate that protocol is compatible with the scheme. For testing purposes,
+	// any protocol should be legal for blackhole.
 	if sink.IsMQScheme(sinkURI.Scheme) || sink.IsStorageScheme(sinkURI.Scheme) {
 		_, err := ParseSinkProtocolFromString(s.Protocol)
 		if err != nil {
 			return err
 		}
-	} else if s.Protocol != "" {
+	} else if sink.IsMySQLCompatibleScheme(sinkURI.Scheme) && s.Protocol != "" {
 		return cerror.ErrSinkURIInvalid.GenWithStackByArgs(fmt.Sprintf("protocol %s "+
 			"is incompatible with %s scheme", s.Protocol, sinkURI.Scheme))
 	}
@@ -319,4 +314,85 @@ func (s *SinkConfig) applyParameter(sinkURI *url.URL) error {
 		zap.String("protocol", s.Protocol),
 		zap.String("txnAtomicity", string(s.TxnAtomicity)))
 	return nil
+}
+
+// applyParameterBySinkURI parse sinkURI and set `Protocol` and `TxnAtomicity` to `SinkConfig`.
+// Return:
+// - ErrIncompatibleSinkConfig to terminate `updated` changefeed operation.
+func (s *SinkConfig) applyParameterBySinkURI(sinkURI *url.URL) error {
+	if sinkURI == nil {
+		return nil
+	}
+
+	cfgInSinkURI := map[string]string{}
+	cfgInFile := map[string]string{}
+	params := sinkURI.Query()
+
+	txnAtomicityFromURI := AtomicityLevel(params.Get(TxnAtomicityKey))
+	if txnAtomicityFromURI != unknownTxnAtomicity {
+		if s.TxnAtomicity != unknownTxnAtomicity && s.TxnAtomicity != txnAtomicityFromURI {
+			cfgInSinkURI[TxnAtomicityKey] = string(txnAtomicityFromURI)
+			cfgInFile[TxnAtomicityKey] = string(s.TxnAtomicity)
+		}
+		s.TxnAtomicity = txnAtomicityFromURI
+	}
+
+	protocolFromURI := params.Get(ProtocolKey)
+	if protocolFromURI != "" {
+		if s.Protocol != "" && s.Protocol != protocolFromURI {
+			cfgInSinkURI[ProtocolKey] = protocolFromURI
+			cfgInFile[ProtocolKey] = s.Protocol
+		}
+		s.Protocol = protocolFromURI
+	}
+
+	getError := func() error {
+		if len(cfgInSinkURI) != len(cfgInFile) {
+			log.Panic("inconsistent configuration items in sink uri and configuration file",
+				zap.Any("cfgInSinkURI", cfgInSinkURI), zap.Any("cfgInFile", cfgInFile))
+		}
+		if len(cfgInSinkURI) == 0 && len(cfgInFile) == 0 {
+			return nil
+		}
+		getErrMsg := func(cfgIn map[string]string) string {
+			var errMsg strings.Builder
+			for k, v := range cfgIn {
+				errMsg.WriteString(fmt.Sprintf("%s=%s, ", k, v))
+			}
+			return errMsg.String()[0 : errMsg.Len()-2]
+		}
+		return cerror.ErrIncompatibleSinkConfig.GenWithStackByArgs(
+			getErrMsg(cfgInSinkURI), getErrMsg(cfgInFile))
+	}
+	return getError()
+}
+
+// CheckCompatibilityWithSinkURI check whether the sinkURI is compatible with the sink config.
+func (s *SinkConfig) CheckCompatibilityWithSinkURI(
+	oldSinkConfig *SinkConfig, sinkURIStr string,
+) error {
+	sinkURI, err := url.Parse(sinkURIStr)
+	if err != nil {
+		return cerror.WrapError(cerror.ErrSinkURIInvalid, err)
+	}
+
+	cfgParamsChanged := s.Protocol != oldSinkConfig.Protocol ||
+		s.TxnAtomicity != oldSinkConfig.TxnAtomicity
+
+	isURIParamsChanged := func(oldCfg SinkConfig) bool {
+		err := oldCfg.applyParameterBySinkURI(sinkURI)
+		return cerror.ErrIncompatibleSinkConfig.Equal(err)
+	}
+	uriParamsChanged := isURIParamsChanged(*oldSinkConfig)
+
+	if !uriParamsChanged && !cfgParamsChanged {
+		return nil
+	}
+
+	compatibilityError := s.applyParameterBySinkURI(sinkURI)
+	if uriParamsChanged && cerror.ErrIncompatibleSinkConfig.Equal(compatibilityError) {
+		// Ignore compatibility error if the sinkURI make such changes.
+		return nil
+	}
+	return compatibilityError
 }

--- a/pkg/config/sink_test.go
+++ b/pkg/config/sink_test.go
@@ -81,27 +81,27 @@ func TestValidateOldValue(t *testing.T) {
 	}
 }
 
-func TestValidateApplyParameter(t *testing.T) {
+func TestValidateTxnAtomicity(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
-		sinkURI       string
-		expectedErr   string
-		expectedLevel AtomicityLevel
+		sinkURI        string
+		expectedErr    string
+		shouldSplitTxn bool
 	}{
 		{
-			sinkURI:       "mysql://normal:123456@127.0.0.1:3306",
-			expectedErr:   "",
-			expectedLevel: noneTxnAtomicity,
+			sinkURI:        "mysql://normal:123456@127.0.0.1:3306",
+			expectedErr:    "",
+			shouldSplitTxn: true,
 		},
 		{
-			sinkURI:       "mysql://normal:123456@127.0.0.1:3306?transaction-atomicity=table",
-			expectedErr:   "",
-			expectedLevel: tableTxnAtomicity,
+			sinkURI:        "mysql://normal:123456@127.0.0.1:3306?transaction-atomicity=table",
+			expectedErr:    "",
+			shouldSplitTxn: false,
 		},
 		{
-			sinkURI:       "mysql://normal:123456@127.0.0.1:3306?transaction-atomicity=none",
-			expectedErr:   "",
-			expectedLevel: noneTxnAtomicity,
+			sinkURI:        "mysql://normal:123456@127.0.0.1:3306?transaction-atomicity=none",
+			expectedErr:    "",
+			shouldSplitTxn: true,
 		},
 		{
 			sinkURI:     "mysql://normal:123456@127.0.0.1:3306?transaction-atomicity=global",
@@ -120,24 +120,34 @@ func TestValidateApplyParameter(t *testing.T) {
 			expectedErr: ".*protocol .* is incompatible with tidb scheme.*",
 		},
 		{
-			sinkURI:       "blackhole://normal:123456@127.0.0.1:3306?transaction-atomicity=none",
-			expectedErr:   "",
-			expectedLevel: noneTxnAtomicity,
+			sinkURI:        "blackhole://normal:123456@127.0.0.1:3306?transaction-atomicity=none",
+			expectedErr:    "",
+			shouldSplitTxn: true,
 		},
 		{
 			sinkURI: "kafka://127.0.0.1:9092?transaction-atomicity=none" +
 				"&protocol=open-protocol",
-			expectedErr:   "",
-			expectedLevel: noneTxnAtomicity,
+			expectedErr:    "",
+			shouldSplitTxn: true,
 		},
 		{
-			sinkURI:       "kafka://127.0.0.1:9092?protocol=default",
-			expectedErr:   "",
-			expectedLevel: noneTxnAtomicity,
+			sinkURI:        "kafka://127.0.0.1:9092?protocol=default",
+			expectedErr:    "",
+			shouldSplitTxn: true,
 		},
 		{
-			sinkURI:     "kafka://127.0.0.1:9092?transaction-atomicity=table",
+			sinkURI:     "kafka://127.0.0.1:9092?transaction-atomicity=none",
 			expectedErr: ".*unknown .* message protocol for sink.*",
+		},
+		{
+			sinkURI: "kafka://127.0.0.1:9092?transaction-atomicity=table" +
+				"&protocol=open-protocol",
+			expectedErr: "table level atomicity is not supported by kafka scheme",
+		},
+		{
+			sinkURI: "kafka://127.0.0.1:9092?transaction-atomicity=invalid" +
+				"&protocol=open-protocol",
+			expectedErr: "invalid level atomicity is not supported by kafka scheme",
 		},
 	}
 
@@ -147,14 +157,14 @@ func TestValidateApplyParameter(t *testing.T) {
 		require.Nil(t, err)
 		if tc.expectedErr == "" {
 			require.Nil(t, cfg.validateAndAdjust(parsedSinkURI, true))
-			require.Equal(t, tc.expectedLevel, cfg.TxnAtomicity)
+			require.Equal(t, tc.shouldSplitTxn, cfg.TxnAtomicity.ShouldSplitTxn())
 		} else {
 			require.Regexp(t, tc.expectedErr, cfg.validateAndAdjust(parsedSinkURI, true))
 		}
 	}
 }
 
-func TestApplyParameter(t *testing.T) {
+func TestValidateProtocol(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		sinkConfig *SinkConfig
@@ -184,8 +194,141 @@ func TestApplyParameter(t *testing.T) {
 	for _, c := range testCases {
 		parsedSinkURI, err := url.Parse(c.sinkURI)
 		require.Nil(t, err)
-		c.sinkConfig.applyParameter(parsedSinkURI)
+		c.sinkConfig.validateAndAdjustSinkURI(parsedSinkURI)
 		require.Equal(t, c.result, c.sinkConfig.Protocol)
+	}
+}
+
+func TestApplyParameterBySinkURI(t *testing.T) {
+	t.Parallel()
+	kafkaURI := "kafka://127.0.0.1:9092?protocol=whatever&transaction-atomicity=none"
+	testCases := []struct {
+		sinkConfig           *SinkConfig
+		sinkURI              string
+		expectedErr          string
+		expectedProtocol     string
+		expectedTxnAtomicity AtomicityLevel
+	}{
+		// test only config file
+		{
+			sinkConfig: &SinkConfig{
+				Protocol:     "default",
+				TxnAtomicity: noneTxnAtomicity,
+			},
+			sinkURI:              "kafka://127.0.0.1:9092",
+			expectedProtocol:     "default",
+			expectedTxnAtomicity: noneTxnAtomicity,
+		},
+		// test only sink uri
+		{
+			sinkConfig:           &SinkConfig{},
+			sinkURI:              kafkaURI,
+			expectedProtocol:     "whatever",
+			expectedTxnAtomicity: noneTxnAtomicity,
+		},
+		// test conflict scenarios
+		{
+			sinkConfig: &SinkConfig{
+				Protocol:     "default",
+				TxnAtomicity: tableTxnAtomicity,
+			},
+			sinkURI:              kafkaURI,
+			expectedProtocol:     "whatever",
+			expectedTxnAtomicity: noneTxnAtomicity,
+			expectedErr:          "incompatible configuration in sink uri",
+		},
+		{
+			sinkConfig: &SinkConfig{
+				Protocol:     "default",
+				TxnAtomicity: unknownTxnAtomicity,
+			},
+			sinkURI:              kafkaURI,
+			expectedProtocol:     "whatever",
+			expectedTxnAtomicity: noneTxnAtomicity,
+			expectedErr:          "incompatible configuration in sink uri",
+		},
+	}
+	for _, tc := range testCases {
+		parsedSinkURI, err := url.Parse(tc.sinkURI)
+		require.Nil(t, err)
+		err = tc.sinkConfig.applyParameterBySinkURI(parsedSinkURI)
+
+		require.Equal(t, tc.expectedProtocol, tc.sinkConfig.Protocol)
+		require.Equal(t, tc.expectedTxnAtomicity, tc.sinkConfig.TxnAtomicity)
+		if tc.expectedErr == "" {
+			require.NoError(t, err)
+		} else {
+			require.ErrorContains(t, err, tc.expectedErr)
+		}
+
+	}
+}
+
+func TestCheckCompatibilityWithSinkURI(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		newSinkConfig        *SinkConfig
+		oldSinkConfig        *SinkConfig
+		newsinkURI           string
+		expectedErr          string
+		expectedProtocol     string
+		expectedTxnAtomicity AtomicityLevel
+	}{
+		// test no update
+		{
+			newSinkConfig:        &SinkConfig{},
+			oldSinkConfig:        &SinkConfig{},
+			newsinkURI:           "kafka://",
+			expectedProtocol:     "",
+			expectedTxnAtomicity: unknownTxnAtomicity,
+		},
+		// test update config return err
+		{
+			newSinkConfig: &SinkConfig{
+				TxnAtomicity: tableTxnAtomicity,
+			},
+			oldSinkConfig: &SinkConfig{
+				TxnAtomicity: noneTxnAtomicity,
+			},
+			newsinkURI:           "kafka://127.0.0.1:9092?transaction-atomicity=none",
+			expectedErr:          "incompatible configuration in sink uri",
+			expectedProtocol:     "",
+			expectedTxnAtomicity: noneTxnAtomicity,
+		},
+		// test update compatible config
+		{
+			newSinkConfig: &SinkConfig{
+				Protocol: "canal",
+			},
+			oldSinkConfig: &SinkConfig{
+				TxnAtomicity: noneTxnAtomicity,
+			},
+			newsinkURI:           "kafka://127.0.0.1:9092?transaction-atomicity=none",
+			expectedProtocol:     "canal",
+			expectedTxnAtomicity: noneTxnAtomicity,
+		},
+		// test update sinkuri
+		{
+			newSinkConfig: &SinkConfig{
+				TxnAtomicity: noneTxnAtomicity,
+			},
+			oldSinkConfig: &SinkConfig{
+				TxnAtomicity: noneTxnAtomicity,
+			},
+			newsinkURI:           "kafka://127.0.0.1:9092?transaction-atomicity=table",
+			expectedProtocol:     "",
+			expectedTxnAtomicity: tableTxnAtomicity,
+		},
+	}
+	for _, tc := range testCases {
+		err := tc.newSinkConfig.CheckCompatibilityWithSinkURI(tc.oldSinkConfig, tc.newsinkURI)
+		if tc.expectedErr == "" {
+			require.NoError(t, err)
+		} else {
+			require.ErrorContains(t, err, tc.expectedErr)
+		}
+		require.Equal(t, tc.expectedProtocol, tc.newSinkConfig.Protocol)
+		require.Equal(t, tc.expectedTxnAtomicity, tc.newSinkConfig.TxnAtomicity)
 	}
 }
 

--- a/pkg/errors/cdc_errors.go
+++ b/pkg/errors/cdc_errors.go
@@ -319,6 +319,10 @@ var (
 		"sink uri invalid '%s'",
 		errors.RFCCodeText("CDC:ErrSinkURIInvalid"),
 	)
+	ErrIncompatibleSinkConfig = errors.Normalize(
+		"incompatible configuration in sink uri(%s) and config file(%s)",
+		errors.RFCCodeText("CDC:ErrIncompatibleSinkConfig"),
+	)
 	ErrSinkUnknownProtocol = errors.Normalize(
 		"unknown '%s' message protocol for sink",
 		errors.RFCCodeText("CDC:ErrSinkUnknownProtocol"),

--- a/pkg/errors/cdc_errors.go
+++ b/pkg/errors/cdc_errors.go
@@ -320,7 +320,8 @@ var (
 		errors.RFCCodeText("CDC:ErrSinkURIInvalid"),
 	)
 	ErrIncompatibleSinkConfig = errors.Normalize(
-		"incompatible configuration in sink uri(%s) and config file(%s)",
+		"incompatible configuration in sink uri(%s) and config file(%s), "+
+			"please try to update the configuration only through sink uri",
 		errors.RFCCodeText("CDC:ErrIncompatibleSinkConfig"),
 	)
 	ErrSinkUnknownProtocol = errors.Normalize(


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7935

### What is changed and how it works?
1. For testing purposes, make [blackhole compatible with any protocol](https://github.com/pingcap/tiflow/pull/7980/files#diff-1aa9ba3321cb0edb368a32b5084da34322b0f9d6a600019beb724ab63bc5e071R308). 
2. Replace `defaultMqTxnAtomicity` and  `defaultMysqlTxnAtomicity` with `defaultTxnAtomicity`. Remove the logic for [changing default value of TxnAtomicity](https://github.com/pingcap/tiflow/pull/7980/files#diff-1aa9ba3321cb0edb368a32b5084da34322b0f9d6a600019beb724ab63bc5e071L267-L292)) and simplify such logic in [`ShouldSplitTxn`](https://github.com/pingcap/tiflow/pull/7980/files#diff-1aa9ba3321cb0edb368a32b5084da34322b0f9d6a600019beb724ab63bc5e071R68) and [`validate`](https://github.com/pingcap/tiflow/pull/7980/files#diff-1aa9ba3321cb0edb368a32b5084da34322b0f9d6a600019beb724ab63bc5e071R74).
3. [Check whether the sinkURI is compatible with the sink config when updating configs](https://github.com/pingcap/tiflow/pull/7980/files#diff-1aa9ba3321cb0edb368a32b5084da34322b0f9d6a600019beb724ab63bc5e071R371).


Note compatibility change: After this pr, `transaction-atomicity` will not be automatically changed when creating changefeed and an error will be returned when any incompatible configuration is encountered.



### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test api
 1. create changefeed use config: ` curl -X POST -H "'Content-type':'application/json'" http://127.0.0.1:8300/api/v1/changefeeds -d '{"changefeed_id":"test","sink_uri":"blackhole://root@10.1.1.1", "sink_config":{"protocol":"canal", "transaction-atomicity":"table"}}'`, then pause changefeed
 2. update via config file: `curl -X PUT -H "'Content-type':'application/json'" http://127.0.0.1:8300/api/v1/changefeeds/test -d '{"sink_config":{"protocol":"canal-json", "transaction-atomicity":"none"}}'`, then query config:
 
>  ./cdc cli changefeed query  -c test --server=127.0.0.1:8300  
```bash
  "sink_uri": "blackhole://root@10.1.1.1",
...
  "sink": {
      "protocol": "canal-json",
      "schema_registry": "",
      "csv": null,
      "column_selectors": null,
      "transaction_atomicity": "none",
      "encoder_concurrency": 0,
      "terminator": "\r\n",
      "date_separator": "",
      "enable_partition_separator": false
    }
...
  ```
 3. update both sinkuri and config file, the configuration in file will be ignored: ` curl -X PUT -H "'Content-type':'application/json'" http://127.0.0.1:8300/api/v1/changefeeds/test -d '{"sink_uri":"blackhole://root@10.1.1.1?protocol=canal&transaction-atomicity=table", "sink_config":{"protocol":"avro", "transaction-atomicity":"none"}}'`
 >  ./cdc cli changefeed query  -c test --server=127.0.0.1:8300  
```bash
   "sink_uri": "blackhole://root@10.1.1.1?protocol=canal\u0026transaction-atomicity=table",
...
   "sink": {
      "protocol": "canal",
      "schema_registry": "",
      "csv": null,
      "column_selectors": null,
      "transaction_atomicity": "table",
      "encoder_concurrency": 0,
      "terminator": "\r\n",
      "date_separator": "",
      "enable_partition_separator": false
    },
...
```

 4. If set config in sinkuri, can not update via config file: `curl -X PUT -H "'Content-type':'application/json'" http://127.0.0.1:8300/api/v1/changefeeds/test -d '{"sink_config":{"protocol":"avro", "transaction-atomicity":"none"}}'`
```bash
{
    "error_msg": "[CDC:ErrChangefeedUpdateRefused]changefeed update error: [CDC:ErrIncompatibleSinkConfig]incompatible configuration in sink uri(transaction-atomicity=table, protocol=canal) and config file(transaction-atomicity=none, protocol=avro)",
    "error_code": "CDC:ErrChangefeedUpdateRefused"
}#
``` 

 - Manual test cli
  1. create changefeed use config: 
```bash
cat > ./cfg.yaml <<  EOF                                                                            
sink.protocol="canal"
sink.transaction-atomicity="table"
EOF
./cdc cli changefeed create --sink-uri="blackhole://root@10.1.1.1" -c test --server=127.0.0.1:8300 --config cfg.y
aml
```
     then pause changefeed
 2. update via config file: 
```bash
cat > ./cfg.yaml <<  EOF                                                                           
sink.protocol="canal-json"
sink.transaction-atomicity="none"
EOF
 ./cdc cli changefeed update -c test --server  http://127.0.0.1:8300/ --config ./cfg.yaml             
Diff of changefeed config:
{Type:update Path:[Config Sink Protocol] From:canal To:canal-json}
{Type:update Path:[Config Sink TxnAtomicity] From:table To:none}
Could you agree to apply changes above to changefeed [Y/N]
Y
Update changefeed config successfully!
ID: test
Info: {"upstream_id":7182840064097419647,"namespace":"default","id":"test","sink_uri":"blackhole://root@10.1.1.1","create_time":"2022-12-30T16:58:23.431511759+08:00","start_ts":438407188528496644,"admin_job_type":1,"engine":"unified","config":{"memory_quota":268435456,"case_sensitive":true,"enable_old_value":true,"force_replicate":false,"ignore_ineligible_table":false,"check_gc_safe_point":true,"enable_sync_point":false,"bdr_mode":false,"sync_point_interval":600000000000,"sync_point_retention":86400000000000,"filter":{"rules":["*.*"],"event_filters":null},"mounter":{"worker_num":16},"sink":{"protocol":"canal-json","schema_registry":"","csv":{"delimiter":",","quote":"\"","null":"\\N","include_commit_ts":false},"column_selectors":null,"transaction_atomicity":"none","encoder_concurrency":16,"terminator":"\r\n","date_separator":"none","enable_partition_separator":false},"consistent":{"level":"none","max_log_size":64,"flush_interval":2000,"storage":""}},"state":"stopped","creator_version":"v6.5.0-master"}
```
3. update both sinkuri and config file, the configuration in file will be ignored:
```bash
cat > ./cfg.yaml <<  EOF                                                                         
sink.protocol="avro"
sink.transaction-atomicity="none"
EOF
./cdc cli changefeed update -c test --server  http://127.0.0.1:8300/ --sink-uri "blackhole://root@10.1.1.1?protocol=canal&transaction-atomicity=table" --config ./cfg.yaml
Diff of changefeed config:
{Type:update Path:[SinkURI] From:blackhole://root@10.1.1.1 To:blackhole://root@10.1.1.1?protocol=canal&transaction-atomicity=table}
{Type:update Path:[Config Sink Protocol] From:canal-json To:avro}
Could you agree to apply changes above to changefeed [Y/N]
Y
Update changefeed config successfully!
ID: test
Info: {"upstream_id":7182840064097419647,"namespace":"default","id":"test","sink_uri":"blackhole://root@10.1.1.1?protocol=canal\u0026transaction-atomicity=table","create_time":"2022-12-30T16:58:23.431511759+08:00","start_ts":438407188528496644,"admin_job_type":1,"engine":"unified","config":{"memory_quota":268435456,"case_sensitive":true,"enable_old_value":true,"force_replicate":false,"ignore_ineligible_table":false,"check_gc_safe_point":true,"enable_sync_point":false,"bdr_mode":false,"sync_point_interval":600000000000,"sync_point_retention":86400000000000,"filter":{"rules":["*.*"],"event_filters":null},"mounter":{"worker_num":16},"sink":{"protocol":"canal","schema_registry":"","csv":{"delimiter":",","quote":"\"","null":"\\N","include_commit_ts":false},"column_selectors":null,"transaction_atomicity":"table","encoder_concurrency":16,"terminator":"\r\n","date_separator":"none","enable_partition_separator":false},"consistent":{"level":"none","max_log_size":64,"flush_interval":2000,"storage":""}},"state":"stopped","creator_version":"v6.5.0-master"}
```
4. If set config in sinkuri, can not update via file:
```bash
 ./cdc cli changefeed update -c test --server  http://127.0.0.1:8300/ --config ./cfg.yaml            
Diff of changefeed config:
{Type:update Path:[Config Sink Protocol] From:canal To:avro}
{Type:update Path:[Config Sink TxnAtomicity] From:table To:none}
Could you agree to apply changes above to changefeed [Y/N]
Y
Error: [CDC:ErrChangefeedUpdateRefused]changefeed update error: [CDC:ErrIncompatibleSinkConfig]incompatible configuration in sink uri(transaction-atomicity=table, protocol=canal) and config file(transaction-atomicity=none, protocol=avro)
```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`Fix the issue of transaction-atomicity and protocol can't be updated via config file`.
```
