### PR TITLE
ci: add component management to `.codecov.yaml` and migrate flag manage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -50,9 +50,9 @@ component_management:
     - component_id: component_cdc # this is an identifier that should not be changed
       name: cdc # this is a display name, and can be changed freely
       paths:
-        - "cdc/**"
-        - "cmd/**"
-        - "pkg/**"
+        - cdc/**
+        - cmd/**
+        - pkg/**
     - component_id: component_dm
       name: dm
       paths:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -24,7 +24,7 @@ parsers:
       macro: no
 
 comment:
-  layout: "header, flags, diff"
+  layout: "header, components, flags, diff"
   behavior: default
   require_changes: no
 
@@ -41,20 +41,49 @@ ignore:
   - "mock/.*"
   - "*_mock.go"
 
-flags:
-  cdc:
-    carryforward: true
-    paths:
-      - "cdc/"
-      - "cmd/"
-      - "pkg/"
+component_management:
+  default_rules:  # default rules that will be inherited by all components
+    statuses:
+      - type: project # in this case every component that doens't have a status defined will have a project type one
+        target: auto
+  individual_components:
+    - component_id: component_cdc # this is an identifier that should not be changed
+      name: cdc # this is a display name, and can be changed freely
+      paths:
+        - "cdc/**"
+        - "cmd/**"
+        - "pkg/**"
+    - component_id: component_dm
+      name: dm
+      paths:
+        - dm/**
+    - component_id: component_engine
+      name: engine
+      paths:
+        - engine/**
+    # more components.
 
-  dm:
+flag_management:
+  default_rules: # the rules that will be followed for any flag added, generally
     carryforward: true
-    paths:
-      - "dm/"
+    statuses:
+      - type: project
+        target: 60%
+      - type: patch
+        target: 60%
 
-  engine:
-    carryforward: true
-    paths:
-      - "engine/"
+  individual_flags: # exceptions to the default rules above, stated flag by flag
+    - name: cdc  #fill in your own flag name
+      paths:
+        - cdc/** #fill in your own path. Note, accepts globs, not regexes
+        - cmd/**
+        - pkg/**
+      carryforward: true
+    - name: dm
+      paths:
+        - dm/**
+      carryforward: true
+    - name: engine
+      paths:
+        - engine/**
+      carryforward: true

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ unit_test_in_verify_ci: check_failpoint_ctl tools/bin/gotestsum tools/bin/gocov 
 	|| { $(FAILPOINT_DISABLE); exit 1; }
 	tools/bin/gocov convert "$(TEST_DIR)/cov.unit.out" | tools/bin/gocov-xml > cdc-coverage.xml
 	$(FAILPOINT_DISABLE)
-	@bash <(curl -s https://codecov.io/bash) -F cdc -f $(TEST_DIR)/cov.unit.out -t $(TICDC_CODECOV_TOKEN)
+	@bash <(curl -s https://codecov.io/bash) -F unit,cdc -f $(TEST_DIR)/cov.unit.out -t $(TICDC_CODECOV_TOKEN)
 
 leak_test: check_failpoint_ctl
 	$(FAILPOINT_ENABLE)
@@ -417,7 +417,7 @@ dm_unit_test_in_verify_ci: check_failpoint_ctl tools/bin/gotestsum tools/bin/goc
 	|| { $(FAILPOINT_DISABLE); exit 1; }
 	tools/bin/gocov convert "$(DM_TEST_DIR)/cov.unit_test.out" | tools/bin/gocov-xml > dm-coverage.xml
 	$(FAILPOINT_DISABLE)
-	@bash <(curl -s https://codecov.io/bash) -F dm -f $(DM_TEST_DIR)/cov.unit_test.out -t $(TICDC_CODECOV_TOKEN)
+	@bash <(curl -s https://codecov.io/bash) -F unit,dm -f $(DM_TEST_DIR)/cov.unit_test.out -t $(TICDC_CODECOV_TOKEN)
 
 dm_integration_test_build: check_failpoint_ctl
 	$(FAILPOINT_ENABLE)
@@ -579,7 +579,7 @@ engine_unit_test_in_verify_ci: check_failpoint_ctl tools/bin/gotestsum tools/bin
 	|| { $(FAILPOINT_DISABLE); exit 1; }
 	tools/bin/gocov convert "$(ENGINE_TEST_DIR)/cov.unit_test.out" | tools/bin/gocov-xml > engine-coverage.xml
 	$(FAILPOINT_DISABLE)
-	@bash <(curl -s https://codecov.io/bash) -F engine -f $(ENGINE_TEST_DIR)/cov.unit_test.out -t $(TICDC_CODECOV_TOKEN)
+	@bash <(curl -s https://codecov.io/bash) -F unit,engine -f $(ENGINE_TEST_DIR)/cov.unit_test.out -t $(TICDC_CODECOV_TOKEN)
 
 prepare_test_binaries:
 	cd scripts && ./download-integration-test-binaries.sh master && cd ..


### PR DESCRIPTION
### What problem does this PR solve?
Codecov's `Flags` should be better be used to split test types and the `components` feature better for components management.

The comonent management is a new feature in codecov, currently we used it in codecov page of `pingcap/tidb`. 

Ref:
- https://docs.codecov.com/docs/flags
- https://docs.codecov.com/docs/components
- PingCAP-QE/ci#2171


### What is changed and how it works?

- migrate flag mangement to Automatic Flag Management: only only with the components flags, also we need to support unit and integration and other test type's covrage data.
- add component management configuration, it no need to set when upload coverage, it will auto display in codecov.io page.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
