### PR TITLE
chngefeed (ticdc): move resolvedTs into globalBarrierTs when redo log is enabled.

### DIFF
--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -372,7 +372,7 @@ func (c *changefeed) tick(ctx cdcContext.Context, captures map[model.CaptureID]*
 	// 再在 redo 开启时候用 resolvedTs 限制 barrierTs 了
 	newCheckpointTs, newResolvedTs, err := c.scheduler.Tick(
 		ctx, preCheckpointTs, allPhysicalTables, captures,
-		barrier.BarrierWithMinTs, c.redoDDLMgr.Enabled())
+		barrier.BarrierWithMinTs)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -524,7 +524,6 @@ LOOP2:
 
 	c.barriers = newBarriers()
 	if util.GetOrZero(c.state.Info.Config.EnableSyncPoint) {
-		log.Info("fizz sync point is enabled", zap.String("changefeed", c.id.String()))
 		c.barriers.Update(syncPointBarrier, resolvedTs)
 	}
 	c.barriers.Update(finishBarrier, c.state.Info.GetTargetTs())

--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -398,18 +398,6 @@ func (c *changefeed) tick(ctx cdcContext.Context, captures map[model.CaptureID]*
 	}
 
 	prevResolvedTs := c.state.Status.ResolvedTs
-	// If allPhysicalTables is empty, newCheckpointTs would advance to min table barrier ts, which may be larger
-	// than preResolvedTs. In this case, we need to set newCheckpointTs to preResolvedTs to guarantee that the
-	// checkpointTs will not cross the preResolvedTs.
-	if newCheckpointTs > prevResolvedTs {
-		newCheckpointTs = prevResolvedTs
-		if newCheckpointTs < preCheckpointTs {
-			log.Panic("checkpointTs should never regress",
-				zap.Uint64("newCheckpointTs", newCheckpointTs),
-				zap.Uint64("checkpointTs", preCheckpointTs))
-		}
-	}
-
 	log.Debug("owner prepares to update status",
 		zap.Uint64("prevResolvedTs", prevResolvedTs),
 		zap.Uint64("newResolvedTs", newResolvedTs),

--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -960,16 +960,15 @@ func (c *changefeed) handleBarrier(ctx cdcContext.Context, barrier *ddlBarrier) 
 
 	if c.redoMetaMgr.Enabled() {
 		flushedMeta := c.redoMetaMgr.GetFlushedMeta()
-		_, flushedResolvedTs := flushedMeta.CheckpointTs, flushedMeta.ResolvedTs
-		if flushedResolvedTs != 0 && flushedResolvedTs < barrier.GlobalBarrierTs {
+		if flushedMeta.ResolvedTs != 0 && flushedMeta.ResolvedTs < barrier.GlobalBarrierTs {
 			// todo: remove this log after fully tested
 			log.Info("fizz redo meta resolved ts is less than barrier ts, use it as barrier ts",
 				zap.Uint64("globalBarrier", barrier.GlobalBarrierTs),
-				zap.Uint64("flushedResolvedTs", flushedResolvedTs))
-			barrier.GlobalBarrierTs = flushedResolvedTs
+				zap.Uint64("flushedResolvedTs", flushedMeta.ResolvedTs))
+			barrier.GlobalBarrierTs = flushedMeta.ResolvedTs
 		}
 		if barrier.GlobalBarrierTs > barrier.redoBarrierTs {
-			barrier.redoBarrierTs = barrier.GlobalBarrierTs
+			barrier.GlobalBarrierTs = barrier.redoBarrierTs
 		}
 	}
 

--- a/cdc/owner/changefeed_test.go
+++ b/cdc/owner/changefeed_test.go
@@ -16,7 +16,6 @@ package owner
 import (
 	"context"
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -28,6 +27,7 @@ import (
 	"github.com/pingcap/tiflow/cdc/entry"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/puller"
+	credo "github.com/pingcap/tiflow/cdc/redo"
 	"github.com/pingcap/tiflow/cdc/scheduler"
 	"github.com/pingcap/tiflow/cdc/scheduler/schedulepb"
 	"github.com/pingcap/tiflow/pkg/config"
@@ -164,7 +164,7 @@ func (m *mockScheduler) Tick(
 	checkpointTs model.Ts,
 	currentTables []model.TableID,
 	captures map[model.CaptureID]*model.CaptureInfo,
-	barrier schedulepb.BarrierWithMinTs,
+	barrier *schedulepb.BarrierWithMinTs,
 ) (newCheckpointTs, newResolvedTs model.Ts, err error) {
 	m.currentTables = currentTables
 	return barrier.MinTableBarrierTs, barrier.GlobalBarrierTs, nil
@@ -224,7 +224,7 @@ func createChangefeed4Test(ctx cdcContext.Context, t *testing.T,
 		// new scheduler
 		func(
 			ctx cdcContext.Context, up *upstream.Upstream, epoch uint64,
-			cfg *config.SchedulerConfig,
+			cfg *config.SchedulerConfig, redoMetaManager credo.MetaManager,
 		) (scheduler.Scheduler, error) {
 			return &mockScheduler{}, nil
 		},
@@ -605,21 +605,28 @@ func TestBarrierAdvance(t *testing.T) {
 		cf.state.Status = &model.ChangeFeedStatus{
 			ResolvedTs:        cf.state.Info.StartTs + 10,
 			CheckpointTs:      cf.state.Info.StartTs,
-			MinTableBarrierTs: cf.state.Info.StartTs,
+			MinTableBarrierTs: cf.state.Info.StartTs + 5,
 		}
 		// Do the preflightCheck and initialize the changefeed.
 		cf.Tick(ctx, captures)
 		tester.MustApplyPatches()
+		if i == 1 {
+			cf.ddlManager.ddlResolvedTs += 10
+		}
+		_, barrier, err := cf.ddlManager.tick(ctx, cf.state.Status.CheckpointTs, nil)
 
-		barrier, err := cf.handleBarrier(ctx)
+		require.Nil(t, err)
+
+		err = cf.handleBarrier(ctx, barrier)
 		require.Nil(t, err)
 
 		if i == 0 {
-			require.Equal(t, uint64(math.MaxUint64), barrier)
+			require.Equal(t, cf.state.Info.StartTs, barrier.GlobalBarrierTs)
 		}
+
 		// sync-point is enabled, sync point barrier is ticked
 		if i == 1 {
-			require.Equal(t, cf.state.Info.StartTs+10, barrier)
+			require.Equal(t, cf.state.Info.StartTs+10, barrier.GlobalBarrierTs)
 		}
 
 		// Suppose tableCheckpoint has been advanced.
@@ -627,14 +634,25 @@ func TestBarrierAdvance(t *testing.T) {
 
 		// Need more 1 tick to advance barrier if sync-point is enabled.
 		if i == 1 {
-			barrier, err := cf.handleBarrier(ctx)
+			err = cf.handleBarrier(ctx, barrier)
 			require.Nil(t, err)
-			require.Equal(t, cf.state.Info.StartTs+10, barrier)
-		}
+			require.Equal(t, cf.state.Info.StartTs+10, barrier.GlobalBarrierTs)
 
-		// Then the last tick barrier must be advanced correctly.
-		barrier, err = cf.handleBarrier(ctx)
-		require.Nil(t, err)
-		require.Less(t, cf.state.Info.StartTs+10, barrier)
+			// Then the last tick barrier must be advanced correctly.
+			cf.ddlManager.ddlResolvedTs += 1000000000000
+			_, barrier, err = cf.ddlManager.tick(ctx, cf.state.Status.CheckpointTs+10, nil)
+			require.Nil(t, err)
+			err = cf.handleBarrier(ctx, barrier)
+
+			nextSyncPointTs := oracle.GoTimeToTS(
+				oracle.GetTimeFromTS(cf.state.Status.CheckpointTs + 10).
+					Add(util.GetOrZero(ctx.ChangefeedVars().Info.Config.SyncPointInterval)),
+			)
+
+			require.Nil(t, err)
+			require.Equal(t, nextSyncPointTs, barrier.GlobalBarrierTs)
+			require.Less(t, cf.state.Status.CheckpointTs+10, barrier.GlobalBarrierTs)
+			require.Less(t, barrier.GlobalBarrierTs, cf.ddlManager.ddlResolvedTs)
+		}
 	}
 }

--- a/cdc/owner/ddl_manager.go
+++ b/cdc/owner/ddl_manager.go
@@ -87,12 +87,6 @@ var redoBarrierDDLs = map[timodel.ActionType]struct{}{
 	timodel.ActionRecoverTable:           {},
 }
 
-type ddlBarrier struct {
-	schedulepb.BarrierWithMinTs
-	// redoBarrierTs is the minimum ts of ddl events that create a new physical table.
-	redoBarrierTs model.Ts
-}
-
 // ddlManager holds the pending DDL events of all tables and responsible for
 // executing them to downstream.
 // It also provides the ability to calculate the barrier of a changefeed.
@@ -183,7 +177,7 @@ func (m *ddlManager) tick(
 	ctx context.Context,
 	checkpointTs model.Ts,
 	tableCheckpoint map[model.TableName]model.Ts,
-) ([]model.TableID, *ddlBarrier, error) {
+) ([]model.TableID, *schedulepb.BarrierWithMinTs, error) {
 	m.justSentDDL = nil
 	m.updateCheckpointTs(checkpointTs, tableCheckpoint)
 
@@ -432,11 +426,8 @@ func (m *ddlManager) getAllTableNextDDL() []*model.DDLEvent {
 }
 
 // barrier returns ddlResolvedTs and tableBarrier
-func (m *ddlManager) barrier() *ddlBarrier {
-	barrier := &ddlBarrier{
-		BarrierWithMinTs: schedulepb.NewBarrierWithMinTs(m.ddlResolvedTs),
-		redoBarrierTs:    m.ddlResolvedTs,
-	}
+func (m *ddlManager) barrier() *schedulepb.BarrierWithMinTs {
+	barrier := schedulepb.NewBarrierWithMinTs(m.ddlResolvedTs)
 	tableBarrierMap := make(map[model.TableID]model.Ts)
 	ddls := m.getAllTableNextDDL()
 	if m.justSentDDL != nil {
@@ -452,8 +443,8 @@ func (m *ddlManager) barrier() *ddlBarrier {
 			// executed, so the table's resolvedTs will not be calculated in redo.
 			// To solve this problem, resovedTs of redo manager should not be greater
 			// than the min commitTs of ddls that create a new physical table.
-			if ddl.CommitTs < barrier.redoBarrierTs {
-				barrier.redoBarrierTs = ddl.CommitTs
+			if ddl.CommitTs < barrier.RedoBarrierTs {
+				barrier.RedoBarrierTs = ddl.CommitTs
 			}
 		}
 		if isGlobalDDL(ddl) {

--- a/cdc/owner/owner_test.go
+++ b/cdc/owner/owner_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tiflow/cdc/entry"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/puller"
+	"github.com/pingcap/tiflow/cdc/redo"
 	"github.com/pingcap/tiflow/cdc/scheduler"
 	"github.com/pingcap/tiflow/pkg/config"
 	cdcContext "github.com/pingcap/tiflow/pkg/context"
@@ -69,7 +70,7 @@ func newOwner4Test(
 	newSink func(model.ChangeFeedID, *model.ChangeFeedInfo, func(error), func(error)) DDLSink,
 	newScheduler func(
 		ctx cdcContext.Context, up *upstream.Upstream, changefeedEpoch uint64,
-		cfg *config.SchedulerConfig,
+		cfg *config.SchedulerConfig, redoMetaManager redo.MetaManager,
 	) (scheduler.Scheduler, error),
 	newDownstreamObserver func(
 		ctx context.Context, sinkURIStr string, replCfg *config.ReplicaConfig,
@@ -119,7 +120,7 @@ func createOwner4Test(ctx cdcContext.Context, t *testing.T) (*ownerImpl, *orches
 		// new scheduler
 		func(
 			ctx cdcContext.Context, up *upstream.Upstream, changefeedEpoch uint64,
-			cfg *config.SchedulerConfig,
+			cfg *config.SchedulerConfig, redoMetaAManager redo.MetaManager,
 		) (scheduler.Scheduler, error) {
 			return &mockScheduler{}, nil
 		},

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -219,7 +219,7 @@ func (p *processor) IsAddTableSpanFinished(span tablepb.Span, isPrepare bool) bo
 		return false
 	}
 
-	globalResolvedTs := p.changefeed.Status.ResolvedTs
+	//globalResolvedTs := p.changefeed.Status.ResolvedTs
 	globalCheckpointTs := p.changefeed.Status.CheckpointTs
 
 	var tableResolvedTs, tableCheckpointTs uint64
@@ -253,7 +253,7 @@ func (p *processor) IsAddTableSpanFinished(span tablepb.Span, isPrepare bool) bo
 			zap.String("changefeed", p.changefeedID.ID),
 			zap.Stringer("span", &span),
 			zap.Uint64("tableResolvedTs", tableResolvedTs),
-			zap.Uint64("globalResolvedTs", globalResolvedTs),
+			//zap.Uint64("globalResolvedTs", globalResolvedTs),
 			zap.Uint64("tableCheckpointTs", tableCheckpointTs),
 			zap.Uint64("globalCheckpointTs", globalCheckpointTs),
 			zap.Any("state", state),
@@ -267,7 +267,7 @@ func (p *processor) IsAddTableSpanFinished(span tablepb.Span, isPrepare bool) bo
 		zap.String("changefeed", p.changefeedID.ID),
 		zap.Stringer("span", &span),
 		zap.Uint64("tableResolvedTs", tableResolvedTs),
-		zap.Uint64("globalResolvedTs", globalResolvedTs),
+		//zap.Uint64("globalResolvedTs", globalResolvedTs),
 		zap.Uint64("tableCheckpointTs", tableCheckpointTs),
 		zap.Uint64("globalCheckpointTs", globalCheckpointTs),
 		zap.Any("state", state),
@@ -813,12 +813,7 @@ func (p *processor) initDDLHandler(ctx context.Context) error {
 func (p *processor) updateBarrierTs(barrier *schedulepb.Barrier) {
 	tableBarrier := p.calculateTableBarrierTs(barrier)
 	globalBarrierTs := barrier.GetGlobalBarrierTs()
-	// when redo is enable, globalBarrierTs must less than or equal to global resolvedTs
-	if p.redo.r.Enabled() {
-		if globalBarrierTs > p.changefeed.Status.ResolvedTs {
-			globalBarrierTs = p.changefeed.Status.ResolvedTs
-		}
-	}
+
 	schemaResolvedTs := p.ddlHandler.r.schemaStorage.ResolvedTs()
 	if schemaResolvedTs < globalBarrierTs {
 		// Do not update barrier ts that is larger than

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -219,7 +219,6 @@ func (p *processor) IsAddTableSpanFinished(span tablepb.Span, isPrepare bool) bo
 		return false
 	}
 
-	// globalResolvedTs := p.changefeed.Status.ResolvedTs
 	globalCheckpointTs := p.changefeed.Status.CheckpointTs
 
 	var tableResolvedTs, tableCheckpointTs uint64
@@ -253,7 +252,6 @@ func (p *processor) IsAddTableSpanFinished(span tablepb.Span, isPrepare bool) bo
 			zap.String("changefeed", p.changefeedID.ID),
 			zap.Stringer("span", &span),
 			zap.Uint64("tableResolvedTs", tableResolvedTs),
-			// zap.Uint64("globalResolvedTs", globalResolvedTs),
 			zap.Uint64("tableCheckpointTs", tableCheckpointTs),
 			zap.Uint64("globalCheckpointTs", globalCheckpointTs),
 			zap.Any("state", state),
@@ -267,7 +265,6 @@ func (p *processor) IsAddTableSpanFinished(span tablepb.Span, isPrepare bool) bo
 		zap.String("changefeed", p.changefeedID.ID),
 		zap.Stringer("span", &span),
 		zap.Uint64("tableResolvedTs", tableResolvedTs),
-		// zap.Uint64("globalResolvedTs", globalResolvedTs),
 		zap.Uint64("tableCheckpointTs", tableCheckpointTs),
 		zap.Uint64("globalCheckpointTs", globalCheckpointTs),
 		zap.Any("state", state),

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -219,7 +219,7 @@ func (p *processor) IsAddTableSpanFinished(span tablepb.Span, isPrepare bool) bo
 		return false
 	}
 
-	//globalResolvedTs := p.changefeed.Status.ResolvedTs
+	// globalResolvedTs := p.changefeed.Status.ResolvedTs
 	globalCheckpointTs := p.changefeed.Status.CheckpointTs
 
 	var tableResolvedTs, tableCheckpointTs uint64
@@ -253,7 +253,7 @@ func (p *processor) IsAddTableSpanFinished(span tablepb.Span, isPrepare bool) bo
 			zap.String("changefeed", p.changefeedID.ID),
 			zap.Stringer("span", &span),
 			zap.Uint64("tableResolvedTs", tableResolvedTs),
-			//zap.Uint64("globalResolvedTs", globalResolvedTs),
+			// zap.Uint64("globalResolvedTs", globalResolvedTs),
 			zap.Uint64("tableCheckpointTs", tableCheckpointTs),
 			zap.Uint64("globalCheckpointTs", globalCheckpointTs),
 			zap.Any("state", state),
@@ -267,7 +267,7 @@ func (p *processor) IsAddTableSpanFinished(span tablepb.Span, isPrepare bool) bo
 		zap.String("changefeed", p.changefeedID.ID),
 		zap.Stringer("span", &span),
 		zap.Uint64("tableResolvedTs", tableResolvedTs),
-		//zap.Uint64("globalResolvedTs", globalResolvedTs),
+		// zap.Uint64("globalResolvedTs", globalResolvedTs),
 		zap.Uint64("tableCheckpointTs", tableCheckpointTs),
 		zap.Uint64("globalCheckpointTs", globalCheckpointTs),
 		zap.Any("state", state),
@@ -761,13 +761,13 @@ func (p *processor) handleErrorCh() (err error) {
 
 func (p *processor) initDDLHandler(ctx context.Context) error {
 	checkpointTs := p.changefeed.Info.GetCheckpointTs(p.changefeed.Status)
-	resolvedTs := p.changefeed.Status.ResolvedTs
+	minTableBarrierTs := p.changefeed.Status.MinTableBarrierTs
 	forceReplicate := p.changefeed.Info.Config.ForceReplicate
 
-	// if resolvedTs == checkpointTs it means owner can't tell whether the DDL on checkpointTs has
+	// if minTableBarrierTs == checkpointTs it means owner can't tell whether the DDL on checkpointTs has
 	// been executed or not. So the DDL puller must start at checkpointTs-1.
 	var ddlStartTs uint64
-	if resolvedTs > checkpointTs {
+	if minTableBarrierTs > checkpointTs {
 		ddlStartTs = checkpointTs
 	} else {
 		ddlStartTs = checkpointTs - 1

--- a/cdc/scheduler/internal/scheduler.go
+++ b/cdc/scheduler/internal/scheduler.go
@@ -47,7 +47,6 @@ type Scheduler interface {
 		// ddl jobs that need to be replicated. The Scheduler will
 		// broadcast the barrierTs to all captures through the Heartbeat.
 		barrier schedulepb.BarrierWithMinTs,
-		enableRedo bool,
 	) (newCheckpointTs, newResolvedTs model.Ts, err error)
 
 	// MoveTable requests that a table be moved to target.

--- a/cdc/scheduler/internal/scheduler.go
+++ b/cdc/scheduler/internal/scheduler.go
@@ -46,7 +46,7 @@ type Scheduler interface {
 		// barrier contains the barrierTs of those tables that have
 		// ddl jobs that need to be replicated. The Scheduler will
 		// broadcast the barrierTs to all captures through the Heartbeat.
-		barrier schedulepb.BarrierWithMinTs,
+		barrier *schedulepb.BarrierWithMinTs,
 	) (newCheckpointTs, newResolvedTs model.Ts, err error)
 
 	// MoveTable requests that a table be moved to target.

--- a/cdc/scheduler/internal/scheduler.go
+++ b/cdc/scheduler/internal/scheduler.go
@@ -47,6 +47,7 @@ type Scheduler interface {
 		// ddl jobs that need to be replicated. The Scheduler will
 		// broadcast the barrierTs to all captures through the Heartbeat.
 		barrier schedulepb.BarrierWithMinTs,
+		enableRedo bool,
 	) (newCheckpointTs, newResolvedTs model.Ts, err error)
 
 	// MoveTable requests that a table be moved to target.

--- a/cdc/scheduler/internal/v3/coordinator.go
+++ b/cdc/scheduler/internal/v3/coordinator.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/processor/tablepb"
+	"github.com/pingcap/tiflow/cdc/redo"
 	"github.com/pingcap/tiflow/cdc/scheduler/internal"
 	"github.com/pingcap/tiflow/cdc/scheduler/internal/v3/compat"
 	"github.com/pingcap/tiflow/cdc/scheduler/internal/v3/keyspan"
@@ -68,6 +69,7 @@ type coordinator struct {
 	compat          *compat.Compat
 	pdClock         pdutil.Clock
 	tableRanges     replication.TableRanges
+	redoMetaManager redo.MetaManager
 
 	lastCollectTime time.Time
 	changefeedID    model.ChangeFeedID
@@ -84,13 +86,14 @@ func NewCoordinator(
 	changefeedEpoch uint64,
 	up *upstream.Upstream,
 	cfg *config.SchedulerConfig,
+	redoMetaManager redo.MetaManager,
 ) (internal.Scheduler, error) {
 	trans, err := transport.NewTransport(
 		ctx, changefeedID, transport.SchedulerRole, messageServer, messageRouter)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	coord := newCoordinator(captureID, changefeedID, ownerRevision, cfg)
+	coord := newCoordinator(captureID, changefeedID, ownerRevision, cfg, redoMetaManager)
 	coord.trans = trans
 	coord.pdClock = up.PDClock
 	coord.changefeedEpoch = changefeedEpoch
@@ -106,6 +109,7 @@ func newCoordinator(
 	changefeedID model.ChangeFeedID,
 	ownerRevision int64,
 	cfg *config.SchedulerConfig,
+	redoMetaManager redo.MetaManager,
 ) *coordinator {
 	revision := schedulepb.OwnerRevision{Revision: ownerRevision}
 
@@ -115,10 +119,11 @@ func newCoordinator(
 		captureID: captureID,
 		replicationM: replication.NewReplicationManager(
 			cfg.MaxTaskConcurrency, changefeedID),
-		captureM:     member.NewCaptureManager(captureID, changefeedID, revision, cfg),
-		schedulerM:   scheduler.NewSchedulerManager(changefeedID, cfg),
-		changefeedID: changefeedID,
-		compat:       compat.New(cfg, map[model.CaptureID]*model.CaptureInfo{}),
+		captureM:        member.NewCaptureManager(captureID, changefeedID, revision, cfg),
+		schedulerM:      scheduler.NewSchedulerManager(changefeedID, cfg),
+		changefeedID:    changefeedID,
+		compat:          compat.New(cfg, map[model.CaptureID]*model.CaptureInfo{}),
+		redoMetaManager: redoMetaManager,
 	}
 }
 
@@ -131,7 +136,7 @@ func (c *coordinator) Tick(
 	currentTables []model.TableID,
 	// All captures that are alive according to the latest Etcd states.
 	aliveCaptures map[model.CaptureID]*model.CaptureInfo,
-	barrier schedulepb.BarrierWithMinTs,
+	barrier *schedulepb.BarrierWithMinTs,
 ) (newCheckpointTs, newResolvedTs model.Ts, err error) {
 	startTime := time.Now()
 	defer func() {
@@ -277,7 +282,7 @@ func (c *coordinator) poll(
 	checkpointTs model.Ts,
 	currentTables []model.TableID,
 	aliveCaptures map[model.CaptureID]*model.CaptureInfo,
-	barrier schedulepb.BarrierWithMinTs,
+	barrier *schedulepb.BarrierWithMinTs,
 ) (newCheckpointTs, newResolvedTs model.Ts, err error) {
 	c.maybeCollectMetrics()
 	if c.compat.UpdateCaptureInfo(aliveCaptures) {
@@ -317,7 +322,12 @@ func (c *coordinator) poll(
 	if !c.captureM.CheckAllCaptureInitialized() {
 		// Skip generating schedule tasks for replication manager,
 		// as not all capture are initialized.
-		newCheckpointTs, newResolvedTs = c.replicationM.AdvanceCheckpoint(&c.tableRanges, pdTime, barrier)
+		newCheckpointTs, newResolvedTs = c.replicationM.AdvanceCheckpoint(&c.tableRanges, pdTime, barrier, c.redoMetaManager)
+		// tick capture manager after checkpoint calculation to take account resolvedTs in barrier
+		// when redo is enabled
+		msgs = c.captureM.Tick(c.replicationM.ReplicationSets(),
+			c.schedulerM.DrainingTarget(), barrier.Barrier)
+		msgBuf = append(msgBuf, msgs...)
 		return newCheckpointTs, newResolvedTs, c.sendMsgs(ctx, msgBuf)
 	}
 
@@ -347,7 +357,7 @@ func (c *coordinator) poll(
 	msgBuf = append(msgBuf, msgs...)
 
 	// Checkpoint calculation
-	newCheckpointTs, newResolvedTs = c.replicationM.AdvanceCheckpoint(&c.tableRanges, pdTime, barrier)
+	newCheckpointTs, newResolvedTs = c.replicationM.AdvanceCheckpoint(&c.tableRanges, pdTime, barrier, c.redoMetaManager)
 
 	// tick capture manager after checkpoint calculation to take account resolvedTs in barrier
 	// when redo is enabled

--- a/cdc/scheduler/internal/v3/coordinator_test.go
+++ b/cdc/scheduler/internal/v3/coordinator_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/processor/tablepb"
+	"github.com/pingcap/tiflow/cdc/redo"
 	"github.com/pingcap/tiflow/cdc/scheduler/internal/v3/compat"
 	"github.com/pingcap/tiflow/cdc/scheduler/internal/v3/keyspan"
 	"github.com/pingcap/tiflow/cdc/scheduler/internal/v3/member"
@@ -201,7 +202,7 @@ func TestCoordinatorTransportCompat(t *testing.T) {
 }
 
 func newTestCoordinator(cfg *config.SchedulerConfig) (*coordinator, *transport.MockTrans) {
-	coord := newCoordinator("a", model.ChangeFeedID{}, 1, cfg)
+	coord := newCoordinator("a", model.ChangeFeedID{}, 1, cfg, redo.NewDisabledMetaManager())
 	trans := transport.NewMockTrans()
 	coord.trans = trans
 	coord.reconciler = keyspan.NewReconcilerForTests(

--- a/cdc/scheduler/internal/v3/info_provider_test.go
+++ b/cdc/scheduler/internal/v3/info_provider_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/processor/tablepb"
+	"github.com/pingcap/tiflow/cdc/redo"
 	"github.com/pingcap/tiflow/cdc/scheduler/internal"
 	"github.com/pingcap/tiflow/cdc/scheduler/internal/v3/keyspan"
 	"github.com/pingcap/tiflow/cdc/scheduler/internal/v3/member"
@@ -34,7 +35,7 @@ func TestInfoProvider(t *testing.T) {
 		MaxTaskConcurrency: 1,
 		ChangefeedSettings: config.GetDefaultReplicaConfig().Scheduler,
 	}
-	coord := newCoordinator("a", model.ChangeFeedID{}, 1, cfg)
+	coord := newCoordinator("a", model.ChangeFeedID{}, 1, cfg, redo.NewDisabledMetaManager())
 	cfg.ChangefeedSettings = config.GetDefaultReplicaConfig().Scheduler
 	coord.reconciler = keyspan.NewReconcilerForTests(
 		keyspan.NewMockRegionCache(), cfg.ChangefeedSettings)
@@ -69,7 +70,7 @@ func TestInfoProviderIsInitialized(t *testing.T) {
 		HeartbeatTick:      math.MaxInt,
 		MaxTaskConcurrency: 1,
 		ChangefeedSettings: config.GetDefaultReplicaConfig().Scheduler,
-	})
+	}, redo.NewDisabledMetaManager())
 	var ip internal.InfoProvider = coord
 
 	// Has not initialized yet.

--- a/cdc/scheduler/internal/v3/replication/replication_manager.go
+++ b/cdc/scheduler/internal/v3/replication/replication_manager.go
@@ -631,6 +631,11 @@ func (r *Manager) AdvanceCheckpoint(
 		if flushedResolvedTs != 0 && flushedResolvedTs < newResolvedTs {
 			newResolvedTs = flushedResolvedTs
 		}
+
+		if newCheckpointTs > newResolvedTs {
+			newCheckpointTs = newResolvedTs
+		}
+
 		if barrier.GlobalBarrierTs > newResolvedTs {
 			barrier.GlobalBarrierTs = newResolvedTs
 		}

--- a/cdc/scheduler/internal/v3/replication/replication_manager.go
+++ b/cdc/scheduler/internal/v3/replication/replication_manager.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/processor/tablepb"
+	"github.com/pingcap/tiflow/cdc/redo"
 	"github.com/pingcap/tiflow/cdc/scheduler/internal"
 	"github.com/pingcap/tiflow/cdc/scheduler/schedulepb"
 	"github.com/pingcap/tiflow/pkg/spanz"
@@ -508,7 +509,8 @@ func (r *Manager) RunningTasks() *spanz.BtreeMap[*ScheduleTask] {
 func (r *Manager) AdvanceCheckpoint(
 	currentTables *TableRanges,
 	currentPDTime time.Time,
-	barrier schedulepb.BarrierWithMinTs,
+	barrier *schedulepb.BarrierWithMinTs,
+	redoMetaManager redo.MetaManager,
 ) (newCheckpointTs, newResolvedTs model.Ts) {
 	newCheckpointTs, newResolvedTs = math.MaxUint64, math.MaxUint64
 	slowestRange := tablepb.Span{}
@@ -610,6 +612,28 @@ func (r *Manager) AdvanceCheckpoint(
 		time.Since(r.lastLogSlowTablesTime) > logSlowTablesInterval {
 		r.logSlowTableInfo(currentPDTime)
 		r.lastLogSlowTablesTime = time.Now()
+	}
+
+	if redoMetaManager.Enabled() {
+		if newResolvedTs > barrier.RedoBarrierTs {
+			newResolvedTs = barrier.RedoBarrierTs
+		}
+		redoMetaManager.UpdateMeta(newCheckpointTs, newResolvedTs)
+		flushedMeta := redoMetaManager.GetFlushedMeta()
+		flushedCheckpointTs, flushedResolvedTs := flushedMeta.CheckpointTs, flushedMeta.ResolvedTs
+		log.Debug("owner gets flushed meta",
+			zap.Uint64("flushedResolvedTs", flushedResolvedTs),
+			zap.Uint64("flushedCheckpointTs", flushedCheckpointTs),
+			zap.Uint64("newResolvedTs", newResolvedTs),
+			zap.Uint64("newCheckpointTs", newCheckpointTs),
+			zap.String("namespace", r.changefeedID.Namespace),
+			zap.String("changefeed", r.changefeedID.ID))
+		if flushedResolvedTs != 0 && flushedResolvedTs < newResolvedTs {
+			newResolvedTs = flushedResolvedTs
+		}
+		if barrier.GlobalBarrierTs > newResolvedTs {
+			barrier.GlobalBarrierTs = newResolvedTs
+		}
 	}
 
 	return newCheckpointTs, newResolvedTs

--- a/cdc/scheduler/internal/v3/replication/replication_manager.go
+++ b/cdc/scheduler/internal/v3/replication/replication_manager.go
@@ -509,7 +509,6 @@ func (r *Manager) AdvanceCheckpoint(
 	currentTables *TableRanges,
 	currentPDTime time.Time,
 	barrier schedulepb.BarrierWithMinTs,
-	enableRedo bool,
 ) (newCheckpointTs, newResolvedTs model.Ts) {
 	newCheckpointTs, newResolvedTs = math.MaxUint64, math.MaxUint64
 	slowestRange := tablepb.Span{}
@@ -603,12 +602,6 @@ func (r *Manager) AdvanceCheckpoint(
 		// 	zap.Any("minTableBarrierTs", barrier.MinTableBarrierTs))
 	}
 
-	// if redo is enabled, global barrier ts should not exceeds newResolvedTs.
-	if enableRedo {
-		if barrier.GlobalBarrierTs > newResolvedTs {
-			barrier.GlobalBarrierTs = newResolvedTs
-		}
-	}
 	// If changefeed's checkpoint lag is larger than 30s,
 	// log the 4 slowlest table infos every minute, which can
 	// help us find the problematic tables.

--- a/cdc/scheduler/internal/v3/replication/replication_manager.go
+++ b/cdc/scheduler/internal/v3/replication/replication_manager.go
@@ -509,6 +509,7 @@ func (r *Manager) AdvanceCheckpoint(
 	currentTables *TableRanges,
 	currentPDTime time.Time,
 	barrier schedulepb.BarrierWithMinTs,
+	enableRedo bool,
 ) (newCheckpointTs, newResolvedTs model.Ts) {
 	newCheckpointTs, newResolvedTs = math.MaxUint64, math.MaxUint64
 	slowestRange := tablepb.Span{}
@@ -602,6 +603,12 @@ func (r *Manager) AdvanceCheckpoint(
 		// 	zap.Any("minTableBarrierTs", barrier.MinTableBarrierTs))
 	}
 
+	// if redo is enabled, global barrier ts should not exceeds newResolvedTs.
+	if enableRedo {
+		if barrier.GlobalBarrierTs > newResolvedTs {
+			barrier.GlobalBarrierTs = newResolvedTs
+		}
+	}
 	// If changefeed's checkpoint lag is larger than 30s,
 	// log the 4 slowlest table infos every minute, which can
 	// help us find the problematic tables.

--- a/cdc/scheduler/rexport.go
+++ b/cdc/scheduler/rexport.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	"github.com/pingcap/tiflow/cdc/model"
+	"github.com/pingcap/tiflow/cdc/redo"
 	"github.com/pingcap/tiflow/cdc/scheduler/internal"
 	v3 "github.com/pingcap/tiflow/cdc/scheduler/internal/v3"
 	v3agent "github.com/pingcap/tiflow/cdc/scheduler/internal/v3/agent"
@@ -88,10 +89,11 @@ func NewScheduler(
 	changefeedEpoch uint64,
 	up *upstream.Upstream,
 	cfg *config.SchedulerConfig,
+	redoMetaManager redo.MetaManager,
 ) (Scheduler, error) {
 	return v3.NewCoordinator(
 		ctx, captureID, changeFeedID, messageServer, messageRouter, ownerRevision,
-		changefeedEpoch, up, cfg)
+		changefeedEpoch, up, cfg, redoMetaManager)
 }
 
 // InitMetrics registers all metrics used in scheduler

--- a/cdc/scheduler/schedulepb/barrier.go
+++ b/cdc/scheduler/schedulepb/barrier.go
@@ -22,14 +22,16 @@ type BarrierWithMinTs struct {
 	// used to check whether there is a pending DDL job at the checkpointTs when
 	// initializing the changefeed.
 	MinTableBarrierTs model.Ts
+	RedoBarrierTs     model.Ts
 }
 
 // NewBarrierWithMinTs creates a new BarrierWithMinTs.
-func NewBarrierWithMinTs(ts model.Ts) BarrierWithMinTs {
-	return BarrierWithMinTs{
+func NewBarrierWithMinTs(ts model.Ts) *BarrierWithMinTs {
+	return &BarrierWithMinTs{
 		Barrier: &Barrier{
 			GlobalBarrierTs: ts,
 		},
 		MinTableBarrierTs: ts,
+		RedoBarrierTs:     ts,
 	}
 }

--- a/tests/integration_tests/consistent_replicate_ddl/run.sh
+++ b/tests/integration_tests/consistent_replicate_ddl/run.sh
@@ -28,7 +28,7 @@ function run() {
 	cd $WORK_DIR
 	run_sql "set @@global.tidb_enable_exchange_partition=on" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 
-	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix consistent_replicate_ddl.server1
 
 	SINK_URI="mysql://normal:123456@127.0.0.1:3306/"
 	changefeed_id=$(cdc cli changefeed create --sink-uri="$SINK_URI" --config="$CUR/conf/changefeed.toml" 2>&1 | tail -n2 | head -n1 | awk '{print $2}')
@@ -48,7 +48,7 @@ function run() {
 	# Inject the failpoint to prevent sink execution, but the global resolved can be moved forward.
 	# Then we can apply redo log to reach an eventual consistent state in downstream.
 	export GO_FAILPOINTS='github.com/pingcap/tiflow/cdc/sink/dmlsink/txn/mysql/MySQLSinkHangLongTime=return(true);github.com/pingcap/tiflow/cdc/sink/ddlsink/mysql/MySQLSinkExecDDLDelay=return(true)'
-	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
+	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --logsuffix consistent_replicate_ddl.server2
 
 	# case 1:
 	# global ddl tests -> ActionRenameTable

--- a/tests/integration_tests/consistent_replicate_ddl/run.sh
+++ b/tests/integration_tests/consistent_replicate_ddl/run.sh
@@ -43,7 +43,7 @@ function run() {
 	check_table_exists "consistent_replicate_ddl.usertable2" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 120
 	check_table_exists "consistent_replicate_ddl.usertable3" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 120
 	check_table_exists "consistent_replicate_ddl.usertable_bak" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 120
-
+	sleep 5
 	cleanup_process $CDC_BINARY
 	# Inject the failpoint to prevent sink execution, but the global resolved can be moved forward.
 	# Then we can apply redo log to reach an eventual consistent state in downstream.


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #9058

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
