### PR TITLE
mounter(ticdc): mount float32 value correctly to avoid the precision lost.

### DIFF
--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -455,7 +455,15 @@ func formatColVal(datum types.Datum, col *timodel.ColumnInfo) (
 			b = emptyBytes
 		}
 		return b, sizeOfBytes(b), "", nil
-	case mysql.TypeFloat, mysql.TypeDouble:
+	case mysql.TypeFloat:
+		v := datum.GetFloat32()
+		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 1) || math.IsInf(float64(v), -1) {
+			warn = fmt.Sprintf("the value is invalid in column: %f", v)
+			v = 0
+		}
+		const sizeOfV = unsafe.Sizeof(v)
+		return v, int(sizeOfV), warn, nil
+	case mysql.TypeDouble:
 		v := datum.GetFloat64()
 		if math.IsNaN(v) || math.IsInf(v, 1) || math.IsInf(v, -1) {
 			warn = fmt.Sprintf("the value is invalid in column: %f", v)

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -973,7 +973,7 @@ func TestGetDefaultZeroValue(t *testing.T) {
 
 	for _, tc := range testCases {
 		_, val, _, _, _ := getDefaultOrZeroValue(&tc.ColInfo)
-		require.Equal(t, tc.Res, val, tc.Name)
+		require.EqualValues(t, tc.Res, val, tc.Name)
 		val = getDDLDefaultDefinition(&tc.ColInfo)
 		require.Equal(t, tc.Default, val, tc.Name)
 	}

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -1273,10 +1273,11 @@ func TestFormatColVal(t *testing.T) {
 
 	var datum types.Datum
 	datum.SetFloat32(123.99)
+	
+	ftTypeFloatNotNull := types.NewFieldType(mysql.TypeFloat)
+	ftTypeFloatNotNull.SetFlag(mysql.NotNullFlag)
 
-	col := &timodel.ColumnInfo{
-		FieldType: *types.NewFieldType(mysql.TypeFloat),
-	}
+	col := &timodel.ColumnInfo{FieldType: *ftTypeFloatNotNull}
 
 	value, _, _, err := formatColVal(datum, col)
 	require.NoError(t, err)

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -1267,3 +1267,18 @@ func TestNewDMRowChange(t *testing.T) {
 		require.Equal(t, []interface{}{1, 2, 1, 2}, argsGot)
 	}
 }
+
+func TestFormatColVal(t *testing.T) {
+	t.Parallel()
+
+	var datum types.Datum
+	datum.SetFloat32(123.99)
+
+	col := &timodel.ColumnInfo{
+		FieldType: *types.NewFieldType(mysql.TypeFloat),
+	}
+
+	value, _, _, err := formatColVal(datum, col)
+	require.NoError(t, err)
+	require.EqualValues(t, float32(123.99), value)
+}

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -689,28 +689,28 @@ func TestGetDefaultZeroValue(t *testing.T) {
 		{
 			Name:    "mysql.TypeFloat + notnull + nodefault",
 			ColInfo: timodel.ColumnInfo{FieldType: *ftTypeFloatNotNull},
-			Res:     float64(0),
+			Res:     float32(0),
 			Default: nil,
 		},
 		// mysql.TypeFloat + notnull + default
 		{
 			Name: "mysql.TypeFloat + notnull + default",
 			ColInfo: timodel.ColumnInfo{
-				OriginDefaultValue: -3.1415,
+				OriginDefaultValue: float32(-3.1415),
 				FieldType:          *ftTypeFloatNotNull,
 			},
-			Res:     float64(-3.1415),
-			Default: float64(-3.1415),
+			Res:     float32(-3.1415),
+			Default: float32(-3.1415),
 		},
 		// mysql.TypeFloat + notnull + default + unsigned
 		{
 			Name: "mysql.TypeFloat + notnull + default + unsigned",
 			ColInfo: timodel.ColumnInfo{
-				OriginDefaultValue: 3.1415,
+				OriginDefaultValue: float32(3.1415),
 				FieldType:          *ftTypeFloatNotNullUnSigned,
 			},
-			Res:     float64(3.1415),
-			Default: float64(3.1415),
+			Res:     float32(3.1415),
+			Default: float32(3.1415),
 		},
 		// mysql.TypeFloat + notnull + unsigned
 		{
@@ -718,18 +718,18 @@ func TestGetDefaultZeroValue(t *testing.T) {
 			ColInfo: timodel.ColumnInfo{
 				FieldType: *ftTypeFloatNotNullUnSigned,
 			},
-			Res:     float64(0),
+			Res:     float32(0),
 			Default: nil,
 		},
 		// mysql.TypeFloat + null + default
 		{
 			Name: "mysql.TypeFloat + null + default",
 			ColInfo: timodel.ColumnInfo{
-				OriginDefaultValue: -3.1415,
+				OriginDefaultValue: float32(-3.1415),
 				FieldType:          *ftTypeFloatNull,
 			},
-			Res:     float64(-3.1415),
-			Default: float64(-3.1415),
+			Res:     float32(-3.1415),
+			Default: float32(-3.1415),
 		},
 		// mysql.TypeFloat + null + nodefault
 		{

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -1273,7 +1273,7 @@ func TestFormatColVal(t *testing.T) {
 
 	var datum types.Datum
 	datum.SetFloat32(123.99)
-	
+
 	ftTypeFloatNotNull := types.NewFieldType(mysql.TypeFloat)
 	ftTypeFloatNotNull.SetFlag(mysql.NotNullFlag)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8490 

### What is changed and how it works?

* For float32 types, fetch it from the`datum` by use the corresponding method.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix float32 types precision lost
```
