### PR TITLE
gc (ticdc): optimize the algorithm calculating gc safepoint 

### DIFF
--- a/cdc/api/v2/changefeed_test.go
+++ b/cdc/api/v2/changefeed_test.go
@@ -283,7 +283,7 @@ func TestGetChangeFeed(t *testing.T) {
 	statusProvider.changefeedInfo = &model.ChangeFeedInfo{
 		ID: validID,
 		Error: &model.RunningError{
-			Code: string(cerrors.ErrGCTTLExceeded.RFCCode()),
+			Code: string(cerrors.ErrStartTsBeforeGC.RFCCode()),
 		},
 	}
 	statusProvider.changefeedStatus = &model.ChangeFeedStatus{
@@ -298,7 +298,7 @@ func TestGetChangeFeed(t *testing.T) {
 	err = json.NewDecoder(w.Body).Decode(&resp)
 	require.Nil(t, err)
 	require.Equal(t, resp.ID, validID)
-	require.Contains(t, resp.Error.Code, "ErrGCTTLExceeded")
+	require.Contains(t, resp.Error.Code, "ErrStartTsBeforeGC")
 
 	// success
 	statusProvider.changefeedInfo = &model.ChangeFeedInfo{ID: validID}

--- a/cdc/model/changefeed_test.go
+++ b/cdc/model/changefeed_test.go
@@ -463,26 +463,6 @@ func TestFixState(t *testing.T) {
 				AdminJobType: AdminNone,
 				State:        StateNormal,
 				Error: &RunningError{
-					Code: string(errors.ErrGCTTLExceeded.RFCCode()),
-				},
-			},
-			expectedState: StateFailed,
-		},
-		{
-			info: &ChangeFeedInfo{
-				AdminJobType: AdminResume,
-				State:        StateNormal,
-				Error: &RunningError{
-					Code: string(errors.ErrGCTTLExceeded.RFCCode()),
-				},
-			},
-			expectedState: StateFailed,
-		},
-		{
-			info: &ChangeFeedInfo{
-				AdminJobType: AdminNone,
-				State:        StateNormal,
-				Error: &RunningError{
 					Code: string(errors.ErrClusterIDMismatch.RFCCode()),
 				},
 			},

--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -254,7 +254,7 @@ func (c *changefeed) checkStaleCheckpointTs(ctx cdcContext.Context, checkpointTs
 	state := c.state.Info.State
 	if state == model.StateNormal || state == model.StateStopped || state == model.StateError {
 		failpoint.Inject("InjectChangefeedFastFailError", func() error {
-			return cerror.ErrGCTTLExceeded.FastGen("InjectChangefeedFastFailError")
+			return cerror.ErrStartTsBeforeGC.FastGen("InjectChangefeedFastFailError")
 		})
 		if err := c.upstream.GCManager.CheckStaleCheckpointTs(ctx, c.id, checkpointTs); err != nil {
 			return errors.Trace(err)

--- a/cdc/owner/feed_state_manager.go
+++ b/cdc/owner/feed_state_manager.go
@@ -136,6 +136,7 @@ func (m *feedStateManager) Tick(state *orchestrator.ChangefeedReactorState) (adm
 	case model.StateError:
 		if m.state.Info.Error.IsChangefeedUnRetryableError() {
 			m.shouldBeRunning = false
+			m.patchState(model.StateFailed)
 			return
 		}
 	}

--- a/cdc/owner/feed_state_manager_test.go
+++ b/cdc/owner/feed_state_manager_test.go
@@ -197,7 +197,7 @@ func TestResumeChangefeedWithCheckpointTs(t *testing.T) {
 		func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 			return &model.TaskPosition{Error: &model.RunningError{
 				Addr:    ctx.GlobalVars().CaptureInfo.AdvertiseAddr,
-				Code:    "CDC:ErrGCTTLExceeded",
+				Code:    "CDC:ErrStartTsBeforeGC",
 				Message: "fake error for test",
 			}}, true, nil
 		})
@@ -347,7 +347,7 @@ func TestHandleFastFailError(t *testing.T) {
 		func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 			return &model.TaskPosition{Error: &model.RunningError{
 				Addr:    ctx.GlobalVars().CaptureInfo.AdvertiseAddr,
-				Code:    "CDC:ErrGCTTLExceeded",
+				Code:    "CDC:ErrStartTsBeforeGC",
 				Message: "fake error for test",
 			}}, true, nil
 		})

--- a/cdc/owner/owner.go
+++ b/cdc/owner/owner.go
@@ -711,7 +711,13 @@ func (o *ownerImpl) ignoreFailedChangeFeedWhenGC(
 		log.Warn("upstream not found", zap.Uint64("ID", upID))
 		return false
 	}
-	return us.GCManager.IgnoreFailedChangeFeed(state.Status.CheckpointTs)
+	// in case the changefeed failed right after it is created
+	// and the status is not initialized yet.
+	ts := state.Info.StartTs
+	if state.Status != nil {
+		ts = state.Status.CheckpointTs
+	}
+	return us.GCManager.IgnoreFailedChangeFeed(ts)
 }
 
 // calculateGCSafepoint calculates GCSafepoint for different upstream.

--- a/cdc/owner/owner_test.go
+++ b/cdc/owner/owner_test.go
@@ -50,7 +50,7 @@ type mockManager struct {
 func (m *mockManager) CheckStaleCheckpointTs(
 	ctx context.Context, changefeedID model.ChangeFeedID, checkpointTs model.Ts,
 ) error {
-	return cerror.ErrGCTTLExceeded.GenWithStackByArgs()
+	return cerror.ErrStartTsBeforeGC.GenWithStackByArgs()
 }
 
 var _ gc.Manager = (*mockManager)(nil)
@@ -199,7 +199,7 @@ func TestCreateRemoveChangefeed(t *testing.T) {
 		Error: nil,
 	}
 
-	// this will make changefeed always meet ErrGCTTLExceeded
+	// this will make changefeed always meet ErrStartTsBeforeGC
 	up, _ := owner.upstreamManager.Get(changefeedInfo.UpstreamID)
 	mockedManager := &mockManager{Manager: up.GCManager}
 	up.GCManager = mockedManager

--- a/errors.toml
+++ b/errors.toml
@@ -301,11 +301,6 @@ error = '''
 flow controller is aborted
 '''
 
-["CDC:ErrGCTTLExceeded"]
-error = '''
-the checkpoint-ts(%d) lag of the changefeed(%s) has exceeded the GC TTL
-'''
-
 ["CDC:ErrGRPCDialFailed"]
 error = '''
 grpc dial failed

--- a/pkg/errors/cdc_errors.go
+++ b/pkg/errors/cdc_errors.go
@@ -586,11 +586,6 @@ var (
 			" caused by GC. checkpoint-ts %d is earlier than or equal to GC safepoint at %d",
 		errors.RFCCodeText("CDC:ErrSnapshotLostByGC"),
 	)
-	ErrGCTTLExceeded = errors.Normalize(
-		"the checkpoint-ts(%d) lag of the changefeed(%s) "+
-			"has exceeded the GC TTL",
-		errors.RFCCodeText("CDC:ErrGCTTLExceeded"),
-	)
 	ErrNotOwner = errors.Normalize(
 		"this capture is not a owner",
 		errors.RFCCodeText("CDC:ErrNotOwner"),

--- a/pkg/errors/helper.go
+++ b/pkg/errors/helper.go
@@ -39,7 +39,7 @@ func WrapError(rfcError *errors.Error, err error, args ...interface{}) error {
 // wants to replicate has been or will be GC. So it makes no sense to try to
 // resume the changefeed, and the changefeed should immediately be failed.
 var changeFeedFastFailError = []*errors.Error{
-	ErrGCTTLExceeded, ErrSnapshotLostByGC, ErrStartTsBeforeGC,
+	ErrSnapshotLostByGC, ErrStartTsBeforeGC,
 }
 
 // IsChangefeedFastFailError checks if an error is a ChangefeedFastFailError

--- a/pkg/errors/helper_test.go
+++ b/pkg/errors/helper_test.go
@@ -98,23 +98,8 @@ func TestIsRetryableError(t *testing.T) {
 
 func TestChangefeedFastFailError(t *testing.T) {
 	t.Parallel()
-	err := ErrGCTTLExceeded.FastGenByArgs()
+	err := ErrSnapshotLostByGC.FastGenByArgs()
 	rfcCode, _ := RFCCode(err)
-	require.Equal(t, true, IsChangefeedFastFailError(err))
-	require.Equal(t, true, IsChangefeedFastFailErrorCode(rfcCode))
-
-	err = ErrGCTTLExceeded.GenWithStack("aa")
-	rfcCode, _ = RFCCode(err)
-	require.Equal(t, true, IsChangefeedFastFailError(err))
-	require.Equal(t, true, IsChangefeedFastFailErrorCode(rfcCode))
-
-	err = ErrGCTTLExceeded.Wrap(errors.New("aa"))
-	rfcCode, _ = RFCCode(err)
-	require.Equal(t, true, IsChangefeedFastFailError(err))
-	require.Equal(t, true, IsChangefeedFastFailErrorCode(rfcCode))
-
-	err = ErrSnapshotLostByGC.FastGenByArgs()
-	rfcCode, _ = RFCCode(err)
 	require.Equal(t, true, IsChangefeedFastFailError(err))
 	require.Equal(t, true, IsChangefeedFastFailErrorCode(rfcCode))
 

--- a/pkg/txnutil/gc/gc_manager.go
+++ b/pkg/txnutil/gc/gc_manager.go
@@ -28,10 +28,10 @@ import (
 	"go.uber.org/zap"
 )
 
-// failedFeedDataRetentionTime is the duration during which data related to a
+// gcTTL is the duration during which data related to a
 // failed feed will be retained, and beyond which point the data will be deleted
 // by garbage collection.
-const failedFeedDataRetentionTime = 24 * time.Hour
+const gcTTL = 24 * time.Hour
 
 // gcSafepointUpdateInterval is the minimum interval that CDC can update gc safepoint
 var gcSafepointUpdateInterval = 1 * time.Minute
@@ -134,10 +134,10 @@ func (m *gcManager) IgnoreFailedChangeFeed(
 		)
 		return false
 	}
-	// ignore the change feed if its current checkpoint TS is earlier
+	// ignore the changefeed if its current checkpoint TS is earlier
 	// than the (currentPDTso - failedFeedDataRetentionTime).
 	gcSafepointUpperBound := checkpointTs - 1
 	return pdTime.Sub(
 		oracle.GetTimeFromTS(gcSafepointUpperBound),
-	) > failedFeedDataRetentionTime
+	) > gcTTL
 }

--- a/pkg/txnutil/gc/gc_manager.go
+++ b/pkg/txnutil/gc/gc_manager.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/cdc/model"
@@ -29,6 +28,11 @@ import (
 	"go.uber.org/zap"
 )
 
+// failedFeedDataRetentionTime is the duration during which data related to a
+// failed feed will be retained, and beyond which point the data will be deleted
+// by garbage collection.
+const failedFeedDataRetentionTime = 24 * time.Hour
+
 // gcSafepointUpdateInterval is the minimum interval that CDC can update gc safepoint
 var gcSafepointUpdateInterval = 1 * time.Minute
 
@@ -39,6 +43,9 @@ type Manager interface {
 	// Set `forceUpdate` to force Manager update.
 	TryUpdateGCSafePoint(ctx context.Context, checkpointTs model.Ts, forceUpdate bool) error
 	CheckStaleCheckpointTs(ctx context.Context, changefeedID model.ChangeFeedID, checkpointTs model.Ts) error
+	// IgnoreFailedChangeFeed verifies whether a failed changefeed should be
+	// disregarded. When calculating the GC safepoint of the related upstream,
+	IgnoreFailedChangeFeed(checkpointTs uint64) bool
 }
 
 type gcManager struct {
@@ -50,7 +57,6 @@ type gcManager struct {
 	lastUpdatedTime   time.Time
 	lastSucceededTime time.Time
 	lastSafePointTs   uint64
-	isTiCDCBlockGC    bool
 }
 
 // NewManager creates a new Manager.
@@ -97,9 +103,6 @@ func (m *gcManager) TryUpdateGCSafePoint(
 		log.Warn("update gc safe point failed, the gc safe point is larger than checkpointTs",
 			zap.Uint64("actual", actual), zap.Uint64("checkpointTs", checkpointTs))
 	}
-	// if the min checkpoint ts is equal to the current gc safe point,
-	// it means that the service gc safe point set by TiCDC is the min service gc safe point
-	m.isTiCDCBlockGC = actual == checkpointTs
 	m.lastSafePointTs = actual
 	m.lastSucceededTime = time.Now()
 	return nil
@@ -109,20 +112,32 @@ func (m *gcManager) CheckStaleCheckpointTs(
 	ctx context.Context, changefeedID model.ChangeFeedID, checkpointTs model.Ts,
 ) error {
 	gcSafepointUpperBound := checkpointTs - 1
-	if m.isTiCDCBlockGC {
-		pdTime, err := m.pdClock.CurrentTime()
-		// TODO: should we return err here, or just log it?
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if pdTime.Sub(oracle.GetTimeFromTS(gcSafepointUpperBound)) > time.Duration(m.gcTTL)*time.Second {
-			return cerror.ErrGCTTLExceeded.GenWithStackByArgs(checkpointTs, changefeedID)
-		}
-	} else {
-		// if `isTiCDCBlockGC` is false, it means there is another service gc point less than the min checkpoint ts.
-		if gcSafepointUpperBound < m.lastSafePointTs {
-			return cerror.ErrSnapshotLostByGC.GenWithStackByArgs(checkpointTs, m.lastSafePointTs)
-		}
+	// if there is another service gc point less than the min checkpoint ts.
+	if gcSafepointUpperBound < m.lastSafePointTs {
+		return cerror.ErrSnapshotLostByGC.
+			GenWithStackByArgs(
+				checkpointTs,
+				m.lastSafePointTs,
+			)
 	}
 	return nil
+}
+
+func (m *gcManager) IgnoreFailedChangeFeed(
+	checkpointTs uint64,
+) bool {
+	pdTime, err := m.pdClock.CurrentTime()
+	if err != nil {
+		log.Warn("failed to get ts",
+			zap.String("GcManagerID", m.gcServiceID),
+			zap.Error(err),
+		)
+		return false
+	}
+	// ignore the change feed if its current checkpoint TS is earlier
+	// than the (currentPDTso - failedFeedDataRetentionTime).
+	gcSafepointUpperBound := checkpointTs - 1
+	return pdTime.Sub(
+		oracle.GetTimeFromTS(gcSafepointUpperBound),
+	) > failedFeedDataRetentionTime
 }

--- a/tests/integration_tests/changefeed_fast_fail/run.sh
+++ b/tests/integration_tests/changefeed_fast_fail/run.sh
@@ -32,7 +32,7 @@ function run() {
 	changefeedid="changefeed-fast-fail"
 	run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" -c $changefeedid
 
-	ensure $MAX_RETRIES check_changefeed_state http://${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid} "failed" "ErrGCTTLExceeded" ""
+	ensure $MAX_RETRIES check_changefeed_state http://${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid} "failed" "ErrStartTsBeforeGC" ""
 
 	# test changefeed remove
 	result=$(cdc cli changefeed remove -c $changefeedid)

--- a/tests/integration_tests/changefeed_resume_with_checkpoint_ts/run.sh
+++ b/tests/integration_tests/changefeed_resume_with_checkpoint_ts/run.sh
@@ -82,7 +82,7 @@ function resume_changefeed_in_failed_state() {
 	pd_addr="http://$UP_PD_HOST_1:$UP_PD_PORT_1"
 	SINK_URI="mysql://normal:123456@127.0.0.1:3306/?max-txn-row=1"
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --pd $pd_addr
-	ensure $MAX_RETRIES check_changefeed_state http://${UP_PD_HOST_1}:${UP_PD_PORT_1} $changefeed_id "failed" "ErrGCTTLExceeded" ""
+	ensure $MAX_RETRIES check_changefeed_state http://${UP_PD_HOST_1}:${UP_PD_PORT_1} $changefeed_id "failed" "ErrStartTsBeforeGC" ""
 
 	cdc cli changefeed resume --changefeed-id=$changefeed_id --pd=$pd_addr --overwrite-checkpoint-ts=now --no-confirm=true
 	ensure $MAX_RETRIES check_changefeed_state http://${UP_PD_HOST_1}:${UP_PD_PORT_1} $changefeed_id "normal" "null" ""

--- a/tests/integration_tests/multi_tables_ddl/run.sh
+++ b/tests/integration_tests/multi_tables_ddl/run.sh
@@ -98,7 +98,7 @@ function run() {
 
 	check_changefeed_state "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}" $cf_normal "normal" "null" ""
 	check_changefeed_state "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}" $cf_err1 "normal" "null" ""
-	check_changefeed_state "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}" $cf_err2 "error" "ErrSyncRenameTableFailed" ""
+	check_changefeed_state "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}" $cf_err2 "failed" "ErrSyncRenameTableFailed" ""
 
 	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 60
 

--- a/tests/integration_tests/multi_tables_ddl_v2/run.sh
+++ b/tests/integration_tests/multi_tables_ddl_v2/run.sh
@@ -71,7 +71,7 @@ function run() {
 
 	check_changefeed_state "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}" $cf_normal "normal" "null" ""
 	check_changefeed_state "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}" $cf_err1 "normal" "null" ""
-	check_changefeed_state "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}" $cf_err2 "error" "ErrSyncRenameTableFailed" ""
+	check_changefeed_state "http://${UP_PD_HOST_1}:${UP_PD_PORT_1}" $cf_err2 "failed" "ErrSyncRenameTableFailed" ""
 
 	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 60
 


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #8403 

### What is changed and how it works?
gc (ticdc): Instead of keeping restarting error changefeed in 24 hours, put the error changefeed into failed state and calculate the ticdc global gc safepoint based on checkpoint ts of all changefeeds and give users 24 hours grace period to handle the failed changefeed.

e.g.,

Have two ChangeFeeds,
cf1(failed) with checkpointTs ts1
cf2(normal) with checkpointTs ts2

the global gc safepoint will be:
min(ts2, max(ts1, currentPDTs - 24 hours))

After this pr being merged:

* Following errors will be set to fail directly:
```
ErrExpressionColumnNotFound,
ErrExpressionParseFailed,
ErrSchemaSnapshotNotFound,
ErrSyncRenameTableFailed,
ErrChangefeedUnretryable,
ErrGCTTLExceeded, 
ErrSnapshotLostByGC,
ErrStartTsBeforeGC,
```
* all other errors will be retried no more than 90 mins
* when cal the `gcsafepoint`, changefeed has been failed for more than 24 hours will be ignored

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->
No

##### Will it cause performance regression or break compatibility?
No

##### Do you need to update user documentation, design documentation or monitoring documentation?
No

### Release note <!-- bugfixes or new features need a release note -->
```release-note
- only retry error changefeed for no more than 90 mins
- cleanup data of changefeed that has been failed for more than 24 hours
```
