### PR TITLE
tracker(dm): remove NO_AUTO_CREATE_USER from sql_mode used by dm

### DIFF
--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -89,7 +89,7 @@ type executorContext struct {
 
 var _ sqlexec.RestrictedSQLExecutor = executorContext{}
 
-const defaultSQLMode = "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+const DefaultSQLMode = "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
 
 func (se executorContext) ParseWithParams(context.Context, string, ...interface{}) (ast.StmtNode, error) {
 	return nil, nil
@@ -477,14 +477,14 @@ func (dt *downstreamTracker) getTableInfoByCreateStmt(tctx *tcontext.Context, ta
 
 // initDownStreamTrackerParser init downstream tracker parser by default sql_mode.
 func (dt *downstreamTracker) initDownStreamSQLModeAndParser(tctx *tcontext.Context) error {
-	setSQLMode := fmt.Sprintf("SET SESSION SQL_MODE = '%s'", defaultSQLMode)
+	setSQLMode := fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLMode)
 	_, err := dt.downstreamConn.ExecuteSQL(tctx, nil, []string{setSQLMode})
 	if err != nil {
-		return dmterror.ErrSchemaTrackerCannotSetDownstreamSQLMode.Delegate(err, defaultSQLMode)
+		return dmterror.ErrSchemaTrackerCannotSetDownstreamSQLMode.Delegate(err, DefaultSQLMode)
 	}
-	stmtParser, err := conn.GetParserFromSQLModeStr(defaultSQLMode)
+	stmtParser, err := conn.GetParserFromSQLModeStr(DefaultSQLMode)
 	if err != nil {
-		return dmterror.ErrSchemaTrackerCannotInitDownstreamParser.Delegate(err, defaultSQLMode)
+		return dmterror.ErrSchemaTrackerCannotInitDownstreamParser.Delegate(err, DefaultSQLMode)
 	}
 	dt.stmtParser = stmtParser
 	return nil

--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -89,7 +89,7 @@ type executorContext struct {
 
 var _ sqlexec.RestrictedSQLExecutor = executorContext{}
 
-const DefaultSQLMode = "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+const DefaultSQLModeMySQL80 = "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
 
 func (se executorContext) ParseWithParams(context.Context, string, ...interface{}) (ast.StmtNode, error) {
 	return nil, nil
@@ -477,14 +477,14 @@ func (dt *downstreamTracker) getTableInfoByCreateStmt(tctx *tcontext.Context, ta
 
 // initDownStreamTrackerParser init downstream tracker parser by default sql_mode.
 func (dt *downstreamTracker) initDownStreamSQLModeAndParser(tctx *tcontext.Context) error {
-	setSQLMode := fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLMode)
+	setSQLMode := fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLModeMySQL80)
 	_, err := dt.downstreamConn.ExecuteSQL(tctx, nil, []string{setSQLMode})
 	if err != nil {
-		return dmterror.ErrSchemaTrackerCannotSetDownstreamSQLMode.Delegate(err, DefaultSQLMode)
+		return dmterror.ErrSchemaTrackerCannotSetDownstreamSQLMode.Delegate(err, DefaultSQLModeMySQL80)
 	}
-	stmtParser, err := conn.GetParserFromSQLModeStr(DefaultSQLMode)
+	stmtParser, err := conn.GetParserFromSQLModeStr(DefaultSQLModeMySQL80)
 	if err != nil {
-		return dmterror.ErrSchemaTrackerCannotInitDownstreamParser.Delegate(err, DefaultSQLMode)
+		return dmterror.ErrSchemaTrackerCannotInitDownstreamParser.Delegate(err, DefaultSQLModeMySQL80)
 	}
 	dt.stmtParser = stmtParser
 	return nil

--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -89,6 +89,8 @@ type executorContext struct {
 
 var _ sqlexec.RestrictedSQLExecutor = executorContext{}
 
+const defaultSQLMode = "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+
 func (se executorContext) ParseWithParams(context.Context, string, ...interface{}) (ast.StmtNode, error) {
 	return nil, nil
 }
@@ -475,14 +477,14 @@ func (dt *downstreamTracker) getTableInfoByCreateStmt(tctx *tcontext.Context, ta
 
 // initDownStreamTrackerParser init downstream tracker parser by default sql_mode.
 func (dt *downstreamTracker) initDownStreamSQLModeAndParser(tctx *tcontext.Context) error {
-	setSQLMode := fmt.Sprintf("SET SESSION SQL_MODE = '%s'", mysql.DefaultSQLMode)
+	setSQLMode := fmt.Sprintf("SET SESSION SQL_MODE = '%s'", defaultSQLMode)
 	_, err := dt.downstreamConn.ExecuteSQL(tctx, nil, []string{setSQLMode})
 	if err != nil {
-		return dmterror.ErrSchemaTrackerCannotSetDownstreamSQLMode.Delegate(err, mysql.DefaultSQLMode)
+		return dmterror.ErrSchemaTrackerCannotSetDownstreamSQLMode.Delegate(err, defaultSQLMode)
 	}
-	stmtParser, err := conn.GetParserFromSQLModeStr(mysql.DefaultSQLMode)
+	stmtParser, err := conn.GetParserFromSQLModeStr(defaultSQLMode)
 	if err != nil {
-		return dmterror.ErrSchemaTrackerCannotInitDownstreamParser.Delegate(err, mysql.DefaultSQLMode)
+		return dmterror.ErrSchemaTrackerCannotInitDownstreamParser.Delegate(err, defaultSQLMode)
 	}
 	dt.stmtParser = stmtParser
 	return nil

--- a/dm/pkg/schema/tracker_test.go
+++ b/dm/pkg/schema/tracker_test.go
@@ -579,7 +579,7 @@ func TestInitDownStreamSQLModeAndParser(t *testing.T) {
 	defer tracker.Close()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLModeMySQL80)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	tctx := tcontext.NewContext(context.Background(), dlog.L())
@@ -606,7 +606,7 @@ func TestGetDownStreamIndexInfo(t *testing.T) {
 	defer tracker.Close()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLModeMySQL80)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	tableID := "`test`.`test`"
@@ -634,7 +634,7 @@ func TestReTrackDownStreamIndex(t *testing.T) {
 	defer tracker.Close()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLModeMySQL80)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	tableID := "`test`.`test`"
@@ -715,7 +715,7 @@ func TestVarchar20000(t *testing.T) {
 	defer tracker.Close()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLModeMySQL80)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	tableID := "`test`.`test`"
@@ -743,7 +743,7 @@ func TestPlacementRule(t *testing.T) {
 	defer tracker.Close()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLModeMySQL80)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	tableID := "`test`.`test`"

--- a/dm/pkg/schema/tracker_test.go
+++ b/dm/pkg/schema/tracker_test.go
@@ -579,7 +579,7 @@ func TestInitDownStreamSQLModeAndParser(t *testing.T) {
 	defer tracker.Close()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", mysql.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", defaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	tctx := tcontext.NewContext(context.Background(), dlog.L())
@@ -606,7 +606,7 @@ func TestGetDownStreamIndexInfo(t *testing.T) {
 	defer tracker.Close()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", mysql.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", defaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	tableID := "`test`.`test`"
@@ -634,7 +634,7 @@ func TestReTrackDownStreamIndex(t *testing.T) {
 	defer tracker.Close()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", mysql.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", defaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	tableID := "`test`.`test`"
@@ -715,7 +715,7 @@ func TestVarchar20000(t *testing.T) {
 	defer tracker.Close()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", mysql.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", defaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	tableID := "`test`.`test`"
@@ -743,7 +743,7 @@ func TestPlacementRule(t *testing.T) {
 	defer tracker.Close()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", mysql.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", defaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	tableID := "`test`.`test`"

--- a/dm/pkg/schema/tracker_test.go
+++ b/dm/pkg/schema/tracker_test.go
@@ -579,7 +579,7 @@ func TestInitDownStreamSQLModeAndParser(t *testing.T) {
 	defer tracker.Close()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", defaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	tctx := tcontext.NewContext(context.Background(), dlog.L())
@@ -606,7 +606,7 @@ func TestGetDownStreamIndexInfo(t *testing.T) {
 	defer tracker.Close()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", defaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	tableID := "`test`.`test`"
@@ -634,7 +634,7 @@ func TestReTrackDownStreamIndex(t *testing.T) {
 	defer tracker.Close()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", defaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	tableID := "`test`.`test`"
@@ -715,7 +715,7 @@ func TestVarchar20000(t *testing.T) {
 	defer tracker.Close()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", defaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	tableID := "`test`.`test`"
@@ -743,7 +743,7 @@ func TestPlacementRule(t *testing.T) {
 	defer tracker.Close()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", defaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	tableID := "`test`.`test`"

--- a/dm/syncer/syncer_test.go
+++ b/dm/syncer/syncer_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/parser/ast"
-	pmysql "github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/util/filter"
 	regexprrouter "github.com/pingcap/tidb/util/regexpr-router"
 	router "github.com/pingcap/tidb/util/table-router"
@@ -778,7 +777,7 @@ func (s *testSyncerSuite) TestRun(c *C) {
 	syncer.metricsProxies = metrics.DefaultMetricsProxies.CacheForOneTask("task", "worker", "source")
 
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", pmysql.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", schema.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 	mock.ExpectQuery("SHOW CREATE TABLE " + "`test_1`.`t_1`").WillReturnRows(
 		sqlmock.NewRows([]string{"Table", "Create Table"}).
@@ -947,7 +946,7 @@ func (s *testSyncerSuite) TestRun(c *C) {
 		WillReturnRows(sqlmock.NewRows([]string{""}).AddRow("01:00:00"))
 	mockGetServerUnixTS(mock)
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", pmysql.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", schema.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 	mock.ExpectQuery("SHOW CREATE TABLE " + "`test_1`.`t_2`").WillReturnRows(
 		sqlmock.NewRows([]string{"Table", "Create Table"}).
@@ -1106,7 +1105,7 @@ func (s *testSyncerSuite) TestExitSafeModeByConfig(c *C) {
 	syncer.ddlDBConn = dbconn.NewDBConn(s.cfg, conn.NewBaseConnForTest(dbConn, &retry.FiniteRetryStrategy{}))
 	syncer.downstreamTrackConn = dbconn.NewDBConn(s.cfg, conn.NewBaseConnForTest(dbConn, &retry.FiniteRetryStrategy{}))
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", pmysql.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", schema.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	mock.ExpectQuery("SHOW CREATE TABLE " + "`test_1`.`t_1`").WillReturnRows(

--- a/dm/syncer/syncer_test.go
+++ b/dm/syncer/syncer_test.go
@@ -777,7 +777,7 @@ func (s *testSyncerSuite) TestRun(c *C) {
 	syncer.metricsProxies = metrics.DefaultMetricsProxies.CacheForOneTask("task", "worker", "source")
 
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", schema.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", schema.DefaultSQLModeMySQL80)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 	mock.ExpectQuery("SHOW CREATE TABLE " + "`test_1`.`t_1`").WillReturnRows(
 		sqlmock.NewRows([]string{"Table", "Create Table"}).
@@ -946,7 +946,7 @@ func (s *testSyncerSuite) TestRun(c *C) {
 		WillReturnRows(sqlmock.NewRows([]string{""}).AddRow("01:00:00"))
 	mockGetServerUnixTS(mock)
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", schema.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", schema.DefaultSQLModeMySQL80)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 	mock.ExpectQuery("SHOW CREATE TABLE " + "`test_1`.`t_2`").WillReturnRows(
 		sqlmock.NewRows([]string{"Table", "Create Table"}).
@@ -1105,7 +1105,7 @@ func (s *testSyncerSuite) TestExitSafeModeByConfig(c *C) {
 	syncer.ddlDBConn = dbconn.NewDBConn(s.cfg, conn.NewBaseConnForTest(dbConn, &retry.FiniteRetryStrategy{}))
 	syncer.downstreamTrackConn = dbconn.NewDBConn(s.cfg, conn.NewBaseConnForTest(dbConn, &retry.FiniteRetryStrategy{}))
 	mock.ExpectBegin()
-	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", schema.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", schema.DefaultSQLModeMySQL80)).WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectCommit()
 
 	mock.ExpectQuery("SHOW CREATE TABLE " + "`test_1`.`t_1`").WillReturnRows(


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8149

### What is changed and how it works?
`NO_AUTO_CREATE_USER` is removed in MySQL8.0([doc](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-11.html#mysqld-8-0-11-deprecation-removal))，so it should not be used in dm.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
