### PR TITLE
sink(ticdc): reuse index number in storage sink

### DIFF
--- a/pkg/sink/cloudstorage/path_test.go
+++ b/pkg/sink/cloudstorage/path_test.go
@@ -203,7 +203,27 @@ func TestGenerateDataFilePathWithIndexFile(t *testing.T) {
 	indexFilePath := f.GenerateIndexFilePath(table, date)
 	err := f.storage.WriteFile(ctx, indexFilePath, []byte("CDC000005.json\n"))
 	require.NoError(t, err)
+
+	// index file exists, but the file is not exist
 	dataFilePath, err := f.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, "test/table1/5/2023-03-09/CDC000005.json", dataFilePath)
+
+	// cleanup cached file index
+	delete(f.fileIndex, table)
+	// index file exists, and the file is empty
+	err = f.storage.WriteFile(ctx, dataFilePath, []byte(""))
+	require.NoError(t, err)
+	dataFilePath, err = f.GenerateDataFilePath(ctx, table, date)
+	require.NoError(t, err)
+	require.Equal(t, "test/table1/5/2023-03-09/CDC000005.json", dataFilePath)
+
+	// cleanup cached file index
+	delete(f.fileIndex, table)
+	// index file exists, and the file is not empty
+	err = f.storage.WriteFile(ctx, dataFilePath, []byte("test"))
+	require.NoError(t, err)
+	dataFilePath, err = f.GenerateDataFilePath(ctx, table, date)
 	require.NoError(t, err)
 	require.Equal(t, "test/table1/5/2023-03-09/CDC000006.json", dataFilePath)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #8189

### What is changed and how it works?
1. Reuse index number in storage sink if the last file does not exists.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
