### PR TITLE
metrics(ticdc): move checkpoint ts and resolved ts p99 panels into lag analyze row

### DIFF
--- a/metrics/grafana/ticdc.json
+++ b/metrics/grafana/ticdc.json
@@ -351,6 +351,202 @@
         },
         {
           "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "each changefeed's checkpoint lag distribution",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 5
+          },
+          "hiddenSeries": false,
+          "id": 633,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile(0.99, sum(rate(ticdc_owner_checkpoint_lag_histogram_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", changefeed=~\"$changefeed\", instance=~\"$ticdc_instance\"}[1m])) by (le,instance,changefeed))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{changefeed}}-p99",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Changefeed checkpoint 99% lag",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "each changefeed's resolved ts lag distribution",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 5
+          },
+          "hiddenSeries": false,
+          "id": 632,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.11",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile(0.99, sum(rate(ticdc_owner_resolved_ts_lag_histogram_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", changefeed=~\"$changefeed\", instance=~\"$ticdc_instance\"}[1m])) by (le,instance,changefeed))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{changefeed}}-p99",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Changefeed resolved ts 99% lag",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
           "bars": true,
           "dashLength": 10,
           "dashes": false,
@@ -368,7 +564,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 5
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 469,
@@ -473,7 +669,7 @@
             "h": 4,
             "w": 12,
             "x": 12,
-            "y": 5
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 466,
@@ -576,7 +772,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 9
+            "y": 16
           },
           "hiddenSeries": false,
           "id": 479,
@@ -680,7 +876,7 @@
             "h": 4,
             "w": 12,
             "x": 12,
-            "y": 9
+            "y": 16
           },
           "hiddenSeries": false,
           "id": 473,
@@ -810,7 +1006,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 13
+            "y": 20
           },
           "hiddenSeries": false,
           "id": 486,
@@ -916,7 +1112,7 @@
             "h": 4,
             "w": 12,
             "x": 12,
-            "y": 13
+            "y": 20
           },
           "hiddenSeries": false,
           "id": 485,
@@ -1024,7 +1220,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 401,
@@ -1133,7 +1329,7 @@
             "h": 4,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 467,
@@ -1242,7 +1438,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 21
+            "y": 28
           },
           "hiddenSeries": false,
           "id": 407,
@@ -1350,7 +1546,7 @@
             "h": 4,
             "w": 12,
             "x": 12,
-            "y": 21
+            "y": 28
           },
           "hiddenSeries": false,
           "id": 470,
@@ -1456,7 +1652,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 25
+            "y": 32
           },
           "hiddenSeries": false,
           "id": 471,
@@ -1565,7 +1761,7 @@
             "h": 4,
             "w": 12,
             "x": 12,
-            "y": 25
+            "y": 32
           },
           "hiddenSeries": false,
           "id": 400,
@@ -1671,7 +1867,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 29
+            "y": 36
           },
           "hiddenSeries": false,
           "id": 433,
@@ -1776,7 +1972,7 @@
             "h": 4,
             "w": 12,
             "x": 12,
-            "y": 29
+            "y": 36
           },
           "hiddenSeries": false,
           "id": 427,
@@ -1885,7 +2081,7 @@
             "h": 4,
             "w": 12,
             "x": 0,
-            "y": 33
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 399,
@@ -1990,7 +2186,7 @@
             "h": 4,
             "w": 12,
             "x": 12,
-            "y": 33
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 472,
@@ -3684,202 +3880,6 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "each changefeed's checkpoint lag distribution",
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 0,
-            "y": 24
-          },
-          "hiddenSeries": false,
-          "id": 633,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": true,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.5.11",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "histogram_quantile(0.99, sum(rate(ticdc_owner_checkpoint_lag_histogram_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", changefeed=~\"$changefeed\", instance=~\"$ticdc_instance\"}[1m])) by (le,instance,changefeed))",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "{{changefeed}}-p99",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "changefeed checkpoint lag duration percentile",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "none",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_TEST-CLUSTER}",
-          "description": "each changefeed's resolved ts lag distribution",
-          "fieldConfig": {
-            "defaults": {},
-            "overrides": []
-          },
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 24
-          },
-          "hiddenSeries": false,
-          "id": 632,
-          "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": true,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "alertThreshold": true
-          },
-          "percentage": false,
-          "pluginVersion": "7.5.11",
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "histogram_quantile(0.99, sum(rate(ticdc_owner_resolved_ts_lag_histogram_bucket{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", changefeed=~\"$changefeed\", instance=~\"$ticdc_instance\"}[1m])) by (le,instance,changefeed))",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "{{changefeed}}-p99",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "changefeed resolved ts lag duration percentile",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "none",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_TEST-CLUSTER}",
           "description": "The difference between changefeed resolved ts and changefeed checkpointTs.",
           "fieldConfig": {
             "defaults": {
@@ -3893,7 +3893,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 31
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 603,
@@ -3996,7 +3996,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 31
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 604,
@@ -4106,7 +4106,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 38
+            "y": 31
           },
           "hiddenSeries": false,
           "id": 606,
@@ -4221,7 +4221,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 38
+            "y": 31
           },
           "hiddenSeries": false,
           "id": 597,
