### PR TITLE
sinkv2(ticdc): remove redundant nextToMount in MountedEventIter

### DIFF
--- a/cdc/processor/sourcemanager/engine/mounted_iter.go
+++ b/cdc/processor/sourcemanager/engine/mounted_iter.go
@@ -49,8 +49,7 @@ func (i *MountedEventIter) Next(ctx context.Context) (event *model.PolymorphicEv
 	// There are no events in mounting. Fetch more events and mounting them.
 	// The batch size is determined by `maxBatchSize`.
 	if i.nextToEmit >= len(i.rawEvents) {
-		err = i.readBatch(ctx)
-		if err != nil {
+		if err = i.readBatch(ctx); err != nil {
 			return
 		}
 	}
@@ -58,11 +57,12 @@ func (i *MountedEventIter) Next(ctx context.Context) (event *model.PolymorphicEv
 	// Check whether there are events in mounting or not.
 	if i.nextToEmit < len(i.rawEvents) {
 		idx := i.nextToEmit
-		if err = i.rawEvents[idx].event.WaitFinished(ctx); err == nil {
-			event = i.rawEvents[idx].event
-			txnFinished = i.rawEvents[idx].txnFinished
-			i.nextToEmit += 1
+		if err = i.rawEvents[idx].event.WaitFinished(ctx); err != nil {
+			return
 		}
+		event = i.rawEvents[idx].event
+		txnFinished = i.rawEvents[idx].txnFinished
+		i.nextToEmit += 1
 	}
 	return
 }

--- a/cdc/processor/sourcemanager/engine/mounted_iter.go
+++ b/cdc/processor/sourcemanager/engine/mounted_iter.go
@@ -89,14 +89,12 @@ func (i *MountedEventIter) readBatch(ctx context.Context) error {
 			i.iter = nil
 			break
 		}
-		i.rawEvents = append(i.rawEvents, rawEvent{event, txnFinished})
-	}
-	for idx := 0; idx < len(i.rawEvents); idx++ {
-		i.rawEvents[idx].event.SetUpFinishedCh()
-		if err := i.mg.AddEvent(ctx, i.rawEvents[idx].event); err != nil {
+		event.SetUpFinishedCh()
+		if err := i.mg.AddEvent(ctx, event); err != nil {
 			i.mg = nil
 			return err
 		}
+		i.rawEvents = append(i.rawEvents, rawEvent{event, txnFinished})
 	}
 	return nil
 }

--- a/cdc/processor/sourcemanager/engine/mounted_iter_test.go
+++ b/cdc/processor/sourcemanager/engine/mounted_iter_test.go
@@ -56,14 +56,12 @@ func TestMountedEventIter(t *testing.T) {
 		require.NotNil(t, event)
 		require.Nil(t, err)
 	}
-	require.Equal(t, iter.nextToMount, 3)
 	require.Equal(t, iter.nextToEmit, 3)
 
 	rawIter.repeatItem = func() *model.PolymorphicEvent { return nil }
 	event, _, err := iter.Next(context.Background())
 	require.Nil(t, event)
 	require.Nil(t, err)
-	require.Equal(t, iter.nextToMount, 0)
 	require.Equal(t, iter.nextToEmit, 0)
 	require.Nil(t, iter.iter)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #5928

### What is changed and how it works?
remove redundant nextToMount in MountedEventIter

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
