### PR TITLE
sinkManager (ticdc): Fix a sorter panic issue caused by uint64 overflow.

### DIFF
--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -344,7 +344,7 @@ func (m *SinkManager) generateSinkTasks() error {
 		// If a task carries events after schemaResolvedTs, mounter group threads
 		// can be blocked on waiting schemaResolvedTs get advanced.
 		schemaTs := m.schemaStorage.ResolvedTs()
-		if tableSinkUpperBoundTs-1 > schemaTs {
+		if tableSinkUpperBoundTs > schemaTs+1 {
 			tableSinkUpperBoundTs = schemaTs + 1
 		}
 

--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -488,7 +488,7 @@ func (m *SinkManager) generateRedoTasks() error {
 		// If a task carries events after schemaResolvedTs, mounter group threads
 		// can be blocked on waiting schemaResolvedTs get advanced.
 		schemaTs := m.schemaStorage.ResolvedTs()
-		if tableSinkUpperBoundTs-1 > schemaTs {
+		if tableSinkUpperBoundTs > schemaTs+1 {
 			tableSinkUpperBoundTs = schemaTs + 1
 		}
 

--- a/cdc/processor/sinkmanager/manager_test.go
+++ b/cdc/processor/sinkmanager/manager_test.go
@@ -148,7 +148,7 @@ func TestRemoveTable(t *testing.T) {
 	addTableAndAddEventsToSortEngine(t, e, span)
 	manager.UpdateBarrierTs(4, nil)
 	manager.UpdateReceivedSorterResolvedTs(span, 5)
-
+	manager.schemaStorage.AdvanceResolvedTs(5)
 	// Check all the events are sent to sink and record the memory usage.
 	require.Eventually(t, func() bool {
 		return manager.sinkMemQuota.GetUsedBytes() == 872
@@ -186,6 +186,7 @@ func TestGenerateTableSinkTaskWithBarrierTs(t *testing.T) {
 	addTableAndAddEventsToSortEngine(t, e, span)
 	manager.UpdateBarrierTs(4, nil)
 	manager.UpdateReceivedSorterResolvedTs(span, 5)
+	manager.schemaStorage.AdvanceResolvedTs(5)
 	err := manager.StartTable(span, 0)
 	require.NoError(t, err)
 
@@ -217,6 +218,7 @@ func TestGenerateTableSinkTaskWithResolvedTs(t *testing.T) {
 	// So there is possibility that the resolved ts is smaller than the global barrier ts.
 	manager.UpdateBarrierTs(4, nil)
 	manager.UpdateReceivedSorterResolvedTs(span, 3)
+	manager.schemaStorage.AdvanceResolvedTs(4)
 	err := manager.StartTable(span, 0)
 	require.NoError(t, err)
 
@@ -247,6 +249,7 @@ func TestGetTableStatsToReleaseMemQuota(t *testing.T) {
 
 	manager.UpdateBarrierTs(4, nil)
 	manager.UpdateReceivedSorterResolvedTs(span, 5)
+	manager.schemaStorage.AdvanceResolvedTs(5)
 	err := manager.StartTable(span, 0)
 	require.NoError(t, err)
 

--- a/cdc/processor/sinkmanager/table_sink_wrapper.go
+++ b/cdc/processor/sinkmanager/table_sink_wrapper.go
@@ -107,6 +107,7 @@ func newTableSinkWrapper(
 	}
 	res.checkpointTs.Store(startTs)
 	res.receivedSorterResolvedTs.Store(startTs)
+	res.barrierTs.Store(startTs)
 	return res
 }
 

--- a/cdc/processor/sinkmanager/table_sink_wrapper_test.go
+++ b/cdc/processor/sinkmanager/table_sink_wrapper_test.go
@@ -310,3 +310,19 @@ func TestGetUpperBoundTs(t *testing.T) {
 	wrapper.barrierTs.Store(uint64(12))
 	require.Equal(t, uint64(11), wrapper.getUpperBoundTs())
 }
+
+func TestNewTableSinkWrapper(t *testing.T) {
+	t.Parallel()
+	wrapper := newTableSinkWrapper(
+		model.DefaultChangeFeedID("1"),
+		spanz.TableIDToComparableSpan(1),
+		nil,
+		tablepb.TableStatePrepared,
+		model.Ts(10),
+		model.Ts(20),
+	)
+	require.NotNil(t, wrapper)
+	require.Equal(t, uint64(10), wrapper.getUpperBoundTs())
+	require.Equal(t, uint64(10), wrapper.getReceivedSorterResolvedTs())
+	require.Equal(t, uint64(10), wrapper.checkpointTs.Load())
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8664 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a sorter panic issue caused by uint64 overflow.
```
