### PR TITLE
capture (ticdc): fix processor exit unexpectedly when some pd node fail

### DIFF
--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -403,11 +404,11 @@ func (c *captureImpl) campaignOwner(ctx cdcContext.Context) error {
 		}
 		// Campaign to be the owner, it blocks until it been elected.
 		if err := c.campaign(ctx); err != nil {
-			switch errors.Cause(err) {
-			case context.Canceled:
+
+			rootErr := errors.Cause(err)
+			if rootErr == context.Canceled {
 				return nil
-			case mvcc.ErrCompacted:
-				// the revision we requested is compacted, just retry
+			} else if rootErr == mvcc.ErrCompacted || isErrCompacted(rootErr) {
 				continue
 			}
 			log.Warn("campaign owner failed",
@@ -550,9 +551,10 @@ func (c *captureImpl) GetOwner() (owner.Owner, error) {
 
 // campaign to be an owner.
 func (c *captureImpl) campaign(ctx context.Context) error {
-	failpoint.Inject("capture-campaign-compacted-error", func() {
-		failpoint.Return(errors.Trace(mvcc.ErrCompacted))
-	})
+	//failpoint.Inject("capture-campaign-compacted-error", func() {
+	//	failpoint.Return(errors.Trace(mvcc.ErrCompacted))
+	//})
+
 	// TODO: `Campaign` will get stuck when send SIGSTOP to pd leader.
 	// For `Campaign`, when send SIGSTOP to pd leader, cdc maybe call `cancel`
 	// (cause by `processor routine` exit). And inside `Campaign`, the routine
@@ -713,4 +715,8 @@ func (c *captureImpl) StatusProvider() owner.StatusProvider {
 
 func (c *captureImpl) IsReady() bool {
 	return c.migrator.IsMigrateDone()
+}
+
+func isErrCompacted(err error) bool {
+	return strings.Contains(err.Error(), "required revision has been compacted")
 }

--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -409,6 +409,8 @@ func (c *captureImpl) campaignOwner(ctx cdcContext.Context) error {
 			if rootErr == context.Canceled {
 				return nil
 			} else if rootErr == mvcc.ErrCompacted || isErrCompacted(rootErr) {
+				log.Warn("campaign owner failed due to etcd revision "+
+					"has been compacted, retry later", zap.Error(err))
 				continue
 			}
 			log.Warn("campaign owner failed",
@@ -551,10 +553,6 @@ func (c *captureImpl) GetOwner() (owner.Owner, error) {
 
 // campaign to be an owner.
 func (c *captureImpl) campaign(ctx context.Context) error {
-	//failpoint.Inject("capture-campaign-compacted-error", func() {
-	//	failpoint.Return(errors.Trace(mvcc.ErrCompacted))
-	//})
-
 	// TODO: `Campaign` will get stuck when send SIGSTOP to pd leader.
 	// For `Campaign`, when send SIGSTOP to pd leader, cdc maybe call `cancel`
 	// (cause by `processor routine` exit). And inside `Campaign`, the routine

--- a/cdc/capture/election.go
+++ b/cdc/capture/election.go
@@ -15,11 +15,11 @@ package capture
 
 import (
 	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
-	"go.etcd.io/etcd/server/v3/mvcc"
-
 	"go.etcd.io/etcd/client/v3/concurrency"
+	"go.etcd.io/etcd/server/v3/mvcc"
 )
 
 // election wraps the owner election methods.

--- a/cdc/capture/election.go
+++ b/cdc/capture/election.go
@@ -15,6 +15,9 @@ package capture
 
 import (
 	"context"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
+	"go.etcd.io/etcd/server/v3/mvcc"
 
 	"go.etcd.io/etcd/client/v3/concurrency"
 )
@@ -37,6 +40,9 @@ func newElection(sess *concurrency.Session, key string) election {
 }
 
 func (e *electionImpl) campaign(ctx context.Context, key string) error {
+	failpoint.Inject("capture-campaign-compacted-error", func() {
+		failpoint.Return(errors.Trace(mvcc.ErrCompacted))
+	})
 	return e.election.Campaign(ctx, key)
 }
 

--- a/tests/integration_tests/availability/owner.sh
+++ b/tests/integration_tests/availability/owner.sh
@@ -137,6 +137,7 @@ function test_owner_cleanup_stale_tasks() {
 function test_owner_retryable_error() {
 	echo "run test case test_owner_retryable_error"
 	export GO_FAILPOINTS='github.com/pingcap/tiflow/cdc/capture/capture-campaign-compacted-error=1*return(true)'
+
 	# start a capture server
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix test_owner_retryable_error.server1
 	# ensure the server become the owner


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8877 #8868

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)

1. deploy 1 tidb cluster with 3 pd and 2 cdc.
2.  create a changefeed 
3. kill pd leader 
4. no cdc processor exit abnormally 

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix processor exit unexpectedly when some pd node fail
```
