### PR TITLE
kafka(ticdc): simplify the client interface by remove partition and topic methods

### DIFF
--- a/cdc/sink/mq/manager/kafka_manager_test.go
+++ b/cdc/sink/mq/manager/kafka_manager_test.go
@@ -25,7 +25,6 @@ import (
 func TestPartitions(t *testing.T) {
 	t.Parallel()
 
-	client := kafka.NewClientMockImpl()
 	adminClient := kafka.NewClusterAdminClientMockImpl()
 	defer func(adminClient *kafka.ClusterAdminClientMockImpl) {
 		_ = adminClient.Close()
@@ -37,7 +36,7 @@ func TestPartitions(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	manager, err := NewKafkaTopicManager(ctx, client, adminClient, cfg)
+	manager, err := NewKafkaTopicManager(ctx, adminClient, cfg)
 	require.Nil(t, err)
 	partitionsNum, err := manager.GetPartitionNum(
 		ctx,
@@ -61,7 +60,7 @@ func TestTryRefreshMeta(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	manager, err := NewKafkaTopicManager(ctx, client, adminClient, cfg)
+	manager, err := NewKafkaTopicManager(ctx, adminClient, cfg)
 	require.Nil(t, err)
 	partitionsNum, err := manager.GetPartitionNum(
 		ctx,
@@ -87,7 +86,6 @@ func TestTryRefreshMeta(t *testing.T) {
 func TestCreateTopic(t *testing.T) {
 	t.Parallel()
 
-	client := kafka.NewClientMockImpl()
 	adminClient := kafka.NewClusterAdminClientMockImpl()
 	defer func(adminClient *kafka.ClusterAdminClientMockImpl) {
 		_ = adminClient.Close()
@@ -100,7 +98,7 @@ func TestCreateTopic(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	manager, err := NewKafkaTopicManager(ctx, client, adminClient, cfg)
+	manager, err := NewKafkaTopicManager(ctx, adminClient, cfg)
 	require.Nil(t, err)
 	partitionNum, err := manager.createTopic(ctx, kafka.DefaultMockTopicName)
 	require.Nil(t, err)
@@ -115,7 +113,7 @@ func TestCreateTopic(t *testing.T) {
 
 	// Try to create a topic without auto create.
 	cfg.AutoCreate = false
-	manager, err = NewKafkaTopicManager(ctx, client, adminClient, cfg)
+	manager, err = NewKafkaTopicManager(ctx, adminClient, cfg)
 	require.Nil(t, err)
 	_, err = manager.createTopic(ctx, "new-topic2")
 	require.Regexp(
@@ -131,7 +129,7 @@ func TestCreateTopic(t *testing.T) {
 		PartitionNum:      2,
 		ReplicationFactor: 4,
 	}
-	manager, err = NewKafkaTopicManager(ctx, client, adminClient, cfg)
+	manager, err = NewKafkaTopicManager(ctx, adminClient, cfg)
 	require.Nil(t, err)
 	_, err = manager.createTopic(ctx, "new-topic-failed")
 	require.Regexp(
@@ -144,7 +142,6 @@ func TestCreateTopic(t *testing.T) {
 func TestCreateTopicWithDelay(t *testing.T) {
 	t.Parallel()
 
-	client := kafka.NewClientMockImpl()
 	adminClient := kafka.NewClusterAdminClientMockImpl()
 	defer func(adminClient *kafka.ClusterAdminClientMockImpl) {
 		_ = adminClient.Close()
@@ -156,7 +153,7 @@ func TestCreateTopicWithDelay(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	manager, err := NewKafkaTopicManager(ctx, client, adminClient, cfg)
+	manager, err := NewKafkaTopicManager(ctx, adminClient, cfg)
 	require.Nil(t, err)
 	partitionNum, err := manager.createTopic(ctx, "new_topic")
 	require.Nil(t, err)

--- a/cdc/sink/mq/manager/kafka_manager_test.go
+++ b/cdc/sink/mq/manager/kafka_manager_test.go
@@ -48,7 +48,6 @@ func TestPartitions(t *testing.T) {
 func TestTryRefreshMeta(t *testing.T) {
 	t.Parallel()
 
-	client := kafka.NewClientMockImpl()
 	adminClient := kafka.NewClusterAdminClientMockImpl()
 	defer func(adminClient *kafka.ClusterAdminClientMockImpl) {
 		_ = adminClient.Close()
@@ -69,7 +68,11 @@ func TestTryRefreshMeta(t *testing.T) {
 	require.Equal(t, int32(3), partitionsNum)
 
 	// Mock create a topic.
-	client.AddTopic("test", 4)
+	adminClient.CreateTopic(ctx, &kafka.TopicDetail{
+		Name:          "test",
+		NumPartitions: 4,
+	}, false)
+
 	manager.lastMetadataRefresh.Store(time.Now().Add(-2 * time.Minute).Unix())
 	partitionsNum, err = manager.GetPartitionNum(ctx, "test")
 	require.Nil(t, err)
@@ -77,7 +80,7 @@ func TestTryRefreshMeta(t *testing.T) {
 
 	// Mock delete a topic.
 	// NOTICE: we do not refresh metadata for the deleted topic.
-	client.DeleteTopic("test")
+	adminClient.DeleteTopic("test")
 	partitionsNum, err = manager.GetPartitionNum(ctx, "test")
 	require.Nil(t, err)
 	require.Equal(t, int32(4), partitionsNum)

--- a/cdc/sink/mq/mq.go
+++ b/cdc/sink/mq/mq.go
@@ -433,7 +433,6 @@ func NewKafkaSink(ctx context.Context, sinkURI *url.URL,
 
 	topicManager, err := manager.NewKafkaTopicManager(
 		ctx,
-		client,
 		adminClient,
 		options.DeriveTopicConfig(),
 	)

--- a/cdc/sinkv2/ddlsink/mq/kafka_ddl_sink.go
+++ b/cdc/sinkv2/ddlsink/mq/kafka_ddl_sink.go
@@ -98,7 +98,6 @@ func NewKafkaDDLSink(
 		ctx,
 		topic,
 		options.DeriveTopicConfig(),
-		client,
 		adminClient,
 	)
 	if err != nil {

--- a/cdc/sinkv2/eventsink/mq/kafka_dml_sink.go
+++ b/cdc/sinkv2/eventsink/mq/kafka_dml_sink.go
@@ -97,7 +97,6 @@ func NewKafkaDMLSink(
 		ctx,
 		topic,
 		options.DeriveTopicConfig(),
-		client,
 		adminClient,
 	)
 	if err != nil {

--- a/cdc/sinkv2/util/helper.go
+++ b/cdc/sinkv2/util/helper.go
@@ -91,12 +91,10 @@ func GetTopicManagerAndTryCreateTopic(
 	ctx context.Context,
 	topic string,
 	topicCfg *kafka.AutoCreateTopicConfig,
-	client kafka.Client,
 	adminClient kafka.ClusterAdminClient,
 ) (manager.TopicManager, error) {
 	topicManager, err := manager.NewKafkaTopicManager(
 		ctx,
-		client,
 		adminClient,
 		topicCfg,
 	)

--- a/pkg/sink/kafka/client.go
+++ b/pkg/sink/kafka/client.go
@@ -27,12 +27,6 @@ import (
 
 // Client is a generic Kafka client.
 type Client interface {
-	// Topics returns the set of available
-	// topics as retrieved from cluster metadata.
-	Topics() ([]string, error)
-	// Partitions returns the sorted list of
-	// all partition IDs for the given topic.
-	Partitions(topic string) ([]int32, error)
 	// SyncProducer creates a sync producer to writer message to kafka
 	SyncProducer() (SyncProducer, error)
 	// AsyncProducer creates an async producer to writer message to kafka
@@ -95,16 +89,6 @@ type AsyncProducer interface {
 
 type saramaKafkaClient struct {
 	client sarama.Client
-}
-
-func (c *saramaKafkaClient) Topics() ([]string, error) {
-	return c.client.Topics()
-}
-
-// Partitions returns the sorted list of
-// all partition IDs for the given topic.
-func (c *saramaKafkaClient) Partitions(topic string) ([]int32, error) {
-	return c.client.Partitions(topic)
 }
 
 func (c *saramaKafkaClient) SyncProducer() (SyncProducer, error) {

--- a/pkg/sink/kafka/client_mock_impl.go
+++ b/pkg/sink/kafka/client_mock_impl.go
@@ -32,20 +32,6 @@ func NewClientMockImpl() *ClientMockImpl {
 	}
 }
 
-// Partitions returns the partitions of the given topic.
-func (c *ClientMockImpl) Partitions(topic string) ([]int32, error) {
-	return c.topics[topic], nil
-}
-
-// Topics returns the all topics.
-func (c *ClientMockImpl) Topics() ([]string, error) {
-	var topics []string
-	for topic := range c.topics {
-		topics = append(topics, topic)
-	}
-	return topics, nil
-}
-
 // AddTopic adds a topic.
 func (c *ClientMockImpl) AddTopic(topicName string, partitions int32) {
 	p := make([]int32, partitions)

--- a/pkg/sink/kafka/client_mock_impl.go
+++ b/pkg/sink/kafka/client_mock_impl.go
@@ -19,31 +19,11 @@ import (
 )
 
 // ClientMockImpl is a mock implementation of Client interface.
-type ClientMockImpl struct {
-	topics map[string][]int32
-}
+type ClientMockImpl struct{}
 
 // NewClientMockImpl creates a new ClientMockImpl instance.
 func NewClientMockImpl() *ClientMockImpl {
-	topics := make(map[string][]int32)
-	topics[DefaultMockTopicName] = []int32{0, 1, 2}
-	return &ClientMockImpl{
-		topics: topics,
-	}
-}
-
-// AddTopic adds a topic.
-func (c *ClientMockImpl) AddTopic(topicName string, partitions int32) {
-	p := make([]int32, partitions)
-	for i := int32(0); i < partitions; i++ {
-		p[i] = i
-	}
-	c.topics[topicName] = p
-}
-
-// DeleteTopic deletes a topic.
-func (c *ClientMockImpl) DeleteTopic(topicName string) {
-	delete(c.topics, topicName)
+	return &ClientMockImpl{}
 }
 
 // SyncProducer creates a sync producer

--- a/pkg/sink/kafka/cluster_admin_client_mock_impl.go
+++ b/pkg/sink/kafka/cluster_admin_client_mock_impl.go
@@ -184,6 +184,11 @@ func (c *ClusterAdminClientMockImpl) CreateTopic(
 	return nil
 }
 
+// DeleteTopic deletes a topic, only used for testing.
+func (c *ClusterAdminClientMockImpl) DeleteTopic(topicName string) {
+	delete(c.topics, topicName)
+}
+
 // Close do nothing.
 func (c *ClusterAdminClientMockImpl) Close() error {
 	return nil

--- a/pkg/sink/kafka/v2/kafka-go-client.go
+++ b/pkg/sink/kafka/v2/kafka-go-client.go
@@ -30,7 +30,6 @@ import (
 	"github.com/segmentio/kafka-go/sasl"
 	"github.com/segmentio/kafka-go/sasl/plain"
 	"github.com/segmentio/kafka-go/sasl/scram"
-	"github.com/segmentio/kafka-go/topics"
 	"go.uber.org/zap"
 )
 
@@ -122,40 +121,6 @@ func completeSASLConfig(o *pkafka.Options) (sasl.Mechanism, error) {
 		}
 	}
 	return nil, nil
-}
-
-// Topics returns the set of available
-// topics as retrieved from cluster metadata.
-func (k *kafkaGoClient) Topics() ([]string, error) {
-	ts, err := topics.List(context.Background(), k.client)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	topicList := make([]string, 0, len(ts))
-	for _, t := range ts {
-		topicList = append(topicList, t.Name)
-	}
-	return topicList, nil
-}
-
-// Partitions returns the sorted list of
-// all partition IDs for the given topic.
-func (k *kafkaGoClient) Partitions(topic string) ([]int32, error) {
-	response, err := k.client.Metadata(context.Background(), &kafka.MetadataRequest{
-		Addr:   k.client.Addr,
-		Topics: []string{topic},
-	})
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if len(response.Topics) != 1 {
-		return nil, errors.New("failed to describe topic " + topic)
-	}
-	partitions := make([]int32, 0, len(response.Topics[0].Partitions))
-	for _, partition := range response.Topics[0].Partitions {
-		partitions = append(partitions, int32(partition.ID))
-	}
-	return partitions, nil
 }
 
 func (k *kafkaGoClient) createWriter() *kafka.Writer {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8164 

### What is changed and how it works?

* `Partitions` and `Topic` methods removed from the `Client` interface


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
