### PR TITLE
redo(ticdc): use uuid in redo meta filename 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,10 @@ kafka_consumer:
 storage_consumer:
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/cdc_storage_consumer ./cmd/storage-consumer/main.go
 
+cdc_test_image: 
+	@which docker || (echo "docker not found in ${PATH}"; exit 1)
+	docker build --platform linux/amd64 -f deployments/ticdc/docker/test.Dockerfile -t cdc:test ./ 
+
 install:
 	go install ./...
 

--- a/cdc/api/v2/model.go
+++ b/cdc/api/v2/model.go
@@ -366,7 +366,7 @@ func GetDefaultReplicaConfig() *ReplicaConfig {
 		Consistent: &ConsistentConfig{
 			Level:             "none",
 			MaxLogSize:        64,
-			FlushIntervalInMs: config.MinFlushIntervalInMs,
+			FlushIntervalInMs: config.DefaultFlushIntervalInMs,
 			Storage:           "",
 		},
 	}

--- a/cdc/owner/changefeed_test.go
+++ b/cdc/owner/changefeed_test.go
@@ -495,7 +495,7 @@ func TestRemoveChangefeed(t *testing.T) {
 	info.Config.Consistent = &config.ConsistentConfig{
 		Level:             "eventual",
 		Storage:           filepath.Join("nfs://", dir),
-		FlushIntervalInMs: config.MinFlushIntervalInMs,
+		FlushIntervalInMs: config.DefaultFlushIntervalInMs,
 	}
 	ctx = cdcContext.WithChangefeedVars(ctx, &cdcContext.ChangefeedVars{
 		ID:   ctx.ChangefeedVars().ID,

--- a/cdc/redo/common/metric.go
+++ b/cdc/redo/common/metric.go
@@ -81,7 +81,7 @@ var (
 		prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
-			Name:      "redo_worker_busy_ratio",
+			Name:      "worker_busy_ratio",
 			Help:      "Busy ratio (X ms in 1s) for redo bgUpdateLog worker.",
 		}, []string{"namespace", "changefeed"})
 )

--- a/cdc/redo/common/metric.go
+++ b/cdc/redo/common/metric.go
@@ -75,6 +75,15 @@ var (
 		Help:      "The latency distributions of flushLog called by redoManager",
 		Buckets:   prometheus.ExponentialBuckets(0.001, 2.0, 13),
 	}, []string{"namespace", "changefeed"})
+
+	// RedoWorkerBusyRatio records the busy ratio of redo bgUpdateLog worker.
+	RedoWorkerBusyRatio = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "redo_worker_busy_ratio",
+			Help:      "Busy ratio (X ms in 1s) for redo bgUpdateLog worker.",
+		}, []string{"namespace", "changefeed"})
 )
 
 // InitMetrics registers all metrics in this file
@@ -85,4 +94,5 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(RedoFlushAllDurationHistogram)
 	registry.MustRegister(RedoWriteLogDurationHistogram)
 	registry.MustRegister(RedoFlushLogDurationHistogram)
+	registry.MustRegister(RedoWorkerBusyRatio)
 }

--- a/cdc/redo/manager.go
+++ b/cdc/redo/manager.go
@@ -588,8 +588,8 @@ func (m *ManagerImpl) bgUpdateLog(
 		}
 	}
 
