### PR TITLE
feat(dm): return error if dm target db privileges precheck fail

### DIFF
--- a/dm/pkg/checker/privilege.go
+++ b/dm/pkg/checker/privilege.go
@@ -206,9 +206,8 @@ func (t *TargetPrivilegeChecker) Check(ctx context.Context) *Result {
 	err2 := verifyPrivilegesWithResult(result, grants, replRequiredPrivs)
 	if err2 != nil {
 		result.Errors = append(result.Errors, err2)
-		// because we cannot be very precisely sure about which table
-		// the binlog will write, so we only throw a warning here.
-		result.State = StateWarning
+		// set to error to avoid user skip this check unexpectedly
+		result.State = StateError
 	}
 	return result
 }

--- a/dm/pkg/checker/privilege.go
+++ b/dm/pkg/checker/privilege.go
@@ -207,7 +207,7 @@ func (t *TargetPrivilegeChecker) Check(ctx context.Context) *Result {
 	if err2 != nil {
 		result.Errors = append(result.Errors, err2)
 		// set to error to avoid user skip this check unexpectedly
-		result.State = StateError
+		result.State = StateFailure
 	}
 	return result
 }

--- a/dm/tests/check_task/run.sh
+++ b/dm/tests/check_task/run.sh
@@ -88,7 +88,7 @@ function test_privilege_precheck() {
 	run_sql_tidb "flush privileges;"
 	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"check-task $cur/conf/task-priv.yaml" \
-		"\"state\": fail" 1 \
+		"\"state\": \"fail\"" 1 \
 		"lack of Update global (*.*) privilege" 1
 	run_sql_tidb "grant update on *.* to 'test1'@'%';"
 	run_sql_tidb "flush privileges;"

--- a/dm/tests/check_task/run.sh
+++ b/dm/tests/check_task/run.sh
@@ -88,7 +88,7 @@ function test_privilege_precheck() {
 	run_sql_tidb "flush privileges;"
 	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"check-task $cur/conf/task-priv.yaml" \
-		"\"warning\": 1" 1 \
+		"\"fail\": 1" 1 \
 		"lack of Update global (*.*) privilege" 1
 	run_sql_tidb "grant update on *.* to 'test1'@'%';"
 	run_sql_tidb "flush privileges;"

--- a/dm/tests/check_task/run.sh
+++ b/dm/tests/check_task/run.sh
@@ -88,7 +88,7 @@ function test_privilege_precheck() {
 	run_sql_tidb "flush privileges;"
 	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"check-task $cur/conf/task-priv.yaml" \
-		"\"fail\": 1" 1 \
+		"\"state\": fail" 1 \
 		"lack of Update global (*.*) privilege" 1
 	run_sql_tidb "grant update on *.* to 'test1'@'%';"
 	run_sql_tidb "flush privileges;"

--- a/engine/test/integration_tests/dm_full_mode/run.sh
+++ b/engine/test/integration_tests/dm_full_mode/run.sh
@@ -55,10 +55,10 @@ function run() {
 
 	# create job & wait for job finished
 	job_id=$(create_job "DM" "$CUR_DIR/conf/job.yaml" "dm_full_mode")
-	exec_with_retry --count 30 "curl \"http://127.0.0.1:10245/api/v1/jobs/$job_id/status\" | tee /dev/stderr | grep -q 'Error 1142 (42000): ALTER command denied'"
+	exec_with_retry --count 30 "curl \"http://127.0.0.1:10245/api/v1/jobs/$job_id/status\" | tee /dev/stderr | grep -q 'is not running'"
 	docker restart server-executor-0 server-executor-1 server-executor-2
 	# check the error is not related to lightning checkpoint
-	exec_with_retry --count 60 "curl \"http://127.0.0.1:10245/api/v1/jobs/$job_id/status\" | tee /dev/stderr | grep -q 'Error 1142 (42000): ALTER command denied'"
+	exec_with_retry --count 60 "curl \"http://127.0.0.1:10245/api/v1/jobs/$job_id/status\" | tee /dev/stderr | grep -q 'is not running'"
 
 	run_sql --port 4000 "GRANT ALTER ON *.* TO 'dm_full'@'%';"
 	curl -X PUT "http://127.0.0.1:10245/api/v1/jobs/$job_id/status" -H 'Content-Type: application/json' -d '{"op": "resume"}'


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8430 

### What is changed and how it works?
return error if dm target db privileges precheck fail

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
return error if dm target db privileges check fail
```
