### PR TITLE
codec(ticdc): refactor avro encoder to use code config directly to avoid duplicate option

### DIFF
--- a/cmd/kafka-consumer/main.go
+++ b/cmd/kafka-consumer/main.go
@@ -49,6 +49,7 @@ import (
 	"github.com/pingcap/tiflow/pkg/sink/codec"
 	"github.com/pingcap/tiflow/pkg/sink/codec/avro"
 	"github.com/pingcap/tiflow/pkg/sink/codec/canal"
+	"github.com/pingcap/tiflow/pkg/sink/codec/common"
 	"github.com/pingcap/tiflow/pkg/sink/codec/open"
 	"github.com/pingcap/tiflow/pkg/spanz"
 	"github.com/pingcap/tiflow/pkg/util"
@@ -567,12 +568,13 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 	case config.ProtocolCanalJSON:
 		decoder = canal.NewBatchDecoder(c.enableTiDBExtension, "")
 	case config.ProtocolAvro:
-		decoder = avro.NewDecoder(&avro.Options{
+		config := &common.Config{
 			EnableTiDBExtension: c.enableTiDBExtension,
 			EnableRowChecksum:   c.enableRowChecksum,
 			// avro must set this to true to make the consumer works.
-			EnableWatermarkEvent: true,
-		}, c.keySchemaM, c.valueSchemaM, kafkaTopic, c.tz)
+			AvroEnableWatermark: true,
+		}
+		decoder = avro.NewDecoder(config, c.keySchemaM, c.valueSchemaM, kafkaTopic, c.tz)
 	default:
 		log.Panic("Protocol not supported", zap.Any("Protocol", c.protocol))
 	}

