### PR TITLE
sink(ticdc): fix incorrect approximateSize in batch dml

### DIFF
--- a/cdc/sink/dmlsink/txn/mysql/mysql.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql.go
@@ -571,6 +571,13 @@ func (s *mysqlBackend) prepareDMLs() *preparedDMLs {
 				sql, value := s.batchSingleTxnDmls(event, tableInfo, translateToInsert)
 				sqls = append(sqls, sql...)
 				values = append(values, value...)
+
+				for _, stmt := range sql {
+					approximateSize += int64(len(stmt))
+				}
+				for _, row := range event.Event.Rows {
+					approximateSize += row.ApproximateDataSize
+				}
 				continue
 			}
 		}
@@ -587,6 +594,7 @@ func (s *mysqlBackend) prepareDMLs() *preparedDMLs {
 					sqls = append(sqls, query)
 					values = append(values, args)
 				}
+				approximateSize += int64(len(query)) + row.ApproximateDataSize
 				continue
 			}
 

--- a/cdc/sink/dmlsink/txn/mysql/mysql_test.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql_test.go
@@ -974,8 +974,9 @@ func TestMysqlSinkSafeModeOff(t *testing.T) {
 					"UPDATE `common_1`.`uk_without_pk` SET `a1`=?,`a3`=? " +
 						"WHERE `a1`=? AND `a3`=? LIMIT 1",
 				},
-				values:   [][]interface{}{{3, 3, 2, 2}},
-				rowCount: 1,
+				values:          [][]interface{}{{3, 3, 2, 2}},
+				rowCount:        1,
+				approximateSize: 83,
 			},
 		}, {
 			name: "update with PK",
@@ -1013,8 +1014,9 @@ func TestMysqlSinkSafeModeOff(t *testing.T) {
 				startTs: []model.Ts{418658114257813516},
 				sqls: []string{"UPDATE `common_1`.`pk` SET `a1`=?,`a3`=? " +
 					"WHERE `a1`=? AND `a3`=? LIMIT 1"},
-				values:   [][]interface{}{{3, 3, 2, 2}},
-				rowCount: 1,
+				values:          [][]interface{}{{3, 3, 2, 2}},
+				rowCount:        1,
+				approximateSize: 72,
 			},
 		}, {
 			name: "batch insert with PK",
@@ -1197,7 +1199,8 @@ func TestPrepareBatchDMLs(t *testing.T) {
 							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: []byte("你好"),
 					}},
-					IndexColumns: [][]int{{1, 2}},
+					IndexColumns:        [][]int{{1, 2}},
+					ApproximateDataSize: 10,
 				},
 				{
 					StartTs:  418658114257813514,
@@ -1216,14 +1219,16 @@ func TestPrepareBatchDMLs(t *testing.T) {
 							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: []byte("世界"),
 					}},
-					IndexColumns: [][]int{{1, 2}},
+					IndexColumns:        [][]int{{1, 2}},
+					ApproximateDataSize: 10,
 				},
 			},
 			expected: &preparedDMLs{
-				startTs:  []model.Ts{418658114257813514},
-				sqls:     []string{"DELETE FROM `common_1`.`uk_without_pk` WHERE (`a1`,`a3`) IN ((?,?),(?,?))"},
-				values:   [][]interface{}{{1, "你好", 2, "世界"}},
-				rowCount: 2,
+				startTs:         []model.Ts{418658114257813514},
+				sqls:            []string{"DELETE FROM `common_1`.`uk_without_pk` WHERE (`a1`,`a3`) IN ((?,?),(?,?))"},
+				values:          [][]interface{}{{1, "你好", 2, "世界"}},
+				rowCount:        2,
+				approximateSize: 93,
 			},
 		},
 		{ // insert event
@@ -1245,7 +1250,8 @@ func TestPrepareBatchDMLs(t *testing.T) {
 						Flag:    model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag,
 						Value:   "你好",
 					}},
-					IndexColumns: [][]int{{1, 1}},
+					IndexColumns:        [][]int{{1, 1}},
+					ApproximateDataSize: 10,
 				},
 				{
 					StartTs:  418658114257813516,
@@ -1264,14 +1270,16 @@ func TestPrepareBatchDMLs(t *testing.T) {
 							model.HandleKeyFlag | model.HandleKeyFlag,
 						Value: "世界",
 					}},
-					IndexColumns: [][]int{{2, 2}},
+					IndexColumns:        [][]int{{2, 2}},
+					ApproximateDataSize: 10,
 				},
 			},
 			expected: &preparedDMLs{
-				startTs:  []model.Ts{418658114257813516},
-				sqls:     []string{"INSERT INTO `common_1`.`uk_without_pk` (`a1`,`a3`) VALUES (?,?),(?,?)"},
-				values:   [][]interface{}{{1, "你好", 2, "世界"}},
-				rowCount: 2,
+				startTs:         []model.Ts{418658114257813516},
+				sqls:            []string{"INSERT INTO `common_1`.`uk_without_pk` (`a1`,`a3`) VALUES (?,?),(?,?)"},
+				values:          [][]interface{}{{1, "你好", 2, "世界"}},
+				rowCount:        2,
+				approximateSize: 89,
 			},
 		},
 		// update event
