### PR TITLE
mysql(ticdc): handle the case when @@sql_mode is null

### DIFF
--- a/cdc/sink/mysql/mysql.go
+++ b/cdc/sink/mysql/mysql.go
@@ -387,13 +387,17 @@ func needSwitchDB(ddl *model.DDLEvent) bool {
 	return true
 }
 
-func querySQLMode(ctx context.Context, db *sql.DB) (sqlMode string, err error) {
+func querySQLMode(ctx context.Context, db *sql.DB) (string, error) {
 	row := db.QueryRowContext(ctx, "SELECT @@SESSION.sql_mode;")
-	err = row.Scan(&sqlMode)
+	var sqlMode sql.NullString
+	err := row.Scan(&sqlMode)
 	if err != nil {
 		err = cerror.WrapError(cerror.ErrMySQLQueryError, err)
 	}
-	return
+	if !sqlMode.Valid {
+		sqlMode.String = ""
+	}
+	return sqlMode.String, err
 }
 
 // check whether the target charset is supported

--- a/cdc/sink/mysql/mysql_test.go
+++ b/cdc/sink/mysql/mysql_test.go
@@ -947,6 +947,10 @@ func TestReduceReplace(t *testing.T) {
 }
 
 func mockTestDB(adjustSQLMode bool) (*sql.DB, error) {
+	return mockTestDBWithSQLMode(adjustSQLMode, "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE")
+}
+
+func mockTestDBWithSQLMode(adjustSQLMode bool, sqlMode interface{}) (*sql.DB, error) {
 	// mock for test db, which is used querying TiDB session variable
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -955,7 +959,7 @@ func mockTestDB(adjustSQLMode bool) (*sql.DB, error) {
 	if adjustSQLMode {
 		mock.ExpectQuery("SELECT @@SESSION.sql_mode;").
 			WillReturnRows(sqlmock.NewRows([]string{"@@SESSION.sql_mode"}).
-				AddRow("ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE"))
+				AddRow(sqlMode))
 	}
 
 	columns := []string{"Variable_name", "Value"}
@@ -998,7 +1002,7 @@ func TestAdjustSQLMode(t *testing.T) {
 		}()
 		if dbIndex == 0 {
 			// test db
-			db, err := mockTestDB(true)
+			db, err := mockTestDBWithSQLMode(true, nil)
 			require.Nil(t, err)
 			return db, nil
 		}

--- a/pkg/sink/mysql/db_helper.go
+++ b/pkg/sink/mysql/db_helper.go
@@ -175,13 +175,17 @@ func generateDSNByConfig(
 	return dsnCfg.FormatDSN(), nil
 }
 
-func querySQLMode(ctx context.Context, db *sql.DB) (sqlMode string, err error) {
+func querySQLMode(ctx context.Context, db *sql.DB) (string, error) {
 	row := db.QueryRowContext(ctx, "SELECT @@SESSION.sql_mode;")
-	err = row.Scan(&sqlMode)
+	var sqlMode sql.NullString
+	err := row.Scan(&sqlMode)
 	if err != nil {
 		err = cerror.WrapError(cerror.ErrMySQLQueryError, err)
 	}
-	return
+	if !sqlMode.Valid {
+		sqlMode.String = ""
+	}
+	return sqlMode.String, err
 }
 
 // check whether the target charset is supported


### PR DESCRIPTION
Signed-off-by: kennytm <kennytm@gmail.com>

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #7989

### What is changed and how it works?

Use `sql.NullString` to receive the result of `select @@sql_mode`. Treat NULL as empty string.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No

##### Do you need to update user documentation, design documentation or monitoring documentation?

No

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
Fix compatibility issue when using Alibaba AnalyzeDB for MySQL as TiCDC sink