### PR TITLE
processor, sink (ticdc): fix processor stuck since sinkmanager run fails

### DIFF
--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -183,7 +183,6 @@ func (m *SinkManager) Run(ctx context.Context) (err error) {
 		m.changefeedInfo.SinkURI,
 		m.changefeedInfo.Config,
 		managerErrors)
-	log.Warn("before failpoint SinkManagerRunError injected")
 	failpoint.Inject("SinkManagerRunError", func() {
 		log.Info("failpoint SinkManagerRunError injected",
 			zap.String("changefeed", m.changefeedID.ID))


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8802 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a bug that leads to changefeed stuck when sinkManager run fails.
```
