### PR TITLE
sink(ticdc): add table default value definition for storage sink

### DIFF
--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -756,6 +756,7 @@ func getDefaultOrZeroValue(col *timodel.ColumnInfo) (types.Datum, any, int, stri
 	return d, v, size, warn, err
 }
 
+// GetDDLDefaultDefinition returns the default definition of a column.
 func GetDDLDefaultDefinition(col *timodel.ColumnInfo) interface{} {
 	defaultValue := col.GetDefaultValue()
 	if defaultValue == nil {

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -383,7 +383,7 @@ func datum2Column(
 				zap.String("column", colInfo.Name.String()))
 		}
 
-		defaultValue := getDDLDefaultDefinition(colInfo)
+		defaultValue := GetDDLDefaultDefinition(colInfo)
 		offset := tableInfo.RowColumnsOffset[colID]
 		rawCols[offset] = colDatums
 		cols[offset] = &model.Column{
@@ -756,7 +756,7 @@ func getDefaultOrZeroValue(col *timodel.ColumnInfo) (types.Datum, any, int, stri
 	return d, v, size, warn, err
 }
 
-func getDDLDefaultDefinition(col *timodel.ColumnInfo) interface{} {
+func GetDDLDefaultDefinition(col *timodel.ColumnInfo) interface{} {
 	defaultValue := col.GetDefaultValue()
 	if defaultValue == nil {
 		defaultValue = col.GetOriginDefaultValue()

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -1003,7 +1003,7 @@ func TestGetDefaultZeroValue(t *testing.T) {
 	for _, tc := range testCases {
 		_, val, _, _, _ := getDefaultOrZeroValue(&tc.ColInfo)
 		require.Equal(t, tc.Res, val, tc.Name)
-		val = getDDLDefaultDefinition(&tc.ColInfo)
+		val = GetDDLDefaultDefinition(&tc.ColInfo)
 		require.Equal(t, tc.Default, val, tc.Name)
 	}
 }

--- a/pkg/sink/cloudstorage/table_definition_test.go
+++ b/pkg/sink/cloudstorage/table_definition_test.go
@@ -30,22 +30,38 @@ func generateTableDef() (TableDefinition, *model.TableInfo) {
 	var columns []*timodel.ColumnInfo
 	ft := types.NewFieldType(mysql.TypeLong)
 	ft.SetFlag(mysql.PriKeyFlag | mysql.NotNullFlag)
-	col := &timodel.ColumnInfo{Name: timodel.NewCIStr("Id"), FieldType: *ft}
+	col := &timodel.ColumnInfo{
+		Name:         timodel.NewCIStr("Id"),
+		FieldType:    *ft,
+		DefaultValue: 10,
+	}
 	columns = append(columns, col)
 
 	ft = types.NewFieldType(mysql.TypeVarchar)
 	ft.SetFlag(mysql.NotNullFlag)
 	ft.SetFlen(128)
-	col = &timodel.ColumnInfo{Name: timodel.NewCIStr("LastName"), FieldType: *ft}
+	col = &timodel.ColumnInfo{
+		Name:         timodel.NewCIStr("LastName"),
+		FieldType:    *ft,
+		DefaultValue: "Default LastName",
+	}
 	columns = append(columns, col)
 
 	ft = types.NewFieldType(mysql.TypeVarchar)
 	ft.SetFlen(64)
-	col = &timodel.ColumnInfo{Name: timodel.NewCIStr("FirstName"), FieldType: *ft}
+	col = &timodel.ColumnInfo{
+		Name:         timodel.NewCIStr("FirstName"),
+		FieldType:    *ft,
+		DefaultValue: "Default FirstName",
+	}
 	columns = append(columns, col)
 
 	ft = types.NewFieldType(mysql.TypeDatetime)
-	col = &timodel.ColumnInfo{Name: timodel.NewCIStr("Birthday"), FieldType: *ft}
+	col = &timodel.ColumnInfo{
+		Name:         timodel.NewCIStr("Birthday"),
+		FieldType:    *ft,
+		DefaultValue: 12345678,
+	}
 	columns = append(columns, col)
 
 	tableInfo := &model.TableInfo{
@@ -380,22 +396,26 @@ func TestTableDefinition(t *testing.T) {
 				"ColumnName": "Id",
 				"ColumnType": "INT",
 				"ColumnPrecision": "11",
+				"ColumnDefault":10,
 				"ColumnNullable": "false",
 				"ColumnIsPk": "true"
 			},
 			{
 				"ColumnName": "LastName",
 				"ColumnType": "VARCHAR",
+				"ColumnDefault":"Default LastName",
 				"ColumnPrecision": "128",
 				"ColumnNullable": "false"
 			},
 			{
 				"ColumnName": "FirstName",
+				"ColumnDefault":"Default FirstName",
 				"ColumnType": "VARCHAR",
 				"ColumnPrecision": "64"
 			},
 			{
 				"ColumnName": "Birthday",
+				"ColumnDefault":1.2345678e+07,
 				"ColumnType": "DATETIME"
 			}
 		],
@@ -424,22 +444,26 @@ func TestTableDefinition(t *testing.T) {
 				"ColumnName": "Id",
 				"ColumnType": "INT",
 				"ColumnPrecision": "11",
+				"ColumnDefault":10,
 				"ColumnNullable": "false",
 				"ColumnIsPk": "true"
 			},
 			{
 				"ColumnName": "LastName",
 				"ColumnType": "VARCHAR",
+				"ColumnDefault":"Default LastName",
 				"ColumnPrecision": "128",
 				"ColumnNullable": "false"
 			},
 			{
 				"ColumnName": "FirstName",
+				"ColumnDefault":"Default FirstName",
 				"ColumnType": "VARCHAR",
 				"ColumnPrecision": "64"
 			},
 			{
 				"ColumnName": "Birthday",
+				"ColumnDefault":1.2345678e+07,
 				"ColumnType": "DATETIME"
 			}
 		],
@@ -471,7 +495,7 @@ func TestTableDefinitionGenFilePath(t *testing.T) {
 	def, _ := generateTableDef()
 	tablePath, err := def.GenerateSchemaFilePath()
 	require.NoError(t, err)
-	require.Equal(t, "schema1/table1/meta/schema_100_0785427252.json", tablePath)
+	require.Equal(t, "schema1/table1/meta/schema_100_3752767265.json", tablePath)
 }
 
 func TestTableDefinitionSum32(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9066

### What is changed and how it works?
add table default value definition for storage sink

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?
need to update user documentation

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`Add table default value definition for storage sink`.
```
