### PR TITLE
redo(ticdc): limit memory usage in applier

### DIFF
--- a/cdc/processor/memquota/mem_quota.go
+++ b/cdc/processor/memquota/mem_quota.go
@@ -68,9 +68,11 @@ func NewMemQuota(changefeedID model.ChangeFeedID, totalBytes uint64, comp string
 		changefeedID:     changefeedID,
 		totalBytes:       totalBytes,
 		blockAcquireCond: sync.NewCond(&sync.Mutex{}),
-		metricTotal:      MemoryQuota.WithLabelValues(changefeedID.Namespace, changefeedID.ID, "total", comp),
-		metricUsed:       MemoryQuota.WithLabelValues(changefeedID.Namespace, changefeedID.ID, "used", comp),
-		closeBg:          make(chan struct{}, 1),
+		metricTotal: MemoryQuota.WithLabelValues(changefeedID.Namespace,
+			changefeedID.ID, "total", comp),
+		metricUsed: MemoryQuota.WithLabelValues(changefeedID.Namespace,
+			changefeedID.ID, "used", comp),
+		closeBg: make(chan struct{}, 1),
 
 		tableMemory: spanz.NewHashMap[[]*MemConsumeRecord](),
 	}

--- a/errors.toml
+++ b/errors.toml
@@ -936,6 +936,11 @@ error = '''
 version is incompatible: %s
 '''
 