@@ -4448,7 +4448,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 45
+            "y": 38
           },
           "id": 163,
           "links": [],
@@ -4501,7 +4501,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 45
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 514,
@@ -4620,7 +4620,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 45
           },
           "hiddenSeries": false,
           "id": 102,
@@ -4723,7 +4723,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 52
+            "y": 45
           },
           "hiddenSeries": false,
           "id": 82,
@@ -19943,7 +19943,7 @@
         "options": [],
         "query": {
           "query": "label_values(go_goroutines, k8s_cluster)",
-          "refId": "test-cluster-k8s_cluster-Variable-Query"
+          "refId": "${DS_TEST-CLUSTER}-k8s_cluster-Variable-Query"
         },
         "refresh": 2,
         "regex": "",
@@ -19970,7 +19970,7 @@
         "options": [],
         "query": {
           "query": "label_values(go_goroutines{k8s_cluster=\"$k8s_cluster\"}, tidb_cluster)",
-          "refId": "test-cluster-tidb_cluster-Variable-Query"
+          "refId": "${DS_TEST-CLUSTER}-tidb_cluster-Variable-Query"
         },
         "refresh": 2,
         "regex": "",
@@ -20024,7 +20024,7 @@
         "options": [],
         "query": {
           "query": "label_values(process_start_time_seconds{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", job=\"ticdc\"}, instance)",
-          "refId": "test-cluster-ticdc_instance-Variable-Query"
+          "refId": "${DS_TEST-CLUSTER}-ticdc_instance-Variable-Query"
         },
         "refresh": 2,
         "regex": "",
@@ -20051,7 +20051,7 @@
         "options": [],
         "query": {
           "query": "label_values(tikv_engine_size_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}, instance)",
-          "refId": "test-cluster-tikv_instance-Variable-Query"
+          "refId": "${DS_TEST-CLUSTER}-tikv_instance-Variable-Query"
         },
         "refresh": 2,
         "regex": "",
@@ -20133,7 +20133,7 @@
         "options": [],
         "query": {
           "query": "label_values(process_start_time_seconds{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", job=\"ticdc\"}, instance)",
-          "refId": "test-cluster-runtime_instance-Variable-Query"
+          "refId": "${DS_TEST-CLUSTER}-runtime_instance-Variable-Query"
         },
         "refresh": 2,
         "regex": "",
@@ -20160,7 +20160,7 @@
         "options": [],
         "query": {
           "query": "label_values(ticdc_actor_number_of_workers{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", job=\"ticdc\"}, name)",
-          "refId": "test-cluster-actor_name-Variable-Query"
+          "refId": "${DS_TEST-CLUSTER}-actor_name-Variable-Query"
         },
         "refresh": 2,
         "regex": "",
@@ -20204,7 +20204,7 @@
     ]
   },
   "timezone": "browser",
-  "title": "Test-Cluster-TiCDC",
+  "title": "${DS_TEST-CLUSTER}-TiCDC",
   "uid": "YiGL8hBZ1",
   "version": 52
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/8524

### What is changed and how it works?
move checkpoint ts and resolved ts p99 panels into lag analyze row.
<img width="1641" alt="image" src="https://user-images.githubusercontent.com/29879298/224972997-e4661e74-4763-4da8-912c-033494e1d1eb.png">



### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new features need a release note -->

```release-note
Move checkpoint ts and resolved ts p99 panels into lag analyze row
```
