### PR TITLE
sink(ticdc): add index config to storage sink

### DIFF
--- a/cdc/api/v2/model.go
+++ b/cdc/api/v2/model.go
@@ -352,6 +352,7 @@ func (c *ReplicaConfig) toInternalReplicaConfigWithOriginConfig(
 			Terminator:               c.Sink.Terminator,
 			DateSeparator:            c.Sink.DateSeparator,
 			EnablePartitionSeparator: c.Sink.EnablePartitionSeparator,
+			FileIndexWidth:           c.Sink.FileIndexWidth,
 			EnableKafkaSinkV2:        c.Sink.EnableKafkaSinkV2,
 			OnlyOutputUpdatedColumns: c.Sink.OnlyOutputUpdatedColumns,
 			KafkaConfig:              kafkaConfig,
@@ -546,6 +547,7 @@ func ToAPIReplicaConfig(c *config.ReplicaConfig) *ReplicaConfig {
 			Terminator:               cloned.Sink.Terminator,
 			DateSeparator:            cloned.Sink.DateSeparator,
 			EnablePartitionSeparator: cloned.Sink.EnablePartitionSeparator,
+			FileIndexWidth:           cloned.Sink.FileIndexWidth,
 			EnableKafkaSinkV2:        cloned.Sink.EnableKafkaSinkV2,
 			OnlyOutputUpdatedColumns: cloned.Sink.OnlyOutputUpdatedColumns,
 			KafkaConfig:              kafkaConfig,
@@ -696,6 +698,7 @@ type SinkConfig struct {
 	Terminator               string              `json:"terminator"`
 	DateSeparator            string              `json:"date_separator"`
 	EnablePartitionSeparator bool                `json:"enable_partition_separator"`
+	FileIndexWidth           int                 `json:"file_index_width"`
 	EnableKafkaSinkV2        bool                `json:"enable_kafka_sink_v2"`
 	OnlyOutputUpdatedColumns *bool               `json:"only_output_updated_columns"`
 	SafeMode                 *bool               `json:"safe_mode,omitempty"`

--- a/cdc/sink/dmlsink/cloudstorage/cloud_storage_dml_sink_test.go
+++ b/cdc/sink/dmlsink/cloudstorage/cloud_storage_dml_sink_test.go
@@ -105,7 +105,7 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 
 	replicaConfig := config.GetDefaultReplicaConfig()
 	replicaConfig.Sink.Protocol = config.ProtocolCsv.String()
-
+	replicaConfig.Sink.FileIndexWidth = 6
 	errCh := make(chan error, 5)
 	s, err := NewDMLSink(ctx, sinkURI, replicaConfig, errCh)
 	require.Nil(t, err)
@@ -182,6 +182,7 @@ func TestCloudStorageWriteEventsWithDateSeparator(t *testing.T) {
 	replicaConfig := config.GetDefaultReplicaConfig()
 	replicaConfig.Sink.Protocol = config.ProtocolCsv.String()
 	replicaConfig.Sink.DateSeparator = config.DateSeparatorDay.String()
+	replicaConfig.Sink.FileIndexWidth = 6
 
 	errCh := make(chan error, 5)
 	s, err := NewDMLSink(ctx, sinkURI, replicaConfig, errCh)

--- a/cdc/sink/dmlsink/cloudstorage/dml_worker_test.go
+++ b/cdc/sink/dmlsink/cloudstorage/dml_worker_test.go
@@ -46,6 +46,7 @@ func testDMLWorker(ctx context.Context, t *testing.T, dir string) *dmlWorker {
 	require.Nil(t, err)
 	cfg := cloudstorage.NewConfig()
 	err = cfg.Apply(context.TODO(), sinkURI, config.GetDefaultReplicaConfig())
+	cfg.FileIndexWidth = 6
 	require.Nil(t, err)
 
 	statistics := metrics.NewStatistics(ctx, sink.TxnSink)

--- a/cmd/storage-consumer/main.go
+++ b/cmd/storage-consumer/main.go
@@ -62,6 +62,7 @@ var (
 	logFile          string
 	logLevel         string
 	flushInterval    time.Duration
+	fileIndexWidth   int
 	enableProfiling  bool
 	timezone         string
 )
@@ -79,6 +80,8 @@ func init() {
 	flag.StringVar(&logFile, "log-file", "", "log file path")
 	flag.StringVar(&logLevel, "log-level", "info", "log level")
 	flag.DurationVar(&flushInterval, "flush-interval", 10*time.Second, "flush interval")
+	flag.IntVar(&fileIndexWidth, "file-index-width",
+		config.DefaultFileIndexWidth, "file index width")
 	flag.BoolVar(&enableProfiling, "enable-profiling", false, "whether to enable profiling")
 	flag.StringVar(&timezone, "tz", "System", "Specify time zone of storage consumer")
 	flag.Parse()
@@ -397,7 +400,7 @@ func (c *consumer) syncExecDMLEvents(
 	key cloudstorage.DmlPathKey,
 	fileIdx uint64,
 ) error {
-	filePath := key.GenerateDMLFilePath(fileIdx, c.fileExtension)
+	filePath := key.GenerateDMLFilePath(fileIdx, c.fileExtension, fileIndexWidth)
 	log.Debug("read from dml file path", zap.String("path", filePath))
 	content, err := c.externalStorage.ReadFile(ctx, filePath)
 	if err != nil {

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -1564,6 +1564,9 @@ var doc = `{
                 "encoder-concurrency": {
                     "type": "integer"
                 },
+                "file-index-digit": {
+                    "type": "integer"
+                },
                 "kafka-config": {
                     "$ref": "#/definitions/config.KafkaConfig"
                 },
@@ -2579,6 +2582,9 @@ var doc = `{
                     "type": "boolean"
                 },
                 "encoder_concurrency": {
+                    "type": "integer"
+                },
+                "file_index_width": {
                     "type": "integer"
                 },
                 "kafka_config": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1545,6 +1545,9 @@
                 "encoder-concurrency": {
                     "type": "integer"
                 },
+                "file-index-digit": {
+                    "type": "integer"
+                },
                 "kafka-config": {
                     "$ref": "#/definitions/config.KafkaConfig"
                 },
@@ -2560,6 +2563,9 @@
                     "type": "boolean"
                 },
                 "encoder_concurrency": {
+                    "type": "integer"
+                },
+                "file_index_width": {
                     "type": "integer"
                 },
                 "kafka_config": {

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -177,6 +177,8 @@ definitions:
         type: boolean
       encoder-concurrency:
         type: integer
+      file-index-digit:
+        type: integer
       kafka-config:
         $ref: '#/definitions/config.KafkaConfig'
       mysql-config:
@@ -856,6 +858,8 @@ definitions:
       enable_partition_separator:
         type: boolean
       encoder_concurrency:
+        type: integer
+      file_index_width:
         type: integer
       kafka_config:
         $ref: '#/definitions/v2.KafkaConfig'

--- a/pkg/cmd/util/helper_test.go
+++ b/pkg/cmd/util/helper_test.go
@@ -228,6 +228,7 @@ func TestAndWriteStorageSinkTOML(t *testing.T) {
 		Terminator:               "\r\n",
 		DateSeparator:            "day",
 		EnablePartitionSeparator: true,
+		FileIndexWidth:           config.DefaultFileIndexWidth,
 		CSVConfig: &config.CSVConfig{
 			Delimiter:       ",",
 			Quote:           "\"",

--- a/pkg/sink/cloudstorage/config.go
+++ b/pkg/sink/cloudstorage/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	WorkerCount              int
 	FlushInterval            time.Duration
 	FileSize                 int
+	FileIndexWidth           int
 	DateSeparator            string
 	EnablePartitionSeparator bool
 }
@@ -111,6 +112,7 @@ func (c *Config) Apply(
 
 	c.DateSeparator = replicaConfig.Sink.DateSeparator
 	c.EnablePartitionSeparator = replicaConfig.Sink.EnablePartitionSeparator
+	c.FileIndexWidth = replicaConfig.Sink.FileIndexWidth
 
 	return nil
 }

--- a/pkg/sink/cloudstorage/config_test.go
+++ b/pkg/sink/cloudstorage/config_test.go
@@ -29,13 +29,18 @@ func TestConfigApply(t *testing.T) {
 	expected.WorkerCount = 32
 	expected.FlushInterval = 10 * time.Second
 	expected.FileSize = 16 * 1024 * 1024
+	expected.FileIndexWidth = config.DefaultFileIndexWidth
 	expected.DateSeparator = config.DateSeparatorNone.String()
 	expected.EnablePartitionSeparator = true
-	uri := "s3://bucket/prefix?worker-count=32&flush-interval=10s&file-size=16777216"
+	uri := "s3://bucket/prefix?worker-count=32&flush-interval=10s&file-size=16777216&protocol=csv"
 	sinkURI, err := url.Parse(uri)
 	require.Nil(t, err)
+
+	replicaConfig := config.GetDefaultReplicaConfig()
+	err = replicaConfig.ValidateAndAdjust(sinkURI)
+	require.NoError(t, err)
 	cfg := NewConfig()
-	err = cfg.Apply(context.TODO(), sinkURI, config.GetDefaultReplicaConfig())
+	err = cfg.Apply(context.TODO(), sinkURI, replicaConfig)
 	require.Nil(t, err)
 	require.Equal(t, expected, cfg)
 }

--- a/pkg/sink/cloudstorage/path_key.go
+++ b/pkg/sink/cloudstorage/path_key.go
@@ -58,7 +58,7 @@ func (s *SchemaPathKey) ParseSchemaFilePath(path string) (uint32, error) {
 	}
 
 	schemaFileName := matches[len(matches)-1]
-	version, checksum := MustParseSchemaName(schemaFileName)
+	version, checksum := mustParseSchemaName(schemaFileName)
 
 	*s = SchemaPathKey{
 		Schema:       schema,
@@ -76,7 +76,9 @@ type DmlPathKey struct {
 }
 
 // GenerateDMLFilePath generates the dml file path.
-func (d *DmlPathKey) GenerateDMLFilePath(idx uint64, extension string) string {
+func (d *DmlPathKey) GenerateDMLFilePath(
+	idx uint64, extension string, fileIndexWidth int,
+) string {
 	var elems []string
 
 	elems = append(elems, d.Schema)
@@ -89,7 +91,7 @@ func (d *DmlPathKey) GenerateDMLFilePath(idx uint64, extension string) string {
 	if len(d.Date) != 0 {
 		elems = append(elems, d.Date)
 	}
-	elems = append(elems, fmt.Sprintf("CDC%06d%s", idx, extension))
+	elems = append(elems, generateDataFileName(idx, extension, fileIndexWidth))
 
 	return strings.Join(elems, "/")
 }

--- a/pkg/sink/cloudstorage/path_key_test.go
+++ b/pkg/sink/cloudstorage/path_key_test.go
@@ -56,3 +56,41 @@ func TestSchemaPathKey(t *testing.T) {
 		require.Equal(t, tc.checksum, checksum)
 	}
 }
+
+func TestDmlPathKey(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		index          int
+		fileIndexWidth int
+		extension      string
+		path           string
+		dmlkey         DmlPathKey
+	}{
+		{
+			index:          10,
+			fileIndexWidth: 20,
+			extension:      ".csv",
+			path:           "schema1/table1/123456/2023-05-09/CDC00000000000000000010.csv",
+			dmlkey: DmlPathKey{
+				SchemaPathKey: SchemaPathKey{
+					Schema:       "schema1",
+					Table:        "table1",
+					TableVersion: 123456,
+				},
+				PartitionNum: 0,
+				Date:         "2023-05-09",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		var dmlkey DmlPathKey
+		idx, err := dmlkey.ParseDMLFilePath("day", tc.path)
+		require.NoError(t, err)
+		require.Equal(t, tc.dmlkey, dmlkey)
+
+		fileName := dmlkey.GenerateDMLFilePath(idx, tc.extension, tc.fileIndexWidth)
+		require.Equal(t, tc.path, fileName)
+	}
+}

--- a/pkg/sink/cloudstorage/path_test.go
+++ b/pkg/sink/cloudstorage/path_test.go
@@ -36,6 +36,7 @@ func testFilePathGenerator(ctx context.Context, t *testing.T, dir string) *FileP
 	require.NoError(t, err)
 	replicaConfig := config.GetDefaultReplicaConfig()
 	replicaConfig.Sink.Protocol = config.ProtocolOpen.String()
+	replicaConfig.Sink.FileIndexWidth = 6
 	cfg := NewConfig()
 	err = cfg.Apply(ctx, sinkURI, replicaConfig)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8919

### What is changed and how it works?
use 20 digits to generage index number in storage sink.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`Fix a issue of that index number used by storage sink may overflow`.
```
