### PR TITLE
DM: fix default physical import mode disk quota

### DIFF
--- a/dm/loader/lightning.go
+++ b/dm/loader/lightning.go
@@ -348,7 +348,9 @@ func GetLightningConfig(globalCfg *lcfg.GlobalConfig, subtaskCfg *config.SubTask
 	// checkpoint meta and updating dm checkpoint meta to 'finished'.
 	cfg.Checkpoint.KeepAfterSuccess = lcfg.CheckpointRemove
 
-	cfg.TikvImporter.DiskQuota = subtaskCfg.LoaderConfig.DiskQuotaPhysical
+	if subtaskCfg.LoaderConfig.DiskQuotaPhysical > 0 {
+		cfg.TikvImporter.DiskQuota = subtaskCfg.LoaderConfig.DiskQuotaPhysical
+	}
 	cfg.TikvImporter.OnDuplicate = string(subtaskCfg.OnDuplicateLogical)
 	cfg.TikvImporter.IncrementalImport = true
 	switch subtaskCfg.OnDuplicatePhysical {

--- a/dm/loader/lightning_test.go
+++ b/dm/loader/lightning_test.go
@@ -68,4 +68,7 @@ func TestGetLightiningConfig(t *testing.T) {
 	require.Equal(t, 32, conf.TikvImporter.RangeConcurrency)
 	require.Equal(t, lcfg.CompressionGzip, conf.TikvImporter.CompressKVPairs)
 	require.Equal(t, lcfg.OpLevelRequired, conf.PostRestore.Analyze)
+	lightningDefaultQuota := lcfg.NewConfig().TikvImporter.DiskQuota
+	// when we don't set dm loader disk quota, it should be equal to lightning's default quota
+	require.Equal(t, lightningDefaultQuota, conf.TikvImporter.DiskQuota)
 }


### PR DESCRIPTION
This PR is a cherry-pick of https://github.com/pingcap/tiflow/pull/8671
---
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/8672

### What is changed and how it works?
Modify lightnig's disk quota when we set DM's `disk-quota-physical` a non-negative value.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
