### PR TITLE
codec(ticdc): remove 2nd parameter from the decoder interface.

### DIFF
--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -1187,7 +1187,7 @@ func TestE2ERowLevelChecksum(t *testing.T) {
 	require.True(t, hasNext)
 	require.Equal(t, model.MessageTypeRow, messageType)
 
-	row, _, err = decoder.NextRowChangedEvent()
+	row, err = decoder.NextRowChangedEvent()
 	// no error, checksum verification passed.
 	require.NoError(t, err)
 }

--- a/cmd/kafka-consumer/main.go
+++ b/cmd/kafka-consumer/main.go
@@ -624,7 +624,7 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 					c.appendDDL(ddl)
 				}
 			case model.MessageTypeRow:
-				row, _, err := decoder.NextRowChangedEvent()
+				row, err := decoder.NextRowChangedEvent()
 				if err != nil {
 					log.Panic("decode message value failed",
 						zap.ByteString("value", message.Value),

--- a/cmd/storage-consumer/main.go
+++ b/cmd/storage-consumer/main.go
@@ -334,7 +334,7 @@ func (c *consumer) emitDMLEvents(
 		cnt++
 
 		if tp == model.MessageTypeRow {
-			row, _, err := decoder.NextRowChangedEvent()
+			row, err := decoder.NextRowChangedEvent()
 			if err != nil {
 				log.Error("failed to get next row changed event", zap.Error(err))
 				return errors.Trace(err)

--- a/pkg/sink/codec/avro/decoder.go
+++ b/pkg/sink/codec/avro/decoder.go
@@ -97,7 +97,7 @@ func (d *decoder) HasNext() (model.MessageType, bool, error) {
 }
 
 // NextRowChangedEvent returns the next row changed event if exists
-func (d *decoder) NextRowChangedEvent() (*model.RowChangedEvent, bool, error) {
+func (d *decoder) NextRowChangedEvent() (*model.RowChangedEvent, error) {
 	var (
 		valueMap    map[string]interface{}
 		valueSchema map[string]interface{}
@@ -107,7 +107,7 @@ func (d *decoder) NextRowChangedEvent() (*model.RowChangedEvent, bool, error) {
 	ctx := context.Background()
 	keyMap, keySchema, err := d.decodeKey(ctx)
 	if err != nil {
-		return nil, false, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 
 	// for the delete event, only have key part, it holds primary key or the unique key columns.
@@ -120,24 +120,24 @@ func (d *decoder) NextRowChangedEvent() (*model.RowChangedEvent, bool, error) {
 	} else {
 		valueMap, valueSchema, err = d.decodeValue(ctx)
 		if err != nil {
-			return nil, false, errors.Trace(err)
+			return nil, errors.Trace(err)
 		}
 	}
 
 	event, err := assembleEvent(keyMap, valueMap, valueSchema, isDelete)
 	if err != nil {
-		return nil, false, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 
 	// Delete event only has Primary Key Columns, but the checksum is calculated based on the whole row columns,
 	// checksum verification cannot be done here, so skip it.
 	if isDelete {
-		return event, false, nil
+		return event, nil
 	}
 
 	expectedChecksum, found, err := extractExpectedChecksum(valueMap)
 	if err != nil {
-		return nil, false, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 
 	if isCorrupted(valueMap) {
@@ -157,11 +157,11 @@ func (d *decoder) NextRowChangedEvent() (*model.RowChangedEvent, bool, error) {
 
 	if found {
 		if err := d.verifyChecksum(event.Columns, expectedChecksum); err != nil {
-			return nil, false, errors.Trace(err)
+			return nil, errors.Trace(err)
 		}
 	}
 
-	return event, false, nil
+	return event, nil
 }
 
 // assembleEvent return a row changed event

--- a/pkg/sink/codec/avro/decoder_test.go
+++ b/pkg/sink/codec/avro/decoder_test.go
@@ -132,9 +132,8 @@ func TestDecodeEvent(t *testing.T) {
 	require.True(t, exist)
 	require.Equal(t, model.MessageTypeRow, messageType)
 
-	decodedEvent, onlyHandleKey, err := decoder.NextRowChangedEvent()
+	decodedEvent, err := decoder.NextRowChangedEvent()
 	require.NoError(t, err)
-	require.False(t, onlyHandleKey)
 	require.NotNil(t, decodedEvent)
 }
 

--- a/pkg/sink/codec/builder/codec_test.go
+++ b/pkg/sink/codec/builder/codec_test.go
@@ -291,7 +291,7 @@ func BenchmarkCraftDecoding(b *testing.B) {
 					if _, hasNext, err := decoder.HasNext(); err != nil {
 						panic(err)
 					} else if hasNext {
-						_, _, _ = decoder.NextRowChangedEvent()
+						_, _ = decoder.NextRowChangedEvent()
 					} else {
 						break
 					}
@@ -312,7 +312,7 @@ func BenchmarkJsonDecoding(b *testing.B) {
 					if _, hasNext, err := decoder.HasNext(); err != nil {
 						panic(err)
 					} else if hasNext {
-						_, _, _ = decoder.NextRowChangedEvent()
+						_, _ = decoder.NextRowChangedEvent()
 					} else {
 						break
 					}

--- a/pkg/sink/codec/canal/canal_json_decoder.go
+++ b/pkg/sink/codec/canal/canal_json_decoder.go
@@ -92,17 +92,17 @@ func (b *batchDecoder) HasNext() (model.MessageType, bool, error) {
 
 // NextRowChangedEvent implements the RowEventDecoder interface
 // `HasNext` should be called before this.
-func (b *batchDecoder) NextRowChangedEvent() (*model.RowChangedEvent, bool, error) {
+func (b *batchDecoder) NextRowChangedEvent() (*model.RowChangedEvent, error) {
 	if b.msg == nil || b.msg.messageType() != model.MessageTypeRow {
-		return nil, false, cerror.ErrCanalDecodeFailed.
+		return nil, cerror.ErrCanalDecodeFailed.
 			GenWithStack("not found row changed event message")
 	}
 	result, err := canalJSONMessage2RowChange(b.msg)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	b.msg = nil
-	return result, false, nil
+	return result, nil
 }
 
 // NextDDLEvent implements the RowEventDecoder interface

--- a/pkg/sink/codec/canal/canal_json_decoder_test.go
+++ b/pkg/sink/codec/canal/canal_json_decoder_test.go
@@ -51,9 +51,8 @@ func TestNewCanalJSONBatchDecoder4RowMessage(t *testing.T) {
 			require.True(t, hasNext)
 			require.Equal(t, model.MessageTypeRow, ty)
 
-			consumed, onlyHandleKey, err := decoder.NextRowChangedEvent()
+			consumed, err := decoder.NextRowChangedEvent()
 			require.NoError(t, err)
-			require.False(t, onlyHandleKey)
 
 			require.Equal(t, testCaseInsert.Table, consumed.Table)
 			if encodeEnable && decodeEnable {
@@ -77,9 +76,8 @@ func TestNewCanalJSONBatchDecoder4RowMessage(t *testing.T) {
 			_, hasNext, _ = decoder.HasNext()
 			require.False(t, hasNext)
 
-			consumed, onlyHandleKey, err = decoder.NextRowChangedEvent()
+			consumed, err = decoder.NextRowChangedEvent()
 			require.Error(t, err)
-			require.False(t, onlyHandleKey)
 			require.Nil(t, consumed)
 		}
 	}
@@ -149,9 +147,8 @@ func TestCanalJSONBatchDecoderWithTerminator(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, model.MessageTypeRow, tp)
 		cnt++
-		event, onlyHandleKey, err := decoder.NextRowChangedEvent()
+		event, err := decoder.NextRowChangedEvent()
 		require.NoError(t, err)
-		require.False(t, onlyHandleKey)
 		require.NotNil(t, event)
 	}
 	require.Equal(t, 3, cnt)

--- a/pkg/sink/codec/craft/craft_decoder.go
+++ b/pkg/sink/codec/craft/craft_decoder.go
@@ -52,27 +52,27 @@ func (b *batchDecoder) NextResolvedEvent() (uint64, error) {
 }
 
 // NextRowChangedEvent implements the RowEventDecoder interface
-func (b *batchDecoder) NextRowChangedEvent() (*model.RowChangedEvent, bool, error) {
+func (b *batchDecoder) NextRowChangedEvent() (*model.RowChangedEvent, error) {
 	ty, hasNext, err := b.HasNext()
 	if err != nil {
-		return nil, false, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	if !hasNext || ty != model.MessageTypeRow {
-		return nil, false, cerror.ErrCraftCodecInvalidData.GenWithStack("not found row changed event message")
+		return nil, cerror.ErrCraftCodecInvalidData.GenWithStack("not found row changed event message")
 	}
 	oldValue, newValue, err := b.decoder.RowChangedEvent(b.index)
 	if err != nil {
-		return nil, false, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	ev := &model.RowChangedEvent{}
 	if oldValue != nil {
 		if ev.PreColumns, err = oldValue.ToModel(); err != nil {
-			return nil, false, errors.Trace(err)
+			return nil, errors.Trace(err)
 		}
 	}
 	if newValue != nil {
 		if ev.Columns, err = newValue.ToModel(); err != nil {
-			return nil, false, errors.Trace(err)
+			return nil, errors.Trace(err)
 		}
 	}
 	ev.CommitTs = b.headers.GetTs(b.index)
@@ -86,7 +86,7 @@ func (b *batchDecoder) NextRowChangedEvent() (*model.RowChangedEvent, bool, erro
 		ev.Table.IsPartition = true
 	}
 	b.index++
-	return ev, false, nil
+	return ev, nil
 }
 
 // NextDDLEvent implements the RowEventDecoder interface

--- a/pkg/sink/codec/craft/craft_encoder_test.go
+++ b/pkg/sink/codec/craft/craft_encoder_test.go
@@ -87,9 +87,8 @@ func TestCraftMaxBatchSize(t *testing.T) {
 			}
 
 			require.Equal(t, model.MessageTypeRow, v)
-			_, onlyHandleKey, err := decoder.NextRowChangedEvent()
+			_, err = decoder.NextRowChangedEvent()
 			require.NoError(t, err)
-			require.False(t, onlyHandleKey)
 			count++
 		}
 		require.LessOrEqual(t, count, 64)
@@ -122,9 +121,8 @@ func testBatchCodec(
 				break
 			}
 			require.Equal(t, model.MessageTypeRow, tp)
-			row, onlyHandleKey, err := decoder.NextRowChangedEvent()
+			row, err := decoder.NextRowChangedEvent()
 			require.NoError(t, err)
-			require.False(t, onlyHandleKey)
 			require.Equal(t, cs[index], row)
 			index++
 		}

--- a/pkg/sink/codec/csv/csv_decoder.go
+++ b/pkg/sink/codec/csv/csv_decoder.go
@@ -104,16 +104,16 @@ func (b *batchDecoder) NextResolvedEvent() (uint64, error) {
 }
 
 // NextRowChangedEvent implements the RowEventDecoder interface.
-func (b *batchDecoder) NextRowChangedEvent() (*model.RowChangedEvent, bool, error) {
+func (b *batchDecoder) NextRowChangedEvent() (*model.RowChangedEvent, error) {
 	if b.closed {
-		return nil, false, cerror.WrapError(cerror.ErrCSVDecodeFailed, errors.New("no csv row can be found"))
+		return nil, cerror.WrapError(cerror.ErrCSVDecodeFailed, errors.New("no csv row can be found"))
 	}
 
 	e, err := csvMsg2RowChangedEvent(b.msg, b.tableInfo.Columns)
 	if err != nil {
-		return nil, false, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
-	return e, false, nil
+	return e, nil
 }
 
 // NextDDLEvent implements the RowEventDecoder interface.

--- a/pkg/sink/codec/csv/csv_decoder_test.go
+++ b/pkg/sink/codec/csv/csv_decoder_test.go
@@ -77,9 +77,8 @@ func TestCSVBatchDecoder(t *testing.T) {
 		require.Nil(t, err)
 		require.True(t, hasNext)
 		require.Equal(t, model.MessageTypeRow, tp)
-		event, onlyHandleKey, err := decoder.NextRowChangedEvent()
+		event, err := decoder.NextRowChangedEvent()
 		require.NoError(t, err)
-		require.False(t, onlyHandleKey)
 		require.NotNil(t, event)
 	}
 

--- a/pkg/sink/codec/decoder.go
+++ b/pkg/sink/codec/decoder.go
@@ -31,9 +31,7 @@ type RowEventDecoder interface {
 	// NextResolvedEvent returns the next resolved event if exists
 	NextResolvedEvent() (uint64, error)
 	// NextRowChangedEvent returns the next row changed event if exists
-	// return true if the event only has handle key sent, only open-protocol support this at the moment
-	// consumer should query the row data by the handle key and commit-ts
-	NextRowChangedEvent() (*model.RowChangedEvent, bool, error)
+	NextRowChangedEvent() (*model.RowChangedEvent, error)
 	// NextDDLEvent returns the next DDL event if exists
 	NextDDLEvent() (*model.DDLEvent, error)
 }

--- a/pkg/sink/codec/internal/batch_tester.go
+++ b/pkg/sink/codec/internal/batch_tester.go
@@ -239,9 +239,8 @@ func (s *BatchTester) TestBatchCodec(
 				break
 			}
 			require.Equal(t, model.MessageTypeRow, tp)
-			row, onlyHandleKey, err := decoder.NextRowChangedEvent()
+			row, err := decoder.NextRowChangedEvent()
 			require.NoError(t, err)
-			require.False(t, onlyHandleKey)
 			sortColumnArrays(row.Columns, row.PreColumns, cs[index].Columns, cs[index].PreColumns)
 			require.Equal(t, cs[index], row)
 			index++

--- a/pkg/sink/codec/open/open_protocol_decoder.go
+++ b/pkg/sink/codec/open/open_protocol_decoder.go
@@ -60,27 +60,26 @@ func (b *BatchMixedDecoder) NextResolvedEvent() (uint64, error) {
 }
 
 // NextRowChangedEvent implements the RowEventDecoder interface
-func (b *BatchMixedDecoder) NextRowChangedEvent() (*model.RowChangedEvent, bool, error) {
+func (b *BatchMixedDecoder) NextRowChangedEvent() (*model.RowChangedEvent, error) {
 	if b.nextKey == nil {
 		if err := b.decodeNextKey(); err != nil {
-			return nil, false, err
+			return nil, err
 		}
 	}
 	b.mixedBytes = b.mixedBytes[b.nextKeyLen+8:]
 	if b.nextKey.Type != model.MessageTypeRow {
-		return nil, false, cerror.ErrOpenProtocolCodecInvalidData.GenWithStack("not found row event message")
+		return nil, cerror.ErrOpenProtocolCodecInvalidData.GenWithStack("not found row event message")
 	}
 	valueLen := binary.BigEndian.Uint64(b.mixedBytes[:8])
 	value := b.mixedBytes[8 : valueLen+8]
 	b.mixedBytes = b.mixedBytes[valueLen+8:]
 	rowMsg := new(messageRow)
 	if err := rowMsg.decode(value); err != nil {
-		return nil, false, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	rowEvent := msgToRowChange(b.nextKey, rowMsg)
-	onlyHandleKey := b.nextKey.OnlyHandleKey
 	b.nextKey = nil
-	return rowEvent, onlyHandleKey, nil
+	return rowEvent, nil
 }
 
 // NextDDLEvent implements the RowEventDecoder interface
@@ -162,27 +161,26 @@ func (b *BatchDecoder) NextResolvedEvent() (uint64, error) {
 }
 
 // NextRowChangedEvent implements the RowEventDecoder interface
-func (b *BatchDecoder) NextRowChangedEvent() (*model.RowChangedEvent, bool, error) {
+func (b *BatchDecoder) NextRowChangedEvent() (*model.RowChangedEvent, error) {
 	if b.nextKey == nil {
 		if err := b.decodeNextKey(); err != nil {
-			return nil, false, err
+			return nil, err
 		}
 	}
 	b.keyBytes = b.keyBytes[b.nextKeyLen+8:]
 	if b.nextKey.Type != model.MessageTypeRow {
-		return nil, false, cerror.ErrOpenProtocolCodecInvalidData.GenWithStack("not found row event message")
+		return nil, cerror.ErrOpenProtocolCodecInvalidData.GenWithStack("not found row event message")
 	}
 	valueLen := binary.BigEndian.Uint64(b.valueBytes[:8])
 	value := b.valueBytes[8 : valueLen+8]
 	b.valueBytes = b.valueBytes[valueLen+8:]
 	rowMsg := new(messageRow)
 	if err := rowMsg.decode(value); err != nil {
-		return nil, false, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	rowEvent := msgToRowChange(b.nextKey, rowMsg)
-	onlyHandleKey := b.nextKey.OnlyHandleKey
 	b.nextKey = nil
-	return rowEvent, onlyHandleKey, nil
+	return rowEvent, nil
 }
 
 // NextDDLEvent implements the RowEventDecoder interface

--- a/pkg/sink/codec/open/open_protocol_decoder_test.go
+++ b/pkg/sink/codec/open/open_protocol_decoder_test.go
@@ -68,9 +68,8 @@ func TestDecodeEvent(t *testing.T) {
 	require.True(t, hasNext)
 	require.Equal(t, model.MessageTypeRow, tp)
 
-	obtained, onlyHandleKey, err := decoder.NextRowChangedEvent()
+	obtained, err := decoder.NextRowChangedEvent()
 	require.NoError(t, err)
-	require.False(t, onlyHandleKey)
 
 	obtainedColumns := make(map[string]*model.Column)
 	for _, col := range obtained.Columns {
@@ -104,9 +103,8 @@ func TestDecodeEventOnlyHandleKeyColumns(t *testing.T) {
 	require.True(t, hasNext)
 	require.Equal(t, model.MessageTypeRow, tp)
 
-	obtained, onlyHandleKey, err := decoder.NextRowChangedEvent()
+	obtained, err := decoder.NextRowChangedEvent()
 	require.NoError(t, err)
-	require.True(t, onlyHandleKey)
 	require.Equal(t, insertEvent.CommitTs, obtained.CommitTs)
 
 	obtainedColumns := make(map[string]*model.Column)

--- a/pkg/sink/codec/open/open_protocol_encoder_test.go
+++ b/pkg/sink/codec/open/open_protocol_encoder_test.go
@@ -113,9 +113,8 @@ func TestMaxBatchSize(t *testing.T) {
 			}
 
 			require.Equal(t, model.MessageTypeRow, v)
-			_, onlyHandleKey, err := decoder.NextRowChangedEvent()
+			_, err = decoder.NextRowChangedEvent()
 			require.NoError(t, err)
-			require.False(t, onlyHandleKey)
 			count++
 		}
 		require.LessOrEqual(t, count, 64)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9332 

### What is changed and how it works?

#9187 add the `onlyHandleKey` to the decoder's `NextRowChangedEvent` method, this PR revert it, since:
* It makes the caller's logic complicated
* we also support `claim-check`, it's unnecessary to expose such to the outside of the decoder

I'd like to wrap all details in the decoder itself, to make caller easier.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
