### PR TITLE
tests(engine): fix unstable unit test in jobmanager

### DIFF
--- a/engine/servermaster/jobmanager_test.go
+++ b/engine/servermaster/jobmanager_test.go
@@ -91,8 +91,6 @@ func TestJobManagerCreateJob(t *testing.T) {
 	}
 	job, err := mgr.CreateJob(ctx, req)
 	require.NoError(t, err)
-	err = mockMaster.Poll(ctx)
-	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
 		return mgr.JobFsm.QueryJob(job.Id) != nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8032

### What is changed and how it works?

It is easy to reproduce the panic with following patch

```diff
diff --git a/engine/servermaster/jobmanager_test.go b/engine/servermaster/jobmanager_test.go
index 12d14fce7..c6a93e5b5 100644
--- a/engine/servermaster/jobmanager_test.go
+++ b/engine/servermaster/jobmanager_test.go
@@ -91,6 +91,7 @@ func TestJobManagerCreateJob(t *testing.T) {
        }
        job, err := mgr.CreateJob(ctx, req)
        require.NoError(t, err)
+       time.Sleep(time.Second)
        err = mockMaster.Poll(ctx)
        require.NoError(t, err)
```

- The root cause is if create worker is called before `mockMaster.Poll`, the `Poll` will trigger more callbacks, where some of fileds of job manager is not initialized in this unit test.
- Since this test verifies the `CreateWorker` staff, it is safe to remove `mockMaster.Poll(ctx)`

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
