### PR TITLE
pkg/sink(ticdc): add oauth support for sarama Kafka sink

### DIFF
--- a/cdc/api/v2/model.go
+++ b/cdc/api/v2/model.go
@@ -306,6 +306,11 @@ func (c *ReplicaConfig) toInternalReplicaConfigWithOriginConfig(
 				SASLGssAPIPassword:           c.Sink.KafkaConfig.SASLGssAPIPassword,
 				SASLGssAPIRealm:              c.Sink.KafkaConfig.SASLGssAPIRealm,
 				SASLGssAPIDisablePafxfast:    c.Sink.KafkaConfig.SASLGssAPIDisablePafxfast,
+				SASLOAuthClientID:            c.Sink.KafkaConfig.SASLOAuthClientID,
+				SASLOAuthClientSecret:        c.Sink.KafkaConfig.SASLOAuthClientSecret,
+				SASLOAuthTokenURL:            c.Sink.KafkaConfig.SASLOAuthTokenURL,
+				SASLOAuthScopes:              c.Sink.KafkaConfig.SASLOAuthScopes,
+				SASLOAuthGrantType:           c.Sink.KafkaConfig.SASLOAuthGrantType,
 				EnableTLS:                    c.Sink.KafkaConfig.EnableTLS,
 				CA:                           c.Sink.KafkaConfig.CA,
 				Cert:                         c.Sink.KafkaConfig.Cert,
@@ -502,6 +507,11 @@ func ToAPIReplicaConfig(c *config.ReplicaConfig) *ReplicaConfig {
 				SASLGssAPIPassword:           cloned.Sink.KafkaConfig.SASLGssAPIPassword,
 				SASLGssAPIRealm:              cloned.Sink.KafkaConfig.SASLGssAPIRealm,
 				SASLGssAPIDisablePafxfast:    cloned.Sink.KafkaConfig.SASLGssAPIDisablePafxfast,
+				SASLOAuthClientID:            cloned.Sink.KafkaConfig.SASLOAuthClientID,
+				SASLOAuthClientSecret:        cloned.Sink.KafkaConfig.SASLOAuthClientSecret,
+				SASLOAuthTokenURL:            cloned.Sink.KafkaConfig.SASLOAuthTokenURL,
+				SASLOAuthScopes:              cloned.Sink.KafkaConfig.SASLOAuthScopes,
+				SASLOAuthGrantType:           cloned.Sink.KafkaConfig.SASLOAuthGrantType,
 				EnableTLS:                    cloned.Sink.KafkaConfig.EnableTLS,
 				CA:                           cloned.Sink.KafkaConfig.CA,
 				Cert:                         cloned.Sink.KafkaConfig.Cert,
@@ -916,6 +926,11 @@ type KafkaConfig struct {
 	SASLGssAPIPassword           *string      `json:"sasl_gssapi_password,omitempty"`
 	SASLGssAPIRealm              *string      `json:"sasl_gssapi_realm,omitempty"`
 	SASLGssAPIDisablePafxfast    *bool        `json:"sasl_gssapi_disable_pafxfast,omitempty"`
+	SASLOAuthClientID            *string      `json:"sasl_oauth_client_id,omitempty"`
+	SASLOAuthClientSecret        *string      `json:"sasl_oauth_client_secret,omitempty"`
+	SASLOAuthTokenURL            *string      `json:"sasl_oauth_token_url,omitempty"`
+	SASLOAuthScopes              []string     `json:"sasl_oauth_scopes,omitempty"`
+	SASLOAuthGrantType           *string      `json:"sasl_oauth_grant_type,omitempty"`
 	EnableTLS                    *bool        `json:"enable_tls,omitempty"`
 	CA                           *string      `json:"ca,omitempty"`
 	Cert                         *string      `json:"cert,omitempty"`

--- a/cdc/api/v2/model.go
+++ b/cdc/api/v2/model.go
@@ -311,6 +311,7 @@ func (c *ReplicaConfig) toInternalReplicaConfigWithOriginConfig(
 				SASLOAuthTokenURL:            c.Sink.KafkaConfig.SASLOAuthTokenURL,
 				SASLOAuthScopes:              c.Sink.KafkaConfig.SASLOAuthScopes,
 				SASLOAuthGrantType:           c.Sink.KafkaConfig.SASLOAuthGrantType,
+				SASLOAuthAudience:            c.Sink.KafkaConfig.SASLOAuthAudience,
 				EnableTLS:                    c.Sink.KafkaConfig.EnableTLS,
 				CA:                           c.Sink.KafkaConfig.CA,
 				Cert:                         c.Sink.KafkaConfig.Cert,
@@ -512,6 +513,7 @@ func ToAPIReplicaConfig(c *config.ReplicaConfig) *ReplicaConfig {
 				SASLOAuthTokenURL:            cloned.Sink.KafkaConfig.SASLOAuthTokenURL,
 				SASLOAuthScopes:              cloned.Sink.KafkaConfig.SASLOAuthScopes,
 				SASLOAuthGrantType:           cloned.Sink.KafkaConfig.SASLOAuthGrantType,
+				SASLOAuthAudience:            cloned.Sink.KafkaConfig.SASLOAuthAudience,
 				EnableTLS:                    cloned.Sink.KafkaConfig.EnableTLS,
 				CA:                           cloned.Sink.KafkaConfig.CA,
 				Cert:                         cloned.Sink.KafkaConfig.Cert,
@@ -931,6 +933,7 @@ type KafkaConfig struct {
 	SASLOAuthTokenURL            *string      `json:"sasl_oauth_token_url,omitempty"`
 	SASLOAuthScopes              []string     `json:"sasl_oauth_scopes,omitempty"`
 	SASLOAuthGrantType           *string      `json:"sasl_oauth_grant_type,omitempty"`
+	SASLOAuthAudience            *string      `json:"sasl_oauth_audience,omitempty"`
 	EnableTLS                    *bool        `json:"enable_tls,omitempty"`
 	CA                           *string      `json:"ca,omitempty"`
 	Cert                         *string      `json:"cert,omitempty"`

--- a/cdc/sink/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
+++ b/cdc/sink/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
@@ -48,7 +48,7 @@ type kafkaDDLProducer struct {
 func NewKafkaDDLProducer(ctx context.Context, factory kafka.Factory) (DDLProducer, error) {
 	changefeedID := contextutil.ChangefeedIDFromCtx(ctx)
 
-	syncProducer, err := factory.SyncProducer()
+	syncProducer, err := factory.SyncProducer(ctx)
 	if err != nil {
 		return nil, cerror.WrapError(cerror.ErrKafkaNewProducer, err)
 	}

--- a/cdc/sink/ddlsink/mq/kafka_ddl_sink.go
+++ b/cdc/sink/ddlsink/mq/kafka_ddl_sink.go
@@ -54,7 +54,7 @@ func NewKafkaDDLSink(
 		return nil, cerror.WrapError(cerror.ErrKafkaNewProducer, err)
 	}
 
-	adminClient, err := factory.AdminClient()
+	adminClient, err := factory.AdminClient(ctx)
 	if err != nil {
 		return nil, cerror.WrapError(cerror.ErrKafkaNewProducer, err)
 	}

--- a/cdc/sink/dmlsink/mq/dmlproducer/kafka_dml_producer_test.go
+++ b/cdc/sink/dmlsink/mq/dmlproducer/kafka_dml_producer_test.go
@@ -78,7 +78,7 @@ func TestProducerAck(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	ctx, cancel := context.WithCancel(context.Background())
-	config, err := kafka.NewSaramaConfig(options)
+	config, err := kafka.NewSaramaConfig(ctx, options)
 	require.Nil(t, err)
 	require.Equal(t, 1, config.Producer.Flush.MaxMessages)
 
@@ -86,7 +86,7 @@ func TestProducerAck(t *testing.T) {
 	factory, err := kafka.NewMockFactory(options, changefeed)
 	require.NoError(t, err)
 
-	adminClient, err := factory.AdminClient()
+	adminClient, err := factory.AdminClient(ctx)
 	require.NoError(t, err)
 
 	producer, err := NewKafkaDMLProducer(ctx, factory, adminClient, errCh)
@@ -144,7 +144,7 @@ func TestProducerSendMsgFailed(t *testing.T) {
 	errCh := make(chan error, 1)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
-	_, err := kafka.NewSaramaConfig(options)
+	_, err := kafka.NewSaramaConfig(ctx, options)
 	require.Nil(t, err)
 	options.MaxMessages = 1
 	options.MaxMessageBytes = 1
@@ -153,7 +153,7 @@ func TestProducerSendMsgFailed(t *testing.T) {
 	factory, err := kafka.NewMockFactory(options, changefeed)
 	require.NoError(t, err)
 
-	adminClient, err := factory.AdminClient()
+	adminClient, err := factory.AdminClient(ctx)
 	require.NoError(t, err)
 
 	producer, err := NewKafkaDMLProducer(ctx, factory, adminClient, errCh)
@@ -215,7 +215,7 @@ func TestProducerDoubleClose(t *testing.T) {
 	factory, err := kafka.NewMockFactory(options, changefeed)
 	require.NoError(t, err)
 
-	adminClient, err := factory.AdminClient()
+	adminClient, err := factory.AdminClient(ctx)
 	require.NoError(t, err)
 
 	require.Nil(t, err)

--- a/cdc/sink/dmlsink/mq/kafka_dml_sink.go
+++ b/cdc/sink/dmlsink/mq/kafka_dml_sink.go
@@ -54,7 +54,7 @@ func NewKafkaDMLSink(
 		return nil, cerror.WrapError(cerror.ErrKafkaNewProducer, err)
 	}
 
-	adminClient, err := factory.AdminClient()
+	adminClient, err := factory.AdminClient(ctx)
 	if err != nil {
 		return nil, cerror.WrapError(cerror.ErrKafkaNewProducer, err)
 	}

--- a/docs/design/2023-03-15-ticdc-storage-sink.md
+++ b/docs/design/2023-03-15-ticdc-storage-sink.md
@@ -136,6 +136,7 @@ Metadata is a JSON-formatted file, for example:
 #### DDL events
 
 ##### Table DDL events
+
 When DDL events cause the table version to change, TiCDC switches to a new path to write data change records. For example, when the version of `test.table1` changes to `441349361156227074`, data will be written to the path `s3://bucket/prefix1/prefix2/schema1/table1/441349361156227074/2022-01-02/CDC000001.csv`. In addition, when DDL events occur, TiCDC generates a file to save the table schema information.
 
 Table schema information is saved in the following path:

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,8 +1,53 @@
 {
   "name": "ticdc-docs",
   "version": "0.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "ticdc-docs",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "husky": "^5.0.9",
+        "prettier": "^2.2.1"
+      }
+    },
+    "node_modules/husky": {
+      "version": "5.2.0",
+      "resolved": "https://registry.nlark.com/husky/download/husky-5.2.0.tgz?cache=0&sync_timestamp=1629854757720&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fhusky%2Fdownload%2Fhusky-5.2.0.tgz",
+      "integrity": "sha1-/F4cIwDTSFXUfeR1NgfQCUP8CAI=",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/typicode"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/husky"
+        }
+      ],
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.4.1",
+      "resolved": "https://registry.nlark.com/prettier/download/prettier-2.4.1.tgz?cache=0&sync_timestamp=1631777154625&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fprettier%2Fdownload%2Fprettier-2.4.1.tgz",
+      "integrity": "sha1-Zx4RyJwUpM/Ids5WQQbEpnJsn1w=",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    }
+  },
   "dependencies": {
     "husky": {
       "version": "5.2.0",

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -1472,6 +1472,24 @@ var doc = `{
                 "sasl-mechanism": {
                     "type": "string"
                 },
+                "sasl-oauth-client-id": {
+                    "type": "string"
+                },
+                "sasl-oauth-client-secret": {
+                    "type": "string"
+                },
+                "sasl-oauth-grant-type": {
+                    "type": "string"
+                },
+                "sasl-oauth-scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sasl-oauth-token-url": {
+                    "type": "string"
+                },
                 "sasl-password": {
                     "type": "string"
                 },
@@ -2327,6 +2345,24 @@ var doc = `{
                     "type": "string"
                 },
                 "sasl_mechanism": {
+                    "type": "string"
+                },
+                "sasl_oauth_client_id": {
+                    "type": "string"
+                },
+                "sasl_oauth_client_secret": {
+                    "type": "string"
+                },
+                "sasl_oauth_grant_type": {
+                    "type": "string"
+                },
+                "sasl_oauth_scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sasl_oauth_token_url": {
                     "type": "string"
                 },
                 "sasl_password": {

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -1472,6 +1472,9 @@ var doc = `{
                 "sasl-mechanism": {
                     "type": "string"
                 },
+                "sasl-oauth-audience": {
+                    "type": "string"
+                },
                 "sasl-oauth-client-id": {
                     "type": "string"
                 },
@@ -2345,6 +2348,9 @@ var doc = `{
                     "type": "string"
                 },
                 "sasl_mechanism": {
+                    "type": "string"
+                },
+                "sasl_oauth_audience": {
                     "type": "string"
                 },
                 "sasl_oauth_client_id": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1453,6 +1453,24 @@
                 "sasl-mechanism": {
                     "type": "string"
                 },
+                "sasl-oauth-client-id": {
+                    "type": "string"
+                },
+                "sasl-oauth-client-secret": {
+                    "type": "string"
+                },
+                "sasl-oauth-grant-type": {
+                    "type": "string"
+                },
+                "sasl-oauth-scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sasl-oauth-token-url": {
+                    "type": "string"
+                },
                 "sasl-password": {
                     "type": "string"
                 },
@@ -2308,6 +2326,24 @@
                     "type": "string"
                 },
                 "sasl_mechanism": {
+                    "type": "string"
+                },
+                "sasl_oauth_client_id": {
+                    "type": "string"
+                },
+                "sasl_oauth_client_secret": {
+                    "type": "string"
+                },
+                "sasl_oauth_grant_type": {
+                    "type": "string"
+                },
+                "sasl_oauth_scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "sasl_oauth_token_url": {
                     "type": "string"
                 },
                 "sasl_password": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1453,6 +1453,9 @@
                 "sasl-mechanism": {
                     "type": "string"
                 },
+                "sasl-oauth-audience": {
+                    "type": "string"
+                },
                 "sasl-oauth-client-id": {
                     "type": "string"
                 },
@@ -2326,6 +2329,9 @@
                     "type": "string"
                 },
                 "sasl_mechanism": {
+                    "type": "string"
+                },
+                "sasl_oauth_audience": {
                     "type": "string"
                 },
                 "sasl_oauth_client_id": {

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -116,6 +116,8 @@ definitions:
         type: string
       sasl-mechanism:
         type: string
+      sasl-oauth-audience:
+        type: string
       sasl-oauth-client-id:
         type: string
       sasl-oauth-client-secret:
@@ -703,6 +705,8 @@ definitions:
       sasl_gssapi_user:
         type: string
       sasl_mechanism:
+        type: string
+      sasl_oauth_audience:
         type: string
       sasl_oauth_client_id:
         type: string

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -116,6 +116,18 @@ definitions:
         type: string
       sasl-mechanism:
         type: string
+      sasl-oauth-client-id:
+        type: string
+      sasl-oauth-client-secret:
+        type: string
+      sasl-oauth-grant-type:
+        type: string
+      sasl-oauth-scopes:
+        items:
+          type: string
+        type: array
+      sasl-oauth-token-url:
+        type: string
       sasl-password:
         type: string
       sasl-user:
@@ -691,6 +703,18 @@ definitions:
       sasl_gssapi_user:
         type: string
       sasl_mechanism:
+        type: string
+      sasl_oauth_client_id:
+        type: string
+      sasl_oauth_client_secret:
+        type: string
+      sasl_oauth_grant_type:
+        type: string
+      sasl_oauth_scopes:
+        items:
+          type: string
+        type: array
+      sasl_oauth_token_url:
         type: string
       sasl_password:
         type: string

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	go.uber.org/zap v1.24.0
 	golang.org/x/exp v0.0.0-20221023144134-a1e5550cf13e
 	golang.org/x/net v0.10.0
-	golang.org/x/oauth2 v0.7.0
+	golang.org/x/oauth2 v0.8.0
 	golang.org/x/sync v0.2.0
 	golang.org/x/sys v0.8.0
 	golang.org/x/text v0.9.0
@@ -286,7 +286,6 @@ require (
 	go.opentelemetry.io/otel/trace v0.20.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.7.0 // indirect
 	golang.org/x/crypto v0.9.0 // indirect
-	golang.org/x/oauth2 v0.8.0 // indirect
 	golang.org/x/term v0.8.0 // indirect
 	golang.org/x/tools v0.9.1 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -102,6 +102,7 @@ require (
 	go.uber.org/zap v1.24.0
 	golang.org/x/exp v0.0.0-20221023144134-a1e5550cf13e
 	golang.org/x/net v0.10.0
+	golang.org/x/oauth2 v0.7.0
 	golang.org/x/sync v0.2.0
 	golang.org/x/sys v0.8.0
 	golang.org/x/text v0.9.0

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -278,6 +278,7 @@ type KafkaConfig struct {
 	SASLOAuthTokenURL            *string      `toml:"sasl-oauth-token-url" json:"sasl-oauth-token-url,omitempty"`
 	SASLOAuthScopes              []string     `toml:"sasl-oauth-scopes" json:"sasl-oauth-scopes,omitempty"`
 	SASLOAuthGrantType           *string      `toml:"sasl-oauth-grant-type" json:"sasl-oauth-grant-type,omitempty"`
+	SASLOAuthAudience            *string      `toml:"sasl-oauth-audience" json:"sasl-oauth-audience,omitempty"`
 	EnableTLS                    *bool        `toml:"enable-tls" json:"enable-tls,omitempty"`
 	CA                           *string      `toml:"ca" json:"ca,omitempty"`
 	Cert                         *string      `toml:"cert" json:"cert,omitempty"`

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -273,6 +273,11 @@ type KafkaConfig struct {
 	SASLGssAPIPassword           *string      `toml:"sasl-gssapi-password" json:"sasl-gssapi-password,omitempty"`
 	SASLGssAPIRealm              *string      `toml:"sasl-gssapi-realm" json:"sasl-gssapi-realm,omitempty"`
 	SASLGssAPIDisablePafxfast    *bool        `toml:"sasl-gssapi-disable-pafxfast" json:"sasl-gssapi-disable-pafxfast,omitempty"`
+	SASLOAuthClientID            *string      `toml:"sasl-oauth-client-id" json:"sasl-oauth-client-id,omitempty"`
+	SASLOAuthClientSecret        *string      `toml:"sasl-oauth-client-secret" json:"sasl-oauth-client-secret,omitempty"`
+	SASLOAuthTokenURL            *string      `toml:"sasl-oauth-token-url" json:"sasl-oauth-token-url,omitempty"`
+	SASLOAuthScopes              []string     `toml:"sasl-oauth-scopes" json:"sasl-oauth-scopes,omitempty"`
+	SASLOAuthGrantType           *string      `toml:"sasl-oauth-grant-type" json:"sasl-oauth-grant-type,omitempty"`
 	EnableTLS                    *bool        `toml:"enable-tls" json:"enable-tls,omitempty"`
 	CA                           *string      `toml:"ca" json:"ca,omitempty"`
 	Cert                         *string      `toml:"cert" json:"cert,omitempty"`

--- a/pkg/security/sasl.go
+++ b/pkg/security/sasl.go
@@ -73,6 +73,7 @@ type OAuth2 struct {
 	TokenURL     string
 	Scopes       []string
 	GrantType    string
+	Audience     string
 }
 
 // Validate validates the parameters of OAuth2.

--- a/pkg/security/sasl.go
+++ b/pkg/security/sasl.go
@@ -35,6 +35,8 @@ const (
 	SCRAM512Mechanism SASLMechanism = sarama.SASLTypeSCRAMSHA512
 	// GSSAPIMechanism means the SASL mechanism is GSSAPI.
 	GSSAPIMechanism SASLMechanism = sarama.SASLTypeGSSAPI
+	// OAuthMechanism means the SASL mechanism is OAuth2.
+	OAuthMechanism SASLMechanism = sarama.SASLTypeOAuth
 )
 
 // SASLMechanismFromString converts the string to SASL mechanism.
@@ -48,6 +50,8 @@ func SASLMechanismFromString(s string) (SASLMechanism, error) {
 		return SCRAM512Mechanism, nil
 	case "gssapi":
 		return GSSAPIMechanism, nil
+	case "oauthbearer":
+		return OAuthMechanism, nil
 	default:
 		return UnknownMechanism, errors.Errorf("unknown %s SASL mechanism", s)
 	}
@@ -55,10 +59,46 @@ func SASLMechanismFromString(s string) (SASLMechanism, error) {
 
 // SASL holds necessary path parameter to support sasl-scram
 type SASL struct {
-	SASLUser      string        `toml:"sasl-user" json:"sasl-user"`
-	SASLPassword  string        `toml:"sasl-password" json:"sasl-password"`
-	SASLMechanism SASLMechanism `toml:"sasl-mechanism" json:"sasl-mechanism"`
-	GSSAPI        GSSAPI        `toml:"sasl-gssapi" json:"sasl-gssapi"`
+	SASLUser      string
+	SASLPassword  string
+	SASLMechanism SASLMechanism
+	GSSAPI        GSSAPI
+	OAuth2        OAuth2
+}
+
+// OAuth2 holds necessary parameters to support sasl-oauth2.
+type OAuth2 struct {
+	ClientID     string
+	ClientSecret string
+	TokenURL     string
+	Scopes       []string
+	GrantType    string
+}
+
+// Validate validates the parameters of OAuth2.
+// Some parameters are required, some are optional.
+func (o *OAuth2) Validate() error {
+	if len(o.ClientID) == 0 {
+		return errors.New("OAuth2 client id is empty")
+	}
+	if len(o.ClientSecret) == 0 {
+		return errors.New("OAuth2 client secret is empty")
+	}
+	if len(o.TokenURL) == 0 {
+		return errors.New("OAuth2 token url is empty")
+	}
+	return nil
+}
+
+// SetDefault sets the default value of OAuth2.
+func (o *OAuth2) SetDefault() {
+	o.GrantType = "client_credentials"
+}
+
+// IsEnable checks whether the OAuth2 is enabled.
+// One of values of ClientID, ClientSecret and TokenURL is not empty means enabled.
+func (o *OAuth2) IsEnable() bool {
+	return len(o.ClientID) > 0 || len(o.ClientSecret) > 0 || len(o.TokenURL) > 0
 }
 
 // GSSAPIAuthType defines the type of GSSAPI authentication.

--- a/pkg/sink/kafka/factory.go
+++ b/pkg/sink/kafka/factory.go
@@ -29,9 +29,9 @@ import (
 // Factory is used to produce all kafka components.
 type Factory interface {
 	// AdminClient return a kafka cluster admin client
-	AdminClient() (ClusterAdminClient, error)
+	AdminClient(ctx context.Context) (ClusterAdminClient, error)
 	// SyncProducer creates a sync producer to writer message to kafka
-	SyncProducer() (SyncProducer, error)
+	SyncProducer(ctx context.Context) (SyncProducer, error)
 	// AsyncProducer creates an async producer to writer message to kafka
 	AsyncProducer(ctx context.Context, closedChan chan struct{}, failpointCh chan error) (AsyncProducer, error)
 	// MetricsCollector returns the kafka metrics collector

--- a/pkg/sink/kafka/mock_factory.go
+++ b/pkg/sink/kafka/mock_factory.go
@@ -39,13 +39,13 @@ func NewMockFactory(
 }
 
 // AdminClient return a mocked admin client
-func (f *MockFactory) AdminClient() (ClusterAdminClient, error) {
+func (f *MockFactory) AdminClient(_ context.Context) (ClusterAdminClient, error) {
 	return NewClusterAdminClientMockImpl(), nil
 }
 
 // SyncProducer creates a sync producer
-func (f *MockFactory) SyncProducer() (SyncProducer, error) {
-	return f.helper.SyncProducer()
+func (f *MockFactory) SyncProducer(ctx context.Context) (SyncProducer, error) {
+	return f.helper.SyncProducer(ctx)
 }
 
 // AsyncProducer creates an async producer

--- a/pkg/sink/kafka/oauth2_token_provider.go
+++ b/pkg/sink/kafka/oauth2_token_provider.go
@@ -1,0 +1,78 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/Shopify/sarama"
+	"github.com/pingcap/errors"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// tsokenProvider is a user-defined callback for generating
+// access tokens for SASL/OAUTHBEARER auth.
+type tokenProvider struct {
+	tokenSource oauth2.TokenSource
+}
+
+var _ sarama.AccessTokenProvider = (*tokenProvider)(nil)
+
+// Token implements the sarama.AccessTokenProvider interface.
+// Token returns an access token. The implementation should ensure token
+// reuse so that multiple calls at connect time do not create multiple
+// tokens. The implementation should also periodically refresh the token in
+// order to guarantee that each call returns an unexpired token.  This
+// method should not block indefinitely--a timeout error should be returned
+// after a short period of inactivity so that the broker connection logic
+// can log debugging information and retry.
+func (t *tokenProvider) Token() (*sarama.AccessToken, error) {
+	token, err := t.tokenSource.Token()
+	if err != nil {
+		// Errors will result in Sarama retrying the broker connection and logging
+		// the transient error, with a Broker connection error surfacing after retry
+		// attempts have been exhausted.
+		return nil, err
+	}
+
+	return &sarama.AccessToken{Token: token.AccessToken}, nil
+}
+
+func newTokenProvider(ctx context.Context, o *Options) (sarama.AccessTokenProvider, error) {
+	// grant_type is by default going to be set to 'client_credentials' by the
+	// clientcredentials library as defined by the spec, however non-compliant
+	// auth server implementations may want a custom type
+	var endpointParams url.Values
+	if o.SASL.OAuth2.GrantType != "" {
+		endpointParams = url.Values{"grant_type": {o.SASL.OAuth2.GrantType}}
+	}
+
+	tokenURL, err := url.Parse(o.SASL.OAuth2.TokenURL)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	cfg := clientcredentials.Config{
+		ClientID:       o.SASL.OAuth2.ClientID,
+		ClientSecret:   o.SASL.OAuth2.ClientSecret,
+		TokenURL:       tokenURL.String(),
+		EndpointParams: endpointParams,
+		Scopes:         o.SASL.OAuth2.Scopes,
+	}
+	return &tokenProvider{
+		tokenSource: cfg.TokenSource(ctx),
+	}, nil
+}

--- a/pkg/sink/kafka/oauth2_token_provider.go
+++ b/pkg/sink/kafka/oauth2_token_provider.go
@@ -57,7 +57,19 @@ func newTokenProvider(ctx context.Context, o *Options) (sarama.AccessTokenProvid
 	// auth server implementations may want a custom type
 	var endpointParams url.Values
 	if o.SASL.OAuth2.GrantType != "" {
-		endpointParams = url.Values{"grant_type": {o.SASL.OAuth2.GrantType}}
+		if endpointParams == nil {
+			endpointParams = url.Values{}
+		}
+		endpointParams.Set("grant_type", o.SASL.OAuth2.GrantType)
+	}
+
+	// audience is an optional parameter that can be used to specify the
+	// intended audience of the token.
+	if o.SASL.OAuth2.Audience != "" {
+		if endpointParams == nil {
+			endpointParams = url.Values{}
+		}
+		endpointParams.Set("audience", o.SASL.OAuth2.Audience)
 	}
 
 	tokenURL, err := url.Parse(o.SASL.OAuth2.TokenURL)

--- a/pkg/sink/kafka/oauth2_token_provider_test.go
+++ b/pkg/sink/kafka/oauth2_token_provider_test.go
@@ -1,0 +1,74 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/tiflow/pkg/security"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTokenProvider(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name        string
+		options     *Options
+		expectedErr string
+	}{
+		{
+			name: "valid",
+			options: &Options{
+				SASL: &security.SASL{
+					OAuth2: security.OAuth2{
+						ClientID:     "client-id",
+						ClientSecret: "client-secret",
+						TokenURL:     "http://localhost:8080/oauth2/token",
+						Scopes:       []string{"scope1", "scope2"},
+						GrantType:    "client_credentials",
+					},
+				},
+			},
+		},
+		{
+			name: "invalid token URL",
+			options: &Options{
+				SASL: &security.SASL{
+					OAuth2: security.OAuth2{
+						ClientID:     "client-id",
+						ClientSecret: "client-secret",
+						TokenURL:     "http://test.com/Segment%%2815197306101420000%29",
+						Scopes:       []string{"scope1", "scope2"},
+						GrantType:    "client_credentials",
+					},
+				},
+			},
+			expectedErr: "invalid URL escape",
+		},
+	} {
+		ts := test
+		t.Run(ts.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := newTokenProvider(context.TODO(), ts.options)
+			if ts.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), ts.expectedErr)
+			}
+		})
+	}
+}

--- a/pkg/sink/kafka/options.go
+++ b/pkg/sink/kafka/options.go
@@ -509,6 +509,10 @@ func (o *Options) applySASL(urlParameter *urlConfig, replicaConfig *config.Repli
 		if replicaConfig.Sink.KafkaConfig.SASLOAuthGrantType != nil {
 			o.SASL.OAuth2.GrantType = *replicaConfig.Sink.KafkaConfig.SASLOAuthGrantType
 		}
+
+		if replicaConfig.Sink.KafkaConfig.SASLOAuthAudience != nil {
+			o.SASL.OAuth2.Audience = *replicaConfig.Sink.KafkaConfig.SASLOAuthAudience
+		}
 	}
 
 	return nil

--- a/pkg/sink/kafka/options_test.go
+++ b/pkg/sink/kafka/options_test.go
@@ -203,7 +203,7 @@ func TestAdjustConfigTopicNotExist(t *testing.T) {
 	// topic not exist, `max-message-bytes` = `message.max.bytes`
 	options.MaxMessageBytes = adminClient.GetBrokerMessageMaxBytes()
 	ctx := context.Background()
-	saramaConfig, err := NewSaramaConfig(options)
+	saramaConfig, err := NewSaramaConfig(ctx, options)
 	require.Nil(t, err)
 
 	err = AdjustOptions(ctx, adminClient, options, "create-random1")
@@ -213,7 +213,7 @@ func TestAdjustConfigTopicNotExist(t *testing.T) {
 
 	// topic not exist, `max-message-bytes` > `message.max.bytes`
 	options.MaxMessageBytes = adminClient.GetBrokerMessageMaxBytes() + 1
-	saramaConfig, err = NewSaramaConfig(options)
+	saramaConfig, err = NewSaramaConfig(ctx, options)
 	require.Nil(t, err)
 	err = AdjustOptions(ctx, adminClient, options, "create-random2")
 	require.Nil(t, err)
@@ -222,7 +222,7 @@ func TestAdjustConfigTopicNotExist(t *testing.T) {
 
 	// topic not exist, `max-message-bytes` < `message.max.bytes`
 	options.MaxMessageBytes = adminClient.GetBrokerMessageMaxBytes() - 1
-	saramaConfig, err = NewSaramaConfig(options)
+	saramaConfig, err = NewSaramaConfig(ctx, options)
 	require.Nil(t, err)
 	err = AdjustOptions(ctx, adminClient, options, "create-random3")
 	require.Nil(t, err)
@@ -241,7 +241,7 @@ func TestAdjustConfigTopicExist(t *testing.T) {
 	options.MaxMessageBytes = adminClient.GetTopicMaxMessageBytes()
 
 	ctx := context.Background()
-	saramaConfig, err := NewSaramaConfig(options)
+	saramaConfig, err := NewSaramaConfig(ctx, options)
 	require.Nil(t, err)
 
 	err = AdjustOptions(ctx, adminClient, options, adminClient.GetDefaultMockTopicName())
@@ -252,7 +252,7 @@ func TestAdjustConfigTopicExist(t *testing.T) {
 
 	// topic exists, `max-message-bytes` > `max.message.bytes`
 	options.MaxMessageBytes = adminClient.GetTopicMaxMessageBytes() + 1
-	saramaConfig, err = NewSaramaConfig(options)
+	saramaConfig, err = NewSaramaConfig(ctx, options)
 	require.Nil(t, err)
 
 	err = AdjustOptions(ctx, adminClient, options, adminClient.GetDefaultMockTopicName())
@@ -263,7 +263,7 @@ func TestAdjustConfigTopicExist(t *testing.T) {
 
 	// topic exists, `max-message-bytes` < `max.message.bytes`
 	options.MaxMessageBytes = adminClient.GetTopicMaxMessageBytes() - 1
-	saramaConfig, err = NewSaramaConfig(options)
+	saramaConfig, err = NewSaramaConfig(ctx, options)
 	require.Nil(t, err)
 
 	err = AdjustOptions(ctx, adminClient, options, adminClient.GetDefaultMockTopicName())
@@ -285,7 +285,7 @@ func TestAdjustConfigTopicExist(t *testing.T) {
 	require.Nil(t, err)
 
 	options.MaxMessageBytes = adminClient.GetBrokerMessageMaxBytes() - 1
-	saramaConfig, err = NewSaramaConfig(options)
+	saramaConfig, err = NewSaramaConfig(ctx, options)
 	require.Nil(t, err)
 
 	err = AdjustOptions(ctx, adminClient, options, topicName)
@@ -298,7 +298,7 @@ func TestAdjustConfigTopicExist(t *testing.T) {
 	// When the topic exists, but the topic doesn't have `max.message.bytes`
 	// `max-message-bytes` > `message.max.bytes`
 	options.MaxMessageBytes = adminClient.GetBrokerMessageMaxBytes() + 1
-	saramaConfig, err = NewSaramaConfig(options)
+	saramaConfig, err = NewSaramaConfig(ctx, options)
 	require.Nil(t, err)
 
 	err = AdjustOptions(ctx, adminClient, options, topicName)
@@ -387,7 +387,7 @@ func TestSkipAdjustConfigMinInsyncReplicasWhenRequiredAcksIsNotWailAll(t *testin
 func TestCreateProducerFailed(t *testing.T) {
 	options := NewOptions()
 	options.Version = "invalid"
-	saramaConfig, err := NewSaramaConfig(options)
+	saramaConfig, err := NewSaramaConfig(context.Background(), options)
 	require.Regexp(t, "invalid version.*", errors.Cause(err))
 	require.Nil(t, saramaConfig)
 }
@@ -602,7 +602,7 @@ func TestConfigurationCombinations(t *testing.T) {
 		factory, err := NewMockFactory(options, changefeed)
 		require.NoError(t, err)
 
-		adminClient, err := factory.AdminClient()
+		adminClient, err := factory.AdminClient(ctx)
 		require.NoError(t, err)
 
 		topic, ok := a.uriParams[0].(string)

--- a/pkg/sink/kafka/sarama.go
+++ b/pkg/sink/kafka/sarama.go
@@ -14,6 +14,7 @@
 package kafka
 
 import (
+	"context"
 	"crypto/tls"
 	"strings"
 	"time"
@@ -27,7 +28,7 @@ import (
 )
 
 // NewSaramaConfig return the default config and set the according version and metrics
-func NewSaramaConfig(o *Options) (*sarama.Config, error) {
+func NewSaramaConfig(ctx context.Context, o *Options) (*sarama.Config, error) {
 	config := sarama.NewConfig()
 	config.ClientID = o.ClientID
 
@@ -117,12 +118,15 @@ func NewSaramaConfig(o *Options) (*sarama.Config, error) {
 		config.Net.TLS.Config.InsecureSkipVerify = o.InsecureSkipVerify
 	}
 
-	completeSaramaSASLConfig(config, o)
+	err = completeSaramaSASLConfig(ctx, config, o)
+	if err != nil {
+		return nil, cerror.WrapError(cerror.ErrKafkaInvalidConfig, err)
+	}
 
 	return config, err
 }
 
-func completeSaramaSASLConfig(config *sarama.Config, o *Options) {
+func completeSaramaSASLConfig(ctx context.Context, config *sarama.Config, o *Options) error {
 	if o.SASL != nil && o.SASL.SASLMechanism != "" {
 		config.Net.SASL.Enable = true
 		config.Net.SASL.Mechanism = sarama.SASLMechanism(o.SASL.SASLMechanism)
@@ -152,6 +156,15 @@ func completeSaramaSASLConfig(config *sarama.Config, o *Options) {
 			case security.KeyTabAuth:
 				config.Net.SASL.GSSAPI.KeyTabPath = o.SASL.GSSAPI.KeyTabPath
 			}
+
+		case SASLTypeOAuth:
+			p, err := newTokenProvider(ctx, o)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			config.Net.SASL.TokenProvider = p
 		}
 	}
+
+	return nil
 }

--- a/pkg/sink/kafka/sarama_factory.go
+++ b/pkg/sink/kafka/sarama_factory.go
@@ -42,8 +42,8 @@ func NewSaramaFactory(
 	}, nil
 }
 
-func (f *saramaFactory) AdminClient() (ClusterAdminClient, error) {
-	config, err := NewSaramaConfig(f.option)
+func (f *saramaFactory) AdminClient(ctx context.Context) (ClusterAdminClient, error) {
+	config, err := NewSaramaConfig(ctx, f.option)
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +52,8 @@ func (f *saramaFactory) AdminClient() (ClusterAdminClient, error) {
 
 // SyncProducer returns a Sync Producer,
 // it should be the caller's responsibility to close the producer
-func (f *saramaFactory) SyncProducer() (SyncProducer, error) {
-	config, err := NewSaramaConfig(f.option)
+func (f *saramaFactory) SyncProducer(ctx context.Context) (SyncProducer, error) {
+	config, err := NewSaramaConfig(ctx, f.option)
 	if err != nil {
 		return nil, err
 	}
@@ -78,11 +78,11 @@ func (f *saramaFactory) SyncProducer() (SyncProducer, error) {
 // AsyncProducer return an Async Producer,
 // it should be the caller's responsibility to close the producer
 func (f *saramaFactory) AsyncProducer(
-	_ context.Context,
+	ctx context.Context,
 	closedChan chan struct{},
 	failpointCh chan error,
 ) (AsyncProducer, error) {
-	config, err := NewSaramaConfig(f.option)
+	config, err := NewSaramaConfig(ctx, f.option)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sink/kafka/sarama_factory_test.go
+++ b/pkg/sink/kafka/sarama_factory_test.go
@@ -63,7 +63,7 @@ func TestSyncProducer(t *testing.T) {
 	factory, ok := f.(*saramaFactory)
 	require.True(t, ok)
 
-	sync, err := factory.SyncProducer()
+	sync, err := factory.SyncProducer(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, sync)
 	sync.Close()

--- a/pkg/sink/kafka/v2/factory.go
+++ b/pkg/sink/kafka/v2/factory.go
@@ -152,6 +152,10 @@ func completeSASLConfig(o *pkafka.Options) (sasl.Mechanism, error) {
 			}
 			return Gokrb5v8(&gokrb5v8ClientImpl{clnt},
 				o.SASL.GSSAPI.ServiceName), nil
+
+		case pkafka.SASLTypeOAuth:
+			return nil, errors.ErrKafkaInvalidConfig.GenWithStack(
+				"OAuth is not yet supported in Kafka sink v2")
 		}
 	}
 	return nil, nil
@@ -196,12 +200,12 @@ func (f *factory) newWriter(async bool) *kafka.Writer {
 	return w
 }
 
-func (f *factory) AdminClient() (pkafka.ClusterAdminClient, error) {
+func (f *factory) AdminClient(_ context.Context) (pkafka.ClusterAdminClient, error) {
 	return newClusterAdminClient(f.options.BrokerEndpoints, f.transport, f.changefeedID), nil
 }
 
 // SyncProducer creates a sync producer to writer message to kafka
-func (f *factory) SyncProducer() (pkafka.SyncProducer, error) {
+func (f *factory) SyncProducer(_ context.Context) (pkafka.SyncProducer, error) {
 	w := f.newWriter(false)
 	// set batch size to 1 to make sure the message is sent immediately
 	w.BatchTimeout = time.Millisecond

--- a/pkg/sink/kafka/v2/factory_test.go
+++ b/pkg/sink/kafka/v2/factory_test.go
@@ -58,7 +58,7 @@ func TestSyncProducer(t *testing.T) {
 	o := newOptions4Test()
 	factory := newFactory4Test(o, t)
 
-	sync, err := factory.SyncProducer()
+	sync, err := factory.SyncProducer(context.Background())
 	require.NoError(t, err)
 
 	p, ok := sync.(*syncWriter)
@@ -295,6 +295,15 @@ func TestCompleteSASLConfig(t *testing.T) {
 	require.Equal(t, pkafka.SASLTypePlaintext, m.Name())
 	require.Equal(t, "user", pm.Username)
 	require.Equal(t, "pass", pm.Password)
+
+	// Unsupported OAUTHBEARER mechanism
+	m, err = completeSASLConfig(&pkafka.Options{
+		SASL: &security.SASL{
+			SASLMechanism: security.OAuthMechanism,
+		},
+	})
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "OAuth is not yet supported in Kafka sink v2")
 }
 
 func TestSyncWriterSendMessage(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/8865

### What is changed and how it works?
add oauth support for sarama Kafka sink. 

Added:
- SASLOAuthClientID  (required)
- SASLOAuthClientSecret  (required)
- SASLOAuthTokenURL (required)
- SASLOAuthScopes 
- SASLOAuthGrantType (default: client_credentials)


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - [Manual test](https://github.com/pingcap/tiflow/pull/8938#issuecomment-1556648439)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new features need a release note -->

```release-note
Add OAuth support for Sarama Kafka sink
```
