### PR TITLE
sinkv2(ticdc): remove useless event ID in the table sink

### DIFF
--- a/cdc/sinkv2/tablesink/table_sink_impl.go
+++ b/cdc/sinkv2/tablesink/table_sink_impl.go
@@ -38,7 +38,6 @@ var (
 type EventTableSink[E eventsink.TableEvent] struct {
 	changefeedID    model.ChangeFeedID
 	span            tablepb.Span
-	eventID         uint64
 	maxResolvedTs   model.ResolvedTs
 	backendSink     eventsink.EventSink[E]
 	progressTracker *progressTracker
@@ -62,7 +61,6 @@ func New[E eventsink.TableEvent](
 	return &EventTableSink[E]{
 		changefeedID:              changefeedID,
 		span:                      span,
-		eventID:                   0,
 		maxResolvedTs:             model.NewResolvedTs(0),
 		backendSink:               backendSink,
 		progressTracker:           newProgressTracker(span, defaultBufferSize),

--- a/cdc/sinkv2/tablesink/table_sink_impl_test.go
+++ b/cdc/sinkv2/tablesink/table_sink_impl_test.go
@@ -159,7 +159,6 @@ func TestNewEventTableSink(t *testing.T) {
 		model.DefaultChangeFeedID("1"), spanz.TableIDToComparableSpan(1),
 		sink, &eventsink.TxnEventAppender{}, prometheus.NewCounter(prometheus.CounterOpts{}))
 
-	require.Equal(t, uint64(0), tb.eventID, "eventID should start from 0")
 	require.Equal(t, model.NewResolvedTs(0), tb.maxResolvedTs, "maxResolvedTs should start from 0")
 	require.NotNil(t, sink, tb.backendSink, "backendSink should be set")
 	require.NotNil(t, tb.progressTracker, "progressTracker should be set")


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref https://github.com/pingcap/tiflow/issues/4954

### What is changed and how it works?
remove useless event ID in the table sink

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
