### PR TITLE
codec(ticdc): avro decode float by using float32

### DIFF
--- a/pkg/sink/codec/avro/avro.go
+++ b/pkg/sink/codec/avro/avro.go
@@ -523,7 +523,12 @@ func columnToAvroSchema(
 			Type:       "long",
 			Parameters: map[string]string{tidbType: tt},
 		}, nil
-	case mysql.TypeFloat, mysql.TypeDouble:
+	case mysql.TypeFloat:
+		return avroSchema{
+			Type:       "float",
+			Parameters: map[string]string{tidbType: tt},
+		}, nil
+	case mysql.TypeDouble:
 		return avroSchema{
 			Type:       "double",
 			Parameters: map[string]string{tidbType: tt},
@@ -683,7 +688,16 @@ func columnToAvroData(
 			return strconv.FormatUint(col.Value.(uint64), 10), "string", nil
 		}
 		return col.Value.(int64), "long", nil
-	case mysql.TypeFloat, mysql.TypeDouble:
+	case mysql.TypeFloat:
+		if v, ok := col.Value.(string); ok {
+			n, err := strconv.ParseFloat(v, 32)
+			if err != nil {
+				return nil, "", cerror.WrapError(cerror.ErrAvroEncodeFailed, err)
+			}
+			return n, "float", nil
+		}
+		return col.Value.(float32), "float", nil
+	case mysql.TypeDouble:
 		if v, ok := col.Value.(string); ok {
 			n, err := strconv.ParseFloat(v, 64)
 			if err != nil {

--- a/pkg/sink/codec/avro/avro_test.go
+++ b/pkg/sink/codec/avro/avro_test.go
@@ -235,15 +235,15 @@ var avroTestColumns = []*avroTestColumnTuple{
 		int64(1), "long",
 	},
 	{
-		model.Column{Name: "float", Value: float64(3.14), Type: mysql.TypeFloat},
+		model.Column{Name: "float", Value: float32(3.14), Type: mysql.TypeFloat},
 		rowcodec.ColInfo{
 			ID:            11,
 			IsPKHandle:    false,
 			VirtualGenCol: false,
 			Ft:            types.NewFieldType(mysql.TypeFloat),
 		},
-		avroSchema{Type: "double", Parameters: map[string]string{"tidb_type": "FLOAT"}},
-		float64(3.14), "double",
+		avroSchema{Type: "float", Parameters: map[string]string{"tidb_type": "FLOAT"}},
+		float32(3.14), "float",
 	},
 	{
 		model.Column{Name: "double", Value: float64(3.14), Type: mysql.TypeDouble},
@@ -824,6 +824,9 @@ func TestAvroEncode(t *testing.T) {
 	for k, v := range res.(map[string]interface{}) {
 		if k == "_tidb_op" {
 			require.Equal(t, "c", v.(string))
+		}
+		if k == "float" {
+			require.Equal(t, float32(3.14), v)
 		}
 	}
 }

--- a/pkg/sink/codec/avro/avro_test_data.go
+++ b/pkg/sink/codec/avro/avro_test_data.go
@@ -241,7 +241,7 @@ var expectedSchemaWithoutExtension = `{
     {
       "name": "float",
       "type": {
-        "type": "double",
+        "type": "float",
         "connect.parameters": {
           "tidb_type": "FLOAT"
         }
@@ -253,7 +253,7 @@ var expectedSchemaWithoutExtension = `{
       "type": [
         "null",
         {
-          "type": "double",
+          "type": "float",
           "connect.parameters": {
             "tidb_type": "FLOAT"
           }
@@ -1053,7 +1053,7 @@ var expectedSchemaWithExtension = `{
     {
       "name": "float",
       "type": {
-        "type": "double",
+        "type": "float",
         "connect.parameters": {
           "tidb_type": "FLOAT"
         }
@@ -1065,7 +1065,7 @@ var expectedSchemaWithExtension = `{
       "type": [
         "null",
         {
-          "type": "double",
+          "type": "float",
           "connect.parameters": {
             "tidb_type": "FLOAT"
           }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8490

### What is changed and how it works?

* parse `mysql.TypeFloat` by using `float32`


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix avro float type precision by using float32 to parse the data correctly
```
