### PR TITLE
ci: skip some CI builds when only changed to documents and OWNERS files

### DIFF
--- a/.github/workflows/check_and_build.yaml
+++ b/.github/workflows/check_and_build.yaml
@@ -5,10 +5,21 @@ on:
     branches:
       - master
       - "release-[0-9].[0-9]*"
+    paths-ignore:
+      - '**/*.md'
+      - '**/OWNERS'
+      - 'OWNERS'
+      - 'OWNERS_ALIASES'
+
   pull_request:
     branches:
       - master
       - "release-[0-9].[0-9]*"
+    paths-ignore:
+      - '**/*.md'
+      - '**/OWNERS'
+      - 'OWNERS'
+      - 'OWNERS_ALIASES'
 
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 concurrency:

--- a/.github/workflows/ticdc_integration.yaml
+++ b/.github/workflows/ticdc_integration.yaml
@@ -9,12 +9,20 @@ on:
     paths-ignore:
       - 'dm/**'
       - 'engine/**'
+      - '**/*.md'
+      - '**/OWNERS'
+      - 'OWNERS'
+      - 'OWNERS_ALIASES'      
   pull_request:
     branches:
       - master
     paths-ignore:
       - 'dm/**'
       - 'engine/**'
+      - '**/*.md'
+      - '**/OWNERS'
+      - 'OWNERS'
+      - 'OWNERS_ALIASES'      
 
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 concurrency:


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Ref:
- PingCAP-QE/ci#2129

### What is changed and how it works?

update check and build and cdc integration test github workflows: skip triggering when only changes to markdown files or `OWNERS` files.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No

##### Do you need to update user documentation, design documentation or monitoring documentation?

No

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
