### PR TITLE
sink(ticdc): add an index file in storage sink to quickly find the largest file number

### DIFF
--- a/cdc/sink/dmlsink/cloudstorage/cloud_storage_dml_sink_test.go
+++ b/cdc/sink/dmlsink/cloudstorage/cloud_storage_dml_sink_test.go
@@ -90,22 +90,25 @@ func TestCloudStorageWriteEvents(t *testing.T) {
 		txns = append(txns, txn)
 	}
 	tableDir := path.Join(parentDir, "test/table1/33")
-	os.MkdirAll(tableDir, 0o755)
 	err = s.WriteEvents(txns...)
 	require.Nil(t, err)
 	time.Sleep(4 * time.Second)
 
 	files, err := os.ReadDir(tableDir)
 	require.Nil(t, err)
-	require.Len(t, files, 2)
+	require.Len(t, files, 3)
 	var fileNames []string
 	for _, f := range files {
 		fileNames = append(fileNames, f.Name())
 	}
-	require.ElementsMatch(t, []string{"CDC000001.json", "schema.json"}, fileNames)
+	require.ElementsMatch(t, []string{"CDC000001.json", "schema.json", "CDC.index"}, fileNames)
 	content, err := os.ReadFile(path.Join(tableDir, "CDC000001.json"))
 	require.Nil(t, err)
 	require.Greater(t, len(content), 0)
+
+	content, err = os.ReadFile(path.Join(tableDir, "CDC.index"))
+	require.Nil(t, err)
+	require.Equal(t, "CDC000001.json\n", string(content))
 
 	require.Equal(t, uint64(1000), atomic.LoadUint64(&cnt))
 	cancel()

--- a/cdc/sink/dmlsink/cloudstorage/defragmenter_test.go
+++ b/cdc/sink/dmlsink/cloudstorage/defragmenter_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tiflow/cdc/sink/dmlsink"
 	"github.com/pingcap/tiflow/cdc/sink/util"
 	"github.com/pingcap/tiflow/pkg/config"
+	"github.com/pingcap/tiflow/pkg/sink/cloudstorage"
 	"github.com/pingcap/tiflow/pkg/sink/codec/builder"
 	"github.com/stretchr/testify/require"
 )
