### PR TITLE
pkg/sink(ticdc): make require acks configuration configurable

### DIFF
--- a/cdc/sink/mq/producer/kafka/kafka.go
+++ b/cdc/sink/mq/producer/kafka/kafka.go
@@ -342,9 +342,14 @@ func AdjustOptions(
 		return errors.Trace(err)
 	}
 
-	err = validateMinInsyncReplicas(ctx, admin, topics, topic, int(options.ReplicationFactor))
-	if err != nil {
-		return errors.Trace(err)
+	// Only check replicationFactor >= minInsyncReplicas when producer's required acks is -1.
+	// If we don't check it, the producer probably can not send message to the topic.
+	// Because it will wait for the ack from all replicas. But we do not have enough replicas.
+	if options.RequiredAcks == kafka.WaitForAll {
+		err = validateMinInsyncReplicas(ctx, admin, topics, topic, int(options.ReplicationFactor))
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	info, exists := topics[topic]
@@ -422,7 +427,9 @@ func AdjustOptions(
 func validateMinInsyncReplicas(
 	ctx context.Context,
 	admin kafka.ClusterAdminClient,
-	topics map[string]kafka.TopicDetail, topic string, replicationFactor int,
+	topics map[string]kafka.TopicDetail,
+	topic string,
+	replicationFactor int,
 ) error {
 	minInsyncReplicasConfigGetter := func() (string, bool, error) {
 		info, exists := topics[topic]
@@ -450,6 +457,11 @@ func validateMinInsyncReplicas(
 	if err != nil {
 		// 'min.insync.replica' is invisible to us in Confluent Cloud Kafka.
 		if cerror.ErrKafkaBrokerConfigNotFound.Equal(err) {
+			log.Warn("TiCDC cannot find `min.insync.replicas` from broker's configuration, " +
+				"please make sure that the replication factor is greater than or equal " +
+				"to the minimum number of in-sync replicas" +
+				"if you want to use `required-acks` = -1." +
+				"Otherwise, TiCDC will not be able to send messages to the topic.")
 			return nil
 		}
 		return err
@@ -471,8 +483,9 @@ func validateMinInsyncReplicas(
 			zap.Int("min.insync.replicas", minInsyncReplicas))
 		return cerror.ErrKafkaInvalidConfig.GenWithStack(
 			"TiCDC Kafka producer's `request.required.acks` defaults to -1, "+
-				"TiCDC cannot deliver messages when the `replication-factor` "+
-				"is smaller than the `min.insync.replicas` of %s", configFrom,
+				"TiCDC cannot deliver messages when the `replication-factor` %d "+
+				"is smaller than the `min.insync.replicas` %d of %s",
+			replicationFactor, minInsyncReplicas, configFrom,
 		)
 	}
 

--- a/cdc/sink/mq/producer/kafka/kafka_test.go
+++ b/cdc/sink/mq/producer/kafka/kafka_test.go
@@ -292,7 +292,7 @@ func TestAdjustConfigMinInsyncReplicas(t *testing.T) {
 	)
 	require.Regexp(
 		t,
-		".*`replication-factor` is smaller than the `min.insync.replicas` of broker.*",
+		".*`replication-factor` 1 is smaller than the `min.insync.replicas` 2 of broker.*",
 		errors.Cause(err),
 	)
 
@@ -325,9 +325,30 @@ func TestAdjustConfigMinInsyncReplicas(t *testing.T) {
 	adminClient.SetMinInsyncReplicas("2")
 	err = AdjustOptions(ctx, adminClient, options, adminClient.GetDefaultMockTopicName())
 	require.Regexp(t,
-		".*`replication-factor` is smaller than the `min.insync.replicas` of topic.*",
+		".*`replication-factor` 1 is smaller than the `min.insync.replicas` 2 of topic.*",
 		errors.Cause(err),
 	)
+}
+
+func TestSkipAdjustConfigMinInsyncReplicasWhenRequiredAcksIsNotWailAll(t *testing.T) {
+	adminClient := kafka.NewClusterAdminClientMockImpl()
+	defer func() {
+		_ = adminClient.Close()
+	}()
+
+	options := kafka.NewOptions()
+	options.BrokerEndpoints = []string{"127.0.0.1:9092"}
+	options.RequiredAcks = kafka.WaitForLocal
+
+	// Do not report an error if the replication-factor is less than min.insync.replicas(1<2).
+	adminClient.SetMinInsyncReplicas("2")
+	err := AdjustOptions(
+		context.Background(),
+		adminClient,
+		options,
+		"skip-check-min-insync-replicas",
+	)
+	require.Nil(t, err, "Should not report an error when `required-acks` is not `all`")
 }
 
 func TestCreateProducerFailed(t *testing.T) {

--- a/errors.toml
+++ b/errors.toml
@@ -586,6 +586,11 @@ error = '''
 invalid partition num %d
 '''
 
+["CDC:ErrKafkaInvalidRequiredAcks"]
+error = '''
+invalid required acks %d, only support these values: 0(NoResponse),1(WaitForLocal) and -1(WaitForAll)
+'''
+
 ["CDC:ErrKafkaInvalidVersion"]
 error = '''
 invalid kafka version

--- a/pkg/errors/cdc_errors.go
+++ b/pkg/errors/cdc_errors.go
@@ -240,6 +240,11 @@ var (
 		"invalid partition num %d",
 		errors.RFCCodeText("CDC:ErrKafkaInvalidPartitionNum"),
 	)
+	ErrKafkaInvalidRequiredAcks = errors.Normalize(
+		"invalid required acks %d, "+
+			"only support these values: 0(NoResponse),1(WaitForLocal) and -1(WaitForAll)",
+		errors.RFCCodeText("CDC:ErrKafkaInvalidRequiredAcks"),
+	)
 	ErrKafkaNewProducer = errors.Normalize(
 		"new kafka producer",
 		errors.RFCCodeText("CDC:ErrKafkaNewProducer"),

--- a/pkg/sink/kafka/sarama.go
+++ b/pkg/sink/kafka/sarama.go
@@ -89,7 +89,7 @@ func NewSaramaConfig(ctx context.Context, o *Options) (*sarama.Config, error) {
 	config.Producer.MaxMessageBytes = o.MaxMessageBytes
 	config.Producer.Return.Successes = true
 	config.Producer.Return.Errors = true
-	config.Producer.RequiredAcks = sarama.WaitForAll
+	config.Producer.RequiredAcks = sarama.RequiredAcks(o.RequiredAcks)
 	compression := strings.ToLower(strings.TrimSpace(o.Compression))
 	switch compression {
 	case "none":


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem. 

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/8098

### What is changed and how it works?

- make required acks configuration configurable, please see https://github.com/pingcap/tiflow/issues/8098#issuecomment-1411652359
- skip check `min.insync.replicas` if required acks is not all, please see https://github.com/pingcap/tiflow/issues/8098#issuecomment-1411655843
- add a warning if TiCDC can not find the `min.insync.replicate` configuration, please see https://github.com/pingcap/tiflow/issues/8098#issuecomment-1413109862

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - [x] Unit test
 - [x] Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
Yes, I'll update it later.
### Release note <!-- bugfixes or new features need a release note -->

```release-note
Make Kafka producer's required acks configuration configurable
```
