### PR TITLE
sqlmodel: skip considering multi-value index in CausalityKeys

### DIFF
--- a/pkg/sqlmodel/causality.go
+++ b/pkg/sqlmodel/causality.go
@@ -144,6 +144,11 @@ func (r *RowChange) getCausalityString(values []interface{}) []string {
 	ret := make([]string, 0, len(pkAndUks))
 
 	for _, indexCols := range pkAndUks {
+		// TODO: should not support multi value index and generate the value
+		// TODO: also fix https://github.com/pingcap/tiflow/issues/3286#issuecomment-971264282
+		if indexCols.MVIndex {
+			continue
+		}
 		cols, vals := getColsAndValuesOfIdx(r.sourceTableInfo.Columns, indexCols, values)
 		// handle prefix index
 		truncVals := truncateIndexValues(r.tiSessionCtx, r.sourceTableInfo, indexCols, cols, vals)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8803

### What is changed and how it works?

temporary skip considering the multi-value index in CausalityKeys. In future we should evaluate the generating expression to get the value of causality key.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
