### PR TITLE
kafka(ticdc): use sarama mock producer in the unit test to workaround the data race

### DIFF
--- a/cdc/sink/ddlsink/mq/ddlproducer/ddl_producer.go
+++ b/cdc/sink/ddlsink/mq/ddlproducer/ddl_producer.go
@@ -37,4 +37,4 @@ type DDLProducer interface {
 
 // Factory is a function to create a producer.
 type Factory func(ctx context.Context, changefeedID model.ChangeFeedID,
-	factory kafka.SyncProducer) (DDLProducer, error)
+	syncProducer kafka.SyncProducer) (DDLProducer, error)

--- a/cdc/sink/ddlsink/mq/ddlproducer/ddl_producer.go
+++ b/cdc/sink/ddlsink/mq/ddlproducer/ddl_producer.go
@@ -37,4 +37,4 @@ type DDLProducer interface {
 
 // Factory is a function to create a producer.
 type Factory func(ctx context.Context, changefeedID model.ChangeFeedID,
-	factory kafka.Factory) (DDLProducer, error)
+	factory kafka.SyncProducer) (DDLProducer, error)

--- a/cdc/sink/ddlsink/mq/ddlproducer/kafka_ddl_mock_producer.go
+++ b/cdc/sink/ddlsink/mq/ddlproducer/kafka_ddl_mock_producer.go
@@ -30,7 +30,7 @@ type MockDDLProducer struct {
 }
 
 // NewMockDDLProducer creates a mock producer.
