### PR TITLE
sink(ticdc): set default value of DateSeparator to day(#8998)

### DIFF
--- a/cdc/api/v2/model_test.go
+++ b/cdc/api/v2/model_test.go
@@ -49,7 +49,7 @@ var defaultAPIConfig = &ReplicaConfig{
 		},
 		EncoderConcurrency:       16,
 		Terminator:               config.CRLF,
-		DateSeparator:            config.DateSeparatorNone.String(),
+		DateSeparator:            config.DateSeparatorDay.String(),
 		EnablePartitionSeparator: true,
 		EnableKafkaSinkV2:        false,
 	},

--- a/cdc/sink/dmlsink/cloudstorage/cloud_storage_dml_sink_test.go
+++ b/cdc/sink/dmlsink/cloudstorage/cloud_storage_dml_sink_test.go
@@ -122,6 +122,7 @@ func TestCloudStorageWriteEventsWithoutDateSeparator(t *testing.T) {
 	require.Nil(t, err)
 
 	replicaConfig := config.GetDefaultReplicaConfig()
+	replicaConfig.Sink.DateSeparator = config.DateSeparatorNone.String()
 	replicaConfig.Sink.Protocol = config.ProtocolCsv.String()
 	replicaConfig.Sink.FileIndexWidth = 6
 	errCh := make(chan error, 5)

--- a/cdc/sink/dmlsink/cloudstorage/dml_worker_test.go
+++ b/cdc/sink/dmlsink/cloudstorage/dml_worker_test.go
@@ -44,7 +44,9 @@ func testDMLWorker(ctx context.Context, t *testing.T, dir string) *dmlWorker {
 	sinkURI, err := url.Parse(uri)
 	require.Nil(t, err)
 	cfg := cloudstorage.NewConfig()
-	err = cfg.Apply(context.TODO(), sinkURI, config.GetDefaultReplicaConfig())
+	replicaConfig := config.GetDefaultReplicaConfig()
+	replicaConfig.Sink.DateSeparator = config.DateSeparatorNone.String()
+	err = cfg.Apply(context.TODO(), sinkURI, replicaConfig)
 	cfg.FileIndexWidth = 6
 	require.Nil(t, err)
 

--- a/pkg/cmd/util/helper_test.go
+++ b/pkg/cmd/util/helper_test.go
@@ -205,7 +205,7 @@ func TestAndWriteExampleReplicaTOML(t *testing.T) {
 			NullString: config.NULL,
 		},
 		Terminator:               "\r\n",
-		DateSeparator:            config.DateSeparatorNone.String(),
+		DateSeparator:            config.DateSeparatorDay.String(),
 		EnablePartitionSeparator: true,
 		Protocol:                 "open-protocol",
 	}, cfg.Sink)

--- a/pkg/config/replica_config.go
+++ b/pkg/config/replica_config.go
@@ -59,7 +59,7 @@ var defaultReplicaConfig = &ReplicaConfig{
 		},
 		EncoderConcurrency:       16,
 		Terminator:               CRLF,
-		DateSeparator:            DateSeparatorNone.String(),
+		DateSeparator:            DateSeparatorDay.String(),
 		EnablePartitionSeparator: true,
 		EnableKafkaSinkV2:        false,
 		TiDBSourceID:             1,

--- a/pkg/sink/cloudstorage/config_test.go
+++ b/pkg/sink/cloudstorage/config_test.go
@@ -37,6 +37,7 @@ func TestConfigApply(t *testing.T) {
 	require.Nil(t, err)
 
 	replicaConfig := config.GetDefaultReplicaConfig()
+	replicaConfig.Sink.DateSeparator = config.DateSeparatorNone.String()
 	err = replicaConfig.ValidateAndAdjust(sinkURI)
 	require.NoError(t, err)
 	cfg := NewConfig()

--- a/pkg/sink/cloudstorage/path_test.go
+++ b/pkg/sink/cloudstorage/path_test.go
@@ -35,6 +35,7 @@ func testFilePathGenerator(ctx context.Context, t *testing.T, dir string) *FileP
 	sinkURI, err := url.Parse(uri)
 	require.NoError(t, err)
 	replicaConfig := config.GetDefaultReplicaConfig()
+	replicaConfig.Sink.DateSeparator = config.DateSeparatorNone.String()
 	replicaConfig.Sink.Protocol = config.ProtocolOpen.String()
 	replicaConfig.Sink.FileIndexWidth = 6
 	cfg := NewConfig()

--- a/tests/integration_tests/api_v2/cases.go
+++ b/tests/integration_tests/api_v2/cases.go
@@ -129,7 +129,7 @@ var defaultReplicaConfig = &ReplicaConfig{
 		},
 		EncoderConcurrency:       16,
 		Terminator:               "\r\n",
-		DateSeparator:            "none",
+		DateSeparator:            "day",
 		EnablePartitionSeparator: true,
 	},
 	Consistent: &ConsistentConfig{


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8997 
cherry pick of #8998 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`Set default value of DateSeparator to day`.
```
