### PR TITLE
sink(ticdc): fix table version used in storage sink

### DIFF
--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -666,9 +666,15 @@ func (d *DDLEvent) FromRenameTablesJob(job *model.Job,
 type SingleTableTxn struct {
 	Table     *TableName
 	TableInfo *TableInfo
-	StartTs   uint64
-	CommitTs  uint64
-	Rows      []*RowChangedEvent
+	// TableInfoVersion is the version of the table info, it is used to generate data path
+	// in storage sink. Generally, TableInfoVersion equals to `SingleTableTxn.TableInfo.Version`.
+	// Besides, if one table is just scheduled to a new processor, the TableInfoVersion should be
+	// greater than or equal to the startTs of table sink.
+	TableInfoVersion uint64
+
+	StartTs  uint64
+	CommitTs uint64
+	Rows     []*RowChangedEvent
 
 	// control fields of SingleTableTxn
 	// FinishWg is a barrier txn, after this txn is received, the worker must

--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -673,7 +673,7 @@ func (m *SinkManager) AddTable(span tablepb.Span, startTs model.Ts, targetTs mod
 	sinkWrapper := newTableSinkWrapper(
 		m.changefeedID,
 		span,
-		m.sinkFactory.CreateTableSink(m.changefeedID, span, m.metricsTableSinkTotalRows),
+		m.sinkFactory.CreateTableSink(m.changefeedID, span, startTs, m.metricsTableSinkTotalRows),
 		tablepb.TableStatePreparing,
 		startTs,
 		targetTs,

--- a/cdc/processor/sinkmanager/table_sink_wrapper_test.go
+++ b/cdc/processor/sinkmanager/table_sink_wrapper_test.go
@@ -79,7 +79,7 @@ func createTableSinkWrapper(
 	tableState := tablepb.TableStatePreparing
 	sink := newMockSink()
 	innerTableSink := tablesink.New[*model.RowChangedEvent](
-		changefeedID, span,
+		changefeedID, span, model.Ts(0),
 		sink, &dmlsink.RowChangeEventAppender{}, prometheus.NewCounter(prometheus.CounterOpts{}))
 	wrapper := newTableSinkWrapper(
 		changefeedID,

--- a/cdc/sink/ddlsink/cloudstorage/cloud_storage_ddl_sink_test.go
+++ b/cdc/sink/ddlsink/cloudstorage/cloud_storage_ddl_sink_test.go
@@ -39,8 +39,9 @@ func TestWriteDDLEvent(t *testing.T) {
 	require.Nil(t, err)
 
 	ddlEvent := &model.DDLEvent{
-		Type:  timodel.ActionAddColumn,
-		Query: "alter table test.table1 add col2 varchar(64)",
+		CommitTs: 100,
+		Type:     timodel.ActionAddColumn,
+		Query:    "alter table test.table1 add col2 varchar(64)",
 		TableInfo: &model.TableInfo{
 			Version: 100,
 			TableName: model.TableName{

--- a/cdc/sink/dmlsink/cloudstorage/cloud_storage_dml_sink_test.go
+++ b/cdc/sink/dmlsink/cloudstorage/cloud_storage_dml_sink_test.go
@@ -45,8 +45,9 @@ func generateTxnEvents(
 	for i := 0; i < 10; i++ {
 		txn := &dmlsink.TxnCallbackableEvent{
 			Event: &model.SingleTableTxn{
-				CommitTs: 100,
-				Table:    &model.TableName{Schema: "test", Table: "table1"},
+				CommitTs:         100,
+				Table:            &model.TableName{Schema: "test", Table: "table1"},
+				TableInfoVersion: 33,
 				TableInfo: &model.TableInfo{
 					TableName: model.TableName{
 						Schema: "test", Table: "table1",

--- a/cdc/sink/dmlsink/cloudstorage/defragmenter_test.go
+++ b/cdc/sink/dmlsink/cloudstorage/defragmenter_test.go
@@ -58,7 +58,7 @@ func TestDeframenter(t *testing.T) {
 		go func(seq uint64) {
 			encoder := encoderBuilder.Build()
 			frag := eventFragment{
-				versionedTable: cloudstorage.VersionedTable{
+				versionedTable: cloudstorage.VersionedTableName{
 					TableNameWithPhysicTableID: model.TableName{
 						Schema:  "test",
 						Table:   "table1",

--- a/cdc/sink/dmlsink/cloudstorage/dml_worker.go
+++ b/cdc/sink/dmlsink/cloudstorage/dml_worker.go
@@ -47,7 +47,7 @@ type dmlWorker struct {
 	// tableEvents maintains a mapping of <table, []eventFragment>.
 	tableEvents *tableEventsMap
 	// fileSize maintains a mapping of <table, file size>.
-	fileSize          map[cloudstorage.VersionedTable]uint64
+	fileSize          map[cloudstorage.VersionedTableName]uint64
 	isClosed          uint64
 	statistics        *metrics.Statistics
 	filePathGenerator *cloudstorage.FilePathGenerator
@@ -58,17 +58,17 @@ type dmlWorker struct {
 
 type tableEventsMap struct {
 	mu        sync.Mutex
-	fragments map[cloudstorage.VersionedTable][]eventFragment
+	fragments map[cloudstorage.VersionedTableName][]eventFragment
 }
 
 func newTableEventsMap() *tableEventsMap {
 	return &tableEventsMap{
-		fragments: make(map[cloudstorage.VersionedTable][]eventFragment),
+		fragments: make(map[cloudstorage.VersionedTableName][]eventFragment),
 	}
 }
 
 type wrappedTable struct {
-	tableName model.TableName
+	cloudstorage.VersionedTableName
 	tableInfo *model.TableInfo
 }
 
@@ -93,7 +93,7 @@ func newDMLWorker(
 		config:            config,
 		tableEvents:       newTableEventsMap(),
 		flushNotifyCh:     make(chan flushTask, 1),
-		fileSize:          make(map[cloudstorage.VersionedTable]uint64),
+		fileSize:          make(map[cloudstorage.VersionedTableName]uint64),
 		statistics:        statistics,
 		filePathGenerator: cloudstorage.NewFilePathGenerator(config, storage, extension, clock),
 		bufferPool: sync.Pool{
@@ -143,10 +143,7 @@ func (d *dmlWorker) flushMessages(ctx context.Context) error {
 				return nil
 			}
 			for _, tbl := range task.targetTables {
-				table := cloudstorage.VersionedTable{
-					TableNameWithPhysicTableID: tbl.tableName,
-					Version:                    tbl.tableInfo.Version,
-				}
+				table := tbl.VersionedTableName
 				d.tableEvents.mu.Lock()
 				events := make([]eventFragment, len(d.tableEvents.fragments[table]))
 				copy(events, d.tableEvents.fragments[table])
@@ -184,7 +181,7 @@ func (d *dmlWorker) flushMessages(ctx context.Context) error {
 				indexFilePath := d.filePathGenerator.GenerateIndexFilePath(table, date)
 
 				// first write the index file to external storage.
-				// the file content is simply the last elemement of the data file path
+				// the file content is simply the last element of the data file path
 				err = d.writeIndexFile(ctx, indexFilePath, path.Base(dataFilePath)+"\n")
 				if err != nil {
 					log.Error("failed to write index file to external storage",
@@ -229,12 +226,12 @@ func (d *dmlWorker) flushMessages(ctx context.Context) error {
 // if it hasn't been created when a DDL event was executed.
 func (d *dmlWorker) writeSchemaFile(
 	ctx context.Context,
-	table cloudstorage.VersionedTable,
+	table cloudstorage.VersionedTableName,
 	tableInfo *model.TableInfo,
 ) error {
 	if ok := d.filePathGenerator.Contains(table); !ok {
 		var tableDetail cloudstorage.TableDefinition
-		tableDetail.FromTableInfo(tableInfo)
+		tableDetail.FromTableInfo(tableInfo, table.TableInfoVersion)
 		path := cloudstorage.GenerateSchemaFilePath(tableDetail)
 		// the file may have been created when a DDL event was executed.
 		exist, err := d.storage.FileExists(ctx, path)
@@ -336,10 +333,7 @@ func (d *dmlWorker) dispatchFlushTasks(ctx context.Context,
 				log.Debug("flush task is emitted successfully when flush interval exceeds",
 					zap.Any("tables", task.targetTables))
 				for elem := range tableSet {
-					tbl := cloudstorage.VersionedTable{
-						TableNameWithPhysicTableID: elem.tableName,
-						Version:                    elem.tableInfo.Version,
-					}
+					tbl := elem.VersionedTableName
 					d.fileSize[tbl] = 0
 				}
 				tableSet = make(map[wrappedTable]struct{})
@@ -355,8 +349,8 @@ func (d *dmlWorker) dispatchFlushTasks(ctx context.Context,
 			d.tableEvents.mu.Unlock()
 
 			key := wrappedTable{
-				tableName: frag.versionedTable.TableNameWithPhysicTableID,
-				tableInfo: frag.event.Event.TableInfo,
+				VersionedTableName: table,
+				tableInfo:          frag.event.Event.TableInfo,
 			}
 
 			tableSet[key] = struct{}{}

--- a/cdc/sink/dmlsink/cloudstorage/dml_worker_test.go
+++ b/cdc/sink/dmlsink/cloudstorage/dml_worker_test.go
@@ -82,9 +82,9 @@ func TestDMLWorkerRun(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		frag := eventFragment{
 			seqNumber: uint64(i),
-			versionedTable: cloudstorage.VersionedTable{
+			versionedTable: cloudstorage.VersionedTableName{
 				TableNameWithPhysicTableID: table1,
-				Version:                    99,
+				TableInfoVersion:           99,
 			},
 			event: &dmlsink.TxnCallbackableEvent{
 				Event: &model.SingleTableTxn{

--- a/cdc/sink/dmlsink/cloudstorage/encoding_worker_test.go
+++ b/cdc/sink/dmlsink/cloudstorage/encoding_worker_test.go
@@ -70,7 +70,7 @@ func TestEncodeEvents(t *testing.T) {
 		},
 	}
 	err := worker.encodeEvents(eventFragment{
-		versionedTable: cloudstorage.VersionedTable{
+		versionedTable: cloudstorage.VersionedTableName{
 			TableNameWithPhysicTableID: model.TableName{
 				Schema:  "test",
 				Table:   "table1",
@@ -158,7 +158,7 @@ func TestEncodingWorkerRun(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		frag := eventFragment{
-			versionedTable: cloudstorage.VersionedTable{
+			versionedTable: cloudstorage.VersionedTableName{
 				TableNameWithPhysicTableID: table,
 			},
 			seqNumber: uint64(i + 1),

--- a/cdc/sink/dmlsink/event_appender_test.go
+++ b/cdc/sink/dmlsink/event_appender_test.go
@@ -23,27 +23,33 @@ import (
 func TestRowChangeEventAppender(t *testing.T) {
 	t.Parallel()
 
-	tableInfo := &model.TableName{
+	tableName := &model.TableName{
 		Schema:      "test",
 		Table:       "t1",
 		TableID:     1,
 		IsPartition: false,
+	}
+	tableInfo := &model.TableInfo{
+		Version: 1,
 	}
 
 	appender := &RowChangeEventAppender{}
 	var buffer []*model.RowChangedEvent
 	rows := []*model.RowChangedEvent{
 		{
-			Table:    tableInfo,
-			CommitTs: 1,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  1,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 2,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  2,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 2,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  2,
 		},
 	}
 	buffer = appender.Append(buffer, rows...)
@@ -57,79 +63,94 @@ func TestRowChangeEventAppender(t *testing.T) {
 func TestTxnEventAppenderWithoutIgnoreStartTs(t *testing.T) {
 	t.Parallel()
 
-	tableInfo := &model.TableName{
+	tableame := &model.TableName{
 		Schema:      "test",
 		Table:       "t1",
 		TableID:     1,
 		IsPartition: false,
+	}
+	tableInfo := &model.TableInfo{
+		Version: 1,
 	}
 
 	appender := &TxnEventAppender{}
 	var buffer []*model.SingleTableTxn
 	rows := []*model.RowChangedEvent{
 		{
-			Table:    tableInfo,
-			CommitTs: 101,
-			StartTs:  98,
+			Table:     tableame,
+			TableInfo: tableInfo,
+			CommitTs:  101,
+			StartTs:   98,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 102,
-			StartTs:  99,
+			Table:     tableame,
+			TableInfo: tableInfo,
+			CommitTs:  102,
+			StartTs:   99,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 102,
-			StartTs:  100,
+			Table:     tableame,
+			TableInfo: tableInfo,
+			CommitTs:  102,
+			StartTs:   100,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 102,
-			StartTs:  100,
+			Table:     tableame,
+			TableInfo: tableInfo,
+			CommitTs:  102,
+			StartTs:   100,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 103,
-			StartTs:  101,
+			Table:     tableame,
+			TableInfo: tableInfo,
+			CommitTs:  103,
+			StartTs:   101,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 103,
-			StartTs:  101,
+			Table:     tableame,
+			TableInfo: tableInfo,
+			CommitTs:  103,
+			StartTs:   101,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 104,
-			StartTs:  102,
+			Table:     tableame,
+			TableInfo: tableInfo,
+			CommitTs:  104,
+			StartTs:   102,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 105,
-			StartTs:  103,
+			Table:     tableame,
+			TableInfo: tableInfo,
+			CommitTs:  105,
+			StartTs:   103,
 			// Batch1
 			SplitTxn: true,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 105,
-			StartTs:  103,
+			Table:     tableame,
+			TableInfo: tableInfo,
+			CommitTs:  105,
+			StartTs:   103,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 105,
-			StartTs:  103,
+			Table:     tableame,
+			TableInfo: tableInfo,
+			CommitTs:  105,
+			StartTs:   103,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 105,
-			StartTs:  103,
+			Table:     tableame,
+			TableInfo: tableInfo,
+			CommitTs:  105,
+			StartTs:   103,
 			// Batch2
 			SplitTxn: true,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 105,
-			StartTs:  103,
+			Table:     tableame,
+			TableInfo: tableInfo,
+			CommitTs:  105,
+			StartTs:   103,
 		},
 	}
 	buffer = appender.Append(buffer, rows...)
@@ -160,12 +181,12 @@ func TestTxnEventAppenderWithoutIgnoreStartTs(t *testing.T) {
 	// Test the case which the commitTs is not strictly increasing.
 	rows = []*model.RowChangedEvent{
 		{
-			Table:    tableInfo,
+			Table:    tableame,
 			CommitTs: 101,
 			StartTs:  98,
 		},
 		{
-			Table:    tableInfo,
+			Table:    tableame,
 			CommitTs: 100,
 			StartTs:  99,
 		},
@@ -178,12 +199,12 @@ func TestTxnEventAppenderWithoutIgnoreStartTs(t *testing.T) {
 	// Test the case which the startTs is not strictly increasing.
 	rows = []*model.RowChangedEvent{
 		{
-			Table:    tableInfo,
+			Table:    tableame,
 			CommitTs: 101,
 			StartTs:  98,
 		},
 		{
-			Table:    tableInfo,
+			Table:    tableame,
 			CommitTs: 101,
 			StartTs:  80,
 		},
@@ -197,79 +218,94 @@ func TestTxnEventAppenderWithoutIgnoreStartTs(t *testing.T) {
 func TestTxnEventAppenderWithIgnoreStartTs(t *testing.T) {
 	t.Parallel()
 
-	tableInfo := &model.TableName{
+	tableName := &model.TableName{
 		Schema:      "test",
 		Table:       "t1",
 		TableID:     1,
 		IsPartition: false,
+	}
+	tableInfo := &model.TableInfo{
+		Version: 1,
 	}
 
 	appender := &TxnEventAppender{IgnoreStartTs: true}
 	var buffer []*model.SingleTableTxn
 	rows := []*model.RowChangedEvent{
 		{
-			Table:    tableInfo,
-			CommitTs: 101,
-			StartTs:  0,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  101,
+			StartTs:   0,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 101,
-			StartTs:  0,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  101,
+			StartTs:   0,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 102,
-			StartTs:  90,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  102,
+			StartTs:   90,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 102,
-			StartTs:  91,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  102,
+			StartTs:   91,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 103,
-			StartTs:  0,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  103,
+			StartTs:   0,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 103,
-			StartTs:  0,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  103,
+			StartTs:   0,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 104,
-			StartTs:  0,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  104,
+			StartTs:   0,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 105,
-			StartTs:  0,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  105,
+			StartTs:   0,
 			// Batch1
 			SplitTxn: true,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 105,
-			StartTs:  0,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  105,
+			StartTs:   0,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 105,
-			StartTs:  0,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  105,
+			StartTs:   0,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 105,
-			StartTs:  0,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  105,
+			StartTs:   0,
 			// Batch2
 			SplitTxn: true,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 105,
-			StartTs:  0,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  105,
+			StartTs:   0,
 		},
 	}
 	buffer = appender.Append(buffer, rows...)
@@ -302,14 +338,16 @@ func TestTxnEventAppenderWithIgnoreStartTs(t *testing.T) {
 	// Test the case which the commitTs is not strictly increasing.
 	rows = []*model.RowChangedEvent{
 		{
-			Table:    tableInfo,
-			CommitTs: 101,
-			StartTs:  98,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  101,
+			StartTs:   98,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 100,
-			StartTs:  99,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  100,
+			StartTs:   99,
 		},
 	}
 	buffer = buffer[:0]
@@ -320,14 +358,16 @@ func TestTxnEventAppenderWithIgnoreStartTs(t *testing.T) {
 	// Test the case which the startTs is not strictly increasing.
 	rows = []*model.RowChangedEvent{
 		{
-			Table:    tableInfo,
-			CommitTs: 101,
-			StartTs:  98,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  101,
+			StartTs:   98,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 101,
-			StartTs:  80,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  101,
+			StartTs:   80,
 		},
 	}
 	buffer = buffer[:0]
@@ -338,14 +378,16 @@ func TestTxnEventAppenderWithIgnoreStartTs(t *testing.T) {
 	// Test the case which the startTs all is 0.
 	rows = []*model.RowChangedEvent{
 		{
-			Table:    tableInfo,
-			CommitTs: 101,
-			StartTs:  0,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  101,
+			StartTs:   0,
 		},
 		{
-			Table:    tableInfo,
-			CommitTs: 101,
-			StartTs:  0,
+			Table:     tableName,
+			TableInfo: tableInfo,
+			CommitTs:  101,
+			StartTs:   0,
 		},
 	}
 	buffer = buffer[:0]

--- a/cdc/sink/dmlsink/factory/factory.go
+++ b/cdc/sink/dmlsink/factory/factory.go
@@ -97,15 +97,17 @@ func New(
 
 // CreateTableSink creates a TableSink by schema.
 func (s *SinkFactory) CreateTableSink(
-	changefeedID model.ChangeFeedID, span tablepb.Span, totalRowsCounter prometheus.Counter,
+	changefeedID model.ChangeFeedID,
+	span tablepb.Span, startTs model.Ts,
+	totalRowsCounter prometheus.Counter,
 ) tablesink.TableSink {
 	if s.txnSink != nil {
-		return tablesink.New(changefeedID, span,
-			s.txnSink, &dmlsink.TxnEventAppender{}, totalRowsCounter)
+		return tablesink.New(changefeedID, span, startTs, s.txnSink,
+			&dmlsink.TxnEventAppender{TableSinkStartTs: startTs}, totalRowsCounter)
 	}
 
-	return tablesink.New(changefeedID, span,
-		s.rowSink, &dmlsink.RowChangeEventAppender{}, totalRowsCounter)
+	return tablesink.New(changefeedID, span, startTs, s.rowSink,
+		&dmlsink.RowChangeEventAppender{}, totalRowsCounter)
 }
 
 // CreateTableSinkForConsumer creates a TableSink by schema for consumer.
@@ -113,17 +115,20 @@ func (s *SinkFactory) CreateTableSink(
 // CreateTableSinkForConsumer will not create a new sink for each table.
 // NOTICE: This only used for the consumer. Please do not use it in the processor.
 func (s *SinkFactory) CreateTableSinkForConsumer(
-	changefeedID model.ChangeFeedID, span tablepb.Span, totalRowsCounter prometheus.Counter,
+	changefeedID model.ChangeFeedID,
+	span tablepb.Span, startTs model.Ts,
+	totalRowsCounter prometheus.Counter,
 ) tablesink.TableSink {
 	if s.txnSink != nil {
-		return tablesink.New(changefeedID, span,
+		return tablesink.New(changefeedID, span, startTs, s.txnSink,
 			// IgnoreStartTs is true because the consumer can
 			// **not** get the start ts of the row changed event.
-			s.txnSink, &dmlsink.TxnEventAppender{IgnoreStartTs: true}, totalRowsCounter)
+			&dmlsink.TxnEventAppender{TableSinkStartTs: startTs, IgnoreStartTs: true},
+			totalRowsCounter)
 	}
 
-	return tablesink.New(changefeedID, span,
-		s.rowSink, &dmlsink.RowChangeEventAppender{}, totalRowsCounter)
+	return tablesink.New(changefeedID, span, startTs, s.rowSink,
+		&dmlsink.RowChangeEventAppender{}, totalRowsCounter)
 }
 
 // Close closes the sink.

--- a/cdc/sink/dmlsink/factory/factory_test.go
+++ b/cdc/sink/dmlsink/factory/factory_test.go
@@ -104,7 +104,7 @@ func TestSinkFactory(t *testing.T) {
 	require.NotNil(t, sinkFactory.rowSink)
 
 	tableSink := sinkFactory.CreateTableSink(model.DefaultChangeFeedID("1"),
-		spanz.TableIDToComparableSpan(1), prometheus.NewCounter(prometheus.CounterOpts{}))
+		spanz.TableIDToComparableSpan(1), 0, prometheus.NewCounter(prometheus.CounterOpts{}))
 	require.NotNil(t, tableSink, "table sink can be created")
 
 	sinkFactory.Close()

--- a/cdc/sink/tablesink/table_sink_impl.go
+++ b/cdc/sink/tablesink/table_sink_impl.go
@@ -35,8 +35,11 @@ var (
 
 // EventTableSink is a table sink that can write events.
 type EventTableSink[E dmlsink.TableEvent, P dmlsink.Appender[E]] struct {
-	changefeedID    model.ChangeFeedID
-	span            tablepb.Span
+	changefeedID model.ChangeFeedID
+	span         tablepb.Span
+	// startTs is the initial checkpointTs of the table sink.
+	startTs model.Ts
+
 	maxResolvedTs   model.ResolvedTs
 	backendSink     dmlsink.EventSink[E]
 	progressTracker *progressTracker
@@ -53,6 +56,7 @@ type EventTableSink[E dmlsink.TableEvent, P dmlsink.Appender[E]] struct {
 func New[E dmlsink.TableEvent, P dmlsink.Appender[E]](
 	changefeedID model.ChangeFeedID,
 	span tablepb.Span,
+	startTs model.Ts,
 	backendSink dmlsink.EventSink[E],
 	appender P,
 	totalRowsCounter prometheus.Counter,
@@ -60,6 +64,7 @@ func New[E dmlsink.TableEvent, P dmlsink.Appender[E]](
 	return &EventTableSink[E, P]{
 		changefeedID:              changefeedID,
 		span:                      span,
+		startTs:                   startTs,
 		maxResolvedTs:             model.NewResolvedTs(0),
 		backendSink:               backendSink,
 		progressTracker:           newProgressTracker(span, defaultBufferSize),

--- a/cdc/sink/tablesink/table_sink_impl_test.go
+++ b/cdc/sink/tablesink/table_sink_impl_test.go
@@ -159,7 +159,7 @@ func TestNewEventTableSink(t *testing.T) {
 
 	sink := &mockEventSink{dead: make(chan struct{})}
 	tb := New[*model.SingleTableTxn](
-		model.DefaultChangeFeedID("1"), spanz.TableIDToComparableSpan(1),
+		model.DefaultChangeFeedID("1"), spanz.TableIDToComparableSpan(1), model.Ts(0),
 		sink, &dmlsink.TxnEventAppender{}, prometheus.NewCounter(prometheus.CounterOpts{}))
 
 	require.Equal(t, model.NewResolvedTs(0), tb.maxResolvedTs, "maxResolvedTs should start from 0")
@@ -175,7 +175,7 @@ func TestAppendRowChangedEvents(t *testing.T) {
 
 	sink := &mockEventSink{dead: make(chan struct{})}
 	tb := New[*model.SingleTableTxn](
-		model.DefaultChangeFeedID("1"), spanz.TableIDToComparableSpan(1),
+		model.DefaultChangeFeedID("1"), spanz.TableIDToComparableSpan(1), model.Ts(0),
 		sink, &dmlsink.TxnEventAppender{}, prometheus.NewCounter(prometheus.CounterOpts{}))
 
 	tb.AppendRowChangedEvents(getTestRows()...)
@@ -187,7 +187,7 @@ func TestUpdateResolvedTs(t *testing.T) {
 
 	sink := &mockEventSink{dead: make(chan struct{})}
 	tb := New[*model.SingleTableTxn](
-		model.DefaultChangeFeedID("1"), spanz.TableIDToComparableSpan(1),
+		model.DefaultChangeFeedID("1"), spanz.TableIDToComparableSpan(1), model.Ts(0),
 		sink, &dmlsink.TxnEventAppender{}, prometheus.NewCounter(prometheus.CounterOpts{}))
 
 	tb.AppendRowChangedEvents(getTestRows()...)
@@ -237,7 +237,7 @@ func TestGetCheckpointTs(t *testing.T) {
 
 	sink := &mockEventSink{dead: make(chan struct{})}
 	tb := New[*model.SingleTableTxn](
-		model.DefaultChangeFeedID("1"), spanz.TableIDToComparableSpan(1),
+		model.DefaultChangeFeedID("1"), spanz.TableIDToComparableSpan(1), model.Ts(0),
 		sink, &dmlsink.TxnEventAppender{}, prometheus.NewCounter(prometheus.CounterOpts{}))
 
 	tb.AppendRowChangedEvents(getTestRows()...)
@@ -274,7 +274,7 @@ func TestClose(t *testing.T) {
 
 	sink := &mockEventSink{dead: make(chan struct{})}
 	tb := New[*model.SingleTableTxn](
-		model.DefaultChangeFeedID("1"), spanz.TableIDToComparableSpan(1),
+		model.DefaultChangeFeedID("1"), spanz.TableIDToComparableSpan(1), model.Ts(0),
 		sink, &dmlsink.TxnEventAppender{}, prometheus.NewCounter(prometheus.CounterOpts{}))
 
 	tb.AppendRowChangedEvents(getTestRows()...)
@@ -303,7 +303,7 @@ func TestCloseCancellable(t *testing.T) {
 
 	sink := &mockEventSink{dead: make(chan struct{})}
 	tb := New[*model.SingleTableTxn](
-		model.DefaultChangeFeedID("1"), spanz.TableIDToComparableSpan(1),
+		model.DefaultChangeFeedID("1"), spanz.TableIDToComparableSpan(1), model.Ts(0),
 		sink, &dmlsink.TxnEventAppender{}, prometheus.NewCounter(prometheus.CounterOpts{}))
 
 	tb.AppendRowChangedEvents(getTestRows()...)
@@ -333,7 +333,7 @@ func TestCloseReentrant(t *testing.T) {
 
 	sink := &mockEventSink{dead: make(chan struct{})}
 	tb := New[*model.SingleTableTxn](
-		model.DefaultChangeFeedID("1"), spanz.TableIDToComparableSpan(1),
+		model.DefaultChangeFeedID("1"), spanz.TableIDToComparableSpan(1), model.Ts(0),
 		sink, &dmlsink.TxnEventAppender{}, prometheus.NewCounter(prometheus.CounterOpts{}))
 
 	tb.AppendRowChangedEvents(getTestRows()...)
@@ -366,7 +366,7 @@ func TestCheckpointTsFrozenWhenStopping(t *testing.T) {
 
 	sink := &mockEventSink{dead: make(chan struct{})}
 	tb := New[*model.SingleTableTxn](
-		model.DefaultChangeFeedID("1"), spanz.TableIDToComparableSpan(1),
+		model.DefaultChangeFeedID("1"), spanz.TableIDToComparableSpan(1), model.Ts(0),
 		sink, &dmlsink.TxnEventAppender{}, prometheus.NewCounter(prometheus.CounterOpts{}))
 
 	tb.AppendRowChangedEvents(getTestRows()...)

--- a/cmd/kafka-consumer/main.go
+++ b/cmd/kafka-consumer/main.go
@@ -626,6 +626,7 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 							sink.tableSinksMap.Store(tableID, c.sinkFactory.CreateTableSinkForConsumer(
 								model.DefaultChangeFeedID("kafka-consumer"),
 								spanz.TableIDToComparableSpan(tableID),
+								events[0].CommitTs,
 								prometheus.NewCounter(prometheus.CounterOpts{}),
 							))
 						}

--- a/cmd/storage-consumer/main.go
+++ b/cmd/storage-consumer/main.go
@@ -471,6 +471,7 @@ func (c *consumer) emitDMLEvents(
 				c.tableSinkMap[tableID] = c.sinkFactory.CreateTableSinkForConsumer(
 					model.DefaultChangeFeedID(defaultChangefeedName),
 					spanz.TableIDToComparableSpan(tableID),
+					row.CommitTs,
 					prometheus.NewCounter(prometheus.CounterOpts{}))
 			}
 

--- a/pkg/applier/redo.go
+++ b/pkg/applier/redo.go
@@ -308,6 +308,7 @@ func (ra *RedoApplier) applyRow(
 		tableSink := ra.sinkFactory.CreateTableSink(
 			model.DefaultChangeFeedID(applierChangefeed),
 			spanz.TableIDToComparableSpan(tableID),
+			checkpointTs,
 			prometheus.NewCounter(prometheus.CounterOpts{}),
 		)
 		ra.tableSinks[tableID] = tableSink

--- a/pkg/sink/cloudstorage/path.go
+++ b/pkg/sink/cloudstorage/path.go
@@ -44,16 +44,16 @@ type indexWithDate struct {
 	currDate, prevDate string
 }
 
-// VersionedTable is used to wrap TableNameWithPhysicTableID with a version.
-type VersionedTable struct {
+// VersionedTableName is used to wrap TableNameWithPhysicTableID with a version.
+type VersionedTableName struct {
 	// Because we need to generate different file paths for different
 	// tables, we need to use the physical table ID instead of the
 	// logical table ID.(Especially when the table is a partitioned table).
 	TableNameWithPhysicTableID model.TableName
-	// Version is consistent with the version of TableInfo recorded in
+	// TableInfoVersion is consistent with the version of TableInfo recorded in
 	// schema storage. It can either be finished ts of a DDL event,
 	// or be the checkpoint ts when processor is restarted.
-	Version uint64
+	TableInfoVersion uint64
 }
 
 // FilePathGenerator is used to generate data file path and index file path.
@@ -62,7 +62,7 @@ type FilePathGenerator struct {
 	config    *Config
 	clock     clock.Clock
 	storage   storage.ExternalStorage
-	fileIndex map[VersionedTable]*indexWithDate
+	fileIndex map[VersionedTableName]*indexWithDate
 }
 
 // NewFilePathGenerator creates a FilePathGenerator.
@@ -77,7 +77,7 @@ func NewFilePathGenerator(
 		extension: extension,
 		storage:   storage,
 		clock:     clock,
-		fileIndex: make(map[VersionedTable]*indexWithDate),
+		fileIndex: make(map[VersionedTableName]*indexWithDate),
 	}
 }
 
@@ -87,7 +87,7 @@ func (f *FilePathGenerator) SetClock(clock clock.Clock) {
 }
 
 // Contains checks if a VersionedTable is cached by FilePathGenerator before.
-func (f *FilePathGenerator) Contains(tbl VersionedTable) bool {
+func (f *FilePathGenerator) Contains(tbl VersionedTableName) bool {
 	_, ok := f.fileIndex[tbl]
 	return ok
 }
@@ -111,12 +111,12 @@ func (f *FilePathGenerator) GenerateDateStr() string {
 	return dateStr
 }
 
-func (f *FilePathGenerator) generateDataDirPath(tbl VersionedTable, date string) string {
+func (f *FilePathGenerator) generateDataDirPath(tbl VersionedTableName, date string) string {
 	var elems []string
 
 	elems = append(elems, tbl.TableNameWithPhysicTableID.Schema)
 	elems = append(elems, tbl.TableNameWithPhysicTableID.Table)
-	elems = append(elems, fmt.Sprintf("%d", tbl.Version))
+	elems = append(elems, fmt.Sprintf("%d", tbl.TableInfoVersion))
 
 	if f.config.EnablePartitionSeparator && tbl.TableNameWithPhysicTableID.IsPartition {
 		elems = append(elems, fmt.Sprintf("%d", tbl.TableNameWithPhysicTableID.TableID))
@@ -152,7 +152,7 @@ func (f *FilePathGenerator) fetchIndexFromFileName(fileName string) (uint64, err
 // GenerateDataFilePath generates a canonical path for data file.
 func (f *FilePathGenerator) GenerateDataFilePath(
 	ctx context.Context,
-	tbl VersionedTable,
+	tbl VersionedTableName,
 	date string,
 ) (string, error) {
 	var elems []string
@@ -183,7 +183,7 @@ func (f *FilePathGenerator) GenerateDataFilePath(
 }
 
 // GenerateIndexFilePath generates a canonical path for index file.
-func (f *FilePathGenerator) GenerateIndexFilePath(tbl VersionedTable, date string) string {
+func (f *FilePathGenerator) GenerateIndexFilePath(tbl VersionedTableName, date string) string {
 	var elems []string
 
 	elems = append(elems, f.generateDataDirPath(tbl, date))
@@ -193,7 +193,7 @@ func (f *FilePathGenerator) GenerateIndexFilePath(tbl VersionedTable, date strin
 }
 
 func (f *FilePathGenerator) getNextFileIdxFromIndexFile(
-	ctx context.Context, tbl VersionedTable, date string,
+	ctx context.Context, tbl VersionedTableName, date string,
 ) (uint64, error) {
 	indexFile := f.GenerateIndexFilePath(tbl, date)
 	exist, err := f.storage.FileExists(ctx, indexFile)

--- a/pkg/sink/cloudstorage/path_test.go
+++ b/pkg/sink/cloudstorage/path_test.go
@@ -48,12 +48,12 @@ func TestGenerateDataFilePath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 
-	table := VersionedTable{
+	table := VersionedTableName{
 		TableNameWithPhysicTableID: model.TableName{
 			Schema: "test",
 			Table:  "table1",
 		},
-		Version: 5,
+		TableInfoVersion: 5,
 	}
 
 	dir := t.TempDir()
@@ -193,12 +193,12 @@ func TestGenerateDataFilePathWithIndexFile(t *testing.T) {
 	f.config.DateSeparator = config.DateSeparatorDay.String()
 	f.clock = mockClock
 	mockClock.Set(time.Date(2023, 3, 9, 23, 59, 59, 0, time.UTC))
-	table := VersionedTable{
+	table := VersionedTableName{
 		TableNameWithPhysicTableID: model.TableName{
 			Schema: "test",
 			Table:  "table1",
 		},
-		Version: 5,
+		TableInfoVersion: 5,
 	}
 	date := f.GenerateDateStr()
 	indexFilePath := f.GenerateIndexFilePath(table, date)

--- a/pkg/sink/cloudstorage/table_definition_test.go
+++ b/pkg/sink/cloudstorage/table_definition_test.go
@@ -355,7 +355,7 @@ func TestTableDefinition(t *testing.T) {
 	columns = append(columns, col)
 
 	tableInfo.TableInfo = &timodel.TableInfo{Columns: columns}
-	def.FromTableInfo(tableInfo)
+	def.FromTableInfo(tableInfo, tableInfo.Version)
 	encodedDef, err := json.MarshalIndent(def, "", "    ")
 	require.NoError(t, err)
 	require.JSONEq(t, `{
@@ -394,6 +394,7 @@ func TestTableDefinition(t *testing.T) {
 
 	def = TableDefinition{}
 	event := &model.DDLEvent{
+		CommitTs:  tableInfo.Version,
 		Type:      timodel.ActionAddColumn,
 		Query:     "alter table test.table1 add Birthday date",
 		TableInfo: tableInfo,

--- a/tests/integration_tests/canal_json_storage_basic/run.sh
+++ b/tests/integration_tests/canal_json_storage_basic/run.sh
@@ -8,38 +8,12 @@ WORK_DIR=$OUT_DIR/$TEST_NAME
 CDC_BINARY=cdc.test
 SINK_TYPE=$1
 
-# start the s3 server
-export MINIO_ACCESS_KEY=cdcs3accesskey
-export MINIO_SECRET_KEY=cdcs3secretkey
-export MINIO_BROWSER=off
-export AWS_ACCESS_KEY_ID=$MINIO_ACCESS_KEY
-export AWS_SECRET_ACCESS_KEY=$MINIO_SECRET_KEY
-export S3_ENDPOINT=127.0.0.1:24927
 rm -rf "$WORK_DIR"
 mkdir -p "$WORK_DIR"
-pkill -9 minio || true
-bin/minio server --address $S3_ENDPOINT "$WORK_DIR/s3" &
-MINIO_PID=$!
-i=0
-while ! curl -o /dev/null -v -s "http://$S3_ENDPOINT/"; do
-	i=$(($i + 1))
-	if [ $i -gt 30 ]; then
-		echo 'Failed to start minio'
-		exit 1
-	fi
-	sleep 2
-done
-
-stop_minio() {
-	kill -2 $MINIO_PID
-}
 
 stop() {
-	stop_minio
 	stop_tidb_cluster
 }
-
-s3cmd --access_key=$MINIO_ACCESS_KEY --secret_key=$MINIO_SECRET_KEY --host=$S3_ENDPOINT --host-bucket=$S3_ENDPOINT --no-ssl mb s3://logbucket
 
 function run() {
 	# Now, we run the storage tests in mysql sink tests.
@@ -53,13 +27,13 @@ function run() {
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
 
 	# Enable tidb extension to generate the commit ts.
-	SINK_URI="s3://logbucket/storage_test?flush-interval=5s&enable-tidb-extension=true&endpoint=http://127.0.0.1:24927/"
+	SINK_URI="file://$WORK_DIR/storage_test?flush-interval=5s&enable-tidb-extension=true"
 	run_cdc_cli changefeed create --sink-uri="$SINK_URI" --config=$CUR/conf/changefeed.toml
 
 	run_sql_file $CUR/data/schema.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql_file $CUR/data/schema.sql ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	run_sql_file $CUR/data/data.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-	run_storage_consumer $WORK_DIR "s3://logbucket/storage_test?endpoint=http://127.0.0.1:24927/" $CUR/conf/changefeed.toml ""
+	run_storage_consumer $WORK_DIR $SINK_URI $CUR/conf/changefeed.toml ""
 	sleep 8
 	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 100
 }

--- a/tests/integration_tests/csv_storage_basic/run.sh
+++ b/tests/integration_tests/csv_storage_basic/run.sh
@@ -8,38 +8,12 @@ WORK_DIR=$OUT_DIR/$TEST_NAME
 CDC_BINARY=cdc.test
 SINK_TYPE=$1
 
-# start the s3 server
-export MINIO_ACCESS_KEY=cdcs3accesskey
-export MINIO_SECRET_KEY=cdcs3secretkey
-export MINIO_BROWSER=off
-export AWS_ACCESS_KEY_ID=$MINIO_ACCESS_KEY
-export AWS_SECRET_ACCESS_KEY=$MINIO_SECRET_KEY
-export S3_ENDPOINT=127.0.0.1:24927
 rm -rf "$WORK_DIR"
 mkdir -p "$WORK_DIR"
-pkill -9 minio || true
-bin/minio server --address $S3_ENDPOINT "$WORK_DIR/s3" &
-MINIO_PID=$!
-i=0
-while ! curl -o /dev/null -v -s "http://$S3_ENDPOINT/"; do
-	i=$(($i + 1))
-	if [ $i -gt 30 ]; then
-		echo 'Failed to start minio'
-		exit 1
-	fi
-	sleep 2
-done
-
-stop_minio() {
-	kill -2 $MINIO_PID
-}
 
 stop() {
-	stop_minio
 	stop_tidb_cluster
 }
-
-s3cmd --access_key=$MINIO_ACCESS_KEY --secret_key=$MINIO_SECRET_KEY --host=$S3_ENDPOINT --host-bucket=$S3_ENDPOINT --no-ssl mb s3://logbucket
 
 function run() {
 	# Now, we run the storage tests in mysql sink tests.
@@ -52,13 +26,13 @@ function run() {
 	cd $WORK_DIR
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
 
-	SINK_URI="s3://logbucket/storage_test?flush-interval=5s&endpoint=http://127.0.0.1:24927/"
+	SINK_URI="file://$WORK_DIR/storage_test?flush-interval=5s"
 	run_cdc_cli changefeed create --sink-uri="$SINK_URI" --config=$CUR/conf/changefeed.toml
 
 	run_sql_file $CUR/data/schema.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql_file $CUR/data/schema.sql ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	run_sql_file $CUR/data/data.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-	run_storage_consumer $WORK_DIR "s3://logbucket/storage_test?endpoint=http://127.0.0.1:24927/" $CUR/conf/changefeed.toml ""
+	run_storage_consumer $WORK_DIR $SINK_URI $CUR/conf/changefeed.toml ""
 	sleep 8
 	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml 100
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8666

### What is changed and how it works?
1. Set `TableInfoVersion` in [SingleTableTxn](https://github.com/pingcap/tiflow/pull/8751/files#diff-eb40c4235fa377719c71b4d416eb38d4f4134b281758dd43687ca525d0ca3549R669), which is [max{TableSinkStartTs, TableInfo.Version}](https://github.com/pingcap/tiflow/pull/8751/files#diff-021e72c7db585ee751d1c0c1985e4e552434699a2e2dcfa5afff9f86513a3225R121-R125).
2. Use correct `TableinfoVersion` in [TableDefinition](https://github.com/pingcap/tiflow/pull/8751/files#diff-ae808f9ebdd6f78efc57b1ee58e765b909c12be355cb2defffe7b44728ca6e44R198).
3. Use [loacl storage in integration test to facilitate debug](https://github.com/pingcap/tiflow/pull/8751/files#diff-0dac0ea75b05049ecd2a171ef67193c96891fc2677187257e06314dea92343d7R30).

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

Need to update user documentation.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`Fix the issue of table version rollback in storage sink when cdc scaling`.
```
