### PR TITLE
makefile, cmd(ticdc): log version in consumer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,13 @@ kafka_consumer:
 storage_consumer:
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/cdc_storage_consumer ./cmd/storage-consumer/main.go
 
+kafka_consumer_image: 
+	@which docker || (echo "docker not found in ${PATH}"; exit 1)
+	DOCKER_BUILDKIT=1 docker build -f ./deployments/ticdc/docker/kafka-consumer.Dockerfile . -t ticdc:kafka-consumer  --platform linux/amd64
+storage_consumer_image: 
+	@which docker || (echo "docker not found in ${PATH}"; exit 1)
+	DOCKER_BUILDKIT=1 docker build -f ./deployments/ticdc/docker/storage-consumer.Dockerfile . -t ticdc:storage-consumer  --platform linux/amd64
+
 install:
 	go install ./...
 

--- a/cmd/kafka-consumer/main.go
+++ b/cmd/kafka-consumer/main.go
@@ -52,6 +52,7 @@ import (
 	"github.com/pingcap/tiflow/pkg/sink/codec/open"
 	"github.com/pingcap/tiflow/pkg/spanz"
 	"github.com/pingcap/tiflow/pkg/util"
+	"github.com/pingcap/tiflow/pkg/version"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
@@ -86,6 +87,7 @@ var (
 )
 
 func init() {
+	version.LogVersionInfo("kafka consumer")
 	var (
 		upstreamURIStr string
 		configFile     string

--- a/cmd/storage-consumer/main.go
+++ b/cmd/storage-consumer/main.go
@@ -50,6 +50,7 @@ import (
 	"github.com/pingcap/tiflow/pkg/sink/codec/csv"
 	"github.com/pingcap/tiflow/pkg/spanz"
 	putil "github.com/pingcap/tiflow/pkg/util"
+	"github.com/pingcap/tiflow/pkg/version"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
@@ -74,6 +75,7 @@ const (
 )
 
 func init() {
+	version.LogVersionInfo("storage consumer")
 	flag.StringVar(&upstreamURIStr, "upstream-uri", "", "storage uri")
 	flag.StringVar(&downstreamURIStr, "downstream-uri", "", "downstream sink uri")
 	flag.StringVar(&configFile, "config", "", "changefeed configuration file")

--- a/deployments/ticdc/docker/kafka-consumer.Dockerfile
+++ b/deployments/ticdc/docker/kafka-consumer.Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.20-alpine as builder
-RUN apk add --no-cache make bash
+RUN apk add --no-cache make bash git
 WORKDIR /go/src/github.com/pingcap/tiflow
 COPY . .
 

--- a/deployments/ticdc/docker/storage-consumer.Dockerfile
+++ b/deployments/ticdc/docker/storage-consumer.Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.20-alpine as builder
-RUN apk add --no-cache make bash
+RUN apk add --no-cache make bash git
 WORKDIR /go/src/github.com/pingcap/tiflow
 COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod go mod download


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #8973

### What is changed and how it works?
 log version in consumer

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 1. storage consumer
```shell
# make storage_consumer_image && docker run --entrypoint /cdc_storage_consumer ticdc:storage-consumer
/usr/bin/docker
DOCKER_BUILDKIT=1 docker build -f ./deployments/ticdc/docker/storage-consumer.Dockerfile . -t ticdc:storage-consumer  --platform linux/amd64
[+] Building 64.8s (14/14) FINISHED                                                                    
 => [internal] load build definition from storage-consumer.Dockerfile                             0.0s
 => => transferring dockerfile: 49B                                                               0.0s
 => [internal] load .dockerignore                                                                 0.0s
 => => transferring context: 78B                                                                  0.0s
 => [internal] load metadata for docker.io/library/alpine:3.15                                    0.0s
 => [internal] load metadata for docker.io/library/golang:1.20-alpine                             0.0s
 => [builder 1/6] FROM docker.io/library/golang:1.20-alpine                                       0.0s
 => CACHED [stage-1 1/2] FROM docker.io/library/alpine:3.15                                       0.0s
 => [internal] load build context                                                                 1.3s
 => => transferring context: 1.79MB                                                               1.3s
 => CACHED [builder 2/6] RUN apk add --no-cache make bash git                                     0.0s
 => CACHED [builder 3/6] WORKDIR /go/src/github.com/pingcap/tiflow                                0.0s
 => [builder 4/6] COPY . .                                                                        5.3s
 => [builder 5/6] RUN --mount=type=cache,target=/go/pkg/mod go mod download                       0.7s
 => [builder 6/6] RUN --mount=type=cache,target=/root/.cache/go-build make storage_consumer      55.5s
 => [stage-1 2/2] COPY --from=builder  /go/src/github.com/pingcap/tiflow/bin/cdc_storage_consume  0.2s 
 => exporting to image                                                                            1.0s 
 => => exporting layers                                                                           1.0s 
 => => writing image sha256:5fe553d31db31d3a46ee35a935ee2bbbce01c69aac3ea465576a559658c168a3      0.0s 
 => => naming to docker.io/library/ticdc:storage-consumer                                         0.0s 
[2023/05/17 02:48:06.053 +00:00] [INFO] [version.go:47] ["Welcome to storage consumer"] [release-version=v7.1.0-master] [git-hash=9d1bfe4a21354d69d00586f99d4d64cf9cebee7a] [git-branch=add-version] [utc-build-time="2023-05-17 02:47:08"] [go-version="go version go1.20.3 linux/amd64"] [failpoint-build=false]
```
2. kafka consumer 
```shell
# make kafka_consumer_image && docker run --entrypoint /cdc_kafka_consumer ticdc:kafka-consumer
/usr/bin/docker
DOCKER_BUILDKIT=1 docker build -f ./deployments/ticdc/docker/kafka-consumer.Dockerfile . -t ticdc:kafka-consumer  --platform linux/amd64
[+] Building 59.9s (14/14) FINISHED                                                                    
 => [internal] load build definition from kafka-consumer.Dockerfile                               0.1s
 => => transferring dockerfile: 464B                                                              0.0s
 => [internal] load .dockerignore                                                                 0.0s
 => => transferring context: 78B                                                                  0.0s
 => [internal] load metadata for docker.io/library/golang:1.20-alpine                             0.0s
 => [internal] load metadata for docker.io/library/alpine:3.15                                    0.0s
 => [builder 1/6] FROM docker.io/library/golang:1.20-alpine                                       0.0s
 => CACHED [stage-1 1/2] FROM docker.io/library/alpine:3.15                                       0.0s
 => [internal] load build context                                                                 1.3s
 => => transferring context: 1.16MB                                                               1.3s
 => CACHED [builder 2/6] RUN apk add --no-cache make bash git                                     0.0s
 => CACHED [builder 3/6] WORKDIR /go/src/github.com/pingcap/tiflow                                0.0s
 => CACHED [builder 4/6] COPY . .                                                                 0.0s
 => CACHED [builder 5/6] RUN --mount=type=cache,target=/go/pkg/mod go mod download                0.0s
 => [builder 6/6] RUN --mount=type=cache,target=/root/.cache/go-build make kafka_consumer        56.5s
 => [stage-1 2/2] COPY --from=builder  /go/src/github.com/pingcap/tiflow/bin/cdc_kafka_consumer   0.3s 
 => exporting to image                                                                            1.1s 
 => => exporting layers                                                                           1.1s 
 => => writing image sha256:5b8cafa5a7d36f384cc1dd479eab4734b35d6ca06a3982436ef0f042ca409d64      0.0s 
 => => naming to docker.io/library/ticdc:kafka-consumer                                           0.0s 
[2023/05/17 02:51:40.891 +00:00] [INFO] [version.go:47] ["Welcome to kafka consumer"] [release-version=v7.1.0-master] [git-hash=9d1bfe4a21354d69d00586f99d4d64cf9cebee7a] [git-branch=add-version] [utc-build-time="2023-05-17 02:50:42"] [go-version="go version go1.20.3 linux/amd64"] [failpoint-build=false]
panic: invalid upstream-uri scheme, the scheme of upstream-uri must be `kafka`
```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
