### PR TITLE
Apply gc-ttl to all changefeeds when calculating the gc safepoint.

### DIFF
--- a/cdc/owner/owner.go
+++ b/cdc/owner/owner.go
@@ -700,9 +700,9 @@ func (o *ownerImpl) updateGCSafepoint(
 	return nil
 }
 
-// ignoreFailedChangeFeedWhenGC checks if a failed changefeed should be ignored
+// ignoreChangeFeedWhenGC checks if a failed changefeed should be ignored
 // when calculating the gc safepoint of the associated upstream.
-func (o *ownerImpl) ignoreFailedChangeFeedWhenGC(
+func (o *ownerImpl) ignoreChangeFeedWhenGC(
 	state *orchestrator.ChangefeedReactorState,
 ) bool {
 	upID := state.Info.UpstreamID
@@ -717,7 +717,7 @@ func (o *ownerImpl) ignoreFailedChangeFeedWhenGC(
 	if state.Status != nil {
 		ts = state.Status.CheckpointTs
 	}
-	return us.GCManager.IgnoreFailedChangeFeed(ts)
+	return us.GCManager.IgnoreChangeFeed(ts)
 }
 
 // calculateGCSafepoint calculates GCSafepoint for different upstream.
@@ -736,9 +736,9 @@ func (o *ownerImpl) calculateGCSafepoint(state *orchestrator.GlobalReactorState)
 		}
 
 		switch changefeedState.Info.State {
-		case model.StateNormal, model.StateStopped, model.StateError:
-		case model.StateFailed:
-			if o.ignoreFailedChangeFeedWhenGC(changefeedState) {
+		case model.StateNormal, model.StateStopped,
+			model.StateError, model.StateFailed:
+			if o.ignoreChangeFeedWhenGC(changefeedState) {
 				continue
 			}
 		default:


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9243 

### What is changed and how it works?

Apply gc-ttl to all changefeeds when calculating the gc safepoint. Changefeeds with checkpoint ts lag larger than gc-ttl duration will be not be considered and will not block the gc process.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
NA

##### Do you need to update user documentation, design documentation or monitoring documentation?
NA

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
