### PR TITLE
kafka(ticdc): fix kafka sink panic when kill the downstream kafka 

### DIFF
--- a/cdc/sink/ddlsink/mq/kafka_ddl_sink.go
+++ b/cdc/sink/ddlsink/mq/kafka_ddl_sink.go
@@ -58,7 +58,7 @@ func NewKafkaDDLSink(
 	// We must close adminClient when this func return cause by an error
 	// otherwise the adminClient will never be closed and lead to a goroutine leak.
 	defer func() {
-		if err != nil {
+		if err != nil && adminClient != nil {
 			adminClient.Close()
 		}
 	}()
@@ -83,7 +83,7 @@ func NewKafkaDDLSink(
 	// Preventing leaks when error occurs.
 	// This also closes the client in p.Close().
 	defer func() {
-		if err != nil {
+		if err != nil && p != nil {
 			p.Close()
 		}
 	}()

--- a/cdc/sink/dmlsink/mq/kafka_dml_sink.go
+++ b/cdc/sink/dmlsink/mq/kafka_dml_sink.go
@@ -62,7 +62,7 @@ func NewKafkaDMLSink(
 	// We must close adminClient when this func return cause by an error
 	// otherwise the adminClient will never be closed and lead to a goroutine leak.
 	defer func() {
-		if err != nil {
+		if err != nil && adminClient != nil {
 			adminClient.Close()
 		}
 	}()
@@ -86,7 +86,7 @@ func NewKafkaDMLSink(
 	// Preventing leaks when error occurs.
 	// This also closes the client in p.Close().
 	defer func() {
-		if err != nil {
+		if err != nil && p != nil {
 			p.Close()
 		}
 	}()


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8523 

### What is changed and how it works?

* check admin client is not nil before close it.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix cdc server panic when all Kafka servers are unavailable
```
