### PR TITLE
(processor/cdc): report module internal warnings

### DIFF
--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -797,11 +797,23 @@ func (h *OpenAPIV2) status(c *gin.Context) {
 			Message: info.Error.Message,
 		}
 	}
+	var lastWarning *RunningError
+	if info.Warning != nil &&
+		oracle.GetTimeFromTS(status.CheckpointTs).Before(info.Warning.Time) {
+		lastWarning = &RunningError{
+			Time:    &info.Warning.Time,
+			Addr:    info.Warning.Addr,
+			Code:    info.Warning.Code,
+			Message: info.Warning.Message,
+		}
+	}
+
 	c.JSON(http.StatusOK, &ChangefeedStatus{
 		State:        string(info.State),
 		CheckpointTs: status.CheckpointTs,
 		ResolvedTs:   status.ResolvedTs,
 		LastError:    lastError,
+		LastWarning:  lastWarning,
 	})
 }
 

--- a/cdc/api/v2/model.go
+++ b/cdc/api/v2/model.go
@@ -956,4 +956,5 @@ type ChangefeedStatus struct {
 	ResolvedTs   uint64        `json:"resolved_ts"`
 	CheckpointTs uint64        `json:"checkpoint_ts"`
 	LastError    *RunningError `json:"last_error,omitempty"`
+	LastWarning  *RunningError `json:"last_warning,omitempty"`
 }

--- a/cdc/entry/mounter_group.go
+++ b/cdc/entry/mounter_group.go
@@ -80,7 +80,7 @@ func NewMounterGroup(
 	}
 }
 
