### PR TITLE
feat(cdc): abort changefeed creation if there are running import tasks

### DIFF
--- a/cdc/api/v2/api_helpers.go
+++ b/cdc/api/v2/api_helpers.go
@@ -15,6 +15,7 @@ package v2
 
 import (
 	"context"
+	"crypto/tls"
 	"net/url"
 	"strings"
 	"time"
@@ -37,10 +38,18 @@ import (
 	"github.com/r3labs/diff"
 	"github.com/tikv/client-go/v2/oracle"
 	pd "github.com/tikv/pd/client"
+	"go.etcd.io/etcd/client/pkg/v3/logutil"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 )
+
+// RegisterImportTaskPrefix denotes the key prefix associated with the entries
+// containning import/restore information in the embedded Etcd of the
+// upstream PD.
+const RegisterImportTaskPrefix = "/tidb/brie/import"
 
 // APIV2Helpers is a collections of helper functions of OpenAPIV2.
 // Defining it as an interface to make APIs more testable.
@@ -88,6 +97,13 @@ type APIV2Helpers interface {
 		pdAddrs []string,
 		credential *security.Credential,
 	) (pd.Client, error)
+
+	// getEtcdClient returns an Etcd client given the PD endpoints and
+	// tls config
+	getEtcdClient(
+		pdAddrs []string,
+		tlsConfig *tls.Config,
+	) (*clientv3.Client, error)
 
 	// getKVCreateTiStore wraps kv.createTiStore method to increase testability
 	createTiStore(
@@ -281,6 +297,7 @@ func (h APIV2HelpersImpl) verifyUpstream(ctx context.Context,
 		return cerror.ErrUpstreamMissMatch.
 			GenWithStackByArgs(cfInfo.UpstreamID, pdClient.GetClusterID(ctx))
 	}
+
 	return nil
 }
 
@@ -438,6 +455,41 @@ func (APIV2HelpersImpl) getPDClient(ctx context.Context,
 		return nil, cerror.WrapError(cerror.ErrAPIGetPDClientFailed, errors.Trace(err))
 	}
 	return pdClient, nil
+}
+
+func (h APIV2HelpersImpl) getEtcdClient(
+	pdAddrs []string, tlsCfg *tls.Config,
+) (*clientv3.Client, error) {
+	conf := config.GetGlobalServerConfig()
+	grpcTLSOption, err := conf.Security.ToGRPCDialOption()
+	if err != nil {
+		return nil, err
+	}
+	logConfig := &logutil.DefaultZapLoggerConfig
+	logConfig.Level = zap.NewAtomicLevelAt(zapcore.ErrorLevel)
+	return clientv3.New(
+		clientv3.Config{
+			Endpoints:   pdAddrs,
+			TLS:         tlsCfg,
+			LogConfig:   logConfig,
+			DialTimeout: 5 * time.Second,
+			DialOptions: []grpc.DialOption{
+				grpcTLSOption,
+				grpc.WithBlock(),
+				grpc.WithConnectParams(
+					grpc.ConnectParams{
+						Backoff: backoff.Config{
+							BaseDelay:  time.Second,
+							Multiplier: 1.1,
+							Jitter:     0.1,
+							MaxDelay:   3 * time.Second,
+						},
+						MinConnectTimeout: 3 * time.Second,
+					},
+				),
+			},
+		},
+	)
 }
 
 // getTiStore wrap the kv.createTiStore method to increase testability

