### PR TITLE
capture(ticdc): fix graceful shutdown in k8s

### DIFF
--- a/cdc/api/owner/owner.go
+++ b/cdc/api/owner/owner.go
@@ -227,18 +227,13 @@ func (h *ownerAPI) handleChangefeedQuery(w http.ResponseWriter, req *http.Reques
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	etcdClient, err := h.capture.GetEtcdClient()
-	if err != nil {
-		api.WriteError(w, http.StatusBadRequest, err)
-		return
-	}
-	cfInfo, err := etcdClient.GetChangeFeedInfo(ctx, changefeedID)
+	cfInfo, err := h.capture.GetEtcdClient().GetChangeFeedInfo(ctx, changefeedID)
 	if err != nil && cerror.ErrChangeFeedNotExists.NotEqual(err) {
 		api.WriteError(w, http.StatusBadRequest,
 			cerror.ErrAPIInvalidParam.GenWithStack("invalid changefeed id: %s", changefeedID))
 		return
 	}
-	cfStatus, _, err := etcdClient.GetChangeFeedStatus(ctx, changefeedID)
+	cfStatus, _, err := h.capture.GetEtcdClient().GetChangeFeedStatus(ctx, changefeedID)
 	if err != nil && cerror.ErrChangeFeedNotExists.NotEqual(err) {
 		api.WriteError(w, http.StatusBadRequest, err)
 		return

--- a/cdc/api/status/status.go
+++ b/cdc/api/status/status.go
@@ -62,13 +62,8 @@ func (h *statusAPI) writeEtcdInfo(ctx context.Context, cli etcd.CDCEtcdClient, w
 func (h *statusAPI) handleDebugInfo(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	h.capture.WriteDebugInfo(ctx, w)
-	etcdClient, err := h.capture.GetEtcdClient()
-	if err != nil {
-		fmt.Fprintf(w, "failed to get etcd client: %s\n\n", err.Error())
-		return
-	}
 	fmt.Fprintf(w, "\n\n*** etcd info ***:\n\n")
-	h.writeEtcdInfo(ctx, etcdClient, w)
+	h.writeEtcdInfo(ctx, h.capture.GetEtcdClient(), w)
 }
 
 func (h *statusAPI) handleStatus(w http.ResponseWriter, req *http.Request) {

--- a/cdc/api/v1/api.go
+++ b/cdc/api/v1/api.go
@@ -313,12 +313,7 @@ func (h *OpenAPI) CreateChangefeed(c *gin.Context) {
 		CAPath:        up.SecurityConfig.CAPath,
 		CertAllowedCN: up.SecurityConfig.CertAllowedCN,
 	}
-	etcdClient, err := h.capture.GetEtcdClient()
-	if err != nil {
-		_ = c.Error(err)
-		return
-	}
-	err = etcdClient.CreateChangefeedInfo(
+	err = h.capture.GetEtcdClient().CreateChangefeedInfo(
 		ctx, upstreamInfo,
 		info, model.DefaultChangeFeedID(changefeedConfig.ID))
 	if err != nil {
@@ -458,12 +453,8 @@ func (h *OpenAPI) UpdateChangefeed(c *gin.Context) {
 		_ = c.Error(err)
 		return
 	}
-	etcdClient, err := h.capture.GetEtcdClient()
-	if err != nil {
-		_ = c.Error(err)
-		return
-	}
-	err = etcdClient.SaveChangeFeedInfo(ctx, newInfo, changefeedID)
+
+	err = h.capture.GetEtcdClient().SaveChangeFeedInfo(ctx, newInfo, changefeedID)
 	if err != nil {
 		_ = c.Error(err)
 		return
@@ -755,12 +746,6 @@ func (h *OpenAPI) ListCapture(c *gin.Context) {
 	}
 	ownerID := info.ID
 
-	etcdClient, err := h.capture.GetEtcdClient()
-	if err != nil {
-		_ = c.Error(err)
-		return
-	}
-
 	captures := make([]*model.Capture, 0, len(captureInfos))
 	for _, c := range captureInfos {
 		isOwner := c.ID == ownerID
@@ -769,7 +754,7 @@ func (h *OpenAPI) ListCapture(c *gin.Context) {
 				ID:            c.ID,
 				IsOwner:       isOwner,
 				AdvertiseAddr: c.AdvertiseAddr,
-				ClusterID:     etcdClient.GetClusterID(),
+				ClusterID:     h.capture.GetEtcdClient().GetClusterID(),
 			})
 	}
 
@@ -860,17 +845,12 @@ func (h *OpenAPI) ServerStatus(c *gin.Context) {
 		_ = c.Error(err)
 		return
 	}
-	etcdClient, err := h.capture.GetEtcdClient()
-	if err != nil {
-		_ = c.Error(err)
-		return
-	}
 	status := model.ServerStatus{
 		Version:   version.ReleaseVersion,
 		GitHash:   version.GitHash,
 		Pid:       os.Getpid(),
 		ID:        info.ID,
-		ClusterID: etcdClient.GetClusterID(),
+		ClusterID: h.capture.GetEtcdClient().GetClusterID(),
 		IsOwner:   h.capture.IsOwner(),
 		Liveness:  h.capture.Liveness(),
 	}

--- a/cdc/api/v1/api_test.go
+++ b/cdc/api/v1/api_test.go
@@ -817,7 +817,7 @@ func TestServerStatusLiveness(t *testing.T) {
 	cp.EXPECT().IsOwner().DoAndReturn(func() bool {
 		return true
 	}).AnyTimes()
-	cp.EXPECT().GetEtcdClient().Return(etcdClient, nil).AnyTimes()
+	cp.EXPECT().GetEtcdClient().Return(etcdClient).AnyTimes()
 
 	// Alive.
 	alive := cp.EXPECT().Liveness().DoAndReturn(func() model.Liveness {

--- a/cdc/api/v1/validator.go
+++ b/cdc/api/v1/validator.go
@@ -77,17 +77,13 @@ func verifyCreateChangefeedConfig(
 		}
 		changefeedConfig.StartTS = oracle.ComposeTS(ts, logical)
 	}
-	etcdClient, err := capture.GetEtcdClient()
-	if err != nil {
-		return nil, err
-	}
 
 	// Ensure the start ts is valid in the next 1 hour.
 	const ensureTTL = 60 * 60
 	if err := gc.EnsureChangefeedStartTsSafety(
 		ctx,
 		up.PDClient,
-		etcdClient.GetEnsureGCServiceID(gc.EnsureGCServiceCreating),
+		capture.GetEtcdClient().GetEnsureGCServiceID(gc.EnsureGCServiceCreating),
 		model.DefaultChangeFeedID(changefeedConfig.ID),
 		ensureTTL, changefeedConfig.StartTS); err != nil {
 		if !cerror.ErrStartTsBeforeGC.Equal(err) {

--- a/cdc/api/v2/capture.go
+++ b/cdc/api/v2/capture.go
@@ -102,11 +102,7 @@ func (h *OpenAPIV2) listCaptures(c *gin.Context) {
 	}
 	ownerID := info.ID
 
-	etcdClient, err := h.capture.GetEtcdClient()
-	if err != nil {
-		_ = c.Error(err)
-		return
-	}
+	etcdClient := h.capture.GetEtcdClient()
 
 	captures := make([]Capture, 0, len(captureInfos))
 	for _, c := range captureInfos {

--- a/cdc/api/v2/changefeed_test.go
+++ b/cdc/api/v2/changefeed_test.go
@@ -62,7 +62,7 @@ func TestCreateChangefeed(t *testing.T) {
 		GetEnsureGCServiceID(gomock.Any()).
 		Return(etcd.GcServiceIDForTest()).AnyTimes()
 	cp.EXPECT().StatusProvider().Return(statusProvider).AnyTimes()
-	cp.EXPECT().GetEtcdClient().Return(etcdClient, nil).AnyTimes()
+	cp.EXPECT().GetEtcdClient().Return(etcdClient).AnyTimes()
 	cp.EXPECT().GetUpstreamManager().Return(mockUpManager, nil).AnyTimes()
 	cp.EXPECT().IsReady().Return(true).AnyTimes()
 	cp.EXPECT().IsOwner().Return(true).AnyTimes()
@@ -369,7 +369,7 @@ func TestUpdateChangefeed(t *testing.T) {
 	etcdClient.EXPECT().
 		GetUpstreamInfo(gomock.Any(), gomock.Eq(uint64(100)), gomock.Any()).
 		Return(nil, cerrors.ErrUpstreamNotFound).Times(1)
-	cp.EXPECT().GetEtcdClient().Return(etcdClient, nil).AnyTimes()
+	cp.EXPECT().GetEtcdClient().Return(etcdClient).AnyTimes()
 
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequestWithContext(context.Background(), update.method,
@@ -386,7 +386,7 @@ func TestUpdateChangefeed(t *testing.T) {
 	etcdClient.EXPECT().
 		GetUpstreamInfo(gomock.Any(), gomock.Eq(uint64(1)), gomock.Any()).
 		Return(nil, nil).AnyTimes()
-	cp.EXPECT().GetEtcdClient().Return(etcdClient, nil).AnyTimes()
+	cp.EXPECT().GetEtcdClient().Return(etcdClient).AnyTimes()
 
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequestWithContext(context.Background(), update.method,
@@ -672,7 +672,7 @@ func TestResumeChangefeed(t *testing.T) {
 		GetEnsureGCServiceID(gomock.Any()).
 		Return(etcd.GcServiceIDForTest()).AnyTimes()
 	cp.EXPECT().StatusProvider().Return(statusProvider).AnyTimes()
-	cp.EXPECT().GetEtcdClient().Return(etcdClient, nil).AnyTimes()
+	cp.EXPECT().GetEtcdClient().Return(etcdClient).AnyTimes()
 	cp.EXPECT().GetUpstreamManager().Return(mockUpManager, nil).AnyTimes()
 	cp.EXPECT().IsReady().Return(true).AnyTimes()
 	cp.EXPECT().IsOwner().Return(true).AnyTimes()
@@ -783,7 +783,7 @@ func TestDeleteChangefeed(t *testing.T) {
 		GetEnsureGCServiceID(gomock.Any()).
 		Return(etcd.GcServiceIDForTest()).AnyTimes()
 	cp.EXPECT().StatusProvider().Return(statusProvider).AnyTimes()
-	cp.EXPECT().GetEtcdClient().Return(etcdClient, nil).AnyTimes()
+	cp.EXPECT().GetEtcdClient().Return(etcdClient).AnyTimes()
 	cp.EXPECT().GetUpstreamManager().Return(mockUpManager, nil).AnyTimes()
 	cp.EXPECT().IsReady().Return(true).AnyTimes()
 	cp.EXPECT().IsOwner().Return(true).AnyTimes()
@@ -870,7 +870,7 @@ func TestPauseChangefeed(t *testing.T) {
 		GetEnsureGCServiceID(gomock.Any()).
 		Return(etcd.GcServiceIDForTest()).AnyTimes()
 	cp.EXPECT().StatusProvider().Return(statusProvider).AnyTimes()
-	cp.EXPECT().GetEtcdClient().Return(etcdClient, nil).AnyTimes()
+	cp.EXPECT().GetEtcdClient().Return(etcdClient).AnyTimes()
 	cp.EXPECT().GetUpstreamManager().Return(mockUpManager, nil).AnyTimes()
 	cp.EXPECT().IsReady().Return(true).AnyTimes()
 	cp.EXPECT().IsOwner().Return(true).AnyTimes()

--- a/cdc/api/v2/status.go
+++ b/cdc/api/v2/status.go
@@ -39,11 +39,7 @@ func (h *OpenAPIV2) serverStatus(c *gin.Context) {
 		_ = c.Error(err)
 		return
 	}
-	etcdClient, err := h.capture.GetEtcdClient()
-	if err != nil {
-		_ = c.Error(err)
-		return
-	}
+	etcdClient := h.capture.GetEtcdClient()
 	status := model.ServerStatus{
 		Version:   version.ReleaseVersion,
 		GitHash:   version.GitHash,

--- a/cdc/api/v2/status_test.go
+++ b/cdc/api/v2/status_test.go
@@ -37,7 +37,7 @@ func TestGetStatus(t *testing.T) {
 
 	etcdClient.EXPECT().
 		GetClusterID().Return("1234").AnyTimes()
-	cp.EXPECT().GetEtcdClient().Return(etcdClient, nil).AnyTimes()
+	cp.EXPECT().GetEtcdClient().Return(etcdClient).AnyTimes()
 	cp.EXPECT().IsReady().Return(true).AnyTimes()
 	cp.EXPECT().IsOwner().Return(true).AnyTimes()
 	cp.EXPECT().Liveness().Return(model.LivenessCaptureStopping).AnyTimes()

--- a/cdc/api/v2/unsafe.go
+++ b/cdc/api/v2/unsafe.go
@@ -35,12 +35,7 @@ import (
 
 // CDCMetaData returns all etcd key values used by cdc
 func (h *OpenAPIV2) CDCMetaData(c *gin.Context) {
-	etcdClient, err := h.capture.GetEtcdClient()
-	if err != nil {
-		_ = c.Error(err)
-		return
-	}
-	kvs, err := etcdClient.GetAllCDCInfo(c)
+	kvs, err := h.capture.GetEtcdClient().GetAllCDCInfo(c)
 	if err != nil {
 		_ = c.Error(err)
 		return
@@ -111,12 +106,8 @@ func (h *OpenAPIV2) DeleteServiceGcSafePoint(c *gin.Context) {
 	}
 	err := h.withUpstreamConfig(c, upstreamConfig,
 		func(ctx context.Context, client pd.Client) error {
-			etcdClient, err := h.capture.GetEtcdClient()
-			if err != nil {
-				return cerror.WrapError(cerror.ErrInternalServerError, err)
-			}
-			err = gc.RemoveServiceGCSafepoint(c, client,
-				etcdClient.GetGCServiceID())
+			err := gc.RemoveServiceGCSafepoint(c, client,
+				h.capture.GetEtcdClient().GetGCServiceID())
 			if err != nil {
 				return cerror.WrapError(cerror.ErrInternalServerError, err)
 			}

--- a/cdc/api/v2/unsafe_test.go
+++ b/cdc/api/v2/unsafe_test.go
@@ -47,7 +47,7 @@ func TestCDCMetaData(t *testing.T) {
 	etcdClient := mock_etcd.NewMockCDCEtcdClient(gomock.NewController(t))
 	cp.EXPECT().IsOwner().Return(true).AnyTimes()
 	cp.EXPECT().IsReady().Return(true).AnyTimes()
-	cp.EXPECT().GetEtcdClient().Return(etcdClient, nil).AnyTimes()
+	cp.EXPECT().GetEtcdClient().Return(etcdClient).AnyTimes()
 
 	// case 1: failed
 	etcdClient.EXPECT().GetAllCDCInfo(gomock.Any()).Return(nil, cerror.ErrPDEtcdAPIError).Times(1)

--- a/cdc/capture/capture_test.go
+++ b/cdc/capture/capture_test.go
@@ -15,7 +15,6 @@ package capture
 
 import (
 	"context"
-	"net/url"
 	"sync"
 	"testing"
 	"time"
@@ -35,39 +34,31 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func genCreateEtcdClientFunc(ctx context.Context, clientURL *url.URL) createEtcdClientFunc {
-	return func() (etcd.CDCEtcdClient, error) {
-		logConfig := logutil.DefaultZapLoggerConfig
-		logConfig.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
-		etcdCli, err := clientv3.New(clientv3.Config{
-			Endpoints:   []string{clientURL.String()},
-			Context:     ctx,
-			LogConfig:   &logConfig,
-			DialTimeout: 3 * time.Second,
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		cdcEtcdClient, err := etcd.NewCDCEtcdClient(ctx, etcdCli, etcd.DefaultCDCClusterID)
-		if err != nil {
-			etcdCli.Close()
-			return nil, err
-		}
-
-		return cdcEtcdClient, nil
-	}
-}
-
 func TestReset(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// init etcd mocker
 	clientURL, etcdServer, err := etcd.SetupEmbedEtcd(t.TempDir())
 	require.Nil(t, err)
+	logConfig := logutil.DefaultZapLoggerConfig
+	logConfig.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
+	etcdCli, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{clientURL.String()},
+		Context:     ctx,
+		LogConfig:   &logConfig,
+		DialTimeout: 3 * time.Second,
+	})
+	require.NoError(t, err)
+
+	client, err := etcd.NewCDCEtcdClient(ctx, etcdCli, etcd.DefaultCDCClusterID)
+	require.Nil(t, err)
+	// Close the client before the test function exits to prevent possible
+	// ctx leaks.
+	// Ref: https://github.com/grpc/grpc-go/blob/master/stream.go#L229
+	defer client.Close()
 
 	cp := NewCapture4Test(nil)
-	cp.createEtcdClient = genCreateEtcdClientFunc(ctx, clientURL)
+	cp.EtcdClient = client
 
 	// simulate network isolation scenarios
 	etcdServer.Close()

--- a/cdc/capture/mock/capture_mock.go
+++ b/cdc/capture/mock/capture_mock.go
@@ -66,12 +66,11 @@ func (mr *MockCaptureMockRecorder) Drain() *gomock.Call {
 }
 
 // GetEtcdClient mocks base method.
-func (m *MockCapture) GetEtcdClient() (etcd.CDCEtcdClient, error) {
+func (m *MockCapture) GetEtcdClient() etcd.CDCEtcdClient {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEtcdClient")
 	ret0, _ := ret[0].(etcd.CDCEtcdClient)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetEtcdClient indicates an expected call of GetEtcdClient.

--- a/cdc/server/server.go
+++ b/cdc/server/server.go
@@ -135,42 +135,41 @@ func (s *server) prepare(ctx context.Context) error {
 	logConfig := logutil.DefaultZapLoggerConfig
 	logConfig.Level = zap.NewAtomicLevelAt(zapcore.ErrorLevel)
 
-	createEtcdClient := func() (etcd.CDCEtcdClient, error) {
-		etcdCli, err := clientv3.New(clientv3.Config{
-			Endpoints:   s.pdEndpoints,
-			TLS:         tlsConfig,
-			LogConfig:   &logConfig,
-			DialTimeout: 5 * time.Second,
-			DialOptions: []grpc.DialOption{
-				grpcTLSOption,
-				grpc.WithBlock(),
-				grpc.WithConnectParams(grpc.ConnectParams{
-					Backoff: backoff.Config{
-						BaseDelay:  time.Second,
-						Multiplier: 1.1,
-						Jitter:     0.1,
-						MaxDelay:   3 * time.Second,
-					},
-					MinConnectTimeout: 3 * time.Second,
-				}),
-			},
-		})
-		if err != nil {
-			return nil, cerror.WrapError(cerror.ErrNewCaptureFailed, err)
-		}
-		cdcEtcdClient, err := etcd.NewCDCEtcdClient(ctx, etcdCli, conf.ClusterID)
-		if err != nil {
-			etcdCli.Close()
-			return nil, cerror.WrapError(cerror.ErrNewCaptureFailed, err)
-		}
-		return cdcEtcdClient, nil
-	}
-
-	cdcEtcdClient, err := createEtcdClient()
+	// we do not pass a `context` to the etcd client,
+	// to prevent it's cancelled when the server is closing.
+	// For example, when the non-owner node goes offline,
+	// it would resign the campaign key which was put by call `campaign`,
+	// if this is not done due to the passed context cancelled,
+	// the key will be kept for the lease TTL, which is 10 seconds,
+	// then cause the new owner cannot be elected immediately after the old owner offline.
+	// see https://github.com/etcd-io/etcd/blob/525d53bd41/client/v3/concurrency/election.go#L98
+	etcdCli, err := clientv3.New(clientv3.Config{
+		Endpoints:   s.pdEndpoints,
+		TLS:         tlsConfig,
+		LogConfig:   &logConfig,
+		DialTimeout: 5 * time.Second,
+		DialOptions: []grpc.DialOption{
+			grpcTLSOption,
+			grpc.WithBlock(),
+			grpc.WithConnectParams(grpc.ConnectParams{
+				Backoff: backoff.Config{
+					BaseDelay:  time.Second,
+					Multiplier: 1.1,
+					Jitter:     0.1,
+					MaxDelay:   3 * time.Second,
+				},
+				MinConnectTimeout: 3 * time.Second,
+			}),
+		},
+	})
 	if err != nil {
 		return cerror.WrapError(cerror.ErrNewCaptureFailed, err)
 	}
 
+	cdcEtcdClient, err := etcd.NewCDCEtcdClient(ctx, etcdCli, conf.ClusterID)
+	if err != nil {
+		return cerror.WrapError(cerror.ErrNewCaptureFailed, err)
+	}
 	s.etcdClient = cdcEtcdClient
 
 	err = s.initDir(ctx)
@@ -183,8 +182,7 @@ func (s *server) prepare(ctx context.Context) error {
 	}
 
 	s.capture = capture.NewCapture(
-		s.pdEndpoints, createEtcdClient, s.grpcService,
-		s.sortEngineFactory)
+		s.pdEndpoints, cdcEtcdClient, s.grpcService, s.sortEngineFactory)
 
 	return nil
 }

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -154,8 +154,6 @@ type CDCEtcdClient interface {
 	DeleteCaptureInfo(context.Context, model.CaptureID) error
 
 	CheckMultipleCDCClusterExist(ctx context.Context) error
-
-	Close() error
 }
 
 // CDCEtcdClientImpl is a wrap of etcd client

--- a/pkg/etcd/mock/etcd_client_mock.go
+++ b/pkg/etcd/mock/etcd_client_mock.go
@@ -52,20 +52,6 @@ func (mr *MockCDCEtcdClientMockRecorder) CheckMultipleCDCClusterExist(ctx interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckMultipleCDCClusterExist", reflect.TypeOf((*MockCDCEtcdClient)(nil).CheckMultipleCDCClusterExist), ctx)
 }
 
-// Close mocks base method.
-func (m *MockCDCEtcdClient) Close() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Close indicates an expected call of Close.
-func (mr *MockCDCEtcdClientMockRecorder) Close() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockCDCEtcdClient)(nil).Close))
-}
-
 // CreateChangefeedInfo mocks base method.
 func (m *MockCDCEtcdClient) CreateChangefeedInfo(arg0 context.Context, arg1 *model.UpstreamInfo, arg2 *model.ChangeFeedInfo, arg3 model.ChangeFeedID) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow!  
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8484

### What is changed and how it works?

1. Allow access etcd client after a capture has been drained.
2. Do not return error in `campaignOwner` after a capture has been drained.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
	Run TiCDC cluster in a k8s cluster and rolling restart all TiCDC nodes.

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix an issue that TiCDC cluster can not graceful upgrade in k8s
```
