### PR TITLE
encoder(ticdc): do not close the output channel to prevent data race.

### DIFF
--- a/cdc/sink/codec/encoder_group.go
+++ b/cdc/sink/codec/encoder_group.go
@@ -81,7 +81,6 @@ func NewEncoderGroup(builder EncoderBuilder, count int, changefeedID model.Chang
 func (g *encoderGroup) Run(ctx context.Context) error {
 	defer func() {
 		encoderGroupInputChanSizeGauge.DeleteLabelValues(g.changefeedID.Namespace, g.changefeedID.ID)
-		close(g.outputCh)
 		log.Info("encoder group exited",
 			zap.String("namespace", g.changefeedID.Namespace),
 			zap.String("changefeed", g.changefeedID.ID))


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8041

### What is changed and how it works?

do not close the output channel when exit the encoder group


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
