### PR TITLE
ticdc(test): add more ut for kafka sink v2 

### DIFF
--- a/pkg/sink/kafka/v2/factory_test.go
+++ b/pkg/sink/kafka/v2/factory_test.go
@@ -15,9 +15,12 @@ package v2
 
 import (
 	"context"
+	"crypto/tls"
 	"testing"
 
 	"github.com/pingcap/tiflow/cdc/model"
+	cerror "github.com/pingcap/tiflow/pkg/errors"
+	"github.com/pingcap/tiflow/pkg/security"
 	pkafka "github.com/pingcap/tiflow/pkg/sink/kafka"
 	"github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/require"
@@ -27,6 +30,13 @@ func newOptions4Test() *pkafka.Options {
 	o := pkafka.NewOptions()
 	o.BrokerEndpoints = []string{"127.0.0.1:9092"}
 	o.ClientID = "kafka-go-test"
+	o.EnableTLS = true
+	o.Credential = &security.Credential{
+		CAPath:        "",
+		CertPath:      "",
+		KeyPath:       "",
+		CertAllowedCN: []string{""},
+	}
 	return o
 }
 
@@ -56,6 +66,13 @@ func TestAsyncProducer(t *testing.T) {
 
 	o := newOptions4Test()
 	factory := newFactory4Test(o, t)
+	require.Equal(
+		t, factory.transport.TLS,
+		&tls.Config{
+			MinVersion: tls.VersionTLS12,
+			NextProtos: []string{"h2", "http/1.1"},
+		},
+	)
 
 	ctx := context.Background()
 	async, err := factory.AsyncProducer(ctx, make(chan struct{}, 1), make(chan error, 1))
@@ -70,4 +87,105 @@ func TestAsyncProducer(t *testing.T) {
 	require.Equal(t, asyncP.w.WriteTimeout, o.WriteTimeout)
 	require.Equal(t, asyncP.w.RequiredAcks, kafka.RequiredAcks(o.RequiredAcks))
 	require.Equal(t, asyncP.w.BatchBytes, int64(o.MaxMessageBytes))
+
+	var (
+		async0, _ = factory.AsyncProducer(
+			ctx,
+			make(chan struct{}, 1),
+			make(chan error, 1),
+		)
+		asyncP0, _ = async0.(*asyncWriter)
+		retErr0    error
+		retChan0   = make(chan struct{})
+	)
+	go func() {
+		retErr0 = asyncP0.AsyncRunCallback(ctx)
+		close(retChan0)
+	}()
+	close(asyncP0.closedChan)
+	<-retChan0
+	require.NoError(t, retErr0)
+
+	var (
+		async1, _ = factory.AsyncProducer(
+			ctx,
+			make(chan struct{}, 1),
+			make(chan error, 1),
+		)
+		asyncP1, _ = async1.(*asyncWriter)
+		retErr1    error
+		retChan1   = make(chan struct{})
+	)
+	go func() {
+		retErr1 = asyncP1.AsyncRunCallback(ctx)
+		close(retChan1)
+	}()
+	sendErr := cerror.New("failed point error")
+	asyncP1.failpointCh <- sendErr
+	<-retChan1
+	require.Equal(t, retErr1.Error(), cerror.Trace(sendErr).Error())
+
+	var (
+		async2, _ = factory.AsyncProducer(
+			ctx,
+			make(chan struct{}, 1),
+			make(chan error, 1),
+		)
+		asyncP2, _ = async2.(*asyncWriter)
+		retErr2    error
+		retChan2   = make(chan struct{})
+	)
+	go func() {
+		retErr2 = asyncP2.AsyncRunCallback(ctx)
+		close(retChan2)
+	}()
+	sendErr2 := cerror.New("errors chan error")
+	asyncP2.errorsChan <- sendErr2
+	<-retChan2
+	require.Equal(
+		t, retErr2.Error(),
+		cerror.WrapError(
+			cerror.ErrKafkaAsyncSendMessage, sendErr2,
+		).Error(),
+	)
+
+	var (
+		async3, _ = factory.AsyncProducer(
+			ctx,
+			make(chan struct{}, 1),
+			make(chan error, 1),
+		)
+		asyncP3, _ = async3.(*asyncWriter)
+		retErr3    error
+		retChan3   = make(chan struct{})
+	)
+	go func() {
+		retErr3 = asyncP3.AsyncRunCallback(ctx)
+		close(retChan3)
+	}()
+	close(asyncP3.errorsChan)
+	<-retChan3
+	require.NoError(t, retErr3)
+
+	var (
+		async4, _ = factory.AsyncProducer(
+			ctx,
+			make(chan struct{}, 1),
+			make(chan error, 1),
+		)
+		asyncP4, _    = async4.(*asyncWriter)
+		retErr4       error
+		retChan4      = make(chan struct{})
+		ctx4, cancel4 = context.WithCancel(context.Background())
+	)
+	go func() {
+		retErr4 = asyncP4.AsyncRunCallback(ctx4)
+		close(retChan4)
+	}()
+	cancel4()
+	<-retChan4
+	require.Equal(
+		t, retErr4.Error(),
+		cerror.Trace(ctx4.Err()).Error(),
+	)
 }


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: ref #8241 

### What is changed and how it works?
Add more ut for kafka sink v2, increase the coverage rate of factory.go from 20% to 37.1%

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - [x] Unit test

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
