### PR TITLE
changefeed(ticdc): fix memory quota incompatible from 6.5.0

### DIFF
--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -299,6 +299,12 @@ func (info *ChangeFeedInfo) FixIncompatible() {
 		info.fixMySQLSinkProtocol()
 		log.Info("Fix incompatibility changefeed sink uri completed", zap.String("changefeed", info.String()))
 	}
+
+	if info.Config.MemoryQuota == uint64(0) {
+		log.Info("Start fixing incompatible memory quota", zap.String("changefeed", info.String()))
+		info.fixMemoryQuota()
+		log.Info("Fix incompatible memory quota completed", zap.String("changefeed", info.String()))
+	}
 }
 
 // fixState attempts to fix state loss from upgrading the old owner to the new owner.
@@ -427,4 +433,8 @@ func (info *ChangeFeedInfo) HasFastFailError() bool {
 		return false
 	}
 	return cerror.IsChangefeedFastFailErrorCode(errors.RFCErrorCode(info.Error.Code))
+}
+
+func (info *ChangeFeedInfo) fixMemoryQuota() {
+	info.Config.MemoryQuota = config.DefaultChangefeedMemoryQuota
 }

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -436,5 +436,5 @@ func (info *ChangeFeedInfo) HasFastFailError() bool {
 }
 
 func (info *ChangeFeedInfo) fixMemoryQuota() {
-	info.Config.MemoryQuota = config.DefaultChangefeedMemoryQuota
+	info.Config.FixMemoryQuota()
 }

--- a/pkg/config/replica_config.go
+++ b/pkg/config/replica_config.go
@@ -188,10 +188,15 @@ func (c *ReplicaConfig) ValidateAndAdjust(sinkURI *url.URL) error {
 		}
 	}
 	if c.MemoryQuota == uint64(0) {
-		c.MemoryQuota = DefaultChangefeedMemoryQuota
+		c.FixMemoryQuota()
 	}
 
 	return nil
+}
+
+// FixMemoryQuota adjusts memory quota to default value
+func (c *ReplicaConfig) FixMemoryQuota() {
+	c.MemoryQuota = DefaultChangefeedMemoryQuota
 }
 
 // GetSinkURIAndAdjustConfigWithSinkURI parses sinkURI as a URI and adjust config with sinkURI.

--- a/pkg/config/replica_config.go
+++ b/pkg/config/replica_config.go
@@ -187,6 +187,9 @@ func (c *ReplicaConfig) ValidateAndAdjust(sinkURI *url.URL) error {
 						minSyncPointRetention.String()))
 		}
 	}
+	if c.MemoryQuota == uint64(0) {
+		c.MemoryQuota = DefaultChangefeedMemoryQuota
+	}
 
 	return nil
 }

--- a/pkg/config/replica_config_test.go
+++ b/pkg/config/replica_config_test.go
@@ -135,7 +135,7 @@ func TestReplicaConfigValidate(t *testing.T) {
 	conf = GetDefaultReplicaConfig()
 	conf.MemoryQuota = 0
 	err = conf.ValidateAndAdjust(nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, uint64(DefaultChangefeedMemoryQuota), conf.MemoryQuota)
 
 	conf.MemoryQuota = uint64(1024)

--- a/pkg/config/replica_config_test.go
+++ b/pkg/config/replica_config_test.go
@@ -130,6 +130,18 @@ func TestReplicaConfigValidate(t *testing.T) {
 	require.Equal(t, "d1", rules[0].PartitionRule)
 	require.Equal(t, "p1", rules[1].PartitionRule)
 	require.Equal(t, "", rules[2].PartitionRule)
+
+	// Test memory quota can be adjusted
+	conf = GetDefaultReplicaConfig()
+	conf.MemoryQuota = 0
+	err = conf.ValidateAndAdjust(nil)
+	require.Nil(t, err)
+	require.Equal(t, uint64(DefaultChangefeedMemoryQuota), conf.MemoryQuota)
+
+	conf.MemoryQuota = uint64(1024)
+	err = conf.ValidateAndAdjust(nil)
+	require.Nil(t, err)
+	require.Equal(t, uint64(1024), conf.MemoryQuota)
 }
 
 func TestValidateAndAdjust(t *testing.T) {

--- a/pkg/config/replica_config_test.go
+++ b/pkg/config/replica_config_test.go
@@ -140,7 +140,7 @@ func TestReplicaConfigValidate(t *testing.T) {
 
 	conf.MemoryQuota = uint64(1024)
 	err = conf.ValidateAndAdjust(nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, uint64(1024), conf.MemoryQuota)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8007 

### What is changed and how it works?

- Auto fix `memory-quota` if it is zero in changefeed info from etcd.
- Auto fix `memory-quota` if it is zero when creating a new changefeed.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix memory-quota is set to zero unexpectedly which will cause replication stuck.
```
