### PR TITLE
puller(ticdc): fix frontier metrics label

### DIFF
--- a/cdc/processor/pipeline/puller.go
+++ b/cdc/processor/pipeline/puller.go
@@ -78,6 +78,7 @@ func (n *pullerNode) startWithSorterNode(ctx pipeline.NodeContext,
 		n.span.TableID,
 		n.tableName,
 		filterLoop,
+		false,
 	)
 	n.wg.Go(func() error {
 		ctx.Throw(errors.Trace(n.plr.Run(ctxC)))

--- a/cdc/processor/sourcemanager/puller/puller_wrapper.go
+++ b/cdc/processor/sourcemanager/puller/puller_wrapper.go
@@ -92,6 +92,7 @@ func (n *Wrapper) Start(
 		n.span.TableID,
 		n.tableName,
 		n.bdrMode,
+		false,
 	)
 	n.wg.Add(1)
 	go func() {

--- a/cdc/puller/ddl_puller.go
+++ b/cdc/puller/ddl_puller.go
@@ -491,6 +491,7 @@ func NewDDLJobPuller(
 			changefeed,
 			-1, DDLPullerTableName,
 			ddLPullerFilterLoop,
+			true,
 		),
 		kvStorage: kvStorage,
 		outputCh:  make(chan *model.DDLJobEntry, defaultPullerOutputChanSize),

--- a/cdc/puller/puller_test.go
+++ b/cdc/puller/puller_test.go
@@ -133,7 +133,8 @@ func newPullerForTest(
 	plr := New(
 		ctx, pdCli, grpcPool, regionCache, store, pdutil.NewClock4Test(),
 		checkpointTs, spans, config.GetDefaultServerConfig().KVClient,
-		model.DefaultChangeFeedID("changefeed-id-test"), 0, "table-test", false)
+		model.DefaultChangeFeedID("changefeed-id-test"), 0,
+		"table-test", false, false)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8027

### What is changed and how it works?
not use span size to check if the puller is a ddl puller, use a bool passed by caller


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
