### PR TITLE
sink(ticdc): disable multi-stmt if dml size is larger than max_allowed_packet

### DIFF
--- a/pkg/sink/mysql/db_helper.go
+++ b/pkg/sink/mysql/db_helper.go
@@ -336,3 +336,13 @@ func QueryMaxPreparedStmtCount(ctx context.Context, db *sql.DB) (int, error) {
 	}
 	return int(maxPreparedStmtCount.Int32), err
 }
+
+// QueryMaxAllowedPacket gets the value of max_allowed_packet
+func QueryMaxAllowedPacket(ctx context.Context, db *sql.DB) (int64, error) {
+	row := db.QueryRowContext(ctx, "select @@global.max_allowed_packet;")
+	var maxAllowedPacket sql.NullInt64
+	if err := row.Scan(&maxAllowedPacket); err != nil {
+		return 0, cerror.WrapError(cerror.ErrMySQLQueryError, err)
+	}
+	return maxAllowedPacket.Int64, nil
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #8057

### What is changed and how it works?

- Pass `ApproximateDataSize` from row changed event to DML
- Check whether dml approximate size is larger than `max_allowed_packet` before using multi statements path.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