@@ -54,7 +55,7 @@ func TestDeframenter(t *testing.T) {
 		go func(seq uint64) {
 			encoder := encoderBuilder.Build()
 			frag := eventFragment{
-				versionedTable: versionedTable{
+				verTable: cloudstorage.VersionedTable{
 					TableName: model.TableName{
 						Schema:  "test",
 						Table:   "table1",

--- a/cdc/sink/dmlsink/cloudstorage/dml_writer.go
+++ b/cdc/sink/dmlsink/cloudstorage/dml_writer.go
@@ -97,7 +97,7 @@ func (d *dmlWriter) dispatchFragToDMLWorker(ctx context.Context) error {
 			if !ok {
 				return nil
 			}
-			tableName := frag.TableName
+			tableName := frag.verTable.TableName
 			d.hasher.Reset()
 			d.hasher.Write([]byte(tableName.Schema), []byte(tableName.Table))
 			workerID := d.hasher.Sum32() % uint32(d.config.WorkerCount)

--- a/cdc/sink/dmlsink/cloudstorage/encoding_worker_test.go
+++ b/cdc/sink/dmlsink/cloudstorage/encoding_worker_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tiflow/cdc/sink/dmlsink"
 	"github.com/pingcap/tiflow/cdc/sink/util"
 	"github.com/pingcap/tiflow/pkg/config"
+	"github.com/pingcap/tiflow/pkg/sink/cloudstorage"
 	"github.com/pingcap/tiflow/pkg/sink/codec/builder"
 	"github.com/stretchr/testify/require"
 )
@@ -52,7 +53,7 @@ func TestEncodeEvents(t *testing.T) {
 	worker, fn := testEncodingWorker(ctx, t)
 	defer fn()
 	err := worker.encodeEvents(ctx, eventFragment{
-		versionedTable: versionedTable{
+		verTable: cloudstorage.VersionedTable{
 			TableName: model.TableName{
 				Schema:  "test",
 				Table:   "table1",
@@ -134,7 +135,7 @@ func TestEncodingWorkerRun(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		frag := eventFragment{
-			versionedTable: versionedTable{
+			verTable: cloudstorage.VersionedTable{
 				TableName: table,
 			},
 			seqNumber: uint64(i + 1),

--- a/pkg/errors/cdc_errors.go
+++ b/pkg/errors/cdc_errors.go
@@ -418,7 +418,7 @@ var (
 		errors.RFCCodeText("CDC:ErrMessageTooLarge"),
 	)
 	ErrStorageSinkInvalidDateSeparator = errors.Normalize(
-		"date separator in cloud storage sink is invalid",
+		"date separator in storage sink is invalid",
 		errors.RFCCodeText("CDC:ErrStorageSinkInvalidDateSeparator"),
 	)
 	ErrCSVEncodeFailed = errors.Normalize(
@@ -429,13 +429,13 @@ var (
 		"csv decode failed",
 		errors.RFCCodeText("CDC:ErrCSVDecodeFailed"),
 	)
-	ErrCloudStorageInvalidConfig = errors.Normalize(
-		"cloud storage config invalid",
-		errors.RFCCodeText("CDC:ErrCloudStorageInvalidConfig"),
+	ErrStorageSinkInvalidConfig = errors.Normalize(
+		"storage sink config invalid",
+		errors.RFCCodeText("CDC:ErrStorageSinkInvalidConfig"),
 	)
-	ErrCloudStorageDefragmentFailed = errors.Normalize(
-		"cloud storage defragment encoded messages failed",
-		errors.RFCCodeText("CDC:ErrCloudStorageDefragmentFailed"),
+	ErrStorageSinkInvalidFileName = errors.Normalize(
+		"filename in storage sink is invalid",
+		errors.RFCCodeText("CDC:ErrStorageSinkInvalidFileName"),
 	)
 
 	// utilities related errors

--- a/pkg/sink/cloudstorage/config.go
+++ b/pkg/sink/cloudstorage/config.go
@@ -72,12 +72,12 @@ func (c *Config) Apply(
 	replicaConfig *config.ReplicaConfig,
 ) (err error) {
 	if sinkURI == nil {
-		return cerror.ErrCloudStorageInvalidConfig.GenWithStack("failed to open cloud storage sink, empty SinkURI")
+		return cerror.ErrStorageSinkInvalidConfig.GenWithStack("failed to open cloud storage sink, empty SinkURI")
 	}
 
 	scheme := strings.ToLower(sinkURI.Scheme)
 	if !psink.IsStorageScheme(scheme) {
-		return cerror.ErrCloudStorageInvalidConfig.GenWithStack("can't create cloud storage sink with unsupported scheme: %s", scheme)
+		return cerror.ErrStorageSinkInvalidConfig.GenWithStack("can't create cloud storage sink with unsupported scheme: %s", scheme)
 	}
 	query := sinkURI.Query()
 	if err = getWorkerCount(query, &c.WorkerCount); err != nil {
@@ -106,10 +106,10 @@ func getWorkerCount(values url.Values, workerCount *int) error {
 
 	c, err := strconv.Atoi(s)
 	if err != nil {
-		return cerror.WrapError(cerror.ErrCloudStorageInvalidConfig, err)
+		return cerror.WrapError(cerror.ErrStorageSinkInvalidConfig, err)
 	}
 	if c <= 0 {
-		return cerror.WrapError(cerror.ErrCloudStorageInvalidConfig,
+		return cerror.WrapError(cerror.ErrStorageSinkInvalidConfig,
 			fmt.Errorf("invalid worker-count %d, it must be greater than 0", c))
 	}
 	if c > maxWorkerCount {
@@ -130,7 +130,7 @@ func getFlushInterval(values url.Values, flushInterval *time.Duration) error {
 
 	d, err := time.ParseDuration(s)
 	if err != nil {
-		return cerror.WrapError(cerror.ErrCloudStorageInvalidConfig, err)
+		return cerror.WrapError(cerror.ErrStorageSinkInvalidConfig, err)
 	}
 
 	if d > maxFlushInterval {
@@ -156,7 +156,7 @@ func getFileSize(values url.Values, fileSize *int) error {
 
 	sz, err := strconv.Atoi(s)
 	if err != nil {
-		return cerror.WrapError(cerror.ErrCloudStorageInvalidConfig, err)
+		return cerror.WrapError(cerror.ErrStorageSinkInvalidConfig, err)
 	}
 	if sz > maxFileSize {
 		log.Warn("file-size is too large",

--- a/pkg/sink/cloudstorage/path.go
+++ b/pkg/sink/cloudstorage/path.go
@@ -1,0 +1,176 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudstorage
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/pingcap/tidb/br/pkg/storage"
+	"github.com/pingcap/tiflow/cdc/model"
+	"github.com/pingcap/tiflow/engine/pkg/clock"
+	"github.com/pingcap/tiflow/pkg/config"
+	cerror "github.com/pingcap/tiflow/pkg/errors"
+)
+
+const (
+	// 3 is the length of "CDC", and the file number contains at least 6 digits (e.g. CDC000001.csv).
+	minFileNamePrefixLen = 9
+	defaultIndexFileName = "CDC.index"
+)
+
+func GenerateSchemaFilePath(def TableDefinition) string {
+	return fmt.Sprintf("%s/%s/%d/schema.json", def.Schema, def.Table, def.TableVersion)
+}
+
+type indexWithDate struct {
+	index              uint64
+	currDate, prevDate string
+}
+
+// VersionedTable is used to wrap TableName with a version
+type VersionedTable struct {
+	model.TableName
+	Version uint64
+}
+
+type FilePathGenerator struct {
+	extension string
+	config    *Config
+	clock     clock.Clock
+	storage   storage.ExternalStorage
+	fileIndex map[VersionedTable]*indexWithDate
+}
+
+func NewFilePathGenerator(config *Config, storage storage.ExternalStorage, extension string) *FilePathGenerator {
+	return &FilePathGenerator{
+		config:    config,
+		extension: extension,
+		storage:   storage,
+		clock:     clock.New(),
+		fileIndex: make(map[VersionedTable]*indexWithDate),
+	}
+}
+
+func (f *FilePathGenerator) Contains(tbl VersionedTable) bool {
+	_, ok := f.fileIndex[tbl]
+	return ok
+}
+
+func (f *FilePathGenerator) GenerateDateStr() string {
+	var dateStr string
+
+	currTime := f.clock.Now()
+	switch f.config.DateSeparator {
+	case config.DateSeparatorYear.String():
+		dateStr = currTime.Format("2006")
+	case config.DateSeparatorMonth.String():
+		dateStr = currTime.Format("2006-01")
+	case config.DateSeparatorDay.String():
+		dateStr = currTime.Format("2006-01-02")
+	default:
+	}
+
+	return dateStr
+}
+
+func (f *FilePathGenerator) GenerateDataDirPath(tbl VersionedTable, date string) string {
+	var elems []string
+
+	elems = append(elems, tbl.Schema)
+	elems = append(elems, tbl.Table)
+	elems = append(elems, fmt.Sprintf("%d", tbl.Version))
+
+	if f.config.EnablePartitionSeparator && tbl.TableName.IsPartition {
+		elems = append(elems, fmt.Sprintf("%d", tbl.TableID))
+	}
+
+	if len(date) != 0 {
+		elems = append(elems, date)
+	}
+
+	return strings.Join(elems, "/")
+}
+
+func (f *FilePathGenerator) fetchIndexFromFileName(fileName string) (uint64, error) {
+	if len(fileName) < minFileNamePrefixLen+len(f.extension) ||
+		!strings.HasPrefix(fileName, "CDC") ||
+		!strings.HasSuffix(fileName, f.extension) {
+		return 0, cerror.WrapError(cerror.ErrStorageSinkInvalidFileName,
+			fmt.Errorf("'%s' is a invalid file name", fileName))
+	}
+
+	extIdx := strings.Index(fileName, f.extension)
+	fileIdxStr := fileName[3:extIdx]
+	if fileIdx, err := strconv.ParseUint(fileIdxStr, 10, 64); err != nil {
+		return 0, cerror.WrapError(cerror.ErrStorageSinkInvalidFileName, err)
+	} else {
+		return fileIdx, nil
+	}
+}
+
+func (f *FilePathGenerator) GenerateDataFilePath(ctx context.Context, tbl VersionedTable, date string) (string, error) {
+	var elems []string
+
+	elems = append(elems, f.GenerateDataDirPath(tbl, date))
+	if idx, ok := f.fileIndex[tbl]; !ok {
+		var fileIdx uint64
+
+		indexFile := f.GenerateIndexFilePath(tbl, date)
+		exist, err := f.storage.FileExists(ctx, indexFile)
+		if err != nil {
+			return "", err
+		}
+		if exist {
+			data, err := f.storage.ReadFile(ctx, indexFile)
+			if err != nil {
+				return "", err
+			}
+			fileName := strings.TrimSuffix(string(data), "\n")
+			maxFileIdx, err := f.fetchIndexFromFileName(fileName)
+			if err != nil {
+				return "", err
+			}
+			fileIdx = maxFileIdx
+		}
+
+		f.fileIndex[tbl] = &indexWithDate{
+			currDate: date,
+			index:    fileIdx,
+		}
+	} else {
+		idx.currDate = date
+	}
+
+	// if date changed, reset the counter
+	if f.fileIndex[tbl].prevDate != f.fileIndex[tbl].currDate {
+		f.fileIndex[tbl].prevDate = f.fileIndex[tbl].currDate
+		f.fileIndex[tbl].index = 0
+	}
+	f.fileIndex[tbl].index++
+	elems = append(elems, fmt.Sprintf("CDC%06d%s", f.fileIndex[tbl].index, f.extension))
+
+	return strings.Join(elems, "/"), nil
+}
+
+func (f *FilePathGenerator) GenerateIndexFilePath(tbl VersionedTable, date string) string {
+	var elems []string
+
+	elems = append(elems, f.GenerateDataDirPath(tbl, date))
+	elems = append(elems, defaultIndexFileName)
+
+	return strings.Join(elems, "/")
+}

--- a/pkg/sink/cloudstorage/path_test.go
+++ b/pkg/sink/cloudstorage/path_test.go
@@ -1,0 +1,205 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cloudstorage
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tiflow/cdc/model"
+	"github.com/pingcap/tiflow/engine/pkg/clock"
+	"github.com/pingcap/tiflow/pkg/config"
+	"github.com/pingcap/tiflow/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+func testFilePathGenerator(ctx context.Context, t *testing.T, dir string) *FilePathGenerator {
+	uri := fmt.Sprintf("file:///%s?flush-interval=2s", dir)
+	storage, err := util.GetExternalStorageFromURI(ctx, uri)
+	require.NoError(t, err)
+
+	sinkURI, err := url.Parse(uri)
+	require.NoError(t, err)
+	replicaConfig := config.GetDefaultReplicaConfig()
+	replicaConfig.Sink.Protocol = config.ProtocolOpen.String()
+	cfg := NewConfig()
+	err = cfg.Apply(ctx, sinkURI, replicaConfig)
+	require.NoError(t, err)
+
+	f := NewFilePathGenerator(cfg, storage, ".json")
+	return f
+}
+
+func TestGenerateDataFilePath(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	table := VersionedTable{
+		TableName: model.TableName{
+			Schema: "test",
+			Table:  "table1",
+		},
+		Version: 5,
+	}
+
+	dir := t.TempDir()
+	f := testFilePathGenerator(ctx, t, dir)
+	date := f.GenerateDateStr()
+	// date-separator: none
+	path, err := f.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, "test/table1/5/CDC000001.json", path)
+	path, err = f.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, "test/table1/5/CDC000002.json", path)
+
+	// date-separator: year
+	mockClock := clock.NewMock()
+	f = testFilePathGenerator(ctx, t, dir)
+	f.config.DateSeparator = config.DateSeparatorYear.String()
+	f.clock = mockClock
+	mockClock.Set(time.Date(2022, 12, 31, 23, 59, 59, 0, time.UTC))
+	date = f.GenerateDateStr()
+	path, err = f.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, "test/table1/5/2022/CDC000001.json", path)
+	path, err = f.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, "test/table1/5/2022/CDC000002.json", path)
+	// year changed
+	mockClock.Set(time.Date(2023, 1, 1, 0, 0, 20, 0, time.UTC))
+	date = f.GenerateDateStr()
+	path, err = f.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, "test/table1/5/2023/CDC000001.json", path)
+	path, err = f.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, "test/table1/5/2023/CDC000002.json", path)
+
+	// date-separator: month
+	mockClock = clock.NewMock()
+	f = testFilePathGenerator(ctx, t, dir)
+	f.config.DateSeparator = config.DateSeparatorMonth.String()
+	f.clock = mockClock
+	mockClock.Set(time.Date(2022, 12, 31, 23, 59, 59, 0, time.UTC))
+	date = f.GenerateDateStr()
+	path, err = f.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, "test/table1/5/2022-12/CDC000001.json", path)
+	path, err = f.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, "test/table1/5/2022-12/CDC000002.json", path)
+	// month changed
+	mockClock.Set(time.Date(2023, 1, 1, 0, 0, 20, 0, time.UTC))
+	date = f.GenerateDateStr()
+	path, err = f.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, "test/table1/5/2023-01/CDC000001.json", path)
+	path, err = f.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, "test/table1/5/2023-01/CDC000002.json", path)
+
+	// date-separator: day
+	mockClock = clock.NewMock()
+	f = testFilePathGenerator(ctx, t, dir)
+	f.config.DateSeparator = config.DateSeparatorDay.String()
+	f.clock = mockClock
+	mockClock.Set(time.Date(2022, 12, 31, 23, 59, 59, 0, time.UTC))
+	date = f.GenerateDateStr()
+	path, err = f.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, "test/table1/5/2022-12-31/CDC000001.json", path)
+	path, err = f.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, "test/table1/5/2022-12-31/CDC000002.json", path)
+	// day changed
+	mockClock.Set(time.Date(2023, 1, 1, 0, 0, 20, 0, time.UTC))
+	date = f.GenerateDateStr()
+	path, err = f.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, "test/table1/5/2023-01-01/CDC000001.json", path)
+	path, err = f.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, "test/table1/5/2023-01-01/CDC000002.json", path)
+}
+
+func TestFetchIndexFromFileName(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	dir := t.TempDir()
+	f := testFilePathGenerator(ctx, t, dir)
+	testCases := []struct {
+		fileName string
+		wantErr  string
+	}{
+		{
+			fileName: "CDC000011.json",
+			wantErr:  "",
+		},
+		{
+			fileName: "CDC1000000.json",
+			wantErr:  "",
+		},
+		{
+			fileName: "CDC1.json",
+			wantErr:  "filename in storage sink is invalid",
+		},
+		{
+			fileName: "cdc000001.json",
+			wantErr:  "filename in storage sink is invalid",
+		},
+		{
+			fileName: "CDC000005.xxx",
+			wantErr:  "filename in storage sink is invalid",
+		},
+		{
+			fileName: "CDChello.json",
+			wantErr:  "filename in storage sink is invalid",
+		},
+	}
+
+	for _, tc := range testCases {
+		_, err := f.fetchIndexFromFileName(tc.fileName)
+		if len(tc.wantErr) != 0 {
+			require.Contains(t, err.Error(), tc.wantErr)
+		} else {
+			require.NoError(t, err)
+		}
+	}
+}
+
+func TestGenerateDataFilePathWithIndexFile(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	dir := t.TempDir()
+	d := testFilePathGenerator(ctx, t, dir)
+	table := VersionedTable{
+		TableName: model.TableName{
+			Schema: "test",
+			Table:  "table1",
+		},
+		Version: 5,
+	}
+	date := d.GenerateDateStr()
+	indexFilePath := d.GenerateIndexFilePath(table, date)
+	err := d.storage.WriteFile(ctx, indexFilePath, []byte("CDC000005.json\n"))
+	require.NoError(t, err)
+	dataFilePath, err := d.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, "test/table1/5/CDC000006.json", dataFilePath)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8256 

### What is changed and how it works?
When a table is scheduled from one node to another, instead of listing dir and fetching the max written file index number, we adopt a new way to accelerate the process:
Before writing the actual data file to external storage, we record the data file name to an index file. When table scheduling happens, we can simply read this index file and fetch the max file index number. Then the number + 1 can be used to generate the new filename. By this way, no existing files could be overwritten.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