-func NewMockDDLProducer(_ context.Context, _ model.ChangeFeedID, _ kafka.Factory) (DDLProducer, error) {
+func NewMockDDLProducer(_ context.Context, _ model.ChangeFeedID, _ kafka.SyncProducer) (DDLProducer, error) {
 	return &MockDDLProducer{
 		events: make(map[string][]*common.Message),
 	}, nil

--- a/cdc/sink/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
+++ b/cdc/sink/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
@@ -46,13 +46,8 @@ type kafkaDDLProducer struct {
 // NewKafkaDDLProducer creates a new kafka producer for replicating DDL.
 func NewKafkaDDLProducer(ctx context.Context,
 	changefeedID model.ChangeFeedID,
-	factory kafka.Factory,
+	syncProducer kafka.SyncProducer,
 ) (DDLProducer, error) {
-	syncProducer, err := factory.SyncProducer(ctx)
-	if err != nil {
-		return nil, cerror.WrapError(cerror.ErrKafkaNewProducer, err)
-	}
-
 	p := &kafkaDDLProducer{
 		id:           changefeedID,
 		syncProducer: syncProducer,

--- a/cdc/sink/ddlsink/mq/ddlproducer/kafka_ddl_producer_test.go
+++ b/cdc/sink/ddlsink/mq/ddlproducer/kafka_ddl_producer_test.go
@@ -15,7 +15,6 @@ package ddlproducer
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -27,33 +26,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func initBroker(t *testing.T) (*sarama.MockBroker, string) {
-	topic := kafka.DefaultMockTopicName
-	leader := sarama.NewMockBroker(t, 2)
-	return leader, topic
-}
-
-func getOptions(addr string) *kafka.Options {
+func getOptions() *kafka.Options {
 	options := kafka.NewOptions()
-	// Because the sarama mock broker is not compatible with version larger than 1.0.0.
-	// We use a smaller version in the following producer tests.
-	// Ref: https://github.com/Shopify/sarama/blob/89707055369768913defac
-	// 030c15cf08e9e57925/async_producer_test.go#L1445-L1447
 	options.Version = "0.9.0.0"
 	options.ClientID = "test-client"
 	options.PartitionNum = int32(kafka.DefaultMockPartitionNum)
 	options.AutoCreate = false
-	options.BrokerEndpoints = strings.Split(addr, ",")
+	options.BrokerEndpoints = []string{"127.0.0.1:9092"}
 
 	return options
 }
 
 func TestSyncBroadcastMessage(t *testing.T) {
-	leader, topic := initBroker(t)
-	defer leader.Close()
-
 	ctx, cancel := context.WithCancel(context.Background())
-	options := getOptions(leader.Addr())
+	options := getOptions()
 	options.MaxMessages = 1
 
 	changefeed := model.DefaultChangeFeedID("changefeed-test")
@@ -69,23 +55,20 @@ func TestSyncBroadcastMessage(t *testing.T) {
 	for i := 0; i < kafka.DefaultMockPartitionNum; i++ {
 		syncProducer.(*kafka.MockSaramaSyncProducer).Producer.ExpectSendMessageAndSucceed()
 	}
-	err = p.SyncBroadcastMessage(ctx, topic,
+	err = p.SyncBroadcastMessage(ctx, kafka.DefaultMockTopicName,
 		kafka.DefaultMockPartitionNum, &common.Message{Ts: 417318403368288260})
 	require.NoError(t, err)
 
 	p.Close()
-	err = p.SyncBroadcastMessage(ctx, topic,
+	err = p.SyncBroadcastMessage(ctx, kafka.DefaultMockTopicName,
 		kafka.DefaultMockPartitionNum, &common.Message{Ts: 417318403368288260})
 	require.ErrorIs(t, err, cerror.ErrKafkaProducerClosed)
 	cancel()
 }
 
 func TestSyncSendMessage(t *testing.T) {
-	leader, topic := initBroker(t)
-	defer leader.Close()
-
 	ctx, cancel := context.WithCancel(context.Background())
-	options := getOptions(leader.Addr())
+	options := getOptions()
 
 	changefeed := model.DefaultChangeFeedID("changefeed-test")
 	factory, err := kafka.NewMockFactory(t, options, changefeed)
@@ -98,22 +81,19 @@ func TestSyncSendMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	syncProducer.(*kafka.MockSaramaSyncProducer).Producer.ExpectSendMessageAndSucceed()
-	err = p.SyncSendMessage(ctx, topic, 0, &common.Message{Ts: 417318403368288260})
+	err = p.SyncSendMessage(ctx, kafka.DefaultMockTopicName, 0, &common.Message{Ts: 417318403368288260})
 	require.NoError(t, err)
 
 	p.Close()
-	err = p.SyncSendMessage(ctx, topic, 0, &common.Message{Ts: 417318403368288260})
+	err = p.SyncSendMessage(ctx, kafka.DefaultMockTopicName, 0, &common.Message{Ts: 417318403368288260})
 	require.ErrorIs(t, err, cerror.ErrKafkaProducerClosed)
 	cancel()
 }
 
 func TestProducerSendMsgFailed(t *testing.T) {
-	leader, topic := initBroker(t)
-	defer leader.Close()
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
-	options := getOptions(leader.Addr())
+	options := getOptions()
 	options.MaxMessages = 1
 	options.MaxMessageBytes = 1
 
@@ -131,17 +111,14 @@ func TestProducerSendMsgFailed(t *testing.T) {
 	defer p.Close()
 
 	syncProducer.(*kafka.MockSaramaSyncProducer).Producer.ExpectSendMessageAndFail(sarama.ErrMessageTooLarge)
-	err = p.SyncSendMessage(ctx, topic, 0, &common.Message{Ts: 417318403368288260})
+	err = p.SyncSendMessage(ctx, kafka.DefaultMockTopicName, 0, &common.Message{Ts: 417318403368288260})
 	require.ErrorIs(t, err, sarama.ErrMessageTooLarge)
 }
 
 func TestProducerDoubleClose(t *testing.T) {
-	leader, _ := initBroker(t)
-	defer leader.Close()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	options := getOptions(leader.Addr())
+	options := getOptions()
 
 	changefeed := model.DefaultChangeFeedID("changefeed-test")
 	factory, err := kafka.NewMockFactory(t, options, changefeed)

--- a/cdc/sink/ddlsink/mq/ddlproducer/kafka_ddl_producer_test.go
+++ b/cdc/sink/ddlsink/mq/ddlproducer/kafka_ddl_producer_test.go
@@ -42,8 +42,9 @@ func TestSyncBroadcastMessage(t *testing.T) {
 	options := getOptions()
 	options.MaxMessages = 1
 
+	ctx = context.WithValue(ctx, "testing.T", t)
 	changefeed := model.DefaultChangeFeedID("changefeed-test")
-	factory, err := kafka.NewMockFactory(t, options, changefeed)
+	factory, err := kafka.NewMockFactory(options, changefeed)
 	require.NoError(t, err)
 
 	syncProducer, err := factory.SyncProducer(ctx)
@@ -70,8 +71,9 @@ func TestSyncSendMessage(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	options := getOptions()
 
+	ctx = context.WithValue(ctx, "testing.T", t)
 	changefeed := model.DefaultChangeFeedID("changefeed-test")
-	factory, err := kafka.NewMockFactory(t, options, changefeed)
+	factory, err := kafka.NewMockFactory(options, changefeed)
 	require.NoError(t, err)
 
 	syncProducer, err := factory.SyncProducer(ctx)
@@ -97,9 +99,11 @@ func TestProducerSendMsgFailed(t *testing.T) {
 	options.MaxMessages = 1
 	options.MaxMessageBytes = 1
 
+	ctx = context.WithValue(ctx, "testing.T", t)
+
 	// This will make the first send failed.
 	changefeed := model.DefaultChangeFeedID("changefeed-test")
-	factory, err := kafka.NewMockFactory(t, options, changefeed)
+	factory, err := kafka.NewMockFactory(options, changefeed)
 	require.NoError(t, err)
 
 	syncProducer, err := factory.SyncProducer(ctx)
@@ -120,8 +124,9 @@ func TestProducerDoubleClose(t *testing.T) {
 	defer cancel()
 	options := getOptions()
 
+	ctx = context.WithValue(ctx, "testing.T", t)
 	changefeed := model.DefaultChangeFeedID("changefeed-test")
-	factory, err := kafka.NewMockFactory(t, options, changefeed)
+	factory, err := kafka.NewMockFactory(options, changefeed)
 	require.NoError(t, err)
 
 	syncProducer, err := factory.SyncProducer(ctx)

--- a/cdc/sink/ddlsink/mq/kafka_ddl_sink.go
+++ b/cdc/sink/ddlsink/mq/kafka_ddl_sink.go
@@ -81,7 +81,13 @@ func NewKafkaDDLSink(
 	start := time.Now()
 	log.Info("Try to create a DDL sink producer",
 		zap.Any("options", options))
-	p, err := producerCreator(ctx, changefeedID, factory)
+
+	syncProducer, err := factory.SyncProducer(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	p, err := producerCreator(ctx, changefeedID, syncProducer)
 	log.Info("DDL sink producer client created", zap.Duration("duration", time.Since(start)))
 	if err != nil {
 		return nil, cerror.WrapError(cerror.ErrKafkaNewProducer, err)

--- a/cdc/sink/ddlsink/mq/kafka_ddl_sink.go
+++ b/cdc/sink/ddlsink/mq/kafka_ddl_sink.go
@@ -86,6 +86,11 @@ func NewKafkaDDLSink(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	defer func() {
+		if err != nil && syncProducer != nil {
+			syncProducer.Close()
+		}
+	}()
 
 	p, err := producerCreator(ctx, changefeedID, syncProducer)
 	log.Info("DDL sink producer client created", zap.Duration("duration", time.Since(start)))

--- a/cdc/sink/ddlsink/mq/mq_ddl_sink_test.go
+++ b/cdc/sink/ddlsink/mq/mq_ddl_sink_test.go
@@ -19,7 +19,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/Shopify/sarama"
 	mm "github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/sink/ddlsink/mq/ddlproducer"
@@ -28,26 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:unparam
-func initBroker(t *testing.T, partitionNum int) (*sarama.MockBroker, string) {
-	topic := kafka.DefaultMockTopicName
-	leader := sarama.NewMockBroker(t, 1)
-
-	metadataResponse := sarama.NewMockMetadataResponse(t)
-	metadataResponse.SetBroker(leader.Addr(), leader.BrokerID())
-	for i := 0; i < partitionNum; i++ {
-		metadataResponse.SetLeader(topic, int32(i), leader.BrokerID())
-	}
-
-	prodSuccess := sarama.NewMockProduceResponse(t)
-	handlerMap := make(map[string]sarama.MockResponse)
-	handlerMap["MetadataRequest"] = metadataResponse
-	handlerMap["ProduceRequest"] = prodSuccess
-	leader.SetHandlerByMap(handlerMap)
-
-	return leader, topic
-}
-
 func TestNewKafkaDDLSinkFailed(t *testing.T) {
 	t.Parallel()
 
@@ -55,17 +34,15 @@ func TestNewKafkaDDLSinkFailed(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	leader, topic := initBroker(t, kafka.DefaultMockPartitionNum)
-	defer leader.Close()
 	uriTemplate := "kafka://%s/%s?kafka-version=0.9.0.0&max-batch-size=1" +
 		"&max-message-bytes=1048576&partition-num=1" +
 		"&kafka-client-id=unit-test&auto-create-topic=false&compression=gzip&protocol=avro"
-	uri := fmt.Sprintf(uriTemplate, leader.Addr(), topic)
+	uri := fmt.Sprintf(uriTemplate, "127.0.0.1:9092", kafka.DefaultMockTopicName)
 
 	sinkURI, err := url.Parse(uri)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	replicaConfig := config.GetDefaultReplicaConfig()
-	require.Nil(t, replicaConfig.ValidateAndAdjust(sinkURI))
+	require.NoError(t, replicaConfig.ValidateAndAdjust(sinkURI))
 
 	ctx = context.WithValue(ctx, "testing.T", t)
 	s, err := NewKafkaDDLSink(ctx, changefeedID, sinkURI, replicaConfig,
@@ -82,23 +59,21 @@ func TestWriteDDLEventToAllPartitions(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	leader, topic := initBroker(t, kafka.DefaultMockPartitionNum)
-	defer leader.Close()
 	uriTemplate := "kafka://%s/%s?kafka-version=0.9.0.0&max-batch-size=1" +
 		"&max-message-bytes=1048576&partition-num=1" +
 		"&kafka-client-id=unit-test&auto-create-topic=false&compression=gzip&protocol=open-protocol"
-	uri := fmt.Sprintf(uriTemplate, leader.Addr(), topic)
+	uri := fmt.Sprintf(uriTemplate, "127.0.0.1:9092", kafka.DefaultMockTopicName)
 
 	sinkURI, err := url.Parse(uri)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	replicaConfig := config.GetDefaultReplicaConfig()
-	require.Nil(t, replicaConfig.ValidateAndAdjust(sinkURI))
+	require.NoError(t, replicaConfig.ValidateAndAdjust(sinkURI))
 
 	ctx = context.WithValue(ctx, "testing.T", t)
 	s, err := NewKafkaDDLSink(ctx, changefeedID, sinkURI, replicaConfig,
 		kafka.NewMockFactory,
 		ddlproducer.NewMockDDLProducer)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, s)
 
 	ddl := &model.DDLEvent{
@@ -112,7 +87,7 @@ func TestWriteDDLEventToAllPartitions(t *testing.T) {
 		Type:  mm.ActionCreateTable,
 	}
 	err = s.WriteDDLEvent(ctx, ddl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, s.producer.(*ddlproducer.MockDDLProducer).GetAllEvents(),
 		3, "All partitions should be broadcast")
 	require.Len(t, s.producer.(*ddlproducer.MockDDLProducer).GetEvents("mock_topic", 0), 1)
@@ -126,24 +101,22 @@ func TestWriteDDLEventToZeroPartition(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	leader, topic := initBroker(t, kafka.DefaultMockPartitionNum)
-	defer leader.Close()
 	uriTemplate := "kafka://%s/%s?kafka-version=0.9.0.0&max-batch-size=1" +
 		"&max-message-bytes=1048576&partition-num=1" +
 		"&kafka-client-id=unit-test&auto-create-topic=false&compression=gzip&protocol=canal-json"
-	uri := fmt.Sprintf(uriTemplate, leader.Addr(), topic)
+	uri := fmt.Sprintf(uriTemplate, "127.0.0.1:9092", kafka.DefaultMockTopicName)
 
 	sinkURI, err := url.Parse(uri)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	replicaConfig := config.GetDefaultReplicaConfig()
-	require.Nil(t, replicaConfig.ValidateAndAdjust(sinkURI))
+	require.NoError(t, replicaConfig.ValidateAndAdjust(sinkURI))
 
 	ctx = context.WithValue(ctx, "testing.T", t)
 	s, err := NewKafkaDDLSink(ctx, model.DefaultChangeFeedID("test"),
 		sinkURI, replicaConfig,
 		kafka.NewMockFactory,
 		ddlproducer.NewMockDDLProducer)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, s)
 
 	ddl := &model.DDLEvent{
@@ -157,7 +130,7 @@ func TestWriteDDLEventToZeroPartition(t *testing.T) {
 		Type:  mm.ActionCreateTable,
 	}
 	err = s.WriteDDLEvent(ctx, ddl)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, s.producer.(*ddlproducer.MockDDLProducer).GetAllEvents(),
 		1, "Only zero partition")
 	require.Len(t, s.producer.(*ddlproducer.MockDDLProducer).GetEvents("mock_topic", 0), 1)
@@ -171,13 +144,11 @@ func TestWriteCheckpointTsToDefaultTopic(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	leader, topic := initBroker(t, kafka.DefaultMockPartitionNum)
-	defer leader.Close()
 	uriTemplate := "kafka://%s/%s?kafka-version=0.9.0.0&max-batch-size=1" +
 		"&max-message-bytes=1048576&partition-num=1" +
 		"&kafka-client-id=unit-test&auto-create-topic=false&compression=gzip" +
 		"&protocol=canal-json&enable-tidb-extension=true"
-	uri := fmt.Sprintf(uriTemplate, leader.Addr(), topic)
+	uri := fmt.Sprintf(uriTemplate, "127.0.0.1:9092", kafka.DefaultMockTopicName)
 
 	sinkURI, err := url.Parse(uri)
 	require.Nil(t, err)
@@ -210,19 +181,17 @@ func TestWriteCheckpointTsToTableTopics(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	leader, topic := initBroker(t, kafka.DefaultMockPartitionNum)
-	defer leader.Close()
 	// Notice: auto create topic is true. Auto created topic will have 1 partition.
 	uriTemplate := "kafka://%s/%s?kafka-version=0.9.0.0&max-batch-size=1" +
 		"&max-message-bytes=1048576&partition-num=1" +
 		"&kafka-client-id=unit-test&auto-create-topic=true&compression=gzip" +
 		"&protocol=canal-json&enable-tidb-extension=true"
-	uri := fmt.Sprintf(uriTemplate, leader.Addr(), topic)
+	uri := fmt.Sprintf(uriTemplate, "127.0.0.1:9092", kafka.DefaultMockTopicName)
 
 	sinkURI, err := url.Parse(uri)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	replicaConfig := config.GetDefaultReplicaConfig()
-	require.Nil(t, replicaConfig.ValidateAndAdjust(sinkURI))
+	require.NoError(t, replicaConfig.ValidateAndAdjust(sinkURI))
 	replicaConfig.Sink.DispatchRules = []*config.DispatchRule{
 		{
 			Matcher:   []string{"*.*"},
@@ -235,7 +204,7 @@ func TestWriteCheckpointTsToTableTopics(t *testing.T) {
 		sinkURI, replicaConfig,
 		kafka.NewMockFactory,
 		ddlproducer.NewMockDDLProducer)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, s)
 
 	checkpointTs := uint64(417318403368288260)
@@ -261,7 +230,7 @@ func TestWriteCheckpointTsToTableTopics(t *testing.T) {
 	}
 
 	err = s.WriteCheckpointTs(ctx, checkpointTs, tables)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Len(t, s.producer.(*ddlproducer.MockDDLProducer).GetAllEvents(),
 		6, "All topics and partitions should be broadcast")
@@ -279,32 +248,30 @@ func TestWriteCheckpointTsWhenCanalJsonTiDBExtensionIsDisable(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	leader, topic := initBroker(t, kafka.DefaultMockPartitionNum)
-	defer leader.Close()
 	// Notice: tidb extension is disabled.
 	uriTemplate := "kafka://%s/%s?kafka-version=0.9.0.0&max-batch-size=1" +
 		"&max-message-bytes=1048576&partition-num=1" +
 		"&kafka-client-id=unit-test&auto-create-topic=false&compression=gzip" +
 		"&protocol=canal-json&enable-tidb-extension=false"
-	uri := fmt.Sprintf(uriTemplate, leader.Addr(), topic)
+	uri := fmt.Sprintf(uriTemplate, "127.0.0.1:9092", kafka.DefaultMockTopicName)
 
 	sinkURI, err := url.Parse(uri)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	replicaConfig := config.GetDefaultReplicaConfig()
-	require.Nil(t, replicaConfig.ValidateAndAdjust(sinkURI))
+	require.NoError(t, replicaConfig.ValidateAndAdjust(sinkURI))
 
 	ctx = context.WithValue(ctx, "testing.T", t)
 	s, err := NewKafkaDDLSink(ctx, model.DefaultChangeFeedID("test"),
 		sinkURI, replicaConfig,
 		kafka.NewMockFactory,
 		ddlproducer.NewMockDDLProducer)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, s)
 
 	checkpointTs := uint64(417318403368288260)
 	var tables []*model.TableInfo
 	err = s.WriteCheckpointTs(ctx, checkpointTs, tables)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Len(t, s.producer.(*ddlproducer.MockDDLProducer).GetAllEvents(),
 		0, "No topic and partition should be broadcast")

--- a/cdc/sink/ddlsink/mq/mq_ddl_sink_test.go
+++ b/cdc/sink/ddlsink/mq/mq_ddl_sink_test.go
@@ -67,6 +67,7 @@ func TestNewKafkaDDLSinkFailed(t *testing.T) {
 	replicaConfig := config.GetDefaultReplicaConfig()
 	require.Nil(t, replicaConfig.ValidateAndAdjust(sinkURI))
 
+	ctx = context.WithValue(ctx, "testing.T", t)
 	s, err := NewKafkaDDLSink(ctx, changefeedID, sinkURI, replicaConfig,
 		kafka.NewMockFactory, ddlproducer.NewMockDDLProducer)
 	require.ErrorContains(t, err, "Avro protocol requires parameter \"schema-registry\"",
@@ -93,6 +94,7 @@ func TestWriteDDLEventToAllPartitions(t *testing.T) {
 	replicaConfig := config.GetDefaultReplicaConfig()
 	require.Nil(t, replicaConfig.ValidateAndAdjust(sinkURI))
 
+	ctx = context.WithValue(ctx, "testing.T", t)
 	s, err := NewKafkaDDLSink(ctx, changefeedID, sinkURI, replicaConfig,
 		kafka.NewMockFactory,
 		ddlproducer.NewMockDDLProducer)
@@ -136,6 +138,7 @@ func TestWriteDDLEventToZeroPartition(t *testing.T) {
 	replicaConfig := config.GetDefaultReplicaConfig()
 	require.Nil(t, replicaConfig.ValidateAndAdjust(sinkURI))
 
+	ctx = context.WithValue(ctx, "testing.T", t)
 	s, err := NewKafkaDDLSink(ctx, model.DefaultChangeFeedID("test"),
 		sinkURI, replicaConfig,
 		kafka.NewMockFactory,
@@ -181,6 +184,7 @@ func TestWriteCheckpointTsToDefaultTopic(t *testing.T) {
 	replicaConfig := config.GetDefaultReplicaConfig()
 	require.Nil(t, replicaConfig.ValidateAndAdjust(sinkURI))
 
+	ctx = context.WithValue(ctx, "testing.T", t)
 	s, err := NewKafkaDDLSink(ctx, model.DefaultChangeFeedID("test"),
 		sinkURI, replicaConfig,
 		kafka.NewMockFactory,
@@ -226,6 +230,7 @@ func TestWriteCheckpointTsToTableTopics(t *testing.T) {
 		},
 	}
 
+	ctx = context.WithValue(ctx, "testing.T", t)
 	s, err := NewKafkaDDLSink(ctx, model.DefaultChangeFeedID("test"),
 		sinkURI, replicaConfig,
 		kafka.NewMockFactory,
@@ -288,6 +293,7 @@ func TestWriteCheckpointTsWhenCanalJsonTiDBExtensionIsDisable(t *testing.T) {
 	replicaConfig := config.GetDefaultReplicaConfig()
 	require.Nil(t, replicaConfig.ValidateAndAdjust(sinkURI))
 
+	ctx = context.WithValue(ctx, "testing.T", t)
 	s, err := NewKafkaDDLSink(ctx, model.DefaultChangeFeedID("test"),
 		sinkURI, replicaConfig,
 		kafka.NewMockFactory,

--- a/cdc/sink/dmlsink/factory/factory_test.go
+++ b/cdc/sink/dmlsink/factory/factory_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Shopify/sarama"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/sink/dmlsink/mq"
 	"github.com/pingcap/tiflow/cdc/sink/dmlsink/mq/dmlproducer"
@@ -31,25 +30,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
-
-func initBroker(t *testing.T, partitionNum int) (*sarama.MockBroker, string) {
-	topic := kafka.DefaultMockTopicName
-	leader := sarama.NewMockBroker(t, 1)
-
-	metadataResponse := sarama.NewMockMetadataResponse(t)
-	metadataResponse.SetBroker(leader.Addr(), leader.BrokerID())
-	for i := 0; i < partitionNum; i++ {
-		metadataResponse.SetLeader(topic, int32(i), leader.BrokerID())
-	}
-
-	prodSuccess := sarama.NewMockProduceResponse(t)
-	handlerMap := make(map[string]sarama.MockResponse)
-	handlerMap["MetadataRequest"] = metadataResponse
-	handlerMap["ProduceRequest"] = prodSuccess
-	leader.SetHandlerByMap(handlerMap)
-
-	return leader, topic
-}
 
 func newForTest(ctx context.Context,
 	sinkURIStr string,
@@ -86,22 +66,21 @@ func TestSinkFactory(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	leader, topic := initBroker(t, kafka.DefaultMockPartitionNum)
-	defer leader.Close()
+	ctx = context.WithValue(ctx, "testing.T", t)
 	uriTemplate := "kafka://%s/%s?kafka-version=0.9.0.0&max-batch-size=1" +
 		"&max-message-bytes=1048576&partition-num=1" +
 		"&kafka-client-id=unit-test&auto-create-topic=false&compression=gzip&protocol=open-protocol"
-	uri := fmt.Sprintf(uriTemplate, leader.Addr(), topic)
+	uri := fmt.Sprintf(uriTemplate, "127.0.0.1:9092", kafka.DefaultMockTopicName)
 
 	sinkURI, err := url.Parse(uri)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	replicaConfig := config.GetDefaultReplicaConfig()
-	require.Nil(t, replicaConfig.ValidateAndAdjust(sinkURI))
+	require.NoError(t, replicaConfig.ValidateAndAdjust(sinkURI))
 	errCh := make(chan error, 1)
 
 	sinkFactory, err := newForTest(ctx, uri, replicaConfig, errCh)
 	require.NotNil(t, sinkFactory)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, sinkFactory.rowSink)
 
 	tableSink := sinkFactory.CreateTableSink(model.DefaultChangeFeedID("1"),

--- a/cdc/sink/dmlsink/mq/dmlproducer/dml_producer.go
+++ b/cdc/sink/dmlsink/mq/dmlproducer/dml_producer.go
@@ -39,5 +39,9 @@ type DMLProducer interface {
 // So we let the GC close errCh.
 // It's usually a buffered channel.
 type Factory func(ctx context.Context, changefeedID model.ChangeFeedID,
-	factory kafka.Factory,
-	adminClient kafka.ClusterAdminClient, errCh chan error) (DMLProducer, error)
+	asyncProducer kafka.AsyncProducer,
+	metricsCollector kafka.MetricsCollector,
+	errCh chan error,
+	closeCh chan struct{},
+	failpointCh chan error,
+) (DMLProducer, error)

--- a/cdc/sink/dmlsink/mq/dmlproducer/kafka_dml_mock_producer.go
+++ b/cdc/sink/dmlsink/mq/dmlproducer/kafka_dml_mock_producer.go
@@ -37,8 +37,8 @@ type MockDMLProducer struct {
 func NewDMLMockProducer(_ context.Context, _ model.ChangeFeedID, asyncProducer kafka.AsyncProducer,
 	_ kafka.MetricsCollector,
 	_ chan error,
-	closeCh chan struct{},
-	failpointCh chan error,
+	_ chan struct{},
+	_ chan error,
 ) (DMLProducer, error) {
 	return &MockDMLProducer{
 		events:        make(map[string][]*common.Message),
@@ -66,7 +66,9 @@ func (m *MockDMLProducer) AsyncSendMessage(_ context.Context, topic string,
 
 // Close do nothing.
 func (m *MockDMLProducer) Close() {
-	m.asyncProducer.Close()
+	if m.asyncProducer != nil {
+		m.asyncProducer.Close()
+	}
 }
 
 // GetAllEvents returns the events received by the mock producer.

--- a/cdc/sink/dmlsink/mq/dmlproducer/kafka_dml_producer_test.go
+++ b/cdc/sink/dmlsink/mq/dmlproducer/kafka_dml_producer_test.go
@@ -36,23 +36,6 @@ func initBroker(t *testing.T) (*sarama.MockBroker, string) {
 	leader := sarama.NewMockBroker(t, 2)
 
 	return leader, topic
-	//metadataResponse := new(sarama.MetadataResponse)
-	//metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
-	//metadataResponse.AddTopicPartition(topic, 0,
-	//	leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
-	//metadataResponse.AddTopicPartition(topic, 1,
-	//	leader.BrokerID(), nil, nil, nil, sarama.ErrNoError)
-	//// Response for `sarama.NewClient`
-	//leader.Returns(metadataResponse)
-	//if withProducerResponse {
-	//	prodSuccess := new(sarama.ProduceResponse)
-	//	prodSuccess.AddTopicPartition(topic, 0, sarama.ErrNoError)
-	//	prodSuccess.AddTopicPartition(topic, 1, sarama.ErrNoError)
-	//	for i := 0; i < 20; i++ {
-	//		leader.Returns(prodSuccess)
-	//	}
-	//}
-	//return leader, topic
 }
 
 func getOptions(addr string) *kafka.Options {

--- a/cdc/sink/dmlsink/mq/dmlproducer/kafka_dml_producer_test.go
+++ b/cdc/sink/dmlsink/mq/dmlproducer/kafka_dml_producer_test.go
@@ -51,8 +51,9 @@ func TestProducerAck(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, 1, config.Producer.Flush.MaxMessages)
 
+	ctx = context.WithValue(ctx, "testing.T", t)
 	changefeed := model.DefaultChangeFeedID("changefeed-test")
-	factory, err := kafka.NewMockFactory(t, options, changefeed)
+	factory, err := kafka.NewMockFactory(options, changefeed)
 	require.NoError(t, err)
 
 	adminClient, err := factory.AdminClient(ctx)
@@ -125,8 +126,9 @@ func TestProducerSendMsgFailed(t *testing.T) {
 	options.MaxMessages = 1
 	options.MaxMessageBytes = 1
 
+	ctx = context.WithValue(ctx, "testing.T", t)
 	changefeed := model.DefaultChangeFeedID("changefeed-test")
-	factory, err := kafka.NewMockFactory(t, options, changefeed)
+	factory, err := kafka.NewMockFactory(options, changefeed)
 	require.NoError(t, err)
 
 	adminClient, err := factory.AdminClient(ctx)
@@ -191,8 +193,9 @@ func TestProducerDoubleClose(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	ctx = context.WithValue(ctx, "testing.T", t)
 	changefeed := model.DefaultChangeFeedID("changefeed-test")
-	factory, err := kafka.NewMockFactory(t, options, changefeed)
+	factory, err := kafka.NewMockFactory(options, changefeed)
 	require.NoError(t, err)
 
 	adminClient, err := factory.AdminClient(ctx)

--- a/cdc/sink/dmlsink/mq/kafka_dml_sink.go
+++ b/cdc/sink/dmlsink/mq/kafka_dml_sink.go
@@ -86,6 +86,11 @@ func NewKafkaDMLSink(
 	if err != nil {
 		return nil, cerror.WrapError(cerror.ErrKafkaNewProducer, err)
 	}
+	defer func() {
+		if err != nil && asyncProducer != nil {
+			asyncProducer.Close()
+		}
+	}()
 
 	metricsCollector := factory.MetricsCollector(tiflowutil.RoleProcessor, adminClient)
 	log.Info("Try to create a DML sink producer",

--- a/cdc/sink/dmlsink/mq/mq_dml_sink_test.go
+++ b/cdc/sink/dmlsink/mq/mq_dml_sink_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Shopify/sarama"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/sink/dmlsink"
 	"github.com/pingcap/tiflow/cdc/sink/dmlsink/mq/dmlproducer"
@@ -30,37 +29,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func initBroker(t *testing.T, partitionNum int) (*sarama.MockBroker, string) {
-	topic := kafka.DefaultMockTopicName
-	leader := sarama.NewMockBroker(t, 1)
-
-	metadataResponse := sarama.NewMockMetadataResponse(t)
-	metadataResponse.SetBroker(leader.Addr(), leader.BrokerID())
-	for i := 0; i < partitionNum; i++ {
-		metadataResponse.SetLeader(topic, int32(i), leader.BrokerID())
-	}
-
-	prodSuccess := sarama.NewMockProduceResponse(t)
-	handlerMap := make(map[string]sarama.MockResponse)
-	handlerMap["MetadataRequest"] = metadataResponse
-	handlerMap["ProduceRequest"] = prodSuccess
-	leader.SetHandlerByMap(handlerMap)
-
-	return leader, topic
-}
-
 func TestNewKafkaDMLSinkFailed(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	leader, topic := initBroker(t, kafka.DefaultMockPartitionNum)
-	defer leader.Close()
 	uriTemplate := "kafka://%s/%s?kafka-version=0.9.0.0&max-batch-size=1" +
 		"&max-message-bytes=1048576&partition-num=1" +
 		"&kafka-client-id=unit-test&auto-create-topic=false&compression=gzip&protocol=avro"
-	uri := fmt.Sprintf(uriTemplate, leader.Addr(), topic)
+	uri := fmt.Sprintf(uriTemplate, "127.0.0.1:9092", kafka.DefaultMockTopicName)
 
 	sinkURI, err := url.Parse(uri)
 	require.NoError(t, err)
@@ -84,12 +62,10 @@ func TestWriteEvents(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	leader, topic := initBroker(t, kafka.DefaultMockPartitionNum)
-	defer leader.Close()
 	uriTemplate := "kafka://%s/%s?kafka-version=0.9.0.0&max-batch-size=1" +
 		"&max-message-bytes=1048576&partition-num=1" +
 		"&kafka-client-id=unit-test&auto-create-topic=false&compression=gzip&protocol=open-protocol"
-	uri := fmt.Sprintf(uriTemplate, leader.Addr(), topic)
+	uri := fmt.Sprintf(uriTemplate, "127.0.0.1:9092", kafka.DefaultMockTopicName)
 
 	sinkURI, err := url.Parse(uri)
 	require.NoError(t, err)

--- a/cdc/sink/dmlsink/mq/worker_test.go
+++ b/cdc/sink/dmlsink/mq/worker_test.go
@@ -37,7 +37,7 @@ func newBatchEncodeWorker(ctx context.Context, t *testing.T) (*worker, dmlproduc
 	encoderConfig := common.NewConfig(config.ProtocolOpen).WithMaxMessageBytes(200)
 	builder, err := builder.NewRowEventEncoderBuilder(context.Background(), id, encoderConfig)
 	require.Nil(t, err)
-	p, err := dmlproducer.NewDMLMockProducer(context.Background(), id, nil, nil, nil)
+	p, err := dmlproducer.NewDMLMockProducer(context.Background(), id, nil, nil, nil, nil, nil)
 	require.Nil(t, err)
 	encoderConcurrency := 4
 	statistics := metrics.NewStatistics(ctx, id, sink.RowSink)
@@ -51,7 +51,7 @@ func newNonBatchEncodeWorker(ctx context.Context, t *testing.T) (*worker, dmlpro
 	builder, err := builder.NewRowEventEncoderBuilder(context.Background(),
 		id, encoderConfig)
 	require.Nil(t, err)
-	p, err := dmlproducer.NewDMLMockProducer(context.Background(), id, nil, nil, nil)
+	p, err := dmlproducer.NewDMLMockProducer(context.Background(), id, nil, nil, nil, nil, nil)
 	require.Nil(t, err)
 	encoderConcurrency := 4
 	statistics := metrics.NewStatistics(ctx, id, sink.RowSink)

--- a/cdc/sink/dmlsink/mq/worker_test.go
+++ b/cdc/sink/dmlsink/mq/worker_test.go
@@ -36,9 +36,9 @@ func newBatchEncodeWorker(ctx context.Context, t *testing.T) (*worker, dmlproduc
 	// 200 is about the size of a rowEvent change.
 	encoderConfig := common.NewConfig(config.ProtocolOpen).WithMaxMessageBytes(200)
 	builder, err := builder.NewRowEventEncoderBuilder(context.Background(), id, encoderConfig)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	p, err := dmlproducer.NewDMLMockProducer(context.Background(), id, nil, nil, nil, nil, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	encoderConcurrency := 4
 	statistics := metrics.NewStatistics(ctx, id, sink.RowSink)
 	return newWorker(id, config.ProtocolOpen, builder, encoderConcurrency, p, statistics), p
@@ -50,9 +50,9 @@ func newNonBatchEncodeWorker(ctx context.Context, t *testing.T) (*worker, dmlpro
 	encoderConfig := common.NewConfig(config.ProtocolCanalJSON).WithMaxMessageBytes(300)
 	builder, err := builder.NewRowEventEncoderBuilder(context.Background(),
 		id, encoderConfig)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	p, err := dmlproducer.NewDMLMockProducer(context.Background(), id, nil, nil, nil, nil, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	encoderConcurrency := 4
 	statistics := metrics.NewStatistics(ctx, id, sink.RowSink)
 	return newWorker(id, config.ProtocolCanalJSON, builder, encoderConcurrency, p, statistics), p

--- a/pkg/sink/kafka/mock_factory.go
+++ b/pkg/sink/kafka/mock_factory.go
@@ -86,10 +86,12 @@ func (f *MockFactory) MetricsCollector(
 	return &mockMetricsCollector{}
 }
 
+// MockSaramaSyncProducer is a mock implementation of SyncProducer interface.
 type MockSaramaSyncProducer struct {
 	Producer *mocks.SyncProducer
 }
 
+// SendMessage implement the SyncProducer interface.
 func (m *MockSaramaSyncProducer) SendMessage(
 	ctx context.Context,
 	topic string, partitionNum int32,
@@ -104,6 +106,7 @@ func (m *MockSaramaSyncProducer) SendMessage(
 	return err
 }
 
+// SendMessages implement the SyncProducer interface.
 func (m *MockSaramaSyncProducer) SendMessages(ctx context.Context,
 	topic string, partitionNum int32,
 	key []byte, value []byte,
@@ -120,16 +123,21 @@ func (m *MockSaramaSyncProducer) SendMessages(ctx context.Context,
 	return m.Producer.SendMessages(msgs)
 }
 
+// Close implement the SyncProducer interface.
 func (m *MockSaramaSyncProducer) Close() {
 	m.Producer.Close()
 }
 
+// MockSaramaAsyncProducer is a mock implementation of AsyncProducer interface.
 type MockSaramaAsyncProducer struct {
 	AsyncProducer *mocks.AsyncProducer
 	closedChan    chan struct{}
 	failpointCh   chan error
+
+	closed bool
 }
 
+// AsyncRunCallback implement the AsyncProducer interface.
 func (p *MockSaramaAsyncProducer) AsyncRunCallback(
 	ctx context.Context,
 ) error {
@@ -162,6 +170,7 @@ func (p *MockSaramaAsyncProducer) AsyncRunCallback(
 	}
 }
 
+// AsyncSend implement the AsyncProducer interface.
 func (p *MockSaramaAsyncProducer) AsyncSend(ctx context.Context, topic string,
 	partition int32, key []byte, value []byte,
 	callback func(),
@@ -183,11 +192,17 @@ func (p *MockSaramaAsyncProducer) AsyncSend(ctx context.Context, topic string,
 	return nil
 }
 
+// Close implement the AsyncProducer interface.
 func (p *MockSaramaAsyncProducer) Close() {
+	if p.closed {
+		return
+	}
 	_ = p.AsyncProducer.Close()
+	p.closed = true
 }
 
 type mockMetricsCollector struct{}
 
+// Run implements the MetricsCollector interface.
 func (m *mockMetricsCollector) Run(ctx context.Context) {
 }

--- a/pkg/sink/kafka/mock_factory.go
+++ b/pkg/sink/kafka/mock_factory.go
@@ -27,18 +27,15 @@ import (
 
 // MockFactory is a mock implementation of Factory interface.
 type MockFactory struct {
-	t            *testing.T
 	o            *Options
 	changefeedID model.ChangeFeedID
 }
 
 // NewMockFactory constructs a Factory with mock implementation.
 func NewMockFactory(
-	t *testing.T,
 	o *Options, changefeedID model.ChangeFeedID,
 ) (Factory, error) {
 	return &MockFactory{
-		t:            t,
 		o:            o,
 		changefeedID: changefeedID,
 	}, nil
@@ -55,7 +52,9 @@ func (f *MockFactory) SyncProducer(ctx context.Context) (SyncProducer, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	syncProducer := mocks.NewSyncProducer(f.t, config)
+
+	t := ctx.Value("testing.T").(*testing.T)
+	syncProducer := mocks.NewSyncProducer(t, config)
 	return &MockSaramaSyncProducer{
 		Producer: syncProducer,
 	}, nil
@@ -71,7 +70,8 @@ func (f *MockFactory) AsyncProducer(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	asyncProducer := mocks.NewAsyncProducer(f.t, config)
+	t := ctx.Value("testing.T").(*testing.T)
+	asyncProducer := mocks.NewAsyncProducer(t, config)
 	return &MockSaramaAsyncProducer{
 		AsyncProducer: asyncProducer,
 		closedChan:    closedChan,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #8493 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