--- a/cdc/api/v2/api_helpers_mock.go
+++ b/cdc/api/v2/api_helpers_mock.go
@@ -6,6 +6,7 @@ package v2
 
 import (
 	context "context"
+	tls "crypto/tls"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -15,6 +16,7 @@ import (
 	config "github.com/pingcap/tiflow/pkg/config"
 	security "github.com/pingcap/tiflow/pkg/security"
 	client "github.com/tikv/pd/client"
+	v3 "go.etcd.io/etcd/client/v3"
 )
 
 // MockAPIV2Helpers is a mock of APIV2Helpers interface.
@@ -53,6 +55,21 @@ func (m *MockAPIV2Helpers) createTiStore(pdAddrs []string, credential *security.
 func (mr *MockAPIV2HelpersMockRecorder) createTiStore(pdAddrs, credential interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "createTiStore", reflect.TypeOf((*MockAPIV2Helpers)(nil).createTiStore), pdAddrs, credential)
+}
+
+// getEtcdClient mocks base method.
+func (m *MockAPIV2Helpers) getEtcdClient(pdAddrs []string, tlsConfig *tls.Config) (*v3.Client, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getEtcdClient", pdAddrs, tlsConfig)
+	ret0, _ := ret[0].(*v3.Client)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getEtcdClient indicates an expected call of getEtcdClient.
+func (mr *MockAPIV2HelpersMockRecorder) getEtcdClient(pdAddrs, tlsConfig interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getEtcdClient", reflect.TypeOf((*MockAPIV2Helpers)(nil).getEtcdClient), pdAddrs, tlsConfig)
 }
 
 // getPDClient mocks base method.

--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tiflow/pkg/upstream"
 	"github.com/pingcap/tiflow/pkg/util"
 	"github.com/tikv/client-go/v2/oracle"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
 )
 
@@ -133,6 +134,24 @@ func (h *OpenAPIV2) createChangefeed(c *gin.Context) {
 		return
 	}
 
+	// cannot create changefeed if there are running lightning/restore tasks
+	tlsCfg, err := credential.ToTLSConfig()
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	cli, err := h.helpers.getEtcdClient(cfg.PDAddrs, tlsCfg)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+	err = hasRunningImport(ctx, cli)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
 	err = h.capture.GetEtcdClient().CreateChangefeedInfo(ctx,
 		upstreamInfo,
 		info,
@@ -149,6 +168,41 @@ func (h *OpenAPIV2) createChangefeed(c *gin.Context) {
 	c.JSON(http.StatusOK, toAPIModel(info,
 		info.StartTs, info.StartTs,
 		nil, true))
+}
+
+// hasRunningImport checks if there is running import tasks on the
+// upstream cluster.
+func hasRunningImport(ctx context.Context, cli *clientv3.Client) error {
+	resp, err := cli.KV.Get(
+		ctx, RegisterImportTaskPrefix, clientv3.WithPrefix(),
+	)
+	if err != nil {
+		return errors.Annotatef(
+			err, "failed to list import task related entries")
+	}
+
+	for _, kv := range resp.Kvs {
+		leaseResp, err := cli.Lease.TimeToLive(ctx, clientv3.LeaseID(kv.Lease))
+		if err != nil {
+			return errors.Annotatef(
+				err, "failed to get time-to-live of lease: %x", kv.Lease,
+			)
+		}
+		// the lease has expired
+		if leaseResp.TTL <= 0 {
+			continue
+		}
+		err = errors.New(
+			"There are lightning/restore tasks running" +
+				"please stop or wait for them to finish. " +
+				"If the lightning/restore task is terminated by system, " +
+				"please wait until the task lease ttl(3 mins) decreases to 0.",
+		)
+		log.Error("failed to create the changefeed", zap.Error(err))
+		return err
+	}
+
+	return nil
 }
 
 // listChangeFeeds lists all changgefeeds in cdc cluster


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #8385

### What is changed and how it works?
feat(cdc): abort changefeed creation if there are running import task

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - [x] Unit test
 - [x] Manual test (add detailed scripts or steps below)

Assume we have full copy backup stored at /tmp/backup-1, log backup stored at /tmp/logbackup, and have a kafka cluster running at localhost:9092

1. setup tidb test cluster locally 
```
tiup playground nightly --tiflash 0
```
2. compiled CDC and start the server locally
```
./bin/cdc server
```
3. start the restore 
```
tiup br:nightly restore point --pd "localhost:2379" \
--storage='local:///tmp/logbackup' \
--full-backup-storage='local:///tmp/backup-1' \
--restored-ts '2023-03-16 16:59:57-0700'
```
4. at the meantime, try to create a changefeed
```
./bin/cdc cli changefeed create \
--pd=http://127.0.0.1:2379 \
--changefeed-id="simple-replication-task" \
--sort-engine="unified" \
--sink-uri="kafka://127.0.0.1:9092/quickstart-events?protocol=canal-json" 
```
and we will see the error message
`Error: There are lightning/restore tasks runningplease stop or wait for them to finish. If the lightning/restore task is terminated by system, please wait until the task lease ttl(3 mins) decreases to 0.`


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No

##### Do you need to update user documentation, design documentation or monitoring documentation?
No

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
