### PR TITLE
sink (ticdc): add retry backoff and limit for sinkManager

### DIFF
--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -61,6 +61,13 @@ type TableStats struct {
 	BarrierTs    model.Ts
 }
 
+type sinkRetry struct {
+	// To control the error retry.
+	lastInternalError  error
+	firstRetryTime     time.Time
+	lastErrorRetryTime time.Time
+}
+
 // SinkManager is the implementation of SinkManager.
 type SinkManager struct {
 	changefeedID model.ChangeFeedID
@@ -99,7 +106,7 @@ type SinkManager struct {
 	sinkWorkerAvailable chan struct{}
 	// sinkMemQuota is used to control the total memory usage of the table sink.
 	sinkMemQuota *memquota.MemQuota
-
+	sinkRetry    sinkRetry
 	// redoWorkers used to pull data from source manager.
 	redoWorkers []*redoWorker
 	// redoTaskChan is used to send tasks to redoWorkers.
@@ -122,11 +129,6 @@ type SinkManager struct {
 
 	// Metric for table sink.
 	metricsTableSinkTotalRows prometheus.Counter
-
-	// To control the error retry.
-	lastInternalError  error
-	firstRetryTime     time.Time
-	lastErrorRetryTime time.Time
 }
 
 // New creates a new sink manager.
@@ -149,6 +151,11 @@ func New(
 		sinkWorkers:         make([]*sinkWorker, 0, sinkWorkerNum),
 		sinkTaskChan:        make(chan *sinkTask),
 		sinkWorkerAvailable: make(chan struct{}, 1),
+		sinkRetry: sinkRetry{
+			lastInternalError:  nil,
+			firstRetryTime:     time.Now(),
+			lastErrorRetryTime: time.Now(),
+		},
 
 		metricsTableSinkTotalRows: tablesinkmetrics.TotalRowsCountCounter.
 			WithLabelValues(changefeedID.Namespace, changefeedID.ID),
@@ -299,26 +306,23 @@ func (m *SinkManager) Run(ctx context.Context, warnings ...chan<- error) (err er
 func (m *SinkManager) getRetryBackoff(err error) (time.Duration, error) {
 	// reset firstRetryTime when the last error is too long ago
 	// it means the last error is retry success, and the sink is running well for some time
-	if m.lastInternalError == nil ||
-		time.Since(m.lastErrorRetryTime) >= errGCInterval {
-		m.firstRetryTime = time.Now()
+	if m.sinkRetry.lastInternalError == nil ||
+		time.Since(m.sinkRetry.lastErrorRetryTime) >= errGCInterval {
+		m.sinkRetry.firstRetryTime = time.Now()
 	}
 
 	// return an unretryable error if retry time is exhausted
-	if time.Since(m.firstRetryTime) >= maxRetryDuration {
+	if time.Since(m.sinkRetry.firstRetryTime) >= maxRetryDuration {
 		return 0, cerror.WrapChangefeedUnretryableErr(err)
 	}
 
-	m.lastInternalError = err
-	m.lastErrorRetryTime = time.Now()
+	m.sinkRetry.lastInternalError = err
+	m.sinkRetry.lastErrorRetryTime = time.Now()
 
 	// interval is in range [5s, 30s)
 	interval := time.Second * time.Duration(rand.Int63n(25)+5)
 	return interval, nil
 }
-
-// 1. add a backoff to avoid retrying too fast and infinitely
-// 2. add a background goroutine to reset backoff when last error time is too long ago (e.g. 30 min)
 
 func (m *SinkManager) initSinkFactory(errCh chan error) error {
 	m.sinkFactoryMu.Lock()

--- a/cdc/processor/sinkmanager/manager_test.go
+++ b/cdc/processor/sinkmanager/manager_test.go
@@ -374,11 +374,11 @@ func TestGetRetryBackoff(t *testing.T) {
 	require.NoError(t, err)
 	require.Less(t, backoff, 30*time.Second)
 	time.Sleep(500 * time.Millisecond)
-	elapsedTime := time.Since(manager.firstRetryTime)
+	elapsedTime := time.Since(manager.sinkRetry.firstRetryTime)
 
 	// mock time to test reset error backoff
-	manager.lastErrorRetryTime = time.Unix(0, 0)
+	manager.sinkRetry.lastErrorRetryTime = time.Unix(0, 0)
 	_, err = manager.getRetryBackoff(errors.New("test"))
 	require.NoError(t, err)
-	require.Less(t, time.Since(manager.firstRetryTime), elapsedTime)
+	require.Less(t, time.Since(manager.sinkRetry.firstRetryTime), elapsedTime)
 }

--- a/cdc/processor/sinkmanager/manager_test.go
+++ b/cdc/processor/sinkmanager/manager_test.go
@@ -372,13 +372,13 @@ func TestGetRetryBackoff(t *testing.T) {
 
 	backoff, err := manager.getRetryBackoff(errors.New("test"))
 	require.NoError(t, err)
-	require.Less(t, backoff, manager.errorBackoff.NextBackOff())
+	require.Less(t, backoff, 30*time.Second)
 	time.Sleep(500 * time.Millisecond)
-	elapsedTime := manager.errorBackoff.GetElapsedTime()
+	elapsedTime := time.Since(manager.firstRetryTime)
 
 	// mock time to test reset error backoff
 	manager.lastErrorRetryTime = time.Unix(0, 0)
 	_, err = manager.getRetryBackoff(errors.New("test"))
 	require.NoError(t, err)
-	require.Less(t, manager.errorBackoff.GetElapsedTime(), elapsedTime)
+	require.Less(t, time.Since(manager.firstRetryTime), elapsedTime)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9272 

### What is changed and how it works?
 Limit `sinkManager` retry on `SinkInternal` error at most 30 minutes. 

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