--- a/pkg/sink/codec/avro/avro.go
+++ b/pkg/sink/codec/avro/avro.go
@@ -42,27 +42,12 @@ import (
 
 // BatchEncoder converts the events to binary Avro data
 type BatchEncoder struct {
-	*Options
-
 	namespace          string
 	keySchemaManager   *SchemaManager
 	valueSchemaManager *SchemaManager
 	result             []*common.Message
-}
 
-// Options is used to initialize the encoder, control the encoding behavior.
-type Options struct {
-	EnableTiDBExtension bool
-	EnableRowChecksum   bool
-
-	// EnableWatermarkEvent set to true, avro encode DDL and checkpoint event
-	// and send to the downstream kafka, they cannot be consumed by the confluent official consumer
-	// and would cause error, so this is only used for ticdc internal testing purpose, should not be
-	// exposed to the outside users.
-	EnableWatermarkEvent bool
-
-	DecimalHandlingMode        string
-	BigintUnsignedHandlingMode string
+	config *common.Config
 }
 
 type avroEncodeInput struct {
@@ -152,7 +137,7 @@ func (a *BatchEncoder) AppendRowChangedEvent(
 // EncodeCheckpointEvent only encode checkpoint event if the watermark event is enabled
 // it's only used for the testing purpose.
 func (a *BatchEncoder) EncodeCheckpointEvent(ts uint64) (*common.Message, error) {
-	if a.EnableTiDBExtension && a.EnableWatermarkEvent {
+	if a.config.EnableTiDBExtension && a.config.AvroEnableWatermark {
 		buf := new(bytes.Buffer)
 		data := []interface{}{checkpointByte, ts}
 		for _, v := range data {
@@ -179,7 +164,7 @@ type ddlEvent struct {
 // EncodeDDLEvent only encode DDL event if the watermark event is enabled
 // it's only used for the testing purpose.
 func (a *BatchEncoder) EncodeDDLEvent(e *model.DDLEvent) (*common.Message, error) {
-	if a.EnableTiDBExtension && a.EnableWatermarkEvent {
+	if a.config.EnableTiDBExtension && a.config.AvroEnableWatermark {
 		buf := new(bytes.Buffer)
 		_ = binary.Write(buf, binary.BigEndian, ddlByte)
 
@@ -246,8 +231,8 @@ func (a *BatchEncoder) avroEncode(
 			colInfos: e.ColInfos,
 		}
 
-		enableTiDBExtension = a.EnableTiDBExtension
-		enableRowLevelChecksum = a.EnableRowChecksum
+		enableTiDBExtension = a.config.EnableTiDBExtension
+		enableRowLevelChecksum = a.config.EnableRowChecksum
 		schemaManager = a.valueSchemaManager
 		if e.IsInsert() {
 			operation = insertOperation
@@ -272,8 +257,8 @@ func (a *BatchEncoder) avroEncode(
 			input,
 			enableTiDBExtension,
 			enableRowLevelChecksum,
-			a.DecimalHandlingMode,
-			a.BigintUnsignedHandlingMode,
+			a.config.AvroDecimalHandlingMode,
+			a.config.AvroBigintUnsignedHandlingMode,
 		)
 		if err != nil {
 			log.Error("AvroEventBatchEncoder: generating schema failed", zap.Error(err))
@@ -297,8 +282,8 @@ func (a *BatchEncoder) avroEncode(
 		e.CommitTs,
 		operation,
 		enableTiDBExtension,
-		a.DecimalHandlingMode,
-		a.BigintUnsignedHandlingMode,
+		a.config.AvroDecimalHandlingMode,
+		a.config.AvroBigintUnsignedHandlingMode,
 	)
 	if err != nil {
 		log.Error("AvroEventBatchEncoder: converting to native failed", zap.Error(err))
@@ -1025,13 +1010,7 @@ func (b *batchEncoderBuilder) Build() codec.RowEventEncoder {
 		keySchemaManager:   b.keySchemaManager,
 		valueSchemaManager: b.valueSchemaManager,
 		result:             make([]*common.Message, 0, 1),
-		Options: &Options{
-			EnableTiDBExtension:        b.config.EnableTiDBExtension,
-			EnableRowChecksum:          b.config.EnableRowChecksum,
-			EnableWatermarkEvent:       b.config.AvroEnableWatermark,
-			DecimalHandlingMode:        b.config.AvroDecimalHandlingMode,
-			BigintUnsignedHandlingMode: b.config.AvroBigintUnsignedHandlingMode,
-		},
+		config:             b.config,
 	}
 	return encoder
 }

--- a/pkg/sink/codec/avro/avro_test.go
+++ b/pkg/sink/codec/avro/avro_test.go
@@ -35,7 +35,7 @@ import (
 
 func setupEncoderAndSchemaRegistry(
 	ctx context.Context,
-	o *Options,
+	config *common.Config,
 ) (*BatchEncoder, error) {
 	startHTTPInterceptForTestingRegistry()
 	keySchemaM, valueSchemaM, err := NewKeyAndValueSchemaManagers(ctx, "http://127.0.0.1:8081", nil)
@@ -48,7 +48,7 @@ func setupEncoderAndSchemaRegistry(
 		valueSchemaManager: valueSchemaM,
 		keySchemaManager:   keySchemaM,
 		result:             make([]*common.Message, 0, 1),
-		Options:            o,
+		config:             config,
 	}, nil
 }
 
@@ -765,17 +765,17 @@ func TestRowToAvroData(t *testing.T) {
 }
 
 func TestAvroEncode4EnableChecksum(t *testing.T) {
-	o := &Options{
-		EnableTiDBExtension:        true,
-		EnableRowChecksum:          true,
-		DecimalHandlingMode:        "string",
-		BigintUnsignedHandlingMode: "string",
+	config := &common.Config{
+		EnableTiDBExtension:            true,
+		EnableRowChecksum:              true,
+		AvroDecimalHandlingMode:        "string",
+		AvroBigintUnsignedHandlingMode: "string",
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	encoder, err := setupEncoderAndSchemaRegistry(ctx, o)
+	encoder, err := setupEncoderAndSchemaRegistry(ctx, config)
 	defer teardownEncoderAndSchemaRegistry()
 	require.NoError(t, err)
 	require.NotNil(t, encoder)
@@ -865,16 +865,16 @@ func TestAvroEncode4EnableChecksum(t *testing.T) {
 }
 
 func TestAvroEncode(t *testing.T) {
-	o := &Options{
-		EnableTiDBExtension:        true,
-		EnableRowChecksum:          false,
-		DecimalHandlingMode:        "precise",
-		BigintUnsignedHandlingMode: "long",
+	config := &common.Config{
+		EnableTiDBExtension:            true,
+		EnableRowChecksum:              false,
+		AvroDecimalHandlingMode:        "precise",
+		AvroBigintUnsignedHandlingMode: "long",
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	encoder, err := setupEncoderAndSchemaRegistry(ctx, o)
+	encoder, err := setupEncoderAndSchemaRegistry(ctx, config)
 	defer teardownEncoderAndSchemaRegistry()
 	require.NoError(t, err)
 	require.NotNil(t, encoder)
@@ -1065,16 +1065,16 @@ func TestGetAvroNamespace(t *testing.T) {
 }
 
 func TestArvoAppendRowChangedEventWithCallback(t *testing.T) {
-	o := &Options{
-		EnableTiDBExtension:        true,
-		EnableRowChecksum:          false,
-		DecimalHandlingMode:        "precise",
-		BigintUnsignedHandlingMode: "long",
+	config := &common.Config{
+		EnableTiDBExtension:            true,
+		EnableRowChecksum:              false,
+		AvroDecimalHandlingMode:        "precise",
+		AvroBigintUnsignedHandlingMode: "long",
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	encoder, err := setupEncoderAndSchemaRegistry(ctx, o)
+	encoder, err := setupEncoderAndSchemaRegistry(ctx, config)
 	defer teardownEncoderAndSchemaRegistry()
 	require.NoError(t, err)
 	require.NotNil(t, encoder)

--- a/pkg/sink/codec/avro/decoder.go
+++ b/pkg/sink/codec/avro/decoder.go
@@ -31,13 +31,14 @@ import (
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/sink/codec"
+	"github.com/pingcap/tiflow/pkg/sink/codec/common"
 	"go.uber.org/zap"
 )
 
 type decoder struct {
-	*Options
-	topic string
-	sc    *stmtctx.StatementContext
+	config *common.Config
+	topic  string
+	sc     *stmtctx.StatementContext
 
 	keySchemaM   *SchemaManager
 	valueSchemaM *SchemaManager
@@ -48,14 +49,14 @@ type decoder struct {
 
 // NewDecoder return an avro decoder
 func NewDecoder(
-	o *Options,
+	config *common.Config,
 	keySchemaM *SchemaManager,
 	valueSchemaM *SchemaManager,
 	topic string,
 	tz *time.Location,
 ) codec.RowEventDecoder {
 	return &decoder{
-		Options:      o,
+		config:       config,
 		topic:        topic,
 		keySchemaM:   keySchemaM,
 		valueSchemaM: valueSchemaM,

--- a/pkg/sink/codec/avro/decoder_test.go
+++ b/pkg/sink/codec/avro/decoder_test.go
@@ -30,16 +30,16 @@ import (
 )
 
 func TestDecodeEvent(t *testing.T) {
-	o := &Options{
-		EnableTiDBExtension:        true,
-		DecimalHandlingMode:        "precise",
-		BigintUnsignedHandlingMode: "long",
+	config := &common.Config{
+		EnableTiDBExtension:            true,
+		AvroDecimalHandlingMode:        "precise",
+		AvroBigintUnsignedHandlingMode: "long",
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	encoder, err := setupEncoderAndSchemaRegistry(ctx, o)
+	encoder, err := setupEncoderAndSchemaRegistry(ctx, config)
 	defer teardownEncoderAndSchemaRegistry()
 	require.NoError(t, err)
 	require.NotNil(t, encoder)
@@ -123,7 +123,7 @@ func TestDecodeEvent(t *testing.T) {
 
 	tz, err := util.GetLocalTimezone()
 	require.NoError(t, err)
-	decoder := NewDecoder(o, keySchemaM, valueSchemaM, topic, tz)
+	decoder := NewDecoder(config, keySchemaM, valueSchemaM, topic, tz)
 	err = decoder.AddKeyValue(message.Key, message.Value)
 	require.NoError(t, err)
 
@@ -140,15 +140,15 @@ func TestDecodeEvent(t *testing.T) {
 func TestDecodeDDLEvent(t *testing.T) {
 	t.Parallel()
 
-	o := &Options{
-		EnableTiDBExtension:  true,
-		EnableWatermarkEvent: true,
+	config := &common.Config{
+		EnableTiDBExtension: true,
+		AvroEnableWatermark: true,
 	}
 
 	encoder := &BatchEncoder{
 		namespace: model.DefaultNamespace,
 		result:    make([]*common.Message, 0, 1),
-		Options:   o,
+		config:    config,
 	}
 
 	message, err := encoder.EncodeDDLEvent(&model.DDLEvent{
@@ -171,7 +171,7 @@ func TestDecodeDDLEvent(t *testing.T) {
 	topic := "test-topic"
 	tz, err := util.GetLocalTimezone()
 	require.NoError(t, err)
-	decoder := NewDecoder(o, nil, nil, topic, tz)
+	decoder := NewDecoder(config, nil, nil, topic, tz)
 	err = decoder.AddKeyValue(message.Key, message.Value)
 	require.NoError(t, err)
 
@@ -195,14 +195,14 @@ func TestDecodeDDLEvent(t *testing.T) {
 func TestDecodeResolvedEvent(t *testing.T) {
 	t.Parallel()
 
-	o := &Options{
-		EnableTiDBExtension:  true,
-		EnableWatermarkEvent: true,
+	config := &common.Config{
+		EnableTiDBExtension: true,
+		AvroEnableWatermark: true,
 	}
 
 	encoder := &BatchEncoder{
 		namespace: model.DefaultNamespace,
-		Options:   o,
+		config:    config,
 		result:    make([]*common.Message, 0, 1),
 	}
 
@@ -214,7 +214,7 @@ func TestDecodeResolvedEvent(t *testing.T) {
 	topic := "test-topic"
 	tz, err := util.GetLocalTimezone()
 	require.NoError(t, err)
-	decoder := NewDecoder(o, nil, nil, topic, tz)
+	decoder := NewDecoder(config, nil, nil, topic, tz)
 	err = decoder.AddKeyValue(message.Key, message.Value)
 	require.NoError(t, err)
 

--- a/pkg/sink/codec/common/config.go
+++ b/pkg/sink/codec/common/config.go
@@ -49,6 +49,10 @@ type Config struct {
 	AvroDecimalHandlingMode        string
 	AvroBigintUnsignedHandlingMode string
 
+	// EnableWatermarkEvent set to true, avro encode DDL and checkpoint event
+	// and send to the downstream kafka, they cannot be consumed by the confluent official consumer
+	// and would cause error, so this is only used for ticdc internal testing purpose, should not be
+	// exposed to the outside users.
 	AvroEnableWatermark bool
 
 	// for sinking to cloud storage


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9137 

### What is changed and how it works?

* avro use codec `common.Config`, and remove `Options`

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
