### PR TITLE
redo(ticdc): set default timeout for accessing external storage to 15 minutes

### DIFF
--- a/cdc/redo/writer/writer.go
+++ b/cdc/redo/writer/writer.go
@@ -21,17 +21,15 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tiflow/cdc/contextutil"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/redo/common"
 	"github.com/pingcap/tiflow/pkg/config"
-	cerror "github.com/pingcap/tiflow/pkg/errors"
+	"github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/redo"
+	"github.com/pingcap/tiflow/pkg/util"
 	"github.com/pingcap/tiflow/pkg/uuid"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -77,7 +75,7 @@ func NewRedoLogWriter(
 
 	scheme := uri.Scheme
 	if !redo.IsValidConsistentStorage(scheme) {
-		return nil, cerror.ErrConsistentStorage.GenWithStackByArgs(scheme)
+		return nil, errors.ErrConsistentStorage.GenWithStackByArgs(scheme)
 	}
 	if redo.IsBlackholeStorage(scheme) {
 		return NewBlackHoleWriter(), nil
@@ -142,7 +140,8 @@ func newLogWriter(
 	ctx context.Context, cfg *logWriterConfig, opts ...Option,
 ) (lw *logWriter, err error) {
 	if cfg == nil {
-		return nil, cerror.WrapError(cerror.ErrRedoConfigInvalid, errors.New("LogWriterConfig can not be nil"))
+		err := errors.New("LogWriterConfig can not be nil")
+		return nil, errors.WrapError(errors.ErrRedoConfigInvalid, err)
 	}
 
 	lw = &logWriter{cfg: cfg}
@@ -215,7 +214,7 @@ func newLogWriter(
 func (l *logWriter) preCleanUpS3(ctx context.Context) error {
 	ret, err := l.extStorage.FileExists(ctx, l.getDeletedChangefeedMarker())
 	if err != nil {
-		return cerror.WrapError(cerror.ErrExternalStorageAPI, err)
+		return errors.WrapError(errors.ErrExternalStorageAPI, err)
 	}
 	if !ret {
 		return nil
@@ -237,8 +236,8 @@ func (l *logWriter) preCleanUpS3(ctx context.Context) error {
 		return err
 	}
 	err = l.extStorage.DeleteFile(ctx, l.getDeletedChangefeedMarker())
-	if !isNotExistInS3(err) {
-		return cerror.WrapError(cerror.ErrExternalStorageAPI, err)
+	if !util.IsNotExistInExtStorage(err) {
+		return errors.WrapError(errors.ErrExternalStorageAPI, err)
 	}
 
 	return nil
@@ -258,12 +257,13 @@ func (l *logWriter) initMeta(ctx context.Context) error {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return cerror.WrapError(cerror.ErrRedoMetaInitialize, errors.Annotate(err, "read meta file fail"))
+		err = errors.Annotate(err, "read meta file fail")
+		return errors.WrapError(errors.ErrRedoMetaInitialize, err)
 	}
 
 	_, err = l.meta.UnmarshalMsg(data)
 	if err != nil {
-		return cerror.WrapError(cerror.ErrRedoMetaInitialize, err)
+		return errors.WrapError(errors.ErrRedoMetaInitialize, err)
 	}
 
 	return nil
@@ -290,7 +290,7 @@ func (l *logWriter) WriteLog(ctx context.Context, rows []*model.RedoRowChangedEv
 	}
 
 	if l.isStopped() {
-		return cerror.ErrRedoWriterStopped.GenWithStackByArgs()
+		return errors.ErrRedoWriterStopped.GenWithStackByArgs()
 	}
 	if len(rows) == 0 {
 		return nil
@@ -304,7 +304,7 @@ func (l *logWriter) WriteLog(ctx context.Context, rows []*model.RedoRowChangedEv
 		rl := &model.RedoLog{RedoRow: r, Type: model.RedoLogTypeRow}
 		data, err := rl.MarshalMsg(nil)
 		if err != nil {
-			return cerror.WrapError(cerror.ErrMarshalFailed, err)
+			return errors.WrapError(errors.ErrMarshalFailed, err)
 		}
 
 		l.rowWriter.AdvanceTs(r.Row.CommitTs)
@@ -325,7 +325,7 @@ func (l *logWriter) SendDDL(ctx context.Context, ddl *model.RedoDDLEvent) error 
 	}
 
 	if l.isStopped() {
-		return cerror.ErrRedoWriterStopped.GenWithStackByArgs()
+		return errors.ErrRedoWriterStopped.GenWithStackByArgs()
 	}
 	if ddl == nil || ddl.DDL == nil {
 		return nil
@@ -334,7 +334,7 @@ func (l *logWriter) SendDDL(ctx context.Context, ddl *model.RedoDDLEvent) error 
 	rl := &model.RedoLog{RedoDDL: ddl, Type: model.RedoLogTypeDDL}
 	data, err := rl.MarshalMsg(nil)
 	if err != nil {
-		return cerror.WrapError(cerror.ErrMarshalFailed, err)
+		return errors.WrapError(errors.ErrMarshalFailed, err)
 	}
 
 	l.ddlWriter.AdvanceTs(ddl.DDL.CommitTs)
@@ -351,10 +351,10 @@ func (l *logWriter) FlushLog(ctx context.Context, checkpointTs, resolvedTs model
 	}
 
 	if l.isStopped() {
-		return cerror.ErrRedoWriterStopped.GenWithStackByArgs()
+		return errors.ErrRedoWriterStopped.GenWithStackByArgs()
 	}
 
-	return l.flush(checkpointTs, resolvedTs)
+	return l.flush(ctx, checkpointTs, resolvedTs)
 }
 
 // GetMeta implement GetMeta api
@@ -377,7 +377,7 @@ func (l *logWriter) DeleteAllLogs(ctx context.Context) (err error) {
 			log.Warn("read removed log dir fail", zap.Error(err))
 			return nil
 		}
-		return cerror.WrapError(cerror.ErrRedoFileOp,
+		return errors.WrapError(errors.ErrRedoFileOp,
 			errors.Annotatef(err, "can't read log file directory: %s", l.cfg.Dir))
 	}
 
@@ -393,7 +393,7 @@ func (l *logWriter) DeleteAllLogs(ctx context.Context) (err error) {
 				log.Warn("removed log dir fail", zap.Error(err))
 				return nil
 			}
-			return cerror.WrapError(cerror.ErrRedoFileOp, err)
+			return errors.WrapError(errors.ErrRedoFileOp, err)
 		}
 	} else {
 		for _, file := range filteredFiles {
@@ -402,7 +402,7 @@ func (l *logWriter) DeleteAllLogs(ctx context.Context) (err error) {
 					log.Warn("removed log dir fail", zap.Error(err))
 					return nil
 				}
-				return cerror.WrapError(cerror.ErrRedoFileOp, err)
+				return errors.WrapError(errors.ErrRedoFileOp, err)
 			}
 		}
 	}
@@ -439,7 +439,7 @@ func (l *logWriter) getDeletedChangefeedMarker() string {
 }
 
 func (l *logWriter) writeDeletedMarkerToS3(ctx context.Context) error {
-	return cerror.WrapError(cerror.ErrExternalStorageAPI,
+	return errors.WrapError(errors.ErrExternalStorageAPI,
 		l.extStorage.WriteFile(ctx, l.getDeletedChangefeedMarker(), []byte("D")))
 }
 
@@ -451,27 +451,14 @@ func (l *logWriter) deleteFilesInS3(ctx context.Context, files []string) error {
 			err := l.extStorage.DeleteFile(eCtx, name)
 			if err != nil {
 				// if fail then retry, may end up with notExit err, ignore the error
-				if !isNotExistInS3(err) {
-					return cerror.WrapError(cerror.ErrExternalStorageAPI, err)
+				if !util.IsNotExistInExtStorage(err) {
+					return errors.WrapError(errors.ErrExternalStorageAPI, err)
 				}
 			}
 			return nil
 		})
 	}
 	return eg.Wait()
-}
-
-func isNotExistInS3(err error) bool {
-	// TODO: support other storage
-	if err != nil {
-		if aerr, ok := errors.Cause(err).(awserr.Error); ok { // nolint:errorlint
-			switch aerr.Code() {
-			case s3.ErrCodeNoSuchKey:
-				return true
-			}
-		}
-	}
-	return false
 }
 
 var getAllFilesInS3 = func(ctx context.Context, l *logWriter) ([]string, error) {
@@ -481,7 +468,7 @@ var getAllFilesInS3 = func(ctx context.Context, l *logWriter) ([]string, error) 
 		return nil
 	})
 	if err != nil {
-		return nil, cerror.WrapError(cerror.ErrExternalStorageAPI, err)
+		return nil, errors.WrapError(errors.ErrExternalStorageAPI, err)
 	}
 
 	return files, nil
@@ -502,7 +489,7 @@ func (l *logWriter) Close() (err error) {
 }
 
 // flush flushes all the buffered data to the disk.
-func (l *logWriter) flush(checkpointTs, resolvedTs model.Ts) (err error) {
+func (l *logWriter) flush(ctx context.Context, checkpointTs, resolvedTs model.Ts) (err error) {
 	if l.cfg.EmitDDLEvents {
 		err = multierr.Append(err, l.ddlWriter.Flush())
 	}
@@ -510,7 +497,7 @@ func (l *logWriter) flush(checkpointTs, resolvedTs model.Ts) (err error) {
 		err = multierr.Append(err, l.rowWriter.Flush())
 	}
 	if l.cfg.EmitMeta {
-		err = multierr.Append(err, l.flushLogMeta(checkpointTs, resolvedTs))
+		err = multierr.Append(err, l.flushLogMeta(ctx, checkpointTs, resolvedTs))
 	}
 	return
 }
@@ -556,12 +543,12 @@ func (l *logWriter) maybeUpdateMeta(checkpointTs, resolvedTs uint64) ([]byte, er
 
 	data, err := l.meta.MarshalMsg(nil)
 	if err != nil {
-		err = cerror.WrapError(cerror.ErrMarshalFailed, err)
+		err = errors.WrapError(errors.ErrMarshalFailed, err)
 	}
 	return data, err
 }
 
-func (l *logWriter) flushLogMeta(checkpointTs, resolvedTs uint64) error {
+func (l *logWriter) flushLogMeta(ctx context.Context, checkpointTs, resolvedTs uint64) error {
 	data, err := l.maybeUpdateMeta(checkpointTs, resolvedTs)
 	if err != nil {
 		return err
@@ -573,34 +560,31 @@ func (l *logWriter) flushLogMeta(checkpointTs, resolvedTs uint64) error {
 	if !l.cfg.UseExternalStorage {
 		return l.flushMetaToLocal(data)
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), defaultS3Timeout)
-	defer cancel()
 	return l.flushMetaToS3(ctx, data)
 }
 
 func (l *logWriter) flushMetaToLocal(data []byte) error {
 	if err := os.MkdirAll(l.cfg.Dir, redo.DefaultDirMode); err != nil {
 		e := errors.Annotate(err, "can't make dir for new redo logfile")
-		return cerror.WrapError(cerror.ErrRedoFileOp, e)
+		return errors.WrapError(errors.ErrRedoFileOp, e)
 	}
 
 	metaFile, err := openTruncFile(l.filePath())
 	if err != nil {
-		return cerror.WrapError(cerror.ErrRedoFileOp, err)
+		return errors.WrapError(errors.ErrRedoFileOp, err)
 	}
 	_, err = metaFile.Write(data)
 	if err != nil {
-		return cerror.WrapError(cerror.ErrRedoFileOp, err)
+		return errors.WrapError(errors.ErrRedoFileOp, err)
 	}
 	err = metaFile.Sync()
 	if err != nil {
-		return cerror.WrapError(cerror.ErrRedoFileOp, err)
+		return errors.WrapError(errors.ErrRedoFileOp, err)
 	}
 
 	if l.preMetaFile != "" {
 		if err := os.Remove(l.preMetaFile); err != nil && !os.IsNotExist(err) {
-			return cerror.WrapError(cerror.ErrRedoFileOp, err)
+			return errors.WrapError(errors.ErrRedoFileOp, err)
 		}
 	}
 	l.preMetaFile = metaFile.Name()
@@ -612,12 +596,17 @@ func (l *logWriter) flushMetaToS3(ctx context.Context, data []byte) error {
 	start := time.Now()
 	metaFile := l.getMetafileName()
 	if err := l.extStorage.WriteFile(ctx, metaFile, data); err != nil {
-		return cerror.WrapError(cerror.ErrExternalStorageAPI, err)
+		return errors.WrapError(errors.ErrExternalStorageAPI, err)
 	}
 
 	if l.preMetaFile != "" {
-		if err := l.extStorage.DeleteFile(ctx, l.preMetaFile); err != nil && !isNotExistInS3(err) {
-			return cerror.WrapError(cerror.ErrExternalStorageAPI, err)
+		if l.preMetaFile == metaFile {
+			// This should only happen when use a constant uuid generator in test.
+			return nil
+		}
+		err := l.extStorage.DeleteFile(ctx, l.preMetaFile)
+		if err != nil && !util.IsNotExistInExtStorage(err) {
+			return errors.WrapError(errors.ErrExternalStorageAPI, err)
 		}
 	}
 	l.preMetaFile = metaFile

--- a/engine/pkg/externalresource/internal/s3/storage_factory.go
+++ b/engine/pkg/externalresource/internal/s3/storage_factory.go
@@ -91,7 +91,7 @@ func GetExternalStorageFromURI(
 	}
 
 	// Note that we may have network I/O here.
-	ret, err := util.GetExternalStorage(ctx, uri, opts)
+	ret, err := util.GetExternalStorage(ctx, uri, opts, util.DefaultS3Retryer())
 	if err != nil {
 		retErr := errors.ErrFailToCreateExternalStorage.Wrap(errors.Trace(err))
 		return nil, retErr.GenWithStackByArgs("creating ExternalStorage for s3")

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/pingcap/tiflow
 go 1.19
 
 require (
+	cloud.google.com/go/storage v1.27.0
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.2.0
 	github.com/BurntSushi/toml v1.2.1
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/Shopify/sarama v1.36.0
@@ -114,11 +116,9 @@ require (
 	cloud.google.com/go/compute v1.13.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.1 // indirect
 	cloud.google.com/go/iam v0.8.0 // indirect
-	cloud.google.com/go/storage v1.27.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.20.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.8.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.2.0 // indirect
 	github.com/DataDog/zstd v1.4.6-0.20210211175136-c6db21d202f4 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect

--- a/pkg/util/external_storage.go
+++ b/pkg/util/external_storage.go
@@ -15,11 +15,16 @@ package util
 
 import (
 	"context"
+	"os"
 	"strings"
 	"time"
 
+	gcsStorage "cloud.google.com/go/storage"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tiflow/pkg/errors"
@@ -30,12 +35,29 @@ import (
 func GetExternalStorageFromURI(
 	ctx context.Context, uri string,
 ) (storage.ExternalStorage, error) {
-	return GetExternalStorage(ctx, uri, nil)
+	return GetExternalStorage(ctx, uri, nil, DefaultS3Retryer())
+}
+
+// GetExternalStorageWithTimeout creates a new storage.ExternalStorage from a uri
+// without retry. It is the caller's responsibility to set timeout to the context.
+func GetExternalStorageWithTimeout(
+	ctx context.Context, uri string, timeout time.Duration,
+) (storage.ExternalStorage, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	s, err := GetExternalStorage(ctx, uri, nil, nil)
+
+	return &extStorageWithTimeout{
+		ExternalStorage: s,
+		timeout:         timeout,
+	}, err
 }
 
 // GetExternalStorage creates a new storage.ExternalStorage based on the uri and options.
 func GetExternalStorage(
-	ctx context.Context, uri string, opts *storage.BackendOptions,
+	ctx context.Context, uri string,
+	opts *storage.BackendOptions,
+	retryer request.Retryer,
 ) (storage.ExternalStorage, error) {
 	backEnd, err := storage.ParseBackend(uri, opts)
 	if err != nil {
@@ -44,7 +66,7 @@ func GetExternalStorage(
 
 	ret, err := storage.New(ctx, backEnd, &storage.ExternalStorageOptions{
 		SendCredentials: false,
-		S3Retryer:       DefaultS3Retryer(),
+		S3Retryer:       retryer,
 	})
 	if err != nil {
 		retErr := errors.ErrFailToCreateExternalStorage.Wrap(errors.Trace(err))
@@ -89,4 +111,103 @@ func DefaultS3Retryer() request.Retryer {
 			MinThrottleDelay: 2 * time.Second,
 		},
 	}
+}
+
+type extStorageWithTimeout struct {
+	storage.ExternalStorage
+	timeout time.Duration
+}
+
+// WriteFile writes a complete file to storage, similar to os.WriteFile,
+// but WriteFile should be atomic
+func (s *extStorageWithTimeout) WriteFile(ctx context.Context, name string, data []byte) error {
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+	return s.ExternalStorage.WriteFile(ctx, name, data)
+}
+
+// ReadFile reads a complete file from storage, similar to os.ReadFile
+func (s *extStorageWithTimeout) ReadFile(ctx context.Context, name string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+	return s.ExternalStorage.ReadFile(ctx, name)
+}
+
+// FileExists return true if file exists
+func (s *extStorageWithTimeout) FileExists(ctx context.Context, name string) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+	return s.ExternalStorage.FileExists(ctx, name)
+}
+
+// DeleteFile delete the file in storage
+func (s *extStorageWithTimeout) DeleteFile(ctx context.Context, name string) error {
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+	return s.ExternalStorage.DeleteFile(ctx, name)
+}
+
+// Open a Reader by file path. path is relative path to storage base path
+func (s *extStorageWithTimeout) Open(
+	ctx context.Context, path string,
+) (storage.ExternalFileReader, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+	return s.ExternalStorage.Open(ctx, path)
+}
+
+// WalkDir traverse all the files in a dir.
+func (s *extStorageWithTimeout) WalkDir(
+	ctx context.Context, opt *storage.WalkOption, fn func(path string, size int64) error,
+) error {
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+	return s.ExternalStorage.WalkDir(ctx, opt, fn)
+}
+
+// Create opens a file writer by path. path is relative path to storage base path
+func (s *extStorageWithTimeout) Create(
+	ctx context.Context, path string,
+) (storage.ExternalFileWriter, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+	return s.ExternalStorage.Create(ctx, path)
+}
+
+// Rename file name from oldFileName to newFileName
+func (s *extStorageWithTimeout) Rename(
+	ctx context.Context, oldFileName, newFileName string,
+) error {
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+	return s.ExternalStorage.Rename(ctx, oldFileName, newFileName)
+}
+
+// IsNotExistInExtStorage checks if the error is caused by the file not exist in external storage.
+func IsNotExistInExtStorage(err error) bool {
+	if err != nil {
+		if os.IsNotExist(errors.Cause(err)) {
+			return true
+		}
+
+		if aerr, ok := errors.Cause(err).(awserr.Error); ok { // nolint:errorlint
+			switch aerr.Code() {
+			case s3.ErrCodeNoSuchBucket, s3.ErrCodeNoSuchKey, "NotFound":
+				return true
+			}
+		}
+
+		if errors.Cause(err) == gcsStorage.ErrObjectNotExist { // nolint:errorlint
+			return true
+		}
+
+		var errResp *azblob.StorageError
+		if internalErr, ok := err.(*azblob.InternalError); ok && internalErr.As(&errResp) {
+			if errResp.ErrorCode == azblob.StorageErrorCodeBlobNotFound {
+				return true
+			}
+		}
+
+	}
+	return false
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8089 

### What is changed and how it works?
Set the default timeout for accessing external storage to 15 minutes

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test 
 1. run consistent_replicate_storage_s3 test
 2. stop minio manually
 3. sleep 5 minutes
 4. restart minio
 The test passed and the following logs were found:
![image](https://user-images.githubusercontent.com/61726649/217419892-36aa9c17-0c47-4850-a400-08a8d9e4b6c7.png)



#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`Fix the issue that redo log cannot tolerate network faults for more than 6 seconds`.
```
