### PR TITLE
kafka(ticdc): use context to close the mq dml sink and the metrics collector

### DIFF
--- a/pkg/sink/kafka/factory.go
+++ b/pkg/sink/kafka/factory.go
@@ -227,8 +227,14 @@ func (p *saramaAsyncProducer) AsyncRunCallback(
 	for {
 		select {
 		case <-ctx.Done():
+			log.Info("async producer exit since context is done",
+				zap.String("namespace", p.changefeedID.Namespace),
+				zap.String("changefeed", p.changefeedID.ID))
 			return errors.Trace(ctx.Err())
 		case <-p.closedChan:
+			log.Info("async producer exit since receive closed signal",
+				zap.String("namespace", p.changefeedID.Namespace),
+				zap.String("changefeed", p.changefeedID.ID))
 			return nil
 		case err := <-p.failpointCh:
 			log.Warn("Receive from failpoint chan in kafka "+

--- a/pkg/sink/kafka/metrics_collector.go
+++ b/pkg/sink/kafka/metrics_collector.go
@@ -80,6 +80,9 @@ func (m *saramaMetricsCollector) Run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			log.Info("Kafka metrics collector stopped",
+				zap.String("namespace", m.changefeedID.Namespace),
+				zap.String("changefeed", m.changefeedID.ID))
 			return
 		case <-ticker.C:
 			m.updateBrokers(ctx)

--- a/pkg/sink/kafka/v2/metrics_collector.go
+++ b/pkg/sink/kafka/v2/metrics_collector.go
@@ -17,9 +17,11 @@ import (
 	"context"
 	"time"
 
+	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/cdc/model"
 	pkafka "github.com/pingcap/tiflow/pkg/sink/kafka"
 	"github.com/pingcap/tiflow/pkg/util"
+	"go.uber.org/zap"
 )
 
 // MetricsCollector is the kafka metrics collector based on kafka-go library.
@@ -53,6 +55,9 @@ func (m *MetricsCollector) Run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			log.Info("Kafka metrics collector stopped",
+				zap.String("namespace", m.changefeedID.Namespace),
+				zap.String("changefeed", m.changefeedID.ID))
 			return
 		case <-ticker.C:
 			m.collectMetrics()


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9041 

### What is changed and how it works?

* add a context to the kafka dml producer to control close the underline metrics collector and the producer running goroutine

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
