### PR TITLE
config(ticdc): integrity only works for kafka sink

### DIFF
--- a/pkg/cmd/util/helper_test.go
+++ b/pkg/cmd/util/helper_test.go
@@ -216,12 +216,14 @@ func TestAndWriteStorageSinkTOML(t *testing.T) {
 	err := StrictDecodeFile("changefeed_storage_sink.toml", "cdc", &cfg)
 	require.NoError(t, err)
 
-	sinkURL, err := url.Parse("kafka://127.0.0.1:9092")
+	sinkURL, err := url.Parse("s3://127.0.0.1:9092")
 	require.NoError(t, err)
 
+	cfg.Sink.Protocol = config.ProtocolCanalJSON.String()
 	err = cfg.ValidateAndAdjust(sinkURL)
 	require.NoError(t, err)
 	require.Equal(t, &config.SinkConfig{
+		Protocol:                 config.ProtocolCanalJSON.String(),
 		EncoderConcurrency:       16,
 		Terminator:               "\r\n",
 		DateSeparator:            "day",

--- a/pkg/cmd/util/helper_test.go
+++ b/pkg/cmd/util/helper_test.go
@@ -16,6 +16,7 @@ package util
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -182,8 +183,12 @@ func TestAndWriteExampleReplicaTOML(t *testing.T) {
 	require.Equal(t, &config.MounterConfig{
 		WorkerNum: 16,
 	}, cfg.Mounter)
-	err = cfg.ValidateAndAdjust(nil)
-	require.Nil(t, err)
+
+	sinkURL, err := url.Parse("kafka://127.0.0.1:9092")
+	require.NoError(t, err)
+
+	err = cfg.ValidateAndAdjust(sinkURL)
+	require.NoError(t, err)
 	require.Equal(t, &config.SinkConfig{
 		EncoderConcurrency: 16,
 		DispatchRules: []*config.DispatchRule{
@@ -209,10 +214,13 @@ func TestAndWriteExampleReplicaTOML(t *testing.T) {
 func TestAndWriteStorageSinkTOML(t *testing.T) {
 	cfg := config.GetDefaultReplicaConfig()
 	err := StrictDecodeFile("changefeed_storage_sink.toml", "cdc", &cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
-	err = cfg.ValidateAndAdjust(nil)
-	require.Nil(t, err)
+	sinkURL, err := url.Parse("kafka://127.0.0.1:9092")
+	require.NoError(t, err)
+
+	err = cfg.ValidateAndAdjust(sinkURL)
+	require.NoError(t, err)
 	require.Equal(t, &config.SinkConfig{
 		EncoderConcurrency:       16,
 		Terminator:               "\r\n",


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8854 

### What is changed and how it works?

* adjust replica config, e2e checksum functionality only works for the kafka sink changefeed.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
