### PR TITLE
pkg/sink(ticdc): Update Kafka cluster every 30min

### DIFF
--- a/pkg/sink/kafka/metrics_collector.go
+++ b/pkg/sink/kafka/metrics_collector.go
@@ -33,8 +33,8 @@ type MetricsCollector interface {
 const (
 	// RefreshMetricsInterval specifies the interval of refresh kafka client metrics.
 	RefreshMetricsInterval = 5 * time.Second
-	// RefreshClusterMetaInterval specifies the interval of refresh kafka cluster meta.
-	RefreshClusterMetaInterval = 30 * time.Minute
+	// refreshClusterMetaInterval specifies the interval of refresh kafka cluster meta.
+	refreshClusterMetaInterval = 30 * time.Minute
 )
 
 // Sarama metrics names, see https://pkg.go.dev/github.com/Shopify/sarama#pkg-overview.
@@ -79,7 +79,7 @@ func (m *saramaMetricsCollector) Run(ctx context.Context) {
 	m.updateBrokers(ctx)
 
 	refreshMetricsTicker := time.NewTicker(RefreshMetricsInterval)
-	refreshClusterMetaTicker := time.NewTicker(RefreshClusterMetaInterval)
+	refreshClusterMetaTicker := time.NewTicker(refreshClusterMetaInterval)
 	defer func() {
 		refreshMetricsTicker.Stop()
 		m.cleanupMetrics()

--- a/pkg/sink/kafka/metrics_collector.go
+++ b/pkg/sink/kafka/metrics_collector.go
@@ -84,6 +84,7 @@ func (m *saramaMetricsCollector) Run(ctx context.Context) {
 	refreshClusterMetaTicker := time.NewTicker(refreshClusterMetaInterval)
 	defer func() {
 		refreshMetricsTicker.Stop()
+		refreshClusterMetaTicker.Stop()
 		m.cleanupMetrics()
 	}()
 

--- a/pkg/sink/kafka/metrics_collector.go
+++ b/pkg/sink/kafka/metrics_collector.go
@@ -34,6 +34,8 @@ const (
 	// RefreshMetricsInterval specifies the interval of refresh kafka client metrics.
 	RefreshMetricsInterval = 5 * time.Second
 	// refreshClusterMetaInterval specifies the interval of refresh kafka cluster meta.
+	// Do not set it too small, because it will cause too many requests to kafka cluster.
+	// Every request will get all topics and all brokers information.
 	refreshClusterMetaInterval = 30 * time.Minute
 )
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/8959

### What is changed and how it works?
Update/Get Kafka cluster every 30min.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new features need a release note -->

```release-note
Only get Kafka cluster metadata every 30 minutes
```
