### PR TITLE
owner, redo(ticdc): decouple globalResolvedTs and globalBarrierTs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ storage_consumer:
 kafka_consumer_image: 
 	@which docker || (echo "docker not found in ${PATH}"; exit 1)
 	DOCKER_BUILDKIT=1 docker build -f ./deployments/ticdc/docker/kafka-consumer.Dockerfile . -t ticdc:kafka-consumer  --platform linux/amd64
+
 storage_consumer_image: 
 	@which docker || (echo "docker not found in ${PATH}"; exit 1)
 	DOCKER_BUILDKIT=1 docker build -f ./deployments/ticdc/docker/storage-consumer.Dockerfile . -t ticdc:storage-consumer  --platform linux/amd64

--- a/cdc/model/owner.go
+++ b/cdc/model/owner.go
@@ -262,9 +262,9 @@ func (p ProcessorsInfos) String() string {
 type ChangeFeedStatus struct {
 	ResolvedTs   uint64 `json:"resolved-ts"`
 	CheckpointTs uint64 `json:"checkpoint-ts"`
-	// MinTableBarrierTs is the minimum table barrier timestamp of all tables.
-	// It is only used when a changefeed is started to check whether there was
-	// a table's DDL job that had not finished when the changefeed was stopped.
+	// minTableBarrierTs is the minimum commitTs of all DDL events and is only
+	// used to check whether there is a pending DDL job at the checkpointTs when
+	// initializing the changefeed.
 	MinTableBarrierTs uint64       `json:"min-table-barrier-ts"`
 	AdminJobType      AdminJobType `json:"admin-job-type"`
 }

--- a/cdc/owner/ddl_manager.go
+++ b/cdc/owner/ddl_manager.go
@@ -34,6 +34,21 @@ import (
 // of tableBarrier in a single barrier.
 const tableBarrierNumberLimit = 256
 
+// The ddls below is globalDDLs, they affect all tables in the changefeed.
+// we need to wait all tables checkpointTs reach the DDL commitTs
+// before we can execute the DDL.
+//timodel.ActionCreateSchema
+//timodel.ActionDropSchema
+//timodel.ActionModifySchemaCharsetAndCollate
+//// We treat create table ddl as a global ddl, because before we execute the ddl,
+//// there is no a tablePipeline for the new table. So we can't prevent the checkpointTs
+//// from advancing. To solve this problem, we just treat create table ddl as a global ddl here.
+//// TODO: Find a better way to handle create table ddl.
+//timodel.ActionCreateTable
+//timodel.ActionRenameTable
+//timodel.ActionRenameTables
+//timodel.ActionExchangeTablePartition
+
 // nonGlobalDDLs are the DDLs that only affect related table
 // so that we should only block related table before execute them.
 var nonGlobalDDLs = map[timodel.ActionType]struct{}{
@@ -64,20 +79,24 @@ var nonGlobalDDLs = map[timodel.ActionType]struct{}{
 	timodel.ActionAlterTTLRemove:               {},
 }
 
-// The ddls below is globalDDLs, they affect all tables in the changefeed.
-// we need to wait all tables checkpointTs reach the DDL commitTs
-// before we can execute the DDL.
-//timodel.ActionCreateSchema
-//timodel.ActionDropSchema
-//timodel.ActionModifySchemaCharsetAndCollate
-//// We treat create table ddl as a global ddl, because before we execute the ddl,
-//// there is no a tablePipeline for the new table. So we can't prevent the checkpointTs
-//// from advancing. To solve this problem, we just treat create table ddl as a global ddl here.
-//// TODO: Find a better way to handle create table ddl.
-//timodel.ActionCreateTable
-//timodel.ActionRenameTable
-//timodel.ActionRenameTables
-//timodel.ActionExchangeTablePartition
+var redoBarrierDDLs = map[timodel.ActionType]struct{}{
+	timodel.ActionCreateTable:            {},
+	timodel.ActionTruncateTable:          {},
+	timodel.ActionAddTablePartition:      {},
+	timodel.ActionTruncateTablePartition: {},
+	timodel.ActionRecoverTable:           {},
+}
+
+type ddlBarrier struct {
+	*schedulepb.Barrier
+	// minTableBarrierTs is the minimum table barrier timestamp of all tables.
+	// It is only used when a changefeed is started to check whether there was
+	// a table's DDL job that had not finished when the changefeed was stopped.
+	minTableBarrierTs model.Ts
+	// physicalTableBarrierTs is the minimum ts of all ddl events that create
+	// a new physical table.
+	physicalTableBarrierTs model.Ts
+}
 
 // ddlManager holds the pending DDL events of all tables and responsible for
 // executing them to downstream.
@@ -169,16 +188,13 @@ func (m *ddlManager) tick(
 	ctx context.Context,
 	checkpointTs model.Ts,
 	tableCheckpoint map[model.TableName]model.Ts,
-) ([]model.TableID, model.Ts, *schedulepb.Barrier, error) {
-	minTableBarrierTs := model.Ts(0)
-	var barrier *schedulepb.Barrier
+) ([]model.TableID, *ddlBarrier, error) {
 	m.justSentDDL = nil
-
 	m.updateCheckpointTs(checkpointTs, tableCheckpoint)
 
 	currentTables, err := m.allTables(ctx)
 	if err != nil {
-		return nil, minTableBarrierTs, barrier, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
 
 	if m.executingDDL == nil {
@@ -187,7 +203,7 @@ func (m *ddlManager) tick(
 
 	tableIDs, err := m.allPhysicalTables(ctx)
 	if err != nil {
-		return nil, minTableBarrierTs, barrier, errors.Trace(err)
+		return nil, nil, errors.Trace(err)
 	}
 
 	// drain all ddl jobs from ddlPuller
@@ -209,7 +225,7 @@ func (m *ddlManager) tick(
 			)
 			events, err := m.schema.BuildDDLEvents(ctx, job)
 			if err != nil {
-				return nil, minTableBarrierTs, barrier, err
+				return nil, nil, err
 			}
 
 			for _, event := range events {
@@ -238,7 +254,7 @@ func (m *ddlManager) tick(
 				for _, event := range events {
 					err := m.redoDDLManager.EmitDDLEvent(ctx, event)
 					if err != nil {
-						return nil, minTableBarrierTs, barrier, err
+						return nil, nil, err
 					}
 				}
 			}
@@ -251,7 +267,7 @@ func (m *ddlManager) tick(
 	if m.redoDDLManager.Enabled() {
 		err := m.redoDDLManager.UpdateResolvedTs(ctx, ddlRts)
 		if err != nil {
-			return nil, minTableBarrierTs, barrier, err
+			return nil, nil, err
 		}
 		redoFlushedDDLRts := m.redoDDLManager.GetResolvedTs()
 		if redoFlushedDDLRts < ddlRts {
@@ -288,14 +304,12 @@ func (m *ddlManager) tick(
 
 			err := m.executeDDL(ctx)
 			if err != nil {
-				return nil, minTableBarrierTs, barrier, err
+				return nil, nil, err
 			}
 		}
 	}
 
-	minTableBarrierTs, barrier = m.barrier()
-
-	return tableIDs, minTableBarrierTs, barrier, nil
+	return tableIDs, m.barrier(), nil
 }
 
 func (m *ddlManager) shouldExecDDL(nextDDL *model.DDLEvent) bool {
@@ -423,22 +437,34 @@ func (m *ddlManager) getAllTableNextDDL() []*model.DDLEvent {
 }
 
 // barrier returns ddlResolvedTs and tableBarrier
-func (m *ddlManager) barrier() (model.Ts, *schedulepb.Barrier) {
+func (m *ddlManager) barrier() *ddlBarrier {
+	barrier := &ddlBarrier{
+		Barrier: &schedulepb.Barrier{
+			GlobalBarrierTs: m.ddlResolvedTs,
+		},
+		minTableBarrierTs:      m.ddlResolvedTs,
+		physicalTableBarrierTs: m.ddlResolvedTs,
+	}
 	tableBarrierMap := make(map[model.TableID]model.Ts)
-	var tableBarrier []*schedulepb.TableBarrier
-	minTableBarrierTs := m.ddlResolvedTs
-	globalBarrierTs := m.ddlResolvedTs
-
 	ddls := m.getAllTableNextDDL()
 	if m.justSentDDL != nil {
 		ddls = append(ddls, m.justSentDDL)
 	}
 	for _, ddl := range ddls {
+		if m.redoMetaManager.Enabled() && isRedoBerrierDDL(ddl) {
+			// The pipeline for a new table does not exist until the ddl is successfully
+			// executed, so the table's resolvedTs will not be calculated in redo.
+			// To solve this problem, resovedTs of redoDMLManager should not be greater
+			// than the min commitTs of create table DDL.
+			if ddl.CommitTs < barrier.physicalTableBarrierTs {
+				barrier.physicalTableBarrierTs = ddl.CommitTs
+			}
+		}
 		// When there is a global DDL, we need to wait all tables
 		// checkpointTs reach its commitTs before we can execute it.
 		if isGlobalDDL(ddl) {
-			if ddl.CommitTs < globalBarrierTs {
-				globalBarrierTs = ddl.CommitTs
+			if ddl.CommitTs < barrier.GlobalBarrierTs {
+				barrier.GlobalBarrierTs = ddl.CommitTs
 			}
 		} else {
 			ids := getPhysicalTableIDs(ddl)
@@ -450,17 +476,18 @@ func (m *ddlManager) barrier() (model.Ts, *schedulepb.Barrier) {
 		// minTableBarrierTs is the min commitTs of all tables DDLs,
 		// it is used to prevent the checkpointTs from advancing too fast
 		// when a changefeed is just resumed.
-		if ddl.CommitTs < minTableBarrierTs {
-			minTableBarrierTs = ddl.CommitTs
+		if ddl.CommitTs < barrier.minTableBarrierTs {
+			barrier.minTableBarrierTs = ddl.CommitTs
 		}
 	}
 
 	for tb, barrierTs := range tableBarrierMap {
-		if barrierTs > globalBarrierTs {
+		if barrierTs > barrier.GlobalBarrierTs {
 			delete(tableBarrierMap, tb)
 		}
 	}
 
+	var tableBarrier []*schedulepb.TableBarrier
 	for tb, barrierTs := range tableBarrierMap {
 		tableBarrier = append(tableBarrier, &schedulepb.TableBarrier{
 			TableID:   tb,
@@ -474,15 +501,13 @@ func (m *ddlManager) barrier() (model.Ts, *schedulepb.Barrier) {
 		return tableBarrier[i].BarrierTs < tableBarrier[j].BarrierTs
 	})
 	if len(tableBarrier) > tableBarrierNumberLimit {
-		globalBarrierTs = tableBarrier[tableBarrierNumberLimit].BarrierTs
+		barrier.GlobalBarrierTs = tableBarrier[tableBarrierNumberLimit].BarrierTs
 		tableBarrier = tableBarrier[:tableBarrierNumberLimit]
 	}
 
 	m.justSentDDL = nil
-	return minTableBarrierTs, &schedulepb.Barrier{
-		TableBarriers:   tableBarrier,
-		GlobalBarrierTs: globalBarrierTs,
-	}
+	barrier.TableBarriers = tableBarrier
+	return barrier
 }
 
 // allTables returns all tables in the schema that
@@ -599,4 +624,9 @@ func getPhysicalTableIDs(ddl *model.DDLEvent) []model.TableID {
 func isGlobalDDL(ddl *model.DDLEvent) bool {
 	_, ok := nonGlobalDDLs[ddl.Type]
 	return !ok
+}
+
+func isRedoBerrierDDL(ddl *model.DDLEvent) bool {
+	_, ok := redoBarrierDDLs[ddl.Type]
+	return ok
 }

--- a/cdc/owner/ddl_manager_test.go
+++ b/cdc/owner/ddl_manager_test.go
@@ -120,7 +120,7 @@ func TestBarriers(t *testing.T) {
 	// advance the ddlResolvedTs
 	dm.ddlResolvedTs = 6
 	ddlBarrier := dm.barrier()
-	minTableBarrierTs, barrier := ddlBarrier.minTableBarrierTs, ddlBarrier.Barrier
+	minTableBarrierTs, barrier := ddlBarrier.minDDLBarrierTs, ddlBarrier.Barrier
 	require.Equal(t, expectedMinTableBarrier, minTableBarrierTs)
 	require.Equal(t, expectedBarrier, barrier)
 
@@ -134,7 +134,7 @@ func TestBarriers(t *testing.T) {
 			newFakeDDLEvent(tableID, tableName.Table, timodel.ActionAddColumn, uint64(i)))
 	}
 	ddlBarrier = dm.barrier()
-	minTableBarrierTs, barrier = ddlBarrier.minTableBarrierTs, ddlBarrier.Barrier
+	minTableBarrierTs, barrier = ddlBarrier.minDDLBarrierTs, ddlBarrier.Barrier
 	require.Equal(t, uint64(0), minTableBarrierTs)
 	require.Equal(t, uint64(256), barrier.GlobalBarrierTs)
 	require.Equal(t, 256, len(barrier.TableBarriers))

--- a/cdc/owner/ddl_manager_test.go
+++ b/cdc/owner/ddl_manager_test.go
@@ -21,6 +21,7 @@ import (
 	timodel "github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tiflow/cdc/entry"
 	"github.com/pingcap/tiflow/cdc/model"
+	"github.com/pingcap/tiflow/cdc/redo"
 	"github.com/pingcap/tiflow/cdc/scheduler/schedulepb"
 	config2 "github.com/pingcap/tiflow/pkg/config"
 	cdcContext "github.com/pingcap/tiflow/pkg/context"
@@ -45,7 +46,8 @@ func createDDLManagerForTest(t *testing.T) *ddlManager {
 		ddlSink,
 		ddlPuller,
 		schema,
-		nil, nil,
+		redo.NewDisabledDDLManager(),
+		redo.NewDisabledMetaManager(),
 		model.DB, false)
 	return res
 }
@@ -117,7 +119,8 @@ func TestBarriers(t *testing.T) {
 	}
 	// advance the ddlResolvedTs
 	dm.ddlResolvedTs = 6
-	minTableBarrierTs, barrier := dm.barrier()
+	ddlBarrier := dm.barrier()
+	minTableBarrierTs, barrier := ddlBarrier.minTableBarrierTs, ddlBarrier.Barrier
 	require.Equal(t, expectedMinTableBarrier, minTableBarrierTs)
 	require.Equal(t, expectedBarrier, barrier)
 
@@ -130,7 +133,8 @@ func TestBarriers(t *testing.T) {
 		dm.pendingDDLs[tableName] = append(dm.pendingDDLs[tableName],
 			newFakeDDLEvent(tableID, tableName.Table, timodel.ActionAddColumn, uint64(i)))
 	}
-	minTableBarrierTs, barrier = dm.barrier()
+	ddlBarrier = dm.barrier()
+	minTableBarrierTs, barrier = ddlBarrier.minTableBarrierTs, ddlBarrier.Barrier
 	require.Equal(t, uint64(0), minTableBarrierTs)
 	require.Equal(t, uint64(256), barrier.GlobalBarrierTs)
 	require.Equal(t, 256, len(barrier.TableBarriers))

--- a/cdc/redo/manager.go
+++ b/cdc/redo/manager.go
@@ -57,6 +57,13 @@ type DDLManager interface {
 	GetResolvedTs() model.Ts
 }
 
+// NewDisabledDDLManager creates a disabled ddl Manager.
+func NewDisabledDDLManager() *ddlManager {
+	return &ddlManager{
+		logManager: &logManager{enabled: false},
+	}
+}
+
 // NewDDLManager creates a new ddl Manager.
 func NewDDLManager(
 	ctx context.Context, cfg *config.ConsistentConfig, ddlStartTs model.Ts,

--- a/cdc/redo/meta_manager.go
+++ b/cdc/redo/meta_manager.go
@@ -68,6 +68,13 @@ type metaManager struct {
 	metricFlushLogDuration prometheus.Observer
 }
 
+// NewDisabledMetaManager creates a disabled Meta Manager.
+func NewDisabledMetaManager() *metaManager {
+	return &metaManager{
+		enabled: false,
+	}
+}
+
 // NewMetaManagerWithInit creates a new Manager and initializes the meta.
 func NewMetaManagerWithInit(
 	ctx context.Context, cfg *config.ConsistentConfig, startTs model.Ts,

--- a/tests/integration_tests/consistent_replicate_ddl/conf/diff_config.toml
+++ b/tests/integration_tests/consistent_replicate_ddl/conf/diff_config.toml
@@ -21,6 +21,7 @@ check-struct-only = false
     port = 4000
     user = "root"
     password = ""
+    snapshot = "<placeholder>"
 
 [data-sources.mysql]
     host = "127.0.0.1"

--- a/tests/integration_tests/consistent_replicate_ddl/run.sh
+++ b/tests/integration_tests/consistent_replicate_ddl/run.sh
@@ -13,7 +13,7 @@ mkdir -p "$WORK_DIR"
 
 stop() {
 	# to distinguish whether the test failed in the DML synchronization phase or the DDL synchronization phase
-	echo $(mysql -h${DOWN_TIDB_HOST} -P${DOWN_TIDB_PORT} -uroot -e "select count(*) from consistent_replicate_ddl.usertable;")
+	echo $(mysql -h${DOWN_TIDB_HOST} -P${DOWN_TIDB_PORT} -uroot -e "SELECT count(*) FROM consistent_replicate_ddl.usertable;")
 	stop_tidb_cluster
 }
 
@@ -33,45 +33,72 @@ function run() {
 	SINK_URI="mysql://normal:123456@127.0.0.1:3306/"
 	changefeed_id=$(cdc cli changefeed create --sink-uri="$SINK_URI" --config="$CUR/conf/changefeed.toml" 2>&1 | tail -n2 | head -n1 | awk '{print $2}')
 
-	run_sql "CREATE DATABASE consistent_replicate_ddl;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "CREATE DATABASE consistent_replicate_ddl CHARACTER SET utf8 COLLATE utf8_unicode_ci" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	go-ycsb load mysql -P $CUR/conf/workload -p mysql.host=${UP_TIDB_HOST} -p mysql.port=${UP_TIDB_PORT} -p mysql.user=root -p mysql.db=consistent_replicate_ddl
-	run_sql "create table consistent_replicate_ddl.usertable2 like consistent_replicate_ddl.usertable" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-	run_sql "create table consistent_replicate_ddl.usertable3 like consistent_replicate_ddl.usertable" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-	check_table_exists "consistent_replicate_ddl.usertable" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
+	run_sql "CREATE TABLE consistent_replicate_ddl.usertable1 like consistent_replicate_ddl.usertable" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "CREATE TABLE consistent_replicate_ddl.usertable2 like consistent_replicate_ddl.usertable" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "CREATE TABLE consistent_replicate_ddl.usertable3 like consistent_replicate_ddl.usertable" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "CREATE TABLE consistent_replicate_ddl.usertable_bak like consistent_replicate_ddl.usertable" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	check_table_exists "consistent_replicate_ddl.usertable1" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	check_table_exists "consistent_replicate_ddl.usertable2" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 120
 	check_table_exists "consistent_replicate_ddl.usertable3" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 120
+	check_table_exists "consistent_replicate_ddl.usertable_bak" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 120
 
-	sleep 20
+	cleanup_process $CDC_BINARY
 	# Inject the failpoint to prevent sink execution, but the global resolved can be moved forward.
 	# Then we can apply redo log to reach an eventual consistent state in downstream.
-	cleanup_process $CDC_BINARY
 	export GO_FAILPOINTS='github.com/pingcap/tiflow/cdc/sink/dmlsink/txn/mysql/MySQLSinkHangLongTime=return(true);github.com/pingcap/tiflow/cdc/sink/ddlsink/mysql/MySQLSinkExecDDLDelay=return(true)'
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
-	run_sql "insert into consistent_replicate_ddl.usertable2 select * from consistent_replicate_ddl.usertable" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+	# case 1:
+	# global ddl tests -> ActionRenameTable
+	# table ddl tests -> ActionDropTable
+	run_sql "DROP TABLE consistent_replicate_ddl.usertable1" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "RENAME TABLE consistent_replicate_ddl.usertable_bak TO consistent_replicate_ddl.usertable1" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "INSERT INTO consistent_replicate_ddl.usertable1 SELECT * FROM consistent_replicate_ddl.usertable limit 10" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	# run_sql "TRUNCATE TABLE consistent_replicate_ddl.usertable1" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "RENAME TABLE consistent_replicate_ddl.usertable1 TO consistent_replicate_ddl.usertable1_1" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "INSERT IGNORE INTO consistent_replicate_ddl.usertable1_1 SELECT * FROM consistent_replicate_ddl.usertable" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+	# case 2:
+	# global ddl tests -> ActionCreateSchema, ActionModifySchemaCharsetAndCollate
+	# table ddl tests -> ActionMultiSchemaChange, ActionAddColumn, ActionDropColumn, ActionModifyTableCharsetAndCollate
+	run_sql "CREATE DATABASE consistent_replicate_ddl1" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "ALTER DATABASE consistent_replicate_ddl CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "ALTER TABLE consistent_replicate_ddl.usertable2 CHARACTER SET utf8mb4 COLLATE utf8mb4_bin" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "INSERT INTO consistent_replicate_ddl.usertable2 SELECT * FROM consistent_replicate_ddl.usertable limit 20" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "ALTER TABLE consistent_replicate_ddl.usertable2 DROP COLUMN FIELD0" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "ALTER TABLE consistent_replicate_ddl.usertable2 ADD COLUMN dummy varchar(30)" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-	run_sql "insert into consistent_replicate_ddl.usertable3 select * from consistent_replicate_ddl.usertable" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-	run_sql "ALTER TABLE consistent_replicate_ddl.usertable3 DROP COLUMN FIELD1" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-	# enable this after global resolved ts is decoupled from globalBarrierTs
-	# run_sql "create table consistent_replicate_ddl.usertable3 like consistent_replicate_ddl.usertable" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-	# run_sql "insert into consistent_replicate_ddl.usertable3 select * from consistent_replicate_ddl.usertable" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-	# run_sql "CREATE table consistent_replicate_ddl.check1(id int primary key);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+	# case 3:
+	# global ddl tests -> ActionDropSchema, ActionRenameTables
+	# table ddl tests -> ActionModifyColumn
+	run_sql "DROP DATABASE consistent_replicate_ddl1" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "ALTER TABLE consistent_replicate_ddl.usertable3 CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "RENAME TABLE consistent_replicate_ddl.usertable2 to consistent_replicate_ddl.usertable2_1, consistent_replicate_ddl.usertable3 TO consistent_replicate_ddl.usertable3_1" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "ALTER TABLE consistent_replicate_ddl.usertable3_1 MODIFY COLUMN FIELD1 varchar(100)" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "INSERT INTO consistent_replicate_ddl.usertable3_1 SELECT * FROM consistent_replicate_ddl.usertable limit 31" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+	run_sql "CREATE table consistent_replicate_ddl.check1(id int primary key);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 
 	# to ensure row changed events have been replicated to TiCDC
-	sleep 20
+	sleep 120
+	cleanup_process $CDC_BINARY
 
 	storage_path="file://$WORK_DIR/redo"
 	tmp_download_path=$WORK_DIR/cdc_data/redo/$changefeed_id
-	current_tso=$(cdc cli tso query --pd=http://$UP_PD_HOST_1:$UP_PD_PORT_1)
-	ensure 50 check_redo_resolved_ts $changefeed_id $current_tso $storage_path $tmp_download_path/meta
-	cleanup_process $CDC_BINARY
-
 	export GO_FAILPOINTS=''
 
+	rts=$(cdc redo meta --storage="$storage_path" --tmp-dir="$tmp_download_path" | grep -oE "resolved-ts:[0-9]+" | awk -F: '{print $2}')
+	sed "s/<placeholder>/$rts/g" $CUR/conf/diff_config.toml >$WORK_DIR/diff_config.toml
+
+	cat $WORK_DIR/diff_config.toml
 	cdc redo apply --tmp-dir="$tmp_download_path/apply" \
 		--storage="$storage_path" \
 		--sink-uri="mysql://normal:123456@127.0.0.1:3306/"
-	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
+
+	# sleep 6000000000000
+	check_sync_diff $WORK_DIR $WORK_DIR/diff_config.toml
 }
 
 trap stop EXIT


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8963

### What is changed and how it works?
1. [Decouple globalResolvedTs and globalBarrierTs](https://github.com/pingcap/tiflow/pull/8964/files#diff-953746562776cf8aa41cd4a971df8c546649d2721ae787607aed2069f3b44eb0R381-R382).
2. [Add a redo ddl barrier to prevent resolvedTs from being advanced too early](https://github.com/pingcap/tiflow/pull/8964/files#diff-22d25e82af60f580f09cf3ace50f4c276f10b5e0d29beb6f4999598605bb39f4R457-R465).

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`Fix the isuue that resolvedTs may be advanced too early when redo enabled`.
```
