### PR TITLE
p2p(ticdc): fix panic issue when peer is not found

### DIFF
--- a/pkg/p2p/server.go
+++ b/pkg/p2p/server.go
@@ -391,6 +391,7 @@ func (m *MessageServer) deregisterPeerByID(ctx context.Context, peerID string) {
 	m.peerLock.Unlock()
 	if !ok {
 		log.Warn("peer not found", zap.String("peerID", peerID))
+		return
 	}
 	m.deregisterPeer(ctx, peer, nil)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9354

### What is changed and how it works?
 fix panic issue when peer is not found


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