+["CDC:ErrWaitFreeMemoryTimeout"]
+error = '''
+wait free memory timeout
+'''
+
 ["CDC:ErrWorkerPoolGracefulUnregisterTimedOut"]
 error = '''
 workerpool handle graceful unregister timed out

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/r3labs/diff v1.1.0
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/segmentio/kafka-go v0.4.39-0.20230217181906-f6986fb02ee7
+	github.com/shirou/gopsutil/v3 v3.23.1
 	github.com/shopspring/decimal v1.3.0
 	github.com/soheilhy/cmux v0.1.5
 	github.com/spf13/cobra v1.6.1
@@ -237,7 +238,6 @@ require (
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/sasha-s/go-deadlock v0.2.0 // indirect
-	github.com/shirou/gopsutil/v3 v3.23.1 // indirect
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
 	github.com/shurcooL/httpgzip v0.0.0-20190720172056-320755c1c1b0 // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546 // indirect

--- a/pkg/applier/redo.go
+++ b/pkg/applier/redo.go
@@ -22,6 +22,7 @@ import (
 	timodel "github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tiflow/cdc/contextutil"
 	"github.com/pingcap/tiflow/cdc/model"
+	"github.com/pingcap/tiflow/cdc/processor/memquota"
 	"github.com/pingcap/tiflow/cdc/redo/reader"
 	"github.com/pingcap/tiflow/cdc/sink/ddlsink"
 	ddlfactory "github.com/pingcap/tiflow/cdc/sink/ddlsink/factory"
@@ -68,12 +69,15 @@ type RedoApplier struct {
 	ddlSink         ddlsink.Sink
 	appliedDDLCount uint64
 
+	memQuota     *memquota.MemQuota
+	pendingQuota uint64
+
 	// sinkFactory is used to create table sinks.
 	sinkFactory *dmlfactory.SinkFactory
 	// tableSinks is a map from tableID to table sink.
 	// We create it when we need it, and close it after we finish applying the redo logs.
 	tableSinks         map[model.TableID]tablesink.TableSink
-	tableResolvedTsMap map[model.TableID]model.ResolvedTs
+	tableResolvedTsMap map[model.TableID]*memquota.MemConsumeRecord
 	appliedLogCount    uint64
 
 	errCh chan error
@@ -129,8 +133,26 @@ func (ra *RedoApplier) initSink(ctx context.Context) (err error) {
 	}
 
 	ra.tableSinks = make(map[model.TableID]tablesink.TableSink)
-	ra.tableResolvedTsMap = make(map[model.TableID]model.ResolvedTs)
+	ra.tableResolvedTsMap = make(map[model.TableID]*memquota.MemConsumeRecord)
 	return nil
+}
+
+func (ra *RedoApplier) bgReleaseQuota(ctx context.Context) error {
+	ra.memQuota = memquota.NewMemQuota(model.DefaultChangeFeedID(applierChangefeed),
+		config.DefaultChangefeedMemoryQuota, "sink")
+	defer ra.memQuota.Close()
+	ticker := time.NewTicker(time.Second)
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.Trace(ctx.Err())
+		case <-ticker.C:
+			for tableID, tableSink := range ra.tableSinks {
+				checkpointTs := tableSink.GetCheckpointTs()
+				ra.memQuota.Release(spanz.TableIDToComparableSpan(tableID), checkpointTs)
+			}
+		}
+	}
 }
 
 func (ra *RedoApplier) consumeLogs(ctx context.Context) error {
@@ -201,6 +223,42 @@ func (ra *RedoApplier) consumeLogs(ctx context.Context) error {
 	return errApplyFinished
 }
 
+func (ra *RedoApplier) resetQuota(rowSize uint64) error {
+	if rowSize >= config.DefaultChangefeedMemoryQuota || rowSize < ra.pendingQuota {
+		log.Panic("row size exceeds memory quota",
+			zap.Uint64("rowSize", rowSize),
+			zap.Uint64("memoryQuota", config.DefaultChangefeedMemoryQuota))
+	}
+
+	// flush all tables before acquire new quota
+	for tableID, tableRecord := range ra.tableResolvedTsMap {
+		if !tableRecord.ResolvedTs.IsBatchMode() {
+			log.Panic("table resolved ts should always be in batch mode when apply redo log")
+		}
+
+		if err := ra.tableSinks[tableID].UpdateResolvedTs(tableRecord.ResolvedTs); err != nil {
+			return err
+		}
+		ra.memQuota.Record(spanz.TableIDToComparableSpan(tableID),
+			tableRecord.ResolvedTs, tableRecord.Size)
+
+		// reset new record
+		ra.tableResolvedTsMap[tableID] = &memquota.MemConsumeRecord{
+			ResolvedTs: tableRecord.ResolvedTs.AdvanceBatch(),
+			Size:       0,
+		}
+	}
+
+	oldQuota := ra.pendingQuota
+	ra.pendingQuota = uint64(rowSize * mysql.DefaultMaxTxnRow)
+	if ra.pendingQuota > config.DefaultChangefeedMemoryQuota {
+		ra.pendingQuota = config.DefaultChangefeedMemoryQuota
+	} else if ra.pendingQuota < 64*1024 {
+		ra.pendingQuota = 64 * 1024
+	}
+	return ra.memQuota.BlockAcquire(ra.pendingQuota - oldQuota)
+}
+
 func (ra *RedoApplier) applyDDL(
 	ctx context.Context, ddl *model.DDLEvent, checkpointTs, resolvedTs uint64,
 ) error {
@@ -244,6 +302,14 @@ func (ra *RedoApplier) applyDDL(
 func (ra *RedoApplier) applyRow(
 	row *model.RowChangedEvent, checkpointTs model.Ts,
 ) error {
+	rowSize := uint64(row.ApproximateBytes())
+	if rowSize > ra.pendingQuota {
+		if err := ra.resetQuota(uint64(row.ApproximateBytes())); err != nil {
+			return err
+		}
+	}
+	ra.pendingQuota -= rowSize
+
 	tableID := row.Table.TableID
 	if _, ok := ra.tableSinks[tableID]; !ok {
 		tableSink := ra.sinkFactory.CreateTableSink(
@@ -254,17 +320,30 @@ func (ra *RedoApplier) applyRow(
 		ra.tableSinks[tableID] = tableSink
 	}
 	if _, ok := ra.tableResolvedTsMap[tableID]; !ok {
-		ra.tableResolvedTsMap[tableID] = model.NewResolvedTs(checkpointTs)
-	}
-	ra.tableSinks[tableID].AppendRowChangedEvents(row)
-	if row.CommitTs > ra.tableResolvedTsMap[tableID].Ts {
-		// Use batch resolvedTs to flush data as quickly as possible.
-		ra.tableResolvedTsMap[tableID] = model.ResolvedTs{
-			Mode:    model.BatchResolvedMode,
-			Ts:      row.CommitTs,
-			BatchID: 1,
+		ra.tableResolvedTsMap[tableID] = &memquota.MemConsumeRecord{
+			ResolvedTs: model.ResolvedTs{
+				Mode:    model.BatchResolvedMode,
+				Ts:      checkpointTs,
+				BatchID: 1,
+			},
+			Size: 0,
 		}
-	} else if row.CommitTs < ra.tableResolvedTsMap[tableID].Ts {
+	}
+
+	ra.tableSinks[tableID].AppendRowChangedEvents(row)
+	record := ra.tableResolvedTsMap[tableID]
+	record.Size += rowSize
+	if row.CommitTs > record.ResolvedTs.Ts {
+		// Use batch resolvedTs to flush data as quickly as possible.
+		ra.tableResolvedTsMap[tableID] = &memquota.MemConsumeRecord{
+			ResolvedTs: model.ResolvedTs{
+				Mode:    model.BatchResolvedMode,
+				Ts:      row.CommitTs,
+				BatchID: 1,
+			},
+			Size: record.Size,
+		}
+	} else if row.CommitTs < ra.tableResolvedTsMap[tableID].ResolvedTs.Ts {
 		log.Panic("commit ts of redo log regressed",
 			zap.Int64("tableID", tableID),
 			zap.Uint64("commitTs", row.CommitTs),
@@ -272,16 +351,6 @@ func (ra *RedoApplier) applyRow(
 	}
 
 	ra.appliedLogCount++
-	if ra.appliedLogCount%mysql.DefaultMaxTxnRow == 0 {
-		for tableID, tableResolvedTs := range ra.tableResolvedTsMap {
-			if err := ra.tableSinks[tableID].UpdateResolvedTs(tableResolvedTs); err != nil {
-				return err
-			}
-			if tableResolvedTs.IsBatchMode() {
-				ra.tableResolvedTsMap[tableID] = tableResolvedTs.AdvanceBatch()
-			}
-		}
-	}
 	return nil
 }
 
@@ -291,13 +360,23 @@ func (ra *RedoApplier) waitTableFlush(
 	ticker := time.NewTicker(warnDuration)
 	defer ticker.Stop()
 
-	resolvedTs := model.NewResolvedTs(rts)
-	ra.tableResolvedTsMap[tableID] = resolvedTs
-	if err := ra.tableSinks[tableID].UpdateResolvedTs(resolvedTs); err != nil {
+	ra.tableResolvedTsMap[tableID] = &memquota.MemConsumeRecord{
+		ResolvedTs: model.ResolvedTs{
+			Mode:    model.BatchResolvedMode,
+			Ts:      rts,
+			BatchID: 1,
+		},
+		Size: ra.tableResolvedTsMap[tableID].Size,
+	}
+	tableRecord := ra.tableResolvedTsMap[tableID]
+	if err := ra.tableSinks[tableID].UpdateResolvedTs(tableRecord.ResolvedTs); err != nil {
 		return err
 	}
+	ra.memQuota.Record(spanz.TableIDToComparableSpan(tableID),
+		tableRecord.ResolvedTs, tableRecord.Size)
+
 	// Make sure all events are flushed to downstream.
-	for !ra.tableSinks[tableID].GetCheckpointTs().EqualOrGreater(resolvedTs) {
+	for !ra.tableSinks[tableID].GetCheckpointTs().EqualOrGreater(tableRecord.ResolvedTs) {
 		select {
 		case <-ctx.Done():
 			return errors.Trace(ctx.Err())
@@ -305,12 +384,18 @@ func (ra *RedoApplier) waitTableFlush(
 			log.Warn(
 				"Table sink is not catching up with resolved ts for a long time",
 				zap.Int64("tableID", tableID),
-				zap.Any("resolvedTs", resolvedTs),
+				zap.Any("resolvedTs", tableRecord.ResolvedTs),
 				zap.Any("checkpointTs", ra.tableSinks[tableID].GetCheckpointTs()),
 			)
 		default:
 			time.Sleep(flushWaitDuration)
 		}
+	}
+
+	// reset new record
+	ra.tableResolvedTsMap[tableID] = &memquota.MemConsumeRecord{
+		ResolvedTs: tableRecord.ResolvedTs.AdvanceBatch(),
+		Size:       0,
 	}
 	return nil
 }
@@ -344,6 +429,9 @@ func (ra *RedoApplier) Apply(egCtx context.Context) (err error) {
 
 	eg.Go(func() error {
 		return ra.rd.Run(egCtx)
+	})
+	eg.Go(func() error {
+		return ra.bgReleaseQuota(egCtx)
 	})
 	eg.Go(func() error {
 		return ra.consumeLogs(egCtx)

--- a/pkg/applier/redo.go
+++ b/pkg/applier/redo.go
@@ -247,7 +247,7 @@ func (ra *RedoApplier) resetQuota(rowSize uint64) error {
 	}
 
 	oldQuota := ra.pendingQuota
-	ra.pendingQuota = uint64(rowSize * mysql.DefaultMaxTxnRow)
+	ra.pendingQuota = rowSize * mysql.DefaultMaxTxnRow
 	if ra.pendingQuota > config.DefaultChangefeedMemoryQuota {
 		ra.pendingQuota = config.DefaultChangefeedMemoryQuota
 	} else if ra.pendingQuota < 64*1024 {

--- a/pkg/errors/cdc_errors.go
+++ b/pkg/errors/cdc_errors.go
@@ -397,6 +397,10 @@ var (
 	ErrDiskFull = errors.Normalize(
 		"failed to preallocate file because disk is full",
 		errors.RFCCodeText("CDC:ErrDiskFull"))
+	ErrWaitFreeMemoryTimeout = errors.Normalize(
+		"wait free memory timeout",
+		errors.RFCCodeText("CDC:ErrWaitFreeMemoryTimeout"),
+	)
 
 	// encode/decode, data format and data integrity errors
 	ErrInvalidRecordKey = errors.Normalize(

--- a/pkg/util/memory_checker.go
+++ b/pkg/util/memory_checker.go
@@ -29,6 +29,7 @@ func CheckMemoryUsage(limit float64) (bool, error) {
 	return stat.UsedPercent < limit, nil
 }
 
+// WaitMemoryAvailable waits until the memory usage is less than the limit.
 func WaitMemoryAvailable(limit float64, timeout time.Duration) error {
 	start := time.Now()
 	for {

--- a/pkg/util/memory_checker.go
+++ b/pkg/util/memory_checker.go
@@ -1,0 +1,46 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"time"
+
+	"github.com/pingcap/tiflow/pkg/errors"
+	"github.com/shirou/gopsutil/v3/mem"
+)
+
+// CheckMemoryUsage checks if the memory usage is less than the limit.
+func CheckMemoryUsage(limit float64) (bool, error) {
+	stat, err := mem.VirtualMemory()
+	if err != nil {
+		return false, err
+	}
+	return stat.UsedPercent < limit, nil
+}
+
+func WaitMemoryAvailable(limit float64, timeout time.Duration) error {
+	start := time.Now()
+	for {
+		hasFreeMemory, err := CheckMemoryUsage(limit)
+		if err != nil {
+			return err
+		}
+		if hasFreeMemory {
+			return nil
+		}
+		if time.Since(start) > timeout {
+			return errors.ErrWaitFreeMemoryTimeout.GenWithStackByArgs()
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #8056

### What is changed and how it works?
1. Limit [total memory usage](https://github.com/pingcap/tiflow/pull/8494/files#diff-a4f2a9712d65b01443a6b810b343317221039c2558b867f82d3d2c3c1fe18e0dR32) in reader.
2. Add memory quota in redo applier.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`Fix the issue that redo apply may cause OOM`.
```
