### PR TITLE
syncer(dm): fix wrong MySQL latin1 decoder

### DIFF
--- a/dm/syncer/dml.go
+++ b/dm/syncer/dml.go
@@ -43,7 +43,9 @@ type genDMLParam struct {
 	extendData      [][]interface{}  // all data include extend data
 }
 
-var latin1Decoder = charmap.ISO8859_1.NewDecoder()
+// latin1Decider is not usually ISO8859_1 in MySQL.
+// ref https://dev.mysql.com/doc/refman/8.0/en/charset-we-sets.html
+var latin1Decoder = charmap.Windows1252.NewDecoder()
 
 // extractValueFromData adjust the values obtained from go-mysql so that
 // - the values can be correctly converted to TiDB datum

--- a/dm/tests/expression_filter/conf/dm-task2.yaml
+++ b/dm/tests/expression_filter/conf/dm-task2.yaml
@@ -56,7 +56,7 @@ expression-filter:
   only_muller:
     schema: "expr_filter"
     table: "t6"
-    insert-value-expr: "name != 'Müller'"
+    insert-value-expr: "name != 'Müller…'"
   e02:
     schema: expr_filter
     table: t7

--- a/dm/tests/expression_filter/data/db1.increment2.sql
+++ b/dm/tests/expression_filter/data/db1.increment2.sql
@@ -42,8 +42,8 @@ update t5 set should_skip = 1, c = 2 where c = 1;
 insert into t5 values (4, 1, 1); -- check this `should_skip = 1` row must be updated to `should_skip = 0` in TiDB
 update t5 set should_skip = 0, c = 3 where c = 1;
 
-insert into t6 (id, name, msg) values (1, 'Müller', 'Müller'), (2, 'X Æ A-12', 'X Æ A-12');
-alter table t6 add column name2 varchar(20) character set latin1 default 'Müller';
+insert into t6 (id, name, msg) values (1, 'Müller…', 'Müller…'), (2, 'X Æ A-12', 'X Æ A-12');
+alter table t6 add column name2 varchar(20) character set latin1 default 'Müller…';
 
 -- test https://github.com/pingcap/tiflow/issues/7774
 UPDATE t7 SET s = s + 1 WHERE a = 1;

--- a/dm/tests/expression_filter/data/db1.prepare2.sql
+++ b/dm/tests/expression_filter/data/db1.prepare2.sql
@@ -9,6 +9,6 @@ create table t2 (id int primary key,
 );
 
 create table t6 (id int, name varchar(20), msg text, primary key(`id`)) character set latin1;
-insert into t6 (id, name, msg) values (0, 'Müller', 'Müller');
+insert into t6 (id, name, msg) values (0, 'Müller…', 'Müller…');
 CREATE TABLE t7 (a BIGINT PRIMARY KEY, r VARCHAR(10), s INT);
 INSERT INTO t7 VALUES (1, 'a', 2);

--- a/dm/tests/expression_filter/run.sh
+++ b/dm/tests/expression_filter/run.sh
@@ -62,9 +62,9 @@ function complex_behaviour() {
 	run_sql_tidb "select count(8) from expr_filter.t5 where should_skip = 1"
 	check_contains "count(8): 0"
 
-	run_sql_tidb "select count(9) from expr_filter.t6 where name = 'Müller' and msg = 'Müller' and name2 = 'Müller'"
+	run_sql_tidb "select count(9) from expr_filter.t6 where name = 'Müller…' and msg = 'Müller…' and name2 = 'Müller…'"
 	check_contains "count(9): 2"
-	run_sql_tidb "select count(10) from expr_filter.t6 where name != 'Müller'"
+	run_sql_tidb "select count(10) from expr_filter.t6 where name != 'Müller…'"
 	check_contains "count(10): 0"
 
 	run_sql_tidb "select count(11) from expr_filter.t7 where r = 'a' and s = 2"


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #7028

### What is changed and how it works?

MySQL's latin1 charset is not the usual "latin1" ISO8859_1 charset.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