@@ -1308,7 +1316,8 @@ func TestPrepareBatchDMLs(t *testing.T) {
 							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: []byte("测试"),
 					}},
-					IndexColumns: [][]int{{1, 2}},
+					IndexColumns:        [][]int{{1, 2}},
+					ApproximateDataSize: 12,
 				},
 				{
 					StartTs:  418658114257813516,
@@ -1340,7 +1349,8 @@ func TestPrepareBatchDMLs(t *testing.T) {
 							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: []byte("北京"),
 					}},
-					IndexColumns: [][]int{{1, 2}},
+					IndexColumns:        [][]int{{1, 2}},
+					ApproximateDataSize: 12,
 				},
 			},
 			expected: &preparedDMLs{
@@ -1354,7 +1364,8 @@ func TestPrepareBatchDMLs(t *testing.T) {
 					1, "开发", 2, 3, "纽约", 4, 1, "开发", "测试", 3,
 					"纽约", "北京", 1, "开发", 3, "纽约",
 				}},
-				rowCount: 2,
+				rowCount:        2,
+				approximateSize: 278,
 			},
 		},
 		// mixed event, and test delete， update, insert are ordered
@@ -1378,8 +1389,8 @@ func TestPrepareBatchDMLs(t *testing.T) {
 							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: []byte("你好"),
 					}},
-
-					IndexColumns: [][]int{{1, 2}},
+					IndexColumns:        [][]int{{1, 2}},
+					ApproximateDataSize: 10,
 				},
 				{
 					StartTs:  418658114257813514,
@@ -1398,7 +1409,8 @@ func TestPrepareBatchDMLs(t *testing.T) {
 							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: []byte("世界"),
 					}},
-					IndexColumns: [][]int{{1, 2}},
+					IndexColumns:        [][]int{{1, 2}},
+					ApproximateDataSize: 10,
 				},
 				{
 					StartTs:  418658114257813514,
@@ -1417,7 +1429,8 @@ func TestPrepareBatchDMLs(t *testing.T) {
 							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: "你好",
 					}},
-					IndexColumns: [][]int{{1, 2}},
+					IndexColumns:        [][]int{{1, 2}},
+					ApproximateDataSize: 10,
 				},
 				{
 					StartTs:  418658114257813516,
@@ -1449,7 +1462,8 @@ func TestPrepareBatchDMLs(t *testing.T) {
 							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: []byte("测试"),
 					}},
-					IndexColumns: [][]int{{1, 2}},
+					IndexColumns:        [][]int{{1, 2}},
+					ApproximateDataSize: 10,
 				},
 				{
 					StartTs:  418658114257813516,
@@ -1481,7 +1495,8 @@ func TestPrepareBatchDMLs(t *testing.T) {
 							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: []byte("北京"),
 					}},
-					IndexColumns: [][]int{{1, 2}},
+					IndexColumns:        [][]int{{1, 2}},
+					ApproximateDataSize: 10,
 				},
 			},
 			expected: &preparedDMLs{
@@ -1503,7 +1518,8 @@ func TestPrepareBatchDMLs(t *testing.T) {
 					},
 					{2, "你好"},
 				},
-				rowCount: 5,
+				rowCount:        5,
+				approximateSize: 440,
 			},
 		},
 		// update event and downstream is mysql and without pk
@@ -1546,7 +1562,8 @@ func TestPrepareBatchDMLs(t *testing.T) {
 							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: []byte("测试"),
 					}},
-					IndexColumns: [][]int{{1, 2}},
+					IndexColumns:        [][]int{{1, 2}},
+					ApproximateDataSize: 10,
 				},
 				{
 					StartTs:  418658114257813516,
@@ -1583,7 +1600,8 @@ func TestPrepareBatchDMLs(t *testing.T) {
 							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: []byte("北京"),
 					}},
-					IndexColumns: [][]int{{1, 2}},
+					IndexColumns:        [][]int{{1, 2}},
+					ApproximateDataSize: 10,
 				},
 			},
 			expected: &preparedDMLs{
@@ -1594,8 +1612,9 @@ func TestPrepareBatchDMLs(t *testing.T) {
 					"UPDATE `common_1`.`uk_without_pk` SET `a1` = ?, " +
 						"`a3` = ? WHERE `a1` = ? AND `a3` = ? LIMIT 1",
 				},
-				values:   [][]interface{}{{2, "测试", 1, "开发"}, {4, "北京", 3, "纽约"}},
-				rowCount: 2,
+				values:          [][]interface{}{{2, "测试", 1, "开发"}, {4, "北京", 3, "纽约"}},
+				rowCount:        2,
+				approximateSize: 204,
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8732

### What is changed and how it works?

BatchDML should calculate `approximateSize`

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 
#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
