### PR TITLE
config(ticdc): mark per table memory quota deprecated

### DIFF
--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -160,7 +160,6 @@ func TestParseCfg(t *testing.T) {
 			KeyPath:       "cc",
 			CertAllowedCN: []string{"dd", "ee"},
 		},
-		PerTableMemoryQuota: config.DefaultTableMemoryQuota,
 		KVClient: &config.KVClientConfig{
 			WorkerConcurrent:    8,
 			WorkerPoolSize:      0,
@@ -305,8 +304,7 @@ check-balance-interval = "10s"
 			MaxMemoryPercentage: 3,
 			SortDir:             config.DefaultSortDir,
 		},
-		Security:            &config.SecurityConfig{},
-		PerTableMemoryQuota: config.DefaultTableMemoryQuota,
+		Security: &config.SecurityConfig{},
 		KVClient: &config.KVClientConfig{
 			WorkerConcurrent:    8,
 			WorkerPoolSize:      0,
@@ -438,7 +436,6 @@ cert-allowed-cn = ["dd","ee"]
 			KeyPath:       "cc",
 			CertAllowedCN: []string{"dd", "ee"},
 		},
-		PerTableMemoryQuota: config.DefaultTableMemoryQuota,
 		KVClient: &config.KVClientConfig{
 			WorkerConcurrent:    8,
 			WorkerPoolSize:      0,

--- a/pkg/config/config_test_data.go
+++ b/pkg/config/config_test_data.go
@@ -98,7 +98,7 @@ const (
     "key-path": "",
     "cert-allowed-cn": null
   },
-  "per-table-memory-quota": 10485760,
+  "per-table-memory-quota": 0,
   "kv-client": {
     "worker-concurrent": 8,
     "worker-pool-size": 0,

--- a/pkg/config/server_config_test.go
+++ b/pkg/config/server_config_test.go
@@ -72,12 +72,6 @@ func TestServerConfigValidateAndAdjust(t *testing.T) {
 	conf.AdvertiseAddr = "advertise"
 	require.Regexp(t, ".*does not contain a port", conf.ValidateAndAdjust())
 	conf.AdvertiseAddr = "advertise:1234"
-	conf.PerTableMemoryQuota = 1
-	require.Nil(t, conf.ValidateAndAdjust())
-	require.EqualValues(t, 1, conf.PerTableMemoryQuota)
-	conf.PerTableMemoryQuota = 0
-	require.Nil(t, conf.ValidateAndAdjust())
-	require.EqualValues(t, GetDefaultServerConfig().PerTableMemoryQuota, conf.PerTableMemoryQuota)
 	conf.Debug.Messages.ServerWorkerPoolSize = 0
 	require.Nil(t, conf.ValidateAndAdjust())
 	require.EqualValues(t, GetDefaultServerConfig().Debug.Messages.ServerWorkerPoolSize, conf.Debug.Messages.ServerWorkerPoolSize)

--- a/tests/integration_tests/server_config_compatibility/conf/server.toml
+++ b/tests/integration_tests/server_config_compatibility/conf/server.toml
@@ -1,3 +1,4 @@
+per-table-memory-quota = 1024
 [debug]
 # Ensure sure removed configarations are not used.
 # TiCDC should ignore the removed configuration silently.


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref https://github.com/pingcap/tiflow/issues/8132

### What is changed and how it works?

mark per table memory quota deprecated
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