-func (m *mounterGroup) Run(ctx context.Context) error {
+func (m *mounterGroup) Run(ctx context.Context, _ ...chan<- error) error {
 	defer func() {
 		mounterGroupInputChanSizeGauge.DeleteLabelValues(m.changefeedID.Namespace, m.changefeedID.ID)
 	}()
@@ -157,7 +157,7 @@ type MockMountGroup struct {
 }
 
 // Run implements util.Runnable.
-func (m *MockMountGroup) Run(ctx context.Context) error {
+func (m *MockMountGroup) Run(ctx context.Context, _ ...chan<- error) error {
 	return nil
 }
 

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -141,9 +141,10 @@ type ChangeFeedInfo struct {
 	// but can be fetched for backward compatibility
 	SortDir string `json:"sort-dir"`
 
-	Config *config.ReplicaConfig `json:"config"`
-	State  FeedState             `json:"state"`
-	Error  *RunningError         `json:"error"`
+	Config  *config.ReplicaConfig `json:"config"`
+	State   FeedState             `json:"state"`
+	Error   *RunningError         `json:"error"`
+	Warning *RunningError         `json:"warning"`
 
 	CreatorVersion string `json:"creator-version"`
 	// Epoch is the epoch of a changefeed, changes on every restart.

--- a/cdc/model/owner.go
+++ b/cdc/model/owner.go
@@ -92,8 +92,10 @@ type TaskPosition struct {
 	// Deprecated: only used in API. TODO: remove API usage.
 	Count uint64 `json:"count"`
 
-	// Error when error happens
+	// Error when changefeed error happens
 	Error *RunningError `json:"error"`
+	// Warning when module error happens
+	Warning *RunningError `json:"error"`
 }
 
 // Marshal returns the json marshal format of a TaskStatus
@@ -128,6 +130,14 @@ func (tp *TaskPosition) Clone() *TaskPosition {
 			Addr:    tp.Error.Addr,
 			Code:    tp.Error.Code,
 			Message: tp.Error.Message,
+		}
+	}
+	if tp.Warning != nil {
+		ret.Warning = &RunningError{
+			Time:    tp.Warning.Time,
+			Addr:    tp.Warning.Addr,
+			Code:    tp.Warning.Code,
+			Message: tp.Warning.Message,
 		}
 	}
 	return ret

--- a/cdc/model/owner.go
+++ b/cdc/model/owner.go
@@ -95,7 +95,7 @@ type TaskPosition struct {
 	// Error when changefeed error happens
 	Error *RunningError `json:"error"`
 	// Warning when module error happens
-	Warning *RunningError `json:"error"`
+	Warning *RunningError `json:"warning"`
 }
 
 // Marshal returns the json marshal format of a TaskStatus

--- a/cdc/model/owner_test.go
+++ b/cdc/model/owner_test.go
@@ -54,7 +54,7 @@ func TestTaskPositionMarshal(t *testing.T) {
 		ResolvedTs:   420875942036766723,
 		CheckPointTs: 420875940070686721,
 	}
-	expected := `{"checkpoint-ts":420875940070686721,"resolved-ts":420875942036766723,"count":0,"error":null}`
+	expected := `{"checkpoint-ts":420875940070686721,"resolved-ts":420875942036766723,"count":0,"error":null,"warning":null}`
 
 	data, err := pos.Marshal()
 	require.Nil(t, err)

--- a/cdc/owner/ddl_sink.go
+++ b/cdc/owner/ddl_sink.go
@@ -172,14 +172,9 @@ func (s *ddlSinkImpl) retrySinkActionWithErrorReport(ctx context.Context, action
 			return err
 		}
 
-		timer := time.NewTimer(5 * time.Second)
-		select {
-		case <-ctx.Done():
-			if !timer.Stop() {
-				<-timer.C
-			}
-			return ctx.Err()
-		case <-timer.C:
+		// Use a 5 second backoff when re-establishing internal resources.
+		if err = util.Hang(ctx, 5*time.Second); err != nil {
+			return errors.Trace(err)
 		}
 	}
 }

--- a/cdc/owner/feed_state_manager.go
+++ b/cdc/owner/feed_state_manager.go
@@ -403,7 +403,8 @@ func (m *feedStateManager) errorsReportedByProcessors() []*model.RunningError {
 			log.Error("processor reports an error",
 				zap.String("namespace", m.state.ID.Namespace),
 				zap.String("changefeed", m.state.ID.ID),
-				zap.String("captureID", captureID), zap.Any("error", position.Error))
+				zap.String("captureID", captureID),
+				zap.Any("error", position.Error))
 			m.state.PatchTaskPosition(captureID, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 				if position == nil {
 					return nil, false, nil
@@ -434,7 +435,8 @@ func (m *feedStateManager) warningsReportedByProcessors() []*model.RunningError 
 			log.Warn("processor reports a warning",
 				zap.String("namespace", m.state.ID.Namespace),
 				zap.String("changefeed", m.state.ID.ID),
-				zap.String("captureID", captureID), zap.Any("error", position.Warning))
+				zap.String("captureID", captureID),
+				zap.Any("warning", position.Warning))
 			m.state.PatchTaskPosition(captureID, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 				if position == nil {
 					return nil, false, nil

--- a/cdc/owner/feed_state_manager.go
+++ b/cdc/owner/feed_state_manager.go
@@ -142,6 +142,8 @@ func (m *feedStateManager) Tick(state *orchestrator.ChangefeedReactorState) (adm
 	}
 	errs := m.errorsReportedByProcessors()
 	m.handleError(errs...)
+	warnings := m.warningsReportedByProcessors()
+	m.handleWarning(warnings...)
 	return
 }
 
@@ -200,7 +202,6 @@ func (m *feedStateManager) handleAdminJob() (jobsPending bool) {
 		jobsPending = true
 		m.patchState(model.StateStopped)
 	case model.AdminRemove:
-
 		switch m.state.Info.State {
 		case model.StateNormal, model.StateError, model.StateFailed,
 			model.StateStopped, model.StateFinished, model.StateRemoved:
@@ -399,7 +400,7 @@ func (m *feedStateManager) errorsReportedByProcessors() []*model.RunningError {
 				runningErrors = make(map[string]*model.RunningError)
 			}
 			runningErrors[position.Error.Code] = position.Error
-			log.Error("processor report an error",
+			log.Error("processor reports an error",
 				zap.String("namespace", m.state.ID.Namespace),
 				zap.String("changefeed", m.state.ID.ID),
 				zap.String("captureID", captureID), zap.Any("error", position.Error))
@@ -417,6 +418,37 @@ func (m *feedStateManager) errorsReportedByProcessors() []*model.RunningError {
 	}
 	result := make([]*model.RunningError, 0, len(runningErrors))
 	for _, err := range runningErrors {
+		result = append(result, err)
+	}
+	return result
+}
+
+func (m *feedStateManager) warningsReportedByProcessors() []*model.RunningError {
+	var runningWarnings map[string]*model.RunningError
+	for captureID, position := range m.state.TaskPositions {
+		if position.Warning != nil {
+			if runningWarnings == nil {
+				runningWarnings = make(map[string]*model.RunningError)
+			}
+			runningWarnings[position.Warning.Code] = position.Warning
+			log.Warn("processor reports a warning",
+				zap.String("namespace", m.state.ID.Namespace),
+				zap.String("changefeed", m.state.ID.ID),
+				zap.String("captureID", captureID), zap.Any("error", position.Warning))
+			m.state.PatchTaskPosition(captureID, func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+				if position == nil {
+					return nil, false, nil
+				}
+				position.Warning = nil
+				return position, true, nil
+			})
+		}
+	}
+	if runningWarnings == nil {
+		return nil
+	}
+	result := make([]*model.RunningError, 0, len(runningWarnings))
+	for _, err := range runningWarnings {
 		result = append(result, err)
 	}
 	return result
@@ -529,6 +561,18 @@ func (m *feedStateManager) handleError(errs ...*model.RunningError) {
 			zap.Duration("oldInterval", oldBackoffInterval),
 			zap.Duration("newInterval", m.backoffInterval))
 	}
+}
+
+func (m *feedStateManager) handleWarning(errs ...*model.RunningError) {
+	m.state.PatchInfo(func(info *model.ChangeFeedInfo) (*model.ChangeFeedInfo, bool, error) {
+		if info == nil {
+			return nil, false, nil
+		}
+		for _, err := range errs {
+			info.Warning = err
+		}
+		return info, len(errs) > 0, nil
+	})
 }
 
 // GenerateChangefeedEpoch generates a unique changefeed epoch.

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -541,6 +541,38 @@ func (p *processor) handleErr(err error) error {
 	return err
 }
 
+func (p *processor) handleWarnings() {
+	var err error
+	select {
+	case err = <-p.ddlHandler.warnings:
+	case err = <-p.mg.warnings:
+	case err = <-p.redo.warnings:
+	case err = <-p.sourceManager.warnings:
+	case err = <-p.sinkManager.warnings:
+	default:
+		return
+	}
+	var code string
+	if rfcCode, ok := cerror.RFCCode(err); ok {
+		code = string(rfcCode)
+	} else {
+		code = string(cerror.ErrProcessorUnknown.RFCCode())
+	}
+	p.changefeed.PatchTaskPosition(p.captureInfo.ID,
+		func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+			if position == nil {
+				position = &model.TaskPosition{}
+			}
+			position.Warning = &model.RunningError{
+				Time:    time.Now(),
+				Addr:    p.captureInfo.AdvertiseAddr,
+				Code:    code,
+				Message: err.Error(),
+			}
+			return position, true, nil
+		})
+}
+
 func (p *processor) tick(ctx cdcContext.Context) error {
 	if !p.checkChangefeedNormal() {
 		return cerror.ErrAdminStopProcessor.GenWithStackByArgs()
@@ -549,6 +581,9 @@ func (p *processor) tick(ctx cdcContext.Context) error {
 	if p.createTaskPosition() {
 		return nil
 	}
+
+	p.handleWarnings()
+
 	if err := p.handleErrorCh(); err != nil {
 		return errors.Trace(err)
 	}
@@ -964,23 +999,25 @@ func (p *processor) calculateTableBarrierTs(
 }
 
 type component[R util.Runnable] struct {
-	r      R
-	name   string
-	ctx    context.Context
-	cancel context.CancelFunc
-	errors chan error
-	wg     sync.WaitGroup
+	r        R
+	name     string
+	ctx      context.Context
+	cancel   context.CancelFunc
+	errors   chan error
+	warnings chan error
+	wg       sync.WaitGroup
 }
 
 func (c *component[R]) spawn(ctx context.Context) {
 	c.ctx, c.cancel = context.WithCancel(ctx)
 	c.errors = make(chan error, 16)
+	c.warnings = make(chan error, 16)
 
 	changefeedID := contextutil.ChangefeedIDFromCtx(c.ctx)
 	c.wg.Add(1)
 	go func() {
 		defer c.wg.Done()
-		err := c.r.Run(c.ctx)
+		err := c.r.Run(c.ctx, c.warnings)
 		if err != nil && errors.Cause(err) != context.Canceled {
 			log.Error("processor sub-component fails",
 				zap.String("namespace", changefeedID.Namespace),
@@ -1022,7 +1059,7 @@ type ddlHandler struct {
 	schemaStorage entry.SchemaStorage
 }
 
-func (d *ddlHandler) Run(ctx context.Context) error {
+func (d *ddlHandler) Run(ctx context.Context, _ ...chan<- error) error {
 	g, ctx := errgroup.WithContext(ctx)
 	// d.puller will update the schemaStorage.
 	g.Go(func() error { return d.puller.Run(ctx) })

--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -266,7 +266,7 @@ func (m *SinkManager) Run(ctx context.Context, warnings ...chan<- error) (err er
 
 		if !cerror.IsChangefeedUnRetryableError(err) && errors.Cause(err) != context.Canceled {
 			select {
-			case <-ctx.Done():
+			case <-m.managerCtx.Done():
 			case warnings[0] <- err:
 			}
 		} else {

--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -34,6 +34,7 @@ import (
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/spanz"
 	"github.com/pingcap/tiflow/pkg/upstream"
+	"github.com/pingcap/tiflow/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tikv/client-go/v2/oracle"
 	"go.uber.org/zap"
@@ -168,7 +169,7 @@ func New(
 }
 
 // Run implements util.Runnable.
-func (m *SinkManager) Run(ctx context.Context) (err error) {
+func (m *SinkManager) Run(ctx context.Context, warnings ...chan<- error) (err error) {
 	var managerCancel context.CancelFunc
 	m.managerCtx, managerCancel = context.WithCancel(ctx)
 	defer func() {
@@ -246,7 +247,7 @@ func (m *SinkManager) Run(ctx context.Context) (err error) {
 		}
 
 		select {
-		case <-ctx.Done():
+		case <-m.managerCtx.Done():
 			return errors.Trace(ctx.Err())
 		case err = <-gcErrors:
 			return errors.Trace(err)
@@ -264,19 +265,15 @@ func (m *SinkManager) Run(ctx context.Context) (err error) {
 		}
 
 		if !cerror.IsChangefeedUnRetryableError(err) && errors.Cause(err) != context.Canceled {
-			// TODO(qupeng): report th warning.
-
-			// Use a 5 second backoff when re-establishing internal resources.
-			timer := time.NewTimer(5 * time.Second)
 			select {
 			case <-ctx.Done():
-				if !timer.Stop() {
-					<-timer.C
-				}
-				return errors.Trace(ctx.Err())
-			case <-timer.C:
+			case warnings[0] <- err:
 			}
 		} else {
+			return errors.Trace(err)
+		}
+		// Use a 5 second backoff when re-establishing internal resources.
+		if err = util.Hang(m.managerCtx, 5*time.Second); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/cdc/processor/sinkmanager/redo_log_advancer_test.go
+++ b/cdc/processor/sinkmanager/redo_log_advancer_test.go
@@ -51,7 +51,7 @@ func (m *mockRedoDMLManager) Enabled() bool {
 	panic("unreachable")
 }
 
-func (m *mockRedoDMLManager) Run(ctx context.Context) error {
+func (m *mockRedoDMLManager) Run(ctx context.Context, _ ...chan<- error) error {
 	panic("unreachable")
 }
 

--- a/cdc/processor/sourcemanager/manager.go
+++ b/cdc/processor/sourcemanager/manager.go
@@ -168,7 +168,7 @@ func (m *SourceManager) ReceivedEvents() int64 {
 }
 
 // Run implements util.Runnable.
-func (m *SourceManager) Run(ctx context.Context) error {
+func (m *SourceManager) Run(ctx context.Context, _ ...chan<- error) error {
 	m.ctx = ctx
 	close(m.ready)
 	select {

--- a/cdc/puller/ddl_puller.go
+++ b/cdc/puller/ddl_puller.go
@@ -84,7 +84,7 @@ type ddlJobPullerImpl struct {
 }
 
 // Run starts the DDLJobPuller.
-func (p *ddlJobPullerImpl) Run(ctx context.Context) error {
+func (p *ddlJobPullerImpl) Run(ctx context.Context, _ ...chan<- error) error {
 	eg, ctx := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {

--- a/cdc/redo/manager.go
+++ b/cdc/redo/manager.go
@@ -252,7 +252,7 @@ func newLogManager(
 }
 
 // Run implements pkg/util.Runnable.
-func (m *logManager) Run(ctx context.Context) error {
+func (m *logManager) Run(ctx context.Context, _ ...chan<- error) error {
 	if m.Enabled() {
 		defer m.close()
 		return m.bgUpdateLog(ctx)

--- a/cdc/redo/meta_manager.go
+++ b/cdc/redo/meta_manager.go
@@ -140,7 +140,7 @@ func (m *metaManager) Enabled() bool {
 }
 
 // Run runs bgFlushMeta and bgGC.
-func (m *metaManager) Run(ctx context.Context) error {
+func (m *metaManager) Run(ctx context.Context, _ ...chan<- error) error {
 	if m.extStorage == nil {
 		log.Warn("extStorage of redo meta manager is nil, skip running")
 		return nil

--- a/cdc/sink/dmlsink/txn/mysql/mysql.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql.go
@@ -749,7 +749,7 @@ func (s *mysqlBackend) execDMLWithMaxRetries(pctx context.Context, dmls *prepare
 			err := logDMLTxnErr(errors.Trace(driver.ErrBadConn), start, s.changefeed, "failpoint", 0, nil)
 			failpoint.Return(err)
 		})
-		failpoint.Inject("MySQLSinkHangLongTime", func() { util.Hang(pctx, time.Hour) })
+		failpoint.Inject("MySQLSinkHangLongTime", func() { _ = util.Hang(pctx, time.Hour) })
 
 		err := s.statistics.RecordBatchExecution(func() (int, error) {
 			tx, err := s.db.BeginTx(pctx, nil)

--- a/pkg/util/runnable.go
+++ b/pkg/util/runnable.go
@@ -34,7 +34,9 @@ type Runnable interface {
 	// descriptors, channels or memory buffers. Those resources may be still
 	// necessary by other components after this Runnable is returned. We can use
 	// Close to release them.
-	Run(ctx context.Context) error
+    //
+    // `warnings` is used to retrieve internal warnings generated when running.
+	Run(ctx context.Context, warnings ...chan<- error) error
 	// WaitForReady blocks the current goroutine until `Run` initializes itself.
 	WaitForReady(ctx context.Context)
 	// Close all internal resources synchronously.

--- a/pkg/util/runnable.go
+++ b/pkg/util/runnable.go
@@ -34,8 +34,8 @@ type Runnable interface {
 	// descriptors, channels or memory buffers. Those resources may be still
 	// necessary by other components after this Runnable is returned. We can use
 	// Close to release them.
-    //
-    // `warnings` is used to retrieve internal warnings generated when running.
+	//
+	// `warnings` is used to retrieve internal warnings generated when running.
 	Run(ctx context.Context, warnings ...chan<- error) error
 	// WaitForReady blocks the current goroutine until `Run` initializes itself.
 	WaitForReady(ctx context.Context)

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -19,13 +19,15 @@ import (
 )
 
 // Hang will block the goroutine for a given duration, or return when `ctx` is done.
-func Hang(ctx context.Context, dur time.Duration) {
+func Hang(ctx context.Context, dur time.Duration) error {
 	timer := time.NewTimer(dur)
 	select {
 	case <-ctx.Done():
 		if !timer.Stop() {
 			<-timer.C
 		}
+		return ctx.Err()
 	case <-timer.C:
+		return nil
 	}
 }

--- a/tests/integration_tests/_utils/check_changefeed_status
+++ b/tests/integration_tests/_utils/check_changefeed_status
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -ex
+
+# parameter 1: cdc endpoint
+# parameter 2: changefeed id
+# parameter 3: expected state
+# parameter 4: last_warning or last_error
+# parameter 5: error msg pattern
+
+endpoint=${1}
+changefeed_id=${2}
+expected_state=${3}
+field=${4}
+error_pattern=${5}
+
+info=$(curl $endpoint/api/v2/changefeeds/$changefeed_id/status)
+echo "$info"
+
+state=$(echo $info | jq -r '.state')
+if [[ ! "$state" == "$expected_state" ]]; then
+	echo "changefeed state $state does not equal to $expected_state"
+	exit 1
+fi
+
+if [[ -z $field ]]; then
+	error_msg=$(echo $info | jq -r ".last_error")
+	if [[ ! $error_msg == "null" ]]; then
+		echo "last_error should be empty as expected"
+		exit 1
+	fi
+	error_msg=$(echo $info | jq -r ".last_warning")
+	if [[ ! $error_msg == "null" ]]; then
+		echo "last_warning should be empty as expected"
+		exit 1
+	fi
+	exit 0
+fi
+
+error_msg=$(echo $info | jq -r ".$field.message")
+if [[ ! "$error_msg" =~ "$error_pattern" ]]; then
+	echo "error message '$error_msg' is not as expected '$error_pattern'"
+	exit 1
+fi

--- a/tests/integration_tests/changefeed_error/run.sh
+++ b/tests/integration_tests/changefeed_error/run.sh
@@ -85,9 +85,8 @@ function run() {
 	changefeedid_1="changefeed-error-1"
 	run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" -c $changefeedid_1
 
-	# TODO(qupeng): add a warning flag to check.
-	# run_sql "CREATE table changefeed_error.DDLERROR(id int primary key, val int);"
-	# ensure $MAX_RETRIES check_changefeed_state http://${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid_1} "error" "[CDC:ErrExecDDLFailed]exec DDL failed" ""
+	run_sql "CREATE table changefeed_error.DDLERROR(id int primary key, val int);"
+	ensure $MAX_RETRIES check_changefeed_status 127.0.0.1:8300 $changefeedid_1 normal last_warning ErrExecDDLFailed
 
 	run_cdc_cli changefeed remove -c $changefeedid_1
 	cleanup_process $CDC_BINARY

--- a/tests/integration_tests/kafka_sink_error_resume/run.sh
+++ b/tests/integration_tests/kafka_sink_error_resume/run.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# TODO(qupeng): fix the case after we can catch an error or warning.
-echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"
-exit 0
-
 set -eu
 
 CUR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -42,9 +38,9 @@ function run() {
 	run_sql "CREATE table kafka_sink_error_resume.t2(id int primary key auto_increment, val int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "INSERT INTO kafka_sink_error_resume.t1 VALUES ();"
 
-	ensure $MAX_RETRIES check_changefeed_state $pd_addr $changefeed_id "error" "kafka sink injected error" ""
+	ensure $MAX_RETRIES check_changefeed_status 127.0.0.1:8300 $changefeed_id "normal" "last_warning" "kafka sink injected error"
 	cdc cli changefeed resume --changefeed-id=$changefeed_id --pd=$pd_addr
-	ensure $MAX_RETRIES check_changefeed_state $pd_addr $changefeed_id "normal" "null" ""
+	ensure $MAX_RETRIES check_changefeed_status 127.0.0.1:8300 $changefeed_id "normal"
 
 	check_table_exists "kafka_sink_error_resume.t1" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	check_table_exists "kafka_sink_error_resume.t2" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #8657 

### What is changed and how it works?

Report model internal warnings to users by `api/v2/changefeeds/{ID}/status`.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

  example of `api/v2/changefeeds/{ID}/status`:

  ```
  {"state":"normal","resolved_ts":441531555227631620,"checkpoint_ts":441531531923030068,"last_warning":{"time":"2023-05-17T15:40:12.504878333+08:00","addr":"10.2.7.2:8300","code":"CDC:ErrMySQLConnectionError","message":"[CDC:ErrMySQLConnectionError]fail to open MySQL connection: dial tcp 10.2.6.117:4000: connect: connection refused"}}
  ```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
