### PR TITLE
redo(ticdc): fix data race issue in meta manager tests

### DIFF
--- a/cdc/redo/main_test.go
+++ b/cdc/redo/main_test.go
@@ -17,8 +17,14 @@ import (
 	"testing"
 
 	"github.com/pingcap/tiflow/pkg/leakutil"
+	"github.com/pingcap/tiflow/pkg/redo"
 )
 
 func TestMain(m *testing.M) {
+	originValue := redo.DefaultGCIntervalInMs
+	redo.DefaultGCIntervalInMs = 20
+	defer func() {
+		redo.DefaultGCIntervalInMs = originValue
+	}()
 	leakutil.SetUpLeakTest(m)
 }

--- a/cdc/redo/meta_manager_test.go
+++ b/cdc/redo/meta_manager_test.go
@@ -216,12 +216,6 @@ func testWriteMeta(t *testing.T, m *metaManager) {
 func TestGCAndCleanup(t *testing.T) {
 	t.Parallel()
 
-	originValue := redo.DefaultGCIntervalInMs
-	redo.DefaultGCIntervalInMs = 20
-	defer func() {
-		redo.DefaultGCIntervalInMs = originValue
-	}()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	captureID := "test-capture"


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #8056

### What is changed and how it works?
1. Modify parameters before starting parallel tests

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
