### PR TITLE
(sorter/cdc): disable block cache by default

### DIFF
--- a/pkg/config/config_test_data.go
+++ b/pkg/config/config_test_data.go
@@ -92,7 +92,7 @@ const (
   "owner-flush-interval": 50000000,
   "processor-flush-interval": 50000000,
   "sorter": {
-    "max-memory-percentage": 10,
+    "max-memory-percentage": 0,
     "sort-dir": "/tmp/sorter",
     "max-memory-consumption": 0,
     "num-workerpool-goroutine": 0,

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -106,7 +106,9 @@ var defaultServerConfig = &ServerConfig{
 	OwnerFlushInterval:     TomlDuration(50 * time.Millisecond),
 	ProcessorFlushInterval: TomlDuration(50 * time.Millisecond),
 	Sorter: &SorterConfig{
-		MaxMemoryPercentage: 10, // 10% is safe on machines with memory capacity <= 16GB
+		// Disable block-cache by default. TiCDC only scans events instead of
+		// accessing them randomly, so block-cache is unnecessary.
+		MaxMemoryPercentage: 0,
 		SortDir:             DefaultSortDir,
 	},
 	Security: &SecurityConfig{},

--- a/pkg/config/sorter.go
+++ b/pkg/config/sorter.go
@@ -38,7 +38,7 @@ type SorterConfig struct {
 
 // ValidateAndAdjust validates and adjusts the sorter configuration
 func (c *SorterConfig) ValidateAndAdjust() error {
-	if c.MaxMemoryPercentage <= 0 || c.MaxMemoryPercentage > 80 {
+	if c.MaxMemoryPercentage < 0 || c.MaxMemoryPercentage > 80 {
 		return errors.ErrIllegalSorterParameter.GenWithStackByArgs(
 			"max-memory-percentage should be a percentage and within (0, 80]")
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8974

### What is changed and how it works?

Disable SortEngine pebble block-cache by default.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
