### PR TITLE
ddlManager (ticdc): only log once when executing a ddl

### DIFF
--- a/cdc/owner/ddl_manager.go
+++ b/cdc/owner/ddl_manager.go
@@ -282,15 +282,13 @@ func (m *ddlManager) tick(
 		}
 
 		if m.shouldExecDDL(nextDDL) {
-			log.Info("execute a ddl event",
-				zap.String("query", nextDDL.Query),
-				zap.Uint64("commitTs", nextDDL.CommitTs),
-				zap.Uint64("checkpointTs", m.checkpointTs))
-
 			if m.executingDDL == nil {
+				log.Info("execute a ddl event",
+					zap.String("query", nextDDL.Query),
+					zap.Uint64("commitTs", nextDDL.CommitTs),
+					zap.Uint64("checkpointTs", m.checkpointTs))
 				m.executingDDL = nextDDL
 			}
-
 			err := m.executeDDL(ctx)
 			if err != nil {
 				return nil, nil, err


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8828 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->


 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
