### PR TITLE
mounter(ticdc): enum type default value set explicitly to avoid wrong enum value fetched by the encoder

### DIFF
--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -729,13 +729,6 @@ func getDefaultOrZeroValue(col *timodel.ColumnInfo) (types.Datum, any, int, stri
 				return d, nil, 0, "", errors.Trace(err)
 			}
 			d = types.NewMysqlEnumDatum(enumValue)
-		case mysql.TypeSet:
-			name := col.FieldType.GetElem(0)
-			setValue, err := types.ParseSetName(col.FieldType.GetElems(), name, col.GetCollate())
-			if err != nil {
-				return d, nil, 0, "", errors.Trace(err)
-			}
-			d = types.NewMysqlSetDatum(setValue, col.GetCollate())
 		case mysql.TypeString, mysql.TypeVarString, mysql.TypeVarchar:
 			return d, emptyBytes, sizeOfEmptyBytes, "", nil
 		default:

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -723,7 +723,11 @@ func getDefaultOrZeroValue(col *timodel.ColumnInfo) (types.Datum, any, int, stri
 		case mysql.TypeEnum:
 			// For enum type, if no default value and not null is set,
 			// the default value is the first element of the enum list
-			d = types.NewDatum(col.FieldType.GetElem(0))
+			enumValue := types.Enum{
+				Name:  col.FieldType.GetElem(0),
+				Value: 1,
+			}
+			d = types.NewMysqlEnumDatum(enumValue)
 		case mysql.TypeString, mysql.TypeVarString, mysql.TypeVarchar:
 			return d, emptyBytes, sizeOfEmptyBytes, "", nil
 		default:

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -999,7 +999,10 @@ func TestGetDefaultZeroValue(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		_, val, _, _, _ := getDefaultOrZeroValue(&tc.ColInfo)
+		datum, val, _, _, _ := getDefaultOrZeroValue(&tc.ColInfo)
+		if datum.Kind() == types.KindMysqlEnum {
+			require.Equal(t, uint64(1), datum.GetMysqlEnum().Value)
+		}
 		require.Equal(t, tc.Res, val, tc.Name)
 		val = GetDDLDefaultDefinition(&tc.ColInfo)
 		require.Equal(t, tc.Default, val, tc.Name)

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -957,7 +957,7 @@ func TestGetDefaultZeroValue(t *testing.T) {
 			ColInfo: timodel.ColumnInfo{FieldType: *ftTypeEnumNotNull},
 			// TypeEnum value will be a string and then translate to []byte
 			// NotNull && no default will choose first element
-			Res:     uint64(0),
+			Res:     uint64(1),
 			Default: nil,
 		},
 		// mysql.TypeEnum + notnull + default
@@ -999,10 +999,7 @@ func TestGetDefaultZeroValue(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		datum, val, _, _, _ := getDefaultOrZeroValue(&tc.ColInfo)
-		if datum.Kind() == types.KindMysqlEnum {
-			require.Equal(t, uint64(1), datum.GetMysqlEnum().Value)
-		}
+		_, val, _, _, _ := getDefaultOrZeroValue(&tc.ColInfo)
 		require.Equal(t, tc.Res, val, tc.Name)
 		val = GetDDLDefaultDefinition(&tc.ColInfo)
 		require.Equal(t, tc.Default, val, tc.Name)

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -613,6 +613,9 @@ func TestGetDefaultZeroValue(t *testing.T) {
 	ftTypeEnumNotNull.SetFlag(mysql.NotNullFlag)
 	ftTypeEnumNotNull.SetElems([]string{"e0", "e1"})
 
+	// mysql.TypeEnum + null
+	ftTypeEnumNull := types.NewFieldType(mysql.TypeEnum)
+
 	// mysql.TypeSet + notnull
 	ftTypeSetNotNull := types.NewFieldType(mysql.TypeSet)
 	ftTypeSetNotNull.SetFlag(mysql.NotNullFlag)
@@ -970,6 +973,14 @@ func TestGetDefaultZeroValue(t *testing.T) {
 			// TypeEnum default value will be a string and then translate to []byte
 			Res:     "e1",
 			Default: "e1",
+		},
+		// mysql.TypeEnum + null
+		{
+			Name: "mysql.TypeEnum + null",
+			ColInfo: timodel.ColumnInfo{
+				FieldType: *ftTypeEnumNull,
+			},
+			Res: nil,
 		},
 		// mysql.TypeSet + notnull
 		{

--- a/pkg/sink/codec/avro/avro.go
+++ b/pkg/sink/codec/avro/avro.go
@@ -917,7 +917,7 @@ func columnToAvroData(
 		number := col.Value.(uint64)
 		enumVar, err := types.ParseEnumValue(elements, number)
 		if err != nil {
-			log.Info("parse enum value failed", zap.Strings("elements", elements), zap.Uint64("number", number))
+			log.Info("avro encoder parse enum value failed", zap.Strings("elements", elements), zap.Uint64("number", number))
 			return nil, "", cerror.WrapError(cerror.ErrAvroEncodeFailed, err)
 		}
 		return enumVar.Name, "string", nil
@@ -925,8 +925,12 @@ func columnToAvroData(
 		if v, ok := col.Value.(string); ok {
 			return v, "string", nil
 		}
-		setVar, err := types.ParseSetValue(ft.GetElems(), col.Value.(uint64))
+		elements := ft.GetElems()
+		number := col.Value.(uint64)
+		setVar, err := types.ParseSetValue(elements, number)
 		if err != nil {
+			log.Info("avro encoder parse set value failed",
+				zap.Strings("elements", elements), zap.Uint64("number", number), zap.Error(err))
 			return nil, "", cerror.WrapError(cerror.ErrAvroEncodeFailed, err)
 		}
 		return setVar.Name, "string", nil
@@ -938,13 +942,14 @@ func columnToAvroData(
 		if v, ok := col.Value.(string); ok {
 			n, err := strconv.ParseInt(v, 10, 32)
 			if err != nil {
+				log.Info("avro encoder parse year value failed", zap.String("value", v), zap.Error(err))
 				return nil, "", cerror.WrapError(cerror.ErrAvroEncodeFailed, err)
 			}
 			return int32(n), "int", nil
 		}
 		return int32(col.Value.(int64)), "int", nil
 	default:
-		log.Error("unknown mysql type", zap.Any("mysqlType", col.Type))
+		log.Error("unknown mysql type", zap.Any("value", col.Value), zap.Any("mysqlType", col.Type))
 		return nil, "", cerror.ErrAvroEncodeFailed.GenWithStack("unknown mysql type")
 	}
 }

--- a/pkg/sink/codec/avro/avro.go
+++ b/pkg/sink/codec/avro/avro.go
@@ -913,8 +913,11 @@ func columnToAvroData(
 		if v, ok := col.Value.(string); ok {
 			return v, "string", nil
 		}
-		enumVar, err := types.ParseEnumValue(ft.GetElems(), col.Value.(uint64))
+		elements := ft.GetElems()
+		number := col.Value.(uint64)
+		enumVar, err := types.ParseEnumValue(elements, number)
 		if err != nil {
+			log.Info("parse enum value failed", zap.Strings("elements", elements), zap.Uint64("number", number))
 			return nil, "", cerror.WrapError(cerror.ErrAvroEncodeFailed, err)
 		}
 		return enumVar.Name, "string", nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9259 

### What is changed and how it works?

* mounter set the default value for the enum type explicitly, to make `enum.Value` set correctly.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
