### PR TITLE
kafka(ticdc): reset the admin client to fix broken pipe

### DIFF
--- a/pkg/sink/kafka/admin.go
+++ b/pkg/sink/kafka/admin.go
@@ -16,6 +16,8 @@ package kafka
 import (
 	"context"
 	"errors"
+	"io"
+	"net"
 	"strconv"
 	"sync"
 	"syscall"
@@ -80,6 +82,12 @@ func (a *saramaAdminClient) queryClusterWithRetry(ctx context.Context, query fun
 		}
 
 		if !errors.Is(err, syscall.EPIPE) {
+			return err
+		}
+		if !errors.Is(err, net.ErrClosed) {
+			return err
+		}
+		if !errors.Is(err, io.EOF) {
 			return err
 		}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8225, close #8223

### What is changed and how it works?

`AdminClient` may meet `write: broken pipe`, it's a know issue have not been addressed yet.

* reset the `admin client` if meet `broken pipe` error.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None`
```
