### PR TITLE
codec(ticdc): fix avro decode update event incorrectly and do not verify empty checksum

### DIFF
--- a/pkg/sink/codec/avro/avro.go
+++ b/pkg/sink/codec/avro/avro.go
@@ -26,6 +26,7 @@ import (
 	"github.com/linkedin/goavro/v2"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
+	timodel "github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/rowcodec"
@@ -167,6 +168,14 @@ func (a *BatchEncoder) EncodeCheckpointEvent(ts uint64) (*common.Message, error)
 	return nil, nil
 }
 
+type ddlEvent struct {
+	Query    string             `json:"query"`
+	Type     timodel.ActionType `json:"type"`
+	Schema   string             `json:"schema"`
+	Table    string             `json:"table"`
+	CommitTs uint64             `json:"commitTs"`
+}
+
 // EncodeDDLEvent only encode DDL event if the watermark event is enabled
 // it's only used for the testing purpose.
 func (a *BatchEncoder) EncodeDDLEvent(e *model.DDLEvent) (*common.Message, error) {
@@ -174,7 +183,14 @@ func (a *BatchEncoder) EncodeDDLEvent(e *model.DDLEvent) (*common.Message, error
 		buf := new(bytes.Buffer)
 		_ = binary.Write(buf, binary.BigEndian, ddlByte)
 
-		bytes, err := json.Marshal(e)
+		event := &ddlEvent{
+			Query:    e.Query,
+			Type:     e.Type,
+			Schema:   e.TableInfo.TableName.Schema,
+			Table:    e.TableInfo.TableName.Table,
+			CommitTs: e.CommitTs,
+		}
+		bytes, err := json.Marshal(event)
 		if err != nil {
 			return nil, cerror.WrapError(cerror.ErrAvroToEnvelopeError, err)
 		}

--- a/pkg/sink/codec/avro/decoder.go
+++ b/pkg/sink/codec/avro/decoder.go
@@ -218,18 +218,9 @@ func (d *decoder) NextRowChangedEvent() (*model.RowChangedEvent, error) {
 		columns = append(columns, col)
 	}
 
-	var (
-		operation string
-		commitTs  int64
-	)
+	var commitTs int64
 	if !isDelete {
-		o, ok := valueMap[tidbOp]
-		if !ok {
-			return nil, errors.New("operation not found")
-		}
-		operation = o.(string)
-
-		o, ok = valueMap[tidbCommitTs]
+		o, ok := valueMap[tidbCommitTs]
 		if !ok {
 			return nil, errors.New("commit ts not found")
 		}
@@ -281,12 +272,8 @@ func (d *decoder) NextRowChangedEvent() (*model.RowChangedEvent, error) {
 		Schema: schemaName,
 		Table:  tableName,
 	}
+	event.Columns = columns
 
-	if operation == insertOperation {
-		event.Columns = columns
-	} else {
-		event.PreColumns = columns
-	}
 	return event, nil
 }
 

--- a/pkg/sink/codec/avro/decoder.go
+++ b/pkg/sink/codec/avro/decoder.go
@@ -296,14 +296,24 @@ func (d *decoder) NextDDLEvent() (*model.DDLEvent, error) {
 		return nil, fmt.Errorf("first byte is not the ddl byte, but got: %+v", d.value[0])
 	}
 
-	result := new(model.DDLEvent)
 	data := d.value[1:]
-
-	err := json.Unmarshal(data, &result)
+	var baseDDLEvent ddlEvent
+	err := json.Unmarshal(data, &baseDDLEvent)
 	if err != nil {
 		return nil, errors.WrapError(errors.ErrDecodeFailed, err)
 	}
 	d.value = nil
+
+	result := new(model.DDLEvent)
+	result.TableInfo = new(model.TableInfo)
+	result.CommitTs = baseDDLEvent.CommitTs
+	result.TableInfo.TableName = model.TableName{
+		Schema: baseDDLEvent.Schema,
+		Table:  baseDDLEvent.Table,
+	}
+	result.Type = baseDDLEvent.Type
+	result.Query = baseDDLEvent.Query
+
 	return result, nil
 }
 

--- a/pkg/sink/codec/avro/decoder_test.go
+++ b/pkg/sink/codec/avro/decoder_test.go
@@ -183,7 +183,6 @@ func TestDecodeDDLEvent(t *testing.T) {
 	decodedEvent, err := decoder.NextDDLEvent()
 	require.NoError(t, err)
 	require.NotNil(t, decodedEvent)
-	require.Equal(t, uint64(1020), decodedEvent.StartTs)
 	require.Equal(t, uint64(1030), decodedEvent.CommitTs)
 	require.Equal(t, timodel.ActionAddColumn, decodedEvent.Type)
 	require.Equal(t, "ALTER TABLE test.t1 ADD COLUMN a int", decodedEvent.Query)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9069 

### What is changed and how it works?

* encode DDL event simply to prevent send too much to the kafka.
* fix avro decoder verify empty checksum
* set columns correctly for the update event


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
