### PR TITLE
codec(ticdc): avro encode watermark event to be compatible with consumer

### DIFF
--- a/pkg/sink/codec/avro/avro.go
+++ b/pkg/sink/codec/avro/avro.go
@@ -54,8 +54,9 @@ type Options struct {
 	EnableTiDBExtension bool
 	EnableRowChecksum   bool
 
-	// EnableWatermarkEvent enabled, then the DDL and watermark event will be
-	// sent to downstream kafka, it's only used for testing purpose, should not be
+	// EnableWatermarkEvent set to true, avro encode DDL and checkpoint event
+	// and send to the downstream kafka, they cannot be consumed by the confluent official consumer
+	// and would cause error, so this is only used for ticdc internal testing purpose, should not be
 	// exposed to the outside users.
 	EnableWatermarkEvent bool
 

--- a/pkg/sink/codec/common/config.go
+++ b/pkg/sink/codec/common/config.go
@@ -43,6 +43,8 @@ type Config struct {
 	AvroDecimalHandlingMode        string
 	AvroBigintUnsignedHandlingMode string
 
+	AvroEnableWatermark bool
+
 	// for sinking to cloud storage
 	Delimiter       string
 	Quote           string
@@ -79,7 +81,11 @@ const (
 	codecOPTAvroDecimalHandlingMode        = "avro-decimal-handling-mode"
 	codecOPTAvroBigintUnsignedHandlingMode = "avro-bigint-unsigned-handling-mode"
 	codecOPTAvroSchemaRegistry             = "schema-registry"
-	codecOPTOnlyOutputUpdatedColumns       = "only-output-updated-columns"
+
+	// codecOPTAvroEnableWatermark is the option for enabling watermark in avro protocol
+	// only used for internal testing, do not expose it to the outside users.
+	codecOPTAvroEnableWatermark      = "avro-enable-watermark"
+	codecOPTOnlyOutputUpdatedColumns = "only-output-updated-columns"
 )
 
 const (
@@ -94,7 +100,7 @@ const (
 )
 
 // Apply fill the Config
-func (c *Config) Apply(sinkURI *url.URL, config *config.ReplicaConfig) error {
+func (c *Config) Apply(sinkURI *url.URL, replicaConfig *config.ReplicaConfig) error {
 	params := sinkURI.Query()
 	if s := params.Get(codecOPTEnableTiDBExtension); s != "" {
 		b, err := strconv.ParseBool(s)
@@ -128,20 +134,30 @@ func (c *Config) Apply(sinkURI *url.URL, config *config.ReplicaConfig) error {
 		c.AvroBigintUnsignedHandlingMode = s
 	}
 
-	if config.Sink != nil && config.Sink.SchemaRegistry != "" {
-		c.AvroSchemaRegistry = config.Sink.SchemaRegistry
+	if s := params.Get(codecOPTAvroEnableWatermark); s != "" {
+		if c.EnableTiDBExtension && c.Protocol == config.ProtocolAvro {
+			b, err := strconv.ParseBool(s)
+			if err != nil {
+				return err
+			}
+			c.AvroEnableWatermark = b
+		}
 	}
 
-	if config.Sink != nil {
-		c.Terminator = config.Sink.Terminator
-		if config.Sink.CSVConfig != nil {
-			c.Delimiter = config.Sink.CSVConfig.Delimiter
-			c.Quote = config.Sink.CSVConfig.Quote
-			c.NullString = config.Sink.CSVConfig.NullString
-			c.IncludeCommitTs = config.Sink.CSVConfig.IncludeCommitTs
+	if replicaConfig.Sink != nil && replicaConfig.Sink.SchemaRegistry != "" {
+		c.AvroSchemaRegistry = replicaConfig.Sink.SchemaRegistry
+	}
+
+	if replicaConfig.Sink != nil {
+		c.Terminator = replicaConfig.Sink.Terminator
+		if replicaConfig.Sink.CSVConfig != nil {
+			c.Delimiter = replicaConfig.Sink.CSVConfig.Delimiter
+			c.Quote = replicaConfig.Sink.CSVConfig.Quote
+			c.NullString = replicaConfig.Sink.CSVConfig.NullString
+			c.IncludeCommitTs = replicaConfig.Sink.CSVConfig.IncludeCommitTs
 		}
 
-		c.OnlyOutputUpdatedColumns = config.Sink.OnlyOutputUpdatedColumns
+		c.OnlyOutputUpdatedColumns = replicaConfig.Sink.OnlyOutputUpdatedColumns
 	}
 	if s := params.Get(codecOPTOnlyOutputUpdatedColumns); s != "" {
 		a, err := strconv.ParseBool(s)
@@ -150,15 +166,15 @@ func (c *Config) Apply(sinkURI *url.URL, config *config.ReplicaConfig) error {
 		}
 		c.OnlyOutputUpdatedColumns = a
 	}
-	if c.OnlyOutputUpdatedColumns && !config.EnableOldValue {
+	if c.OnlyOutputUpdatedColumns && !replicaConfig.EnableOldValue {
 		return cerror.ErrCodecInvalidConfig.GenWithStack(
 			`old value must be enabled when configuration "%s" is true.`,
 			codecOPTOnlyOutputUpdatedColumns,
 		)
 	}
 
-	if config.Integrity != nil {
-		c.EnableRowChecksum = config.Integrity.Enabled()
+	if replicaConfig.Integrity != nil {
+		c.EnableRowChecksum = replicaConfig.Integrity.Enabled()
 	}
 
 	return nil

--- a/pkg/sink/codec/common/config.go
+++ b/pkg/sink/codec/common/config.go
@@ -83,7 +83,8 @@ const (
 	codecOPTAvroSchemaRegistry             = "schema-registry"
 
 	// codecOPTAvroEnableWatermark is the option for enabling watermark in avro protocol
-	// only used for internal testing, do not expose it to the outside users.
+	// only used for internal testing, do not set this in the production environment since the
+	// confluent official consumer cannot handle watermark.
 	codecOPTAvroEnableWatermark      = "avro-enable-watermark"
 	codecOPTOnlyOutputUpdatedColumns = "only-output-updated-columns"
 )

--- a/pkg/sink/codec/common/config.go
+++ b/pkg/sink/codec/common/config.go
@@ -64,11 +64,13 @@ func NewConfig(protocol config.Protocol) *Config {
 		MaxMessageBytes: config.DefaultMaxMessageBytes,
 		MaxBatchSize:    defaultMaxBatchSize,
 
-		EnableTiDBExtension:            false,
-		EnableRowChecksum:              false,
+		EnableTiDBExtension: false,
+		EnableRowChecksum:   false,
+
 		AvroSchemaRegistry:             "",
 		AvroDecimalHandlingMode:        "precise",
 		AvroBigintUnsignedHandlingMode: "long",
+		AvroEnableWatermark:            false,
 
 		OnlyOutputUpdatedColumns: false,
 	}

--- a/pkg/sink/codec/common/config_test.go
+++ b/pkg/sink/codec/common/config_test.go
@@ -88,6 +88,25 @@ func TestConfigApplyValidate4EnableRowChecksum(t *testing.T) {
 		err = c.Validate()
 		require.Error(t, err)
 	}
+
+	// avro, enable tidb extension and enable watermark event.
+	uri = "kafka://127.0.0.1:9092/avro?protocol=avro&enable-tidb-extension=true&avro-enable-watermark=true"
+	sinkURI, err = url.Parse(uri)
+	require.NoError(t, err)
+
+	protocol = sinkURI.Query().Get("protocol")
+	p, err = config.ParseSinkProtocolFromString(protocol)
+	require.NoError(t, err)
+	c = NewConfig(p)
+
+	replicaConfig = config.GetDefaultReplicaConfig()
+	replicaConfig.Sink.SchemaRegistry = "some-schema-registry"
+	err = c.Apply(sinkURI, replicaConfig)
+	require.NoError(t, err)
+
+	err = c.Validate()
+	require.NoError(t, err)
+	require.True(t, c.AvroEnableWatermark)
 }
 
 func TestConfigApplyValidate(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8869

### What is changed and how it works?

Originally, avro does not support encode DDL and checkpoint event, which means the downstream kafka consumer does not the DDL exsitance and data stream progress, this is incompatible with the current cdc kafka consumer.

* add a new config in the sink url, named `avro-enable-watermark`
* encoding DDL and checkpoint event so that can be sink to the kafka

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->
- Unit test
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
