### PR TITLE
sink(cdc): close MemoryQuota to stop SinkManager correctly

### DIFF
--- a/cdc/processor/memquota/mem_quota.go
+++ b/cdc/processor/memquota/mem_quota.go
@@ -14,6 +14,7 @@
 package memquota
 
 import (
+	"context"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -22,7 +23,6 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/processor/tablepb"
-	cerrors "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/spanz"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -124,7 +124,7 @@ func (m *MemQuota) ForceAcquire(nBytes uint64) {
 func (m *MemQuota) BlockAcquire(nBytes uint64) error {
 	for {
 		if m.isClosed.Load() {
-			return cerrors.ErrFlowControllerAborted.GenWithStackByArgs()
+			return context.Canceled
 		}
 		usedBytes := m.usedBytes.Load()
 		if usedBytes+nBytes > m.totalBytes {

--- a/cdc/processor/memquota/mem_quota_test.go
+++ b/cdc/processor/memquota/mem_quota_test.go
@@ -14,11 +14,11 @@
 package memquota
 
 import (
+	"context"
 	"sync"
 	"testing"
 
 	"github.com/pingcap/tiflow/cdc/model"
-	cerrors "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/spanz"
 	"github.com/stretchr/testify/require"
 )
@@ -92,7 +92,7 @@ func TestMemQuotaClose(t *testing.T) {
 		defer wg.Done()
 		err := m.BlockAcquire(50)
 		if err != nil {
-			require.ErrorIs(t, err, cerrors.ErrFlowControllerAborted)
+			require.ErrorIs(t, err, context.Canceled)
 		}
 	}()
 	wg.Add(1)
@@ -100,7 +100,7 @@ func TestMemQuotaClose(t *testing.T) {
 		defer wg.Done()
 		err := m.BlockAcquire(50)
 		if err != nil {
-			require.ErrorIs(t, err, cerrors.ErrFlowControllerAborted)
+			require.ErrorIs(t, err, context.Canceled)
 		}
 	}()
 	wg.Add(1)
@@ -108,7 +108,7 @@ func TestMemQuotaClose(t *testing.T) {
 		defer wg.Done()
 		err := m.BlockAcquire(50)
 		if err != nil {
-			require.ErrorIs(t, err, cerrors.ErrFlowControllerAborted)
+			require.ErrorIs(t, err, context.Canceled)
 		}
 	}()
 

--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -171,13 +171,13 @@ func New(
 }
 
 // Run implements util.Runnable.
+// When it returns, all sub-goroutines should be closed.
 func (m *SinkManager) Run(ctx context.Context, warnings ...chan<- error) (err error) {
 	m.managerCtx, m.managerCancel = context.WithCancel(ctx)
 	m.wg.Add(1) // So `SinkManager.Close` will also wait the function.
 	defer func() {
-		m.managerCancel()
 		m.wg.Done()
-		m.wg.Wait()
+		m.waitSubroutines()
 		log.Info("Sink manager exists",
 			zap.String("namespace", m.changefeedID.Namespace),
 			zap.String("changefeed", m.changefeedID.ID),
@@ -964,6 +964,17 @@ func (m *SinkManager) WaitForReady(ctx context.Context) {
 	}
 }
 
+// wait all sub-routines associated with `m.wg` returned.
+func (m *SinkManager) waitSubroutines() {
+	m.managerCancel()
+	// Sink workers and redo workers can be blocked on MemQuota.BlockAcquire,
+	// which doesn't watch m.managerCtx. So we must close these 2 MemQuotas
+	// before wait them.
+	m.sinkMemQuota.Close()
+	m.redoMemQuota.Close()
+	m.wg.Wait()
+}
+
 // Close closes the manager. Must be called after `Run` returned.
 func (m *SinkManager) Close() {
 	log.Info("Closing sink manager",
@@ -971,10 +982,7 @@ func (m *SinkManager) Close() {
 		zap.String("changefeed", m.changefeedID.ID))
 
 	start := time.Now()
-	m.managerCancel()
-	m.wg.Wait()
-	m.sinkMemQuota.Close()
-	m.redoMemQuota.Close()
+	m.waitSubroutines()
 	m.tableSinks.Range(func(_ tablepb.Span, value interface{}) bool {
 		sink := value.(*tableSinkWrapper)
 		sink.close()

--- a/cdc/processor/sinkmanager/redo_log_advancer_test.go
+++ b/cdc/processor/sinkmanager/redo_log_advancer_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pingcap/tiflow/cdc/processor/sourcemanager/engine"
 	"github.com/pingcap/tiflow/cdc/processor/tablepb"
 	"github.com/pingcap/tiflow/cdc/redo"
-	cerrors "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/spanz"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -479,7 +478,7 @@ func (suite *redoLogAdvancerSuite) TestTryAdvanceAndBlockAcquireWithSplitTxn() {
 			false,
 		)
 		require.False(suite.T(), advanced)
-		require.ErrorIs(suite.T(), err, cerrors.ErrFlowControllerAborted)
+		require.ErrorIs(suite.T(), err, context.Canceled)
 		down <- struct{}{}
 	}()
 

--- a/cdc/processor/sinkmanager/redo_log_worker_test.go
+++ b/cdc/processor/sinkmanager/redo_log_worker_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/tiflow/cdc/processor/sourcemanager/engine"
 	"github.com/pingcap/tiflow/cdc/processor/sourcemanager/engine/memory"
 	"github.com/pingcap/tiflow/cdc/processor/tablepb"
-	cerrors "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/spanz"
 	"github.com/pingcap/tiflow/pkg/upstream"
 	"github.com/stretchr/testify/require"
@@ -210,7 +209,7 @@ func (suite *redoLogWorkerSuite) TestHandleTaskAbortWhenNoMemAndBlocked() {
 	go func() {
 		defer wg.Done()
 		err := w.handleTasks(ctx, taskChan)
-		require.ErrorIs(suite.T(), err, cerrors.ErrFlowControllerAborted)
+		require.ErrorIs(suite.T(), err, context.Canceled)
 	}()
 
 	callback := func(lastWritePos engine.Position) {

--- a/cdc/processor/sinkmanager/table_sink_advancer_test.go
+++ b/cdc/processor/sinkmanager/table_sink_advancer_test.go
@@ -14,6 +14,7 @@
 package sinkmanager
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -22,7 +23,6 @@ import (
 	"github.com/pingcap/tiflow/cdc/processor/memquota"
 	"github.com/pingcap/tiflow/cdc/processor/sourcemanager/engine"
 	"github.com/pingcap/tiflow/cdc/processor/tablepb"
-	cerrors "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/spanz"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -746,7 +746,7 @@ func (suite *tableSinkAdvancerSuite) TestTryAdvanceAndBlockAcquireWithSplitTxn()
 			false,
 			false,
 		)
-		require.ErrorIs(suite.T(), err, cerrors.ErrFlowControllerAborted)
+		require.ErrorIs(suite.T(), err, context.Canceled)
 		down <- struct{}{}
 	}()
 

--- a/cdc/processor/sinkmanager/table_sink_worker_test.go
+++ b/cdc/processor/sinkmanager/table_sink_worker_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/tiflow/cdc/processor/sourcemanager/engine"
 	"github.com/pingcap/tiflow/cdc/processor/sourcemanager/engine/memory"
 	"github.com/pingcap/tiflow/cdc/processor/tablepb"
-	cerrors "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/spanz"
 	"github.com/pingcap/tiflow/pkg/upstream"
 	"github.com/stretchr/testify/require"
@@ -294,7 +293,7 @@ func (suite *tableSinkWorkerSuite) TestHandleTaskWithSplitTxnAndAbortWhenNoMemAn
 	go func() {
 		defer wg.Done()
 		err := w.handleTasks(ctx, taskChan)
-		require.ErrorIs(suite.T(), err, cerrors.ErrFlowControllerAborted)
+		require.ErrorIs(suite.T(), err, context.Canceled)
 	}()
 
 	wrapper, sink := createTableSinkWrapper(suite.testChangefeedID, suite.testSpan)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9073
Issue Number: close #9067 

### What is changed and how it works?

In `SinkManager.Run` or `SinkManager.Close`, we wait a `WaitGroup`, which is associated to sink workers and redo workers.
But sink workers and redo workers can be blocked on `MemQuota.BlockAcquire`, so the wait can't be finished forever.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
