### PR TITLE
kafka(ticdc): sarama admin client use cached topic and partitions

### DIFF
--- a/pkg/sink/kafka/admin.go
+++ b/pkg/sink/kafka/admin.go
@@ -39,7 +39,7 @@ type saramaAdminClient struct {
 }
 
 const (
-	defaultRetryBackoff  = 50
+	defaultRetryBackoff  = 20
 	defaultRetryMaxTries = 3
 )
 

--- a/pkg/sink/kafka/admin.go
+++ b/pkg/sink/kafka/admin.go
@@ -80,7 +80,7 @@ func (a *saramaAdminClient) reset() error {
 	_ = a.close()
 	a.client = newClient
 	a.admin = newAdmin
-
+	log.Info("kafka admin client is reset")
 	return errors.New("retry after reset")
 }
 
@@ -92,6 +92,8 @@ func (a *saramaAdminClient) queryClusterWithRetry(ctx context.Context, query fun
 		if err == nil {
 			return nil
 		}
+
+		log.Warn("query kafka cluster meta failed, retry it", zap.Error(err))
 
 		if !errors.Is(err, syscall.EPIPE) {
 			return err

--- a/pkg/sink/kafka/cluster_admin_client.go
+++ b/pkg/sink/kafka/cluster_admin_client.go
@@ -46,6 +46,9 @@ type ClusterAdminClient interface {
 	// which available in the cluster with the default options.
 	GetAllTopicsMeta(ctx context.Context) (map[string]TopicDetail, error)
 
+	// GetTopicsPartitions return all topics number of partitions.
+	GetTopicsPartitions(ctx context.Context) (map[string]int32, error)
+
 	// GetTopicsMeta return all target topics' metadata
 	// if `ignoreTopicError` is true, ignore the topic error and return the metadata of valid topics
 	GetTopicsMeta(ctx context.Context,

--- a/pkg/sink/kafka/cluster_admin_client_mock_impl.go
+++ b/pkg/sink/kafka/cluster_admin_client_mock_impl.go
@@ -91,6 +91,15 @@ func NewClusterAdminClientMockImpl() *ClusterAdminClientMockImpl {
 	}
 }
 
+func (c *ClusterAdminClientMockImpl) GetTopicsPartitions(
+	_ context.Context) (map[string]int32, error) {
+	result := make(map[string]int32)
+	for topic, detail := range c.topics {
+		result[topic] = detail.NumPartitions
+	}
+	return result, nil
+}
+
 // GetAllTopicsMeta returns all topics directly.
 func (c *ClusterAdminClientMockImpl) GetAllTopicsMeta(
 	context.Context,

--- a/pkg/sink/kafka/cluster_admin_client_mock_impl.go
+++ b/pkg/sink/kafka/cluster_admin_client_mock_impl.go
@@ -91,8 +91,10 @@ func NewClusterAdminClientMockImpl() *ClusterAdminClientMockImpl {
 	}
 }
 
+// GetTopicsPartitions all topics' number of partitions.
 func (c *ClusterAdminClientMockImpl) GetTopicsPartitions(
-	_ context.Context) (map[string]int32, error) {
+	_ context.Context,
+) (map[string]int32, error) {
 	result := make(map[string]int32)
 	for topic, detail := range c.topics {
 		result[topic] = detail.NumPartitions

--- a/pkg/sink/kafka/v2/admin.go
+++ b/pkg/sink/kafka/v2/admin.go
@@ -123,6 +123,18 @@ func (a *admin) GetBrokerConfig(ctx context.Context, configName string) (string,
 	return entry.ConfigValue, nil
 }
 
+func (a *admin) GetTopicsPartitions(ctx context.Context) (map[string]int32, error) {
+	response, err := a.clusterMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]int32, len(response.Topics))
+	for _, topic := range response.Topics {
+		result[topic.Name] = int32(len(topic.Partitions))
+	}
+	return result, nil
+}
+
 func (a *admin) GetAllTopicsMeta(ctx context.Context) (map[string]pkafka.TopicDetail, error) {
 	response, err := a.clusterMetadata(ctx)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #8225 

### What is changed and how it works?

* admin client use cached client's topics and partitions

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
