### PR TITLE
cdc: fail the changefeed blocking global gc and suppressing the gc-ttl

### DIFF
--- a/errors.toml
+++ b/errors.toml
@@ -308,7 +308,7 @@ flow controller is aborted
 
 ["CDC:ErrGCTTLExceeded"]
 error = '''
-the checkpoint-ts(%d) lag of the changefeed(%s) has exceeded the GC TTL
+the checkpoint-ts(%d) lag of the changefeed(%s) has exceeded the GC TTL and the changefeed is blocking global GC progression
 '''
 
 ["CDC:ErrGRPCDialFailed"]

--- a/errors.toml
+++ b/errors.toml
@@ -306,6 +306,11 @@ error = '''
 flow controller is aborted
 '''
 
+["CDC:ErrGCTTLExceeded"]
+error = '''
+the checkpoint-ts(%d) lag of the changefeed(%s) has exceeded the GC TTL
+'''
+
 ["CDC:ErrGRPCDialFailed"]
 error = '''
 grpc dial failed

--- a/pkg/errors/cdc_errors.go
+++ b/pkg/errors/cdc_errors.go
@@ -595,8 +595,8 @@ var (
 		errors.RFCCodeText("CDC:ErrSnapshotLostByGC"),
 	)
 	ErrGCTTLExceeded = errors.Normalize(
-		"the checkpoint-ts(%d) lag of the changefeed(%s) "+
-			"has exceeded the GC TTL",
+		"the checkpoint-ts(%d) lag of the changefeed(%s) has exceeded "+
+			"the GC TTL and the changefeed is blocking global GC progression",
 		errors.RFCCodeText("CDC:ErrGCTTLExceeded"),
 	)
 	ErrNotOwner = errors.Normalize(

--- a/pkg/errors/cdc_errors.go
+++ b/pkg/errors/cdc_errors.go
@@ -594,6 +594,11 @@ var (
 			" caused by GC. checkpoint-ts %d is earlier than or equal to GC safepoint at %d",
 		errors.RFCCodeText("CDC:ErrSnapshotLostByGC"),
 	)
+	ErrGCTTLExceeded = errors.Normalize(
+		"the checkpoint-ts(%d) lag of the changefeed(%s) "+
+			"has exceeded the GC TTL",
+		errors.RFCCodeText("CDC:ErrGCTTLExceeded"),
+	)
 	ErrNotOwner = errors.Normalize(
 		"this capture is not a owner",
 		errors.RFCCodeText("CDC:ErrNotOwner"),

--- a/pkg/errors/helper.go
+++ b/pkg/errors/helper.go
@@ -39,7 +39,7 @@ func WrapError(rfcError *errors.Error, err error, args ...interface{}) error {
 // wants to replicate has been or will be GC. So it makes no sense to try to
 // resume the changefeed, and the changefeed should immediately be failed.
 var changeFeedFastFailError = []*errors.Error{
-	ErrSnapshotLostByGC, ErrStartTsBeforeGC,
+	ErrGCTTLExceeded, ErrSnapshotLostByGC, ErrStartTsBeforeGC,
 }
 
 // IsChangefeedFastFailError checks if an error is a ChangefeedFastFailError

--- a/pkg/txnutil/gc/gc_manager.go
+++ b/pkg/txnutil/gc/gc_manager.go
@@ -28,11 +28,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// gcTTL is the duration during which data related to a
-// failed feed will be retained, and beyond which point the data will be deleted
-// by garbage collection.
-const gcTTL = 24 * time.Hour
-
 // gcSafepointUpdateInterval is the minimum interval that CDC can update gc safepoint
 var gcSafepointUpdateInterval = 1 * time.Minute
 
@@ -57,6 +52,7 @@ type gcManager struct {
 	lastUpdatedTime   time.Time
 	lastSucceededTime time.Time
 	lastSafePointTs   uint64
+	isTiCDCBlockGC    bool
 }
 
 // NewManager creates a new Manager.
@@ -103,6 +99,10 @@ func (m *gcManager) TryUpdateGCSafePoint(
 		log.Warn("update gc safe point failed, the gc safe point is larger than checkpointTs",
 			zap.Uint64("actual", actual), zap.Uint64("checkpointTs", checkpointTs))
 	}
+	// if the min checkpoint ts is equal to the current gc safe point, it
+	// means that the service gc safe point set by TiCDC is the min service
+	// gc safe point
+	m.isTiCDCBlockGC = actual == checkpointTs
 	m.lastSafePointTs = actual
 	m.lastSucceededTime = time.Now()
 	return nil
@@ -112,13 +112,27 @@ func (m *gcManager) CheckStaleCheckpointTs(
 	ctx context.Context, changefeedID model.ChangeFeedID, checkpointTs model.Ts,
 ) error {
 	gcSafepointUpperBound := checkpointTs - 1
-	// if there is another service gc point less than the min checkpoint ts.
-	if gcSafepointUpperBound < m.lastSafePointTs {
-		return cerror.ErrSnapshotLostByGC.
-			GenWithStackByArgs(
-				checkpointTs,
-				m.lastSafePointTs,
-			)
+	if m.isTiCDCBlockGC {
+		pdTime := m.pdClock.CurrentTime()
+		if pdTime.Sub(
+			oracle.GetTimeFromTS(gcSafepointUpperBound),
+		) > time.Duration(m.gcTTL)*time.Second {
+			return cerror.ErrGCTTLExceeded.
+				GenWithStackByArgs(
+					checkpointTs,
+					changefeedID,
+				)
+		}
+	} else {
+		// if `isTiCDCBlockGC` is false, it means there is another service gc
+		// point less than the min checkpoint ts.
+		if gcSafepointUpperBound < m.lastSafePointTs {
+			return cerror.ErrSnapshotLostByGC.
+				GenWithStackByArgs(
+					checkpointTs,
+					m.lastSafePointTs,
+				)
+		}
 	}
 	return nil
 }
@@ -132,5 +146,5 @@ func (m *gcManager) IgnoreFailedChangeFeed(
 	gcSafepointUpperBound := checkpointTs - 1
 	return pdTime.Sub(
 		oracle.GetTimeFromTS(gcSafepointUpperBound),
-	) > gcTTL
+	) > time.Duration(m.gcTTL)
 }

--- a/pkg/txnutil/gc/gc_manager.go
+++ b/pkg/txnutil/gc/gc_manager.go
@@ -146,5 +146,5 @@ func (m *gcManager) IgnoreFailedChangeFeed(
 	gcSafepointUpperBound := checkpointTs - 1
 	return pdTime.Sub(
 		oracle.GetTimeFromTS(gcSafepointUpperBound),
-	) > time.Duration(m.gcTTL) * time.Second
+	) > time.Duration(m.gcTTL)*time.Second
 }

--- a/pkg/txnutil/gc/gc_manager.go
+++ b/pkg/txnutil/gc/gc_manager.go
@@ -146,5 +146,5 @@ func (m *gcManager) IgnoreFailedChangeFeed(
 	gcSafepointUpperBound := checkpointTs - 1
 	return pdTime.Sub(
 		oracle.GetTimeFromTS(gcSafepointUpperBound),
-	) > time.Duration(m.gcTTL)
+	) > time.Duration(m.gcTTL) * time.Second
 }

--- a/pkg/txnutil/gc/gc_manager_test.go
+++ b/pkg/txnutil/gc/gc_manager_test.go
@@ -112,6 +112,7 @@ func TestIgnoreFailedFeed(t *testing.T) {
 	pdClock := pdutil.NewClock4Test()
 	gcManager := NewManager(etcd.GcServiceIDForTest(),
 		mockPDClient, pdClock).(*gcManager)
+	gcManager.gcTTL = 24 * 60 * 60
 
 	// 5 hours ago
 	ts1 := oracle.GoTimeToTS(time.Now().Add(-time.Hour * 5))


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: close #9303 
Issue Number: close #9243 
### What is changed and how it works?
If the service responsible for blocking the garbage collection process, make sure to verify if the checkpoint timestamp of the changefeed has surpassed the time-to-live (TTL) for garbage collection when ticking.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - [x] Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
NA

##### Do you need to update user documentation, design documentation or monitoring documentation?
NA

### Release note <!-- bugfixes or new features need a release note -->

```release-note
A changefeed will fail if it is the service block the gc of the update stream TiDB and has surpassed the gc-ttl.
```