-	overseerTimer := time.NewTicker(time.Second * 5)
-	defer overseerTimer.Stop()
+	overseerTicker := time.NewTicker(time.Second * 5)
+	defer overseerTicker.Stop()
 	var workTimeSlice time.Duration
 	startToWork := time.Now()
 	for {
@@ -621,7 +621,7 @@ func (m *ManagerImpl) bgUpdateLog(
 					log.Panic("redo manager receives unknown event type")
 				}
 				workTimeSlice += time.Since(startToHandleEvent)
-			case now := <-overseerTimer.C:
+			case now := <-overseerTicker.C:
 				busyRatio := int(workTimeSlice.Seconds() / now.Sub(startToWork).Seconds() * 1000)
 				m.metricRedoWorkerBusyRatio.Add(float64(busyRatio))
 				startToWork = now
@@ -658,7 +658,7 @@ func (m *ManagerImpl) bgUpdateLog(
 					log.Panic("redo manager receives unknown event type")
 				}
 				workTimeSlice += time.Since(startToHandleEvent)
-			case now := <-overseerTimer.C:
+			case now := <-overseerTicker.C:
 				busyRatio := int(workTimeSlice.Seconds() / now.Sub(startToWork).Seconds() * 1000)
 				m.metricRedoWorkerBusyRatio.Add(float64(busyRatio))
 				startToWork = now

--- a/cdc/redo/manager.go
+++ b/cdc/redo/manager.go
@@ -143,8 +143,10 @@ type ManagerImpl struct {
 	flushing      int64
 	lastFlushTime time.Time
 
-	metricWriteLogDuration prometheus.Observer
-	metricFlushLogDuration prometheus.Observer
+	metricWriteLogDuration    prometheus.Observer
+	metricFlushLogDuration    prometheus.Observer
+	metricTotalRowsCount      prometheus.Counter
+	metricRedoWorkerBusyRatio prometheus.Counter
 }
 
 // NewManager creates a new Manager
@@ -180,6 +182,10 @@ func NewManager(ctx context.Context, cfg *config.ConsistentConfig, opts *Manager
 		WithLabelValues(m.changeFeedID.Namespace, m.changeFeedID.ID)
 	m.metricFlushLogDuration = common.RedoFlushLogDurationHistogram.
 		WithLabelValues(m.changeFeedID.Namespace, m.changeFeedID.ID)
+	m.metricTotalRowsCount = common.RedoTotalRowsCountGauge.
+		WithLabelValues(m.changeFeedID.Namespace, m.changeFeedID.ID)
+	m.metricRedoWorkerBusyRatio = common.RedoWorkerBusyRatio.
+		WithLabelValues(m.changeFeedID.Namespace, m.changeFeedID.ID)
 
 	// TODO: better to wait background goroutines after the context is canceled.
 	if m.opts.EnableBgRunner {
@@ -203,7 +209,7 @@ func NewMockManager(ctx context.Context) (*ManagerImpl, error) {
 	cfg := &config.ConsistentConfig{
 		Level:             string(redo.ConsistentLevelEventual),
 		Storage:           "blackhole://",
-		FlushIntervalInMs: config.MinFlushIntervalInMs,
+		FlushIntervalInMs: config.DefaultFlushIntervalInMs,
 	}
 
 	errCh := make(chan error, 1)
@@ -372,6 +378,10 @@ func (m *ManagerImpl) Cleanup(ctx context.Context) error {
 		DeleteLabelValues(m.changeFeedID.Namespace, m.changeFeedID.ID)
 	common.RedoFlushLogDurationHistogram.
 		DeleteLabelValues(m.changeFeedID.Namespace, m.changeFeedID.ID)
+	common.RedoTotalRowsCountGauge.
+		DeleteLabelValues(m.changeFeedID.Namespace, m.changeFeedID.ID)
+	common.RedoWorkerBusyRatio.
+		DeleteLabelValues(m.changeFeedID.Namespace, m.changeFeedID.ID)
 	return m.withLock(func(m *ManagerImpl) error { return m.writer.DeleteAllLogs(ctx) })
 }
 
@@ -440,7 +450,13 @@ func (m *ManagerImpl) postFlushMeta(metaCheckpoint, metaResolved model.Ts) {
 	m.metaCheckpointTs.setFlushed(metaCheckpoint)
 }
 
-func (m *ManagerImpl) flushLog(ctx context.Context, handleErr func(err error)) {
+func (m *ManagerImpl) flushLog(
+	ctx context.Context, handleErr func(err error), workTimeSlice *time.Duration,
+) {
+	start := time.Now()
+	defer func() {
+		*workTimeSlice += time.Since(start)
+	}()
 	if !atomic.CompareAndSwapInt64(&m.flushing, 0, 1) {
 		log.Debug("Fail to update flush flag, " +
 			"the previous flush operation hasn't finished yet")
@@ -494,7 +510,8 @@ func (m *ManagerImpl) bgUpdateLog(
 
 	log.Info("redo manager bgUpdateLog is running",
 		zap.String("namespace", m.changeFeedID.Namespace),
-		zap.String("changefeed", m.changeFeedID.ID))
+		zap.String("changefeed", m.changeFeedID.ID),
+		zap.Int64("flushIntervalInMs", flushIntervalInMs))
 
 	ticker := time.NewTicker(time.Duration(flushIntervalInMs) * time.Millisecond)
 	defer func() {
@@ -524,7 +541,11 @@ func (m *ManagerImpl) bgUpdateLog(
 	rtsMap := spanz.NewHashMap[model.Ts]()
 	releaseMemoryCbs := make([]func(), 0, 1024)
 
-	emitBatch := func() {
+	emitBatch := func(workTimeSlice *time.Duration) {
+		start := time.Now()
+		defer func() {
+			*workTimeSlice += time.Since(start)
+		}()
 		if len(logs) > 0 {
 			start := time.Now()
 			err = m.writer.WriteLog(ctx, logs)
@@ -535,6 +556,7 @@ func (m *ManagerImpl) bgUpdateLog(
 				zap.Int("rows", len(logs)),
 				zap.Error(err),
 				zap.Duration("writeLogElapse", writeLogElapse))
+			m.metricTotalRowsCount.Add(float64(len(logs)))
 			m.metricWriteLogDuration.Observe(writeLogElapse.Seconds())
 
 			for _, releaseMemory := range releaseMemoryCbs {
@@ -566,14 +588,18 @@ func (m *ManagerImpl) bgUpdateLog(
 		}
 	}
 
+	overseerTimer := time.NewTicker(time.Second)
+	defer overseerTimer.Stop()
+	var workTimeSlice time.Duration
+	startToWork := time.Now()
 	for {
 		if len(logs) > 0 || rtsMap.Len() > 0 {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				emitBatch()
-				m.flushLog(ctx, handleErr)
+				emitBatch(&workTimeSlice)
+				m.flushLog(ctx, handleErr, &workTimeSlice)
 			case cache, ok := <-m.logBuffer.Out():
 				if !ok {
 					return // channel closed
@@ -593,17 +619,22 @@ func (m *ManagerImpl) bgUpdateLog(
 				default:
 					log.Panic("redo manager receives unknown event type")
 				}
+			case now := <-overseerTimer.C:
+				busyRatio := int(workTimeSlice.Seconds() / now.Sub(startToWork).Seconds() * 1000)
+				m.metricRedoWorkerBusyRatio.Add(float64(busyRatio))
+				startToWork = now
+				workTimeSlice = 0
 			case err = <-logErrCh:
 			default:
-				emitBatch()
+				emitBatch(&workTimeSlice)
 			}
 		} else {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				emitBatch()
-				m.flushLog(ctx, handleErr)
+				emitBatch(&workTimeSlice)
+				m.flushLog(ctx, handleErr, &workTimeSlice)
 			case cache, ok := <-m.logBuffer.Out():
 				if !ok {
 					return // channel closed

--- a/cdc/redo/manager_test.go
+++ b/cdc/redo/manager_test.go
@@ -102,7 +102,7 @@ func TestLogManagerInProcessor(t *testing.T) {
 	defer logMgr.Cleanup(ctx)
 
 	checkResolvedTs := func(mgr LogManager, expectedRts uint64) {
-		time.Sleep(time.Duration(config.MinFlushIntervalInMs+200) * time.Millisecond)
+		time.Sleep(time.Duration(config.DefaultFlushIntervalInMs+200) * time.Millisecond)
 		resolvedTs := mgr.GetMinResolvedTs()
 		require.Equal(t, expectedRts, resolvedTs)
 	}
@@ -336,7 +336,7 @@ func TestManagerError(t *testing.T) {
 	cfg := &config.ConsistentConfig{
 		Level:             string(redo.ConsistentLevelEventual),
 		Storage:           "blackhole://",
-		FlushIntervalInMs: config.MinFlushIntervalInMs,
+		FlushIntervalInMs: config.DefaultFlushIntervalInMs,
 	}
 
 	errCh := make(chan error, 1)
@@ -401,7 +401,7 @@ func TestReuseWritter(t *testing.T) {
 	cfg := &config.ConsistentConfig{
 		Level:             string(redo.ConsistentLevelEventual),
 		Storage:           "local://" + dir,
-		FlushIntervalInMs: config.MinFlushIntervalInMs,
+		FlushIntervalInMs: config.DefaultFlushIntervalInMs,
 	}
 
 	errCh := make(chan error, 1)
@@ -424,7 +424,8 @@ func TestReuseWritter(t *testing.T) {
 	time.Sleep(time.Duration(100) * time.Millisecond)
 
 	// The another redo manager shouldn't be influenced.
-	mgrs[1].flushLog(ctxs[1], func(err error) { opts.ErrCh <- err })
+	var workTimeSlice time.Duration
+	mgrs[1].flushLog(ctxs[1], func(err error) { opts.ErrCh <- err }, &workTimeSlice)
 	select {
 	case x := <-errCh:
 		log.Panic("shouldn't get an error", zap.Error(x))

--- a/cdc/redo/reader/file.go
+++ b/cdc/redo/reader/file.go
@@ -133,7 +133,7 @@ func selectDownLoadFile(
 			return nil
 		})
 	if err != nil {
-		return nil, cerror.WrapError(cerror.ErrS3StorageAPI, err)
+		return nil, cerror.WrapError(cerror.ErrExternalStorageAPI, err)
 	}
 
 	return files, nil
@@ -153,7 +153,7 @@ func downLoadToLocal(
 		eg.Go(func() error {
 			data, err := extStorage.ReadFile(eCtx, f)
 			if err != nil {
-				return cerror.WrapError(cerror.ErrS3StorageAPI, err)
+				return cerror.WrapError(cerror.ErrExternalStorageAPI, err)
 			}
 
 			err = os.MkdirAll(dir, redo.DefaultDirMode)

--- a/cdc/redo/writer/file.go
+++ b/cdc/redo/writer/file.go
@@ -365,7 +365,7 @@ func (w *Writer) close() error {
 		if err != nil {
 			w.file.Close()
 			w.file = nil
-			return cerror.WrapError(cerror.ErrS3StorageAPI, err)
+			return cerror.WrapError(cerror.ErrExternalStorageAPI, err)
 		}
 	}
 
@@ -489,7 +489,7 @@ func (w *Writer) GC(checkPointTs uint64) error {
 				errs = multierr.Append(errs, err)
 			}
 			if errs != nil {
-				errs = cerror.WrapError(cerror.ErrS3StorageAPI, errs)
+				errs = cerror.WrapError(cerror.ErrExternalStorageAPI, errs)
 				log.Warn("delete redo log in s3 fail", zap.Error(errs))
 			}
 		}()
@@ -616,7 +616,7 @@ func (w *Writer) writeToS3(ctx context.Context, name string) error {
 	// Key in s3: aws.String(rs.options.Prefix + name), prefix should be changefeed name
 	err = w.storage.WriteFile(ctx, filepath.Base(name), fileData)
 	if err != nil {
-		return cerror.WrapError(cerror.ErrS3StorageAPI, err)
+		return cerror.WrapError(cerror.ErrExternalStorageAPI, err)
 	}
 
 	// in case the page cache piling up triggered the OS memory reclaming which may cause

--- a/cdc/redo/writer/writer.go
+++ b/cdc/redo/writer/writer.go
@@ -621,7 +621,7 @@ func (l *logWriter) flushMetaToS3(ctx context.Context, data []byte) error {
 		}
 	}
 	l.preMetaFile = metaFile
-	log.Warn("flush meta to s3",
+	log.Debug("flush meta to s3",
 		zap.String("metaFile", metaFile),
 		zap.Any("cost", time.Since(start).Milliseconds()))
 	return nil

--- a/cdc/redo/writer/writer.go
+++ b/cdc/redo/writer/writer.go
@@ -33,7 +33,6 @@ import (
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/redo"
 	"github.com/pingcap/tiflow/pkg/uuid"
-	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -137,8 +136,6 @@ type logWriter struct {
 	meta          *common.LogMeta
 	preMetaFile   string
 	uuidGenerator uuid.Generator
-
-	metricTotalRowsCount prometheus.Gauge
 }
 
 func newLogWriter(

--- a/cdc/redo/writer/writer_test.go
+++ b/cdc/redo/writer/writer_test.go
@@ -129,8 +129,6 @@ func TestLogWriterWriteLog(t *testing.T) {
 			rowWriter: mockWriter,
 			ddlWriter: mockWriter,
 			meta:      &common.LogMeta{},
-			metricTotalRowsCount: common.RedoTotalRowsCountGauge.
-				WithLabelValues("default", ""),
 		}
 		if tt.name == "context cancel" {
 			ctx, cancel := context.WithCancel(context.Background())

--- a/cdc/redo/writer/writer_test.go
+++ b/cdc/redo/writer/writer_test.go
@@ -314,7 +314,7 @@ func TestLogWriterFlushLog(t *testing.T) {
 		mockStorage := mockstorage.NewMockExternalStorage(controller)
 		if tt.isRunning && tt.name != "context cancel" {
 			mockStorage.EXPECT().WriteFile(gomock.Any(),
-				"cp_test-cf_meta.meta",
+				"cp_default_test-cf_meta_uid.meta",
 				gomock.Any()).Return(nil).Times(1)
 		}
 		mockWriter := &mockFileWriter{}
@@ -333,11 +333,12 @@ func TestLogWriterFlushLog(t *testing.T) {
 			UseExternalStorage: true,
 		}
 		writer := logWriter{
-			cfg:        cfg,
-			rowWriter:  mockWriter,
-			ddlWriter:  mockWriter,
-			meta:       &common.LogMeta{},
-			extStorage: mockStorage,
+			cfg:           cfg,
+			uuidGenerator: uuid.NewConstGenerator("uid"),
+			rowWriter:     mockWriter,
+			ddlWriter:     mockWriter,
+			meta:          &common.LogMeta{},
+			extStorage:    mockStorage,
 		}
 
 		if tt.name == "context cancel" {
@@ -421,7 +422,7 @@ func TestNewLogWriter(t *testing.T) {
 		CaptureID:    "cp",
 		MaxLogSize:   10,
 	}
-	l, err := newLogWriter(ctx, cfg)
+	l, err := newLogWriter(ctx, cfg, WithUUIDGenerator(func() uuid.Generator { return uuidGen }))
 	require.Nil(t, err)
 	err = l.Close()
 	require.Nil(t, err)
@@ -435,7 +436,7 @@ func TestNewLogWriter(t *testing.T) {
 	_, err = f.Write(data)
 	require.Nil(t, err)
 
-	l, err = newLogWriter(ctx, cfg)
+	l, err = newLogWriter(ctx, cfg, WithUUIDGenerator(func() uuid.Generator { return uuidGen }))
 	require.Nil(t, err)
 	err = l.Close()
 	require.Nil(t, err)

--- a/cdc/sinkv2/eventsink/txn/worker.go
+++ b/cdc/sinkv2/eventsink/txn/worker.go
@@ -137,8 +137,8 @@ func (w *worker) runBackgroundLoop() {
 		defer ticker.Stop()
 
 		var flushTimeSlice, totalTimeSlice time.Duration
-		overseerTimer := time.NewTicker(time.Second)
-		defer overseerTimer.Stop()
+		overseerTicker := time.NewTicker(time.Second)
+		defer overseerTicker.Stop()
 		startToWork := time.Now()
 	Loop:
 		for {
@@ -163,7 +163,7 @@ func (w *worker) runBackgroundLoop() {
 				if w.doFlush(&flushTimeSlice) {
 					break Loop
 				}
-			case now := <-overseerTimer.C:
+			case now := <-overseerTicker.C:
 				totalTimeSlice = now.Sub(startToWork)
 				busyRatio := int(flushTimeSlice.Seconds() / totalTimeSlice.Seconds() * 1000)
 				w.metricTxnWorkerBusyRatio.Add(float64(busyRatio) / float64(w.workerCount))

--- a/deployments/ticdc/docker/test.Dockerfile
+++ b/deployments/ticdc/docker/test.Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.15
+RUN apk add --no-cache tzdata bash curl socat
+COPY ./bin/cdc /cdc
+EXPOSE 8300
+CMD [ "/cdc" ]
+

--- a/engine/pkg/externalresource/internal/s3/file_manager.go
+++ b/engine/pkg/externalresource/internal/s3/file_manager.go
@@ -119,7 +119,7 @@ func (m *FileManager) GetPersistedResource(
 
 	ok, err := storage.FileExists(ctx, placeholderFileName)
 	if err != nil {
-		return nil, errors.ErrS3StorageAPI.Wrap(err).GenWithStackByArgs("check placeholder file")
+		return nil, errors.ErrExternalStorageAPI.Wrap(err).GenWithStackByArgs("check placeholder file")
 	}
 	if !ok {
 		return nil, errors.ErrResourceFilesNotFound.GenWithStackByArgs()
@@ -293,7 +293,7 @@ func (m *FileManager) removeFilesIf(
 		return nil
 	})
 	if err != nil {
-		return errors.ErrS3StorageAPI.Wrap(err).GenWithStackByArgs("RemoveTemporaryFiles")
+		return errors.ErrExternalStorageAPI.Wrap(err).GenWithStackByArgs("RemoveTemporaryFiles")
 	}
 
 	log.Info("Removing resources",
@@ -303,7 +303,7 @@ func (m *FileManager) removeFilesIf(
 
 	for _, path := range toRemoveFiles {
 		if err := storage.DeleteFile(ctx, path); err != nil {
-			return errors.ErrS3StorageAPI.Wrap(err)
+			return errors.ErrExternalStorageAPI.Wrap(err)
 		}
 	}
 	return nil
@@ -312,25 +312,25 @@ func (m *FileManager) removeFilesIf(
 func createPlaceholderFile(ctx context.Context, storage brStorage.ExternalStorage) error {
 	exists, err := storage.FileExists(ctx, placeholderFileName)
 	if err != nil {
-		return errors.ErrS3StorageAPI.Wrap(err).GenWithStackByArgs("checking placeholder file")
+		return errors.ErrExternalStorageAPI.Wrap(err).GenWithStackByArgs("checking placeholder file")
 	}
 	if exists {
 		// This should not happen in production. Unless the caller of the FileManager has a bug.
-		return errors.ErrS3StorageAPI.GenWithStackByArgs("resource already exists")
+		return errors.ErrExternalStorageAPI.GenWithStackByArgs("resource already exists")
 	}
 
 	writer, err := storage.Create(ctx, placeholderFileName)
 	if err != nil {
-		return errors.ErrS3StorageAPI.Wrap(err).GenWithStackByArgs("creating placeholder file")
+		return errors.ErrExternalStorageAPI.Wrap(err).GenWithStackByArgs("creating placeholder file")
 	}
 
 	_, err = writer.Write(ctx, []byte("placeholder"))
 	if err != nil {
-		return errors.ErrS3StorageAPI.Wrap(err).GenWithStackByArgs("writing placeholder file")
+		return errors.ErrExternalStorageAPI.Wrap(err).GenWithStackByArgs("writing placeholder file")
 	}
 
 	if err := writer.Close(ctx); err != nil {
-		return errors.ErrS3StorageAPI.Wrap(err).GenWithStackByArgs("closing placeholder file")
+		return errors.ErrExternalStorageAPI.Wrap(err).GenWithStackByArgs("closing placeholder file")
 	}
 	return nil
 }

--- a/errors.toml
+++ b/errors.toml
@@ -998,7 +998,7 @@ failed to seek to the beginning of request body
 
 ["CDC:ErrS3StorageAPI"]
 error = '''
-s3 storage api
+external storage api
 '''
 
 ["CDC:ErrScanLockFailed"]

--- a/metrics/grafana/ticdc.json
+++ b/metrics/grafana/ticdc.json
@@ -20704,6 +20704,104 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "Redo bgUpdateLog worker busy ratio",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 106
+          },
+          "hiddenSeries": false,
+          "id": 723,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(rate(ticdc_redo_worker_busy_ratio{k8s_cluster=\"$k8s_cluster\",tidb_cluster=\"$tidb_cluster\",changefeed=~\"$changefeed\",instance=~\"$ticdc_instance\"}[1m])/10) by (changefeed,instance)",
+              "interval": "",
+              "legendFormat": "{{changefeed}}-{{instance}}",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Worker Busy Ratio",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "title": "Redo",

--- a/pkg/config/consistent.go
+++ b/pkg/config/consistent.go
@@ -22,9 +22,10 @@ import (
 )
 
 const (
-	// MinFlushIntervalInMs is the minimum value of flush interval, which is set
-	// to two seconds to reduce the frequency of accessing external storage.
-	MinFlushIntervalInMs = 2000
+	// DefaultFlushIntervalInMs is the default flush interval for redo log.
+	DefaultFlushIntervalInMs = 2000
+	// minFlushIntervalInMs is the minimum flush interval for redo log.
+	minFlushIntervalInMs = 50
 )
 
 // ConsistentConfig represents replication consistency config for a changefeed.
@@ -41,10 +42,14 @@ func (c *ConsistentConfig) ValidateAndAdjust() error {
 		return nil
 	}
 
-	if c.FlushIntervalInMs < MinFlushIntervalInMs {
+	if c.FlushIntervalInMs == 0 {
+		c.FlushIntervalInMs = DefaultFlushIntervalInMs
+	}
+
+	if c.FlushIntervalInMs < minFlushIntervalInMs {
 		return cerror.ErrInvalidReplicaConfig.FastGenByArgs(
 			fmt.Sprintf("The consistent.flush-interval:%d must be equal or greater than %d",
-				c.FlushIntervalInMs, MinFlushIntervalInMs))
+				c.FlushIntervalInMs, minFlushIntervalInMs))
 	}
 
 	uri, err := storage.ParseRawURL(c.Storage)

--- a/pkg/config/replica_config.go
+++ b/pkg/config/replica_config.go
@@ -63,7 +63,7 @@ var defaultReplicaConfig = &ReplicaConfig{
 	Consistent: &ConsistentConfig{
 		Level:             "none",
 		MaxLogSize:        64,
-		FlushIntervalInMs: MinFlushIntervalInMs,
+		FlushIntervalInMs: DefaultFlushIntervalInMs,
 		Storage:           "",
 	},
 	Scheduler: &ChangefeedSchedulerConfig{

--- a/pkg/errors/cdc_errors.go
+++ b/pkg/errors/cdc_errors.go
@@ -299,8 +299,8 @@ var (
 		"rawData size %d exceeds maximum file size %d",
 		errors.RFCCodeText("CDC:ErrFileSizeExceed"),
 	)
-	ErrS3StorageAPI = errors.Normalize(
-		"s3 storage api",
+	ErrExternalStorageAPI = errors.Normalize(
+		"external storage api",
 		errors.RFCCodeText("CDC:ErrS3StorageAPI"),
 	)
 	ErrStorageInitialize = errors.Normalize(

--- a/pkg/redo/config.go
+++ b/pkg/redo/config.go
@@ -39,8 +39,6 @@ const (
 	LogEXT = ".log"
 	// MetaEXT is the meta file ext of meta file after safely wrote to disk
 	MetaEXT = ".meta"
-	// MetaTmpEXT is the meta file ext of meta file before safely wrote to disk
-	MetaTmpEXT = ".mtmp"
 	// SortLogEXT is the sorted log file ext of log file after safely wrote to disk
 	SortLogEXT = ".sort"
 
@@ -202,6 +200,9 @@ const (
 	// RedoLogFileFormatV2 is available since v6.1.0, which contains namespace information
 	// layout: captureID_namespace_changefeedID_fileType_maxEventCommitTs_uuid.fileExtName
 	RedoLogFileFormatV2 = "%s_%s_%s_%s_%d_%s%s"
+	// RedoMetaFileFormat is the format of redo meta file, which contains namespace information.
+	// layout: captureID_namespace_changefeedID_fileType_uuid.fileExtName
+	RedoMetaFileFormat = "%s_%s_%s_%s_%s%s"
 )
 
 // logFormat2ParseFormat converts redo log file name format to the space separated


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8074, close #8028

### What is changed and how it works?
1. Use uuid in redo meta filename to avoid frequent access to the same object.
2. Add metricRedoWorkerBusyRatio to redoManager.
![image](https://user-images.githubusercontent.com/61726649/213391713-2ced7f05-be4a-4083-a751-6072ee69044a.png)

4. Fix the limit on flush-interval.
5. Add test.Dockerfile facilitate testing. 

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
