### PR TITLE
pkg/sink(ticdc): Add support for `select @@variable_name;` statement when getting the variables from downstream

### DIFF
--- a/pkg/sink/mysql/config_test.go
+++ b/pkg/sink/mysql/config_test.go
@@ -100,12 +100,11 @@ func TestGenerateDSNByConfig(t *testing.T) {
 		db, mock, err := sqlmock.New()
 		require.Nil(t, err)
 		defer db.Close() // nolint:errcheck
-		columns := []string{"Variable_name", "Value"}
-		mock.ExpectQuery("show session variables like 'allow_auto_random_explicit_insert';").WillReturnRows(
-			sqlmock.NewRows(columns).AddRow("allow_auto_random_explicit_insert", "0"),
+		mock.ExpectQuery("select @@allow_auto_random_explicit_insert;").WillReturnRows(
+			sqlmock.NewRows([]string{"@@allow_auto_random_explicit_insert"}).AddRow("0"),
 		)
-		mock.ExpectQuery("show session variables like 'tidb_txn_mode';").WillReturnRows(
-			sqlmock.NewRows(columns).AddRow("tidb_txn_mode", "pessimistic"),
+		mock.ExpectQuery("select @@tidb_txn_mode;").WillReturnRows(
+			sqlmock.NewRows([]string{"@@tidb_txn_mode"}).AddRow("pessimistic"),
 		)
 		// simulate error
 		dsn, err := dmysql.ParseDSN("root:123456@tcp(127.0.0.1:4000)/")
@@ -116,22 +115,23 @@ func TestGenerateDSNByConfig(t *testing.T) {
 		require.Error(t, err)
 
 		// simulate no transaction_isolation
-		mock.ExpectQuery("show session variables like 'allow_auto_random_explicit_insert';").WillReturnRows(
-			sqlmock.NewRows(columns).AddRow("allow_auto_random_explicit_insert", "0"),
+		mock.ExpectQuery("select @@allow_auto_random_explicit_insert;").WillReturnRows(
+			sqlmock.NewRows([]string{"@@allow_auto_random_explicit_insert"}).AddRow("0"),
 		)
-		mock.ExpectQuery("show session variables like 'tidb_txn_mode';").WillReturnRows(
-			sqlmock.NewRows(columns).AddRow("tidb_txn_mode", "pessimistic"),
+		mock.ExpectQuery("select @@tidb_txn_mode;").WillReturnRows(
+			sqlmock.NewRows([]string{"@@tidb_txn_mode"}).AddRow("pessimistic"),
 		)
+		mock.ExpectQuery("select @@transaction_isolation;").WillReturnError(sql.ErrNoRows)
 		mock.ExpectQuery("show session variables like 'transaction_isolation';").WillReturnError(sql.ErrNoRows)
-		mock.ExpectQuery("show session variables like 'tidb_placement_mode';").
+		mock.ExpectQuery("select @@tidb_placement_mode;").
 			WillReturnRows(
-				sqlmock.NewRows(columns).
-					AddRow("tidb_placement_mode", "IGNORE"),
+				sqlmock.NewRows([]string{"@@tidb_placement_mode"}).
+					AddRow("IGNORE"),
 			)
-		mock.ExpectQuery("show session variables like 'tidb_enable_external_ts_read';").
+		mock.ExpectQuery("select @@tidb_enable_external_ts_read;").
 			WillReturnRows(
-				sqlmock.NewRows(columns).
-					AddRow("tidb_enable_external_ts_read", "OFF"),
+				sqlmock.NewRows([]string{"@@tidb_enable_external_ts_read"}).
+					AddRow("OFF"),
 			)
 		dsnStr, err = generateDSNByConfig(context.TODO(), dsn, cfg, db)
 		require.Nil(t, err)
@@ -143,24 +143,24 @@ func TestGenerateDSNByConfig(t *testing.T) {
 		}
 
 		// simulate transaction_isolation
-		mock.ExpectQuery("show session variables like 'allow_auto_random_explicit_insert';").WillReturnRows(
-			sqlmock.NewRows(columns).AddRow("allow_auto_random_explicit_insert", "0"),
+		mock.ExpectQuery("select @@allow_auto_random_explicit_insert;").WillReturnRows(
+			sqlmock.NewRows([]string{"@@allow_auto_random_explicit_insert"}).AddRow("0"),
 		)
-		mock.ExpectQuery("show session variables like 'tidb_txn_mode';").WillReturnRows(
-			sqlmock.NewRows(columns).AddRow("tidb_txn_mode", "pessimistic"),
+		mock.ExpectQuery("select @@tidb_txn_mode;").WillReturnRows(
+			sqlmock.NewRows([]string{"@@tidb_txn_mode"}).AddRow("pessimistic"),
 		)
-		mock.ExpectQuery("show session variables like 'transaction_isolation';").WillReturnRows(
-			sqlmock.NewRows(columns).AddRow("transaction_isolation", "REPEATED-READ"),
+		mock.ExpectQuery("select @@transaction_isolation;").WillReturnRows(
+			sqlmock.NewRows([]string{"@@transaction_isolation"}).AddRow("REPEATED-READ"),
 		)
-		mock.ExpectQuery("show session variables like 'tidb_placement_mode';").
+		mock.ExpectQuery("select @@tidb_placement_mode;").
 			WillReturnRows(
-				sqlmock.NewRows(columns).
-					AddRow("tidb_placement_mode", "IGNORE"),
+				sqlmock.NewRows([]string{"@@tidb_placement_mode"}).
+					AddRow("IGNORE"),
 			)
-		mock.ExpectQuery("show session variables like 'tidb_enable_external_ts_read';").
+		mock.ExpectQuery("select @@tidb_enable_external_ts_read;").
 			WillReturnRows(
-				sqlmock.NewRows(columns).
-					AddRow("tidb_enable_external_ts_read", "OFF"),
+				sqlmock.NewRows([]string{"@@tidb_enable_external_ts_read"}).
+					AddRow("OFF"),
 			)
 		dsnStr, err = generateDSNByConfig(context.TODO(), dsn, cfg, db)
 		require.Nil(t, err)

--- a/pkg/sink/mysql/config_test.go
+++ b/pkg/sink/mysql/config_test.go
@@ -331,7 +331,8 @@ func TestCheckTiDBVariable(t *testing.T) {
 	require.Equal(t, "1", val)
 
 	// If it is not existed, return the "".
-	mock.ExpectQuery("select @@no_exist_variable;").WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("select @@no_exist_variable;").WillReturnError(sql.ErrConnDone)
+	mock.ExpectQuery("show session variables like 'no_exist_variable';").WillReturnError(sql.ErrNoRows)
 	val, err = checkTiDBVariable(context.TODO(), db, "no_exist_variable", "0")
 	require.Nil(t, err)
 	require.Equal(t, "", val)

--- a/pkg/sink/mysql/db_helper.go
+++ b/pkg/sink/mysql/db_helper.go
@@ -220,7 +220,7 @@ func checkTiDBVariable(ctx context.Context, db *sql.DB, variableName, defaultVal
 	// we try to use `show session variables like '%s'` instead.
 	// SAFETY: variableName is a constant string, so it is safe to use it.
 	//nolint:gosec
-	querySQL := fmt.Sprintf("select @@%s;", variableName)
+	querySQL := fmt.Sprintf("select @%s;", variableName)
 	err := db.QueryRowContext(ctx, querySQL).Scan(&value)
 	if err != nil {
 		log.Warn("Fail to select session variable, try to use show session variable instead",

--- a/pkg/sink/mysql/db_helper.go
+++ b/pkg/sink/mysql/db_helper.go
@@ -215,7 +215,7 @@ func checkCharsetSupport(ctx context.Context, db *sql.DB, charsetName string) (b
 func checkTiDBVariable(ctx context.Context, db *sql.DB, variableName, defaultValue string) (string, error) {
 	var name string
 	var value string
-	// Some database may only support `select @@variable_name` to get the value of session variable.
+	// Some database may only support `select @variable_name` to get the value of session variable.
 	// So we try to use `select @variable_name` first, if it fails,
 	// we try to use `show session variables like '%s'` instead.
 	// SAFETY: variableName is a constant string, so it is safe to use it.

--- a/pkg/sink/mysql/db_helper.go
+++ b/pkg/sink/mysql/db_helper.go
@@ -236,9 +236,13 @@ func checkTiDBVariable(ctx context.Context, db *sql.DB, variableName, defaultVal
 	}
 	// session variable works, use given default value
 	if err == nil {
+		log.Info("Session variable works", zap.String("variableName", variableName),
+			zap.String("value", value),
+			zap.String("defaultValue", defaultValue))
 		return defaultValue, nil
 	}
 	// session variable not exists, return "" to ignore it
+	log.Info("Session variable not exists", zap.String("variableName", variableName))
 	return "", nil
 }
 

--- a/pkg/sink/mysql/db_helper.go
+++ b/pkg/sink/mysql/db_helper.go
@@ -216,7 +216,7 @@ func checkTiDBVariable(ctx context.Context, db *sql.DB, variableName, defaultVal
 	var name string
 	var value string
 	// Some database may only support `select @@variable_name` to get the value of session variable.
-	// So we try to use `select @@variable_name` first, if it fails,
+	// So we try to use `select @variable_name` first, if it fails,
 	// we try to use `show session variables like '%s'` instead.
 	// SAFETY: variableName is a constant string, so it is safe to use it.
 	//nolint:gosec

--- a/pkg/sink/mysql/db_helper.go
+++ b/pkg/sink/mysql/db_helper.go
@@ -218,8 +218,11 @@ func checkTiDBVariable(ctx context.Context, db *sql.DB, variableName, defaultVal
 	querySQL := fmt.Sprintf("show session variables like '%s';", variableName)
 	err := db.QueryRowContext(ctx, querySQL).Scan(&name, &value)
 	if err != nil && err != sql.ErrNoRows {
-		errMsg := "fail to query session variable " + variableName
-		return "", cerror.ErrMySQLQueryError.Wrap(err).GenWithStack(errMsg)
+		err = db.QueryRowContext(ctx, "select @@?;", variableName).Scan(&value)
+		if err != nil && err != sql.ErrNoRows {
+			errMsg := "fail to query session variable " + variableName
+			return "", cerror.ErrMySQLQueryError.Wrap(err).GenWithStack(errMsg)
+		}
 	}
 	// session variable works, use given default value
 	if err == nil {

--- a/pkg/sink/mysql/db_helper.go
+++ b/pkg/sink/mysql/db_helper.go
@@ -215,12 +215,12 @@ func checkCharsetSupport(ctx context.Context, db *sql.DB, charsetName string) (b
 func checkTiDBVariable(ctx context.Context, db *sql.DB, variableName, defaultValue string) (string, error) {
 	var name string
 	var value string
-	// Some database may only support `select @variable_name` to get the value of session variable.
-	// So we try to use `select @variable_name` first, if it fails,
+	// Some database may only support `select @@variable_name` to get the value of session variable.
+	// So we try to use `select @@variable_name` first, if it fails,
 	// we try to use `show session variables like '%s'` instead.
 	// SAFETY: variableName is a constant string, so it is safe to use it.
 	//nolint:gosec
-	querySQL := fmt.Sprintf("select @%s;", variableName)
+	querySQL := fmt.Sprintf("select @@%s;", variableName)
 	err := db.QueryRowContext(ctx, querySQL).Scan(&value)
 	if err != nil {
 		log.Warn("Fail to select session variable, try to use show session variable instead",

--- a/pkg/sink/mysql/mock_db.go
+++ b/pkg/sink/mysql/mock_db.go
@@ -32,25 +32,24 @@ func MockTestDB(adjustSQLMode bool) (*sql.DB, error) {
 				AddRow("ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE"))
 	}
 
-	columns := []string{"Variable_name", "Value"}
-	mock.ExpectQuery("show session variables like 'allow_auto_random_explicit_insert';").WillReturnRows(
-		sqlmock.NewRows(columns).AddRow("allow_auto_random_explicit_insert", "0"),
+	mock.ExpectQuery("select @@allow_auto_random_explicit_insert;").WillReturnRows(
+		sqlmock.NewRows([]string{"@@allow_auto_random_explicit_insert"}).AddRow("0"),
 	)
-	mock.ExpectQuery("show session variables like 'tidb_txn_mode';").WillReturnRows(
-		sqlmock.NewRows(columns).AddRow("tidb_txn_mode", "pessimistic"),
+	mock.ExpectQuery("select @@tidb_txn_mode;").WillReturnRows(
+		sqlmock.NewRows([]string{"@@tidb_txn_mode"}).AddRow("pessimistic"),
 	)
-	mock.ExpectQuery("show session variables like 'transaction_isolation';").WillReturnRows(
-		sqlmock.NewRows(columns).AddRow("transaction_isolation", "REPEATED-READ"),
+	mock.ExpectQuery("select @@transaction_isolation;").WillReturnRows(
+		sqlmock.NewRows([]string{"@@transaction_isolation"}).AddRow("REPEATED-READ"),
 	)
-	mock.ExpectQuery("show session variables like 'tidb_placement_mode';").
+	mock.ExpectQuery("select @@tidb_placement_mode;").
 		WillReturnRows(
-			sqlmock.NewRows(columns).
-				AddRow("tidb_placement_mode", "IGNORE"),
+			sqlmock.NewRows([]string{"@@tidb_placement_mode"}).
+				AddRow("IGNORE"),
 		)
-	mock.ExpectQuery("show session variables like 'tidb_enable_external_ts_read';").
+	mock.ExpectQuery("select @@tidb_enable_external_ts_read;").
 		WillReturnRows(
-			sqlmock.NewRows(columns).
-				AddRow("tidb_enable_external_ts_read", "OFF"),
+			sqlmock.NewRows([]string{"@@tidb_enable_external_ts_read"}).
+				AddRow("OFF"),
 		)
 	mock.ExpectQuery("select character_set_name from information_schema.character_sets " +
 		"where character_set_name = 'gbk';").WillReturnRows(


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR. 
-->

### What problem does this PR solve?  
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/8857

### What is changed and how it works?
 Add support for `select @@?;` statement when getting the variables from downstream.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - [x] Unit test
 - [x] Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new features need a release note -->

```release-note
Add support for `select @@variable_name;` statement when getting the variables from downstream
```
