### PR TITLE
changefeed (ticdc): remove error state and add pending, warning state

### DIFF
--- a/cdc/api/v2/changefeed_test.go
+++ b/cdc/api/v2/changefeed_test.go
@@ -546,11 +546,19 @@ func TestListChangeFeeds(t *testing.T) {
 			model.DefaultChangeFeedID("cf3"): {
 				State: model.StateStopped,
 			},
+			model.DefaultChangeFeedID("cf4"): {
+				State: model.StatePending,
+			},
+			model.DefaultChangeFeedID("cf5"): {
+				State: model.StateFinished,
+			},
 		},
 		changefeedStatuses: map[model.ChangeFeedID]*model.ChangeFeedStatusForAPI{
 			model.DefaultChangeFeedID("cf1"): {},
 			model.DefaultChangeFeedID("cf2"): {},
 			model.DefaultChangeFeedID("cf3"): {},
+			model.DefaultChangeFeedID("cf4"): {},
+			model.DefaultChangeFeedID("cf5"): {},
 		},
 	}
 	cp.EXPECT().StatusProvider().Return(provider1).AnyTimes()
@@ -569,11 +577,11 @@ func TestListChangeFeeds(t *testing.T) {
 	resp := ListResponse[model.ChangefeedCommonInfo]{}
 	err := json.NewDecoder(w.Body).Decode(&resp)
 	require.Nil(t, err)
-	require.Equal(t, 3, resp.Total)
+	require.Equal(t, 5, resp.Total)
 	// changefeed info must be sorted by ID
 	require.Equal(t, true, sorted(resp.Items))
 
-	// case 2: only list changefeed with state 'normal', 'stopped' and 'failed'
+	// case 2: only list changefeed with state 'normal', 'stopped' and 'failed', "pending", "warning"
 	metaInfo2 := testCase{
 		url:    "/api/v2/changefeeds",
 		method: "GET",
@@ -588,7 +596,7 @@ func TestListChangeFeeds(t *testing.T) {
 	resp2 := ListResponse[model.ChangefeedCommonInfo]{}
 	err = json.NewDecoder(w.Body).Decode(&resp2)
 	require.Nil(t, err)
-	require.Equal(t, 2, resp2.Total)
+	require.Equal(t, 4, resp2.Total)
 	// changefeed info must be sorted by ID
 	require.Equal(t, true, sorted(resp2.Items))
 }

--- a/cdc/api/v2/changefeed_test.go
+++ b/cdc/api/v2/changefeed_test.go
@@ -541,7 +541,7 @@ func TestListChangeFeeds(t *testing.T) {
 				State: model.StateNormal,
 			},
 			model.DefaultChangeFeedID("cf2"): {
-				State: model.StateError,
+				State: model.StateWarning,
 			},
 			model.DefaultChangeFeedID("cf3"): {
 				State: model.StateStopped,

--- a/cdc/api/v2/model.go
+++ b/cdc/api/v2/model.go
@@ -102,6 +102,27 @@ type ChangefeedCommonInfo struct {
 	RunningError   *model.RunningError `json:"error"`
 }
 
+// MarshalJSON marshal changefeed common info to json
+// we need to set feed state to normal if it is uninitialized and pending to warning
+// to hide the detail of uninitialized and pending state from user
+func (c ChangefeedCommonInfo) MarshalJSON() ([]byte, error) {
+	// alias the original type to prevent recursive call of MarshalJSON
+	type Alias ChangefeedCommonInfo
+
+	if c.FeedState == model.StateUnInitialized {
+		c.FeedState = model.StateNormal
+	}
+	if c.FeedState == model.StatePending {
+		c.FeedState = model.StateWarning
+	}
+
+	return json.Marshal(struct {
+		Alias
+	}{
+		Alias: Alias(c),
+	})
+}
+
 // ChangefeedConfig use by create changefeed api
 type ChangefeedConfig struct {
 	Namespace     string         `json:"namespace"`

--- a/cdc/api/v2/model_test.go
+++ b/cdc/api/v2/model_test.go
@@ -21,6 +21,7 @@ import (
 
 	bf "github.com/pingcap/tidb-tools/pkg/binlog-filter"
 	filter "github.com/pingcap/tidb/util/table-filter"
+	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/pkg/config"
 	"github.com/pingcap/tiflow/pkg/redo"
 	"github.com/pingcap/tiflow/pkg/util"
@@ -228,4 +229,27 @@ func TestEventFilterRuleConvert(t *testing.T) {
 		require.Equal(t, c.apiRule, ToAPIEventFilterRule(c.inRule))
 		require.Equal(t, c.inRule, c.apiRule.ToInternalEventFilterRule())
 	}
+}
+
+func TestMarshalChangefeedCommonInfo(t *testing.T) {
+	t.Parallel()
+
+	cfInfo := &ChangefeedCommonInfo{
+		ID:        "test-id",
+		FeedState: model.StatePending,
+	}
+
+	cfInfoJSON, err := json.Marshal(cfInfo)
+	require.Nil(t, err)
+	require.False(t, strings.Contains(string(cfInfoJSON), "pending"))
+	require.True(t, strings.Contains(string(cfInfoJSON), "warning"))
+
+	cfInfo = &ChangefeedCommonInfo{
+		ID:        "test-id",
+		FeedState: model.StateUnInitialized,
+	}
+
+	cfInfoJSON, err = json.Marshal(cfInfo)
+	require.Nil(t, err)
+	require.True(t, strings.Contains(string(cfInfoJSON), "normal"))
 }

--- a/cdc/api/v2/processor.go
+++ b/cdc/api/v2/processor.go
@@ -66,7 +66,7 @@ func (h *OpenAPIV2) getProcessor(c *gin.Context) {
 		_ = c.Error(err)
 		return
 	}
-	if info.State != model.StateNormal {
+	if !info.State.IsRunning() {
 		_ = c.Error(
 			cerror.WrapError(
 				cerror.ErrAPIInvalidParam,

--- a/cdc/api/v2/processor_test.go
+++ b/cdc/api/v2/processor_test.go
@@ -94,7 +94,7 @@ func TestGetProcessor(t *testing.T) {
 	{
 		provider := &mockStatusProvider{
 			changefeedInfo: &model.ChangeFeedInfo{
-				State: model.StateError,
+				State: model.StateWarning,
 			},
 		}
 		cp := mock_capture.NewMockCapture(gomock.NewController(t))

--- a/cdc/api/v2/processor_test.go
+++ b/cdc/api/v2/processor_test.go
@@ -94,7 +94,7 @@ func TestGetProcessor(t *testing.T) {
 	{
 		provider := &mockStatusProvider{
 			changefeedInfo: &model.ChangeFeedInfo{
-				State: model.StateWarning,
+				State: model.StatePending,
 			},
 		}
 		cp := mock_capture.NewMockCapture(gomock.NewController(t))

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -135,6 +135,11 @@ func (s FeedState) IsNeeded(need string) bool {
 	return need == string(s)
 }
 
+// IsRunning return true if the feedState represents a running state.
+func (s FeedState) IsRunning() bool {
+	return s == StateNormal || s == StateWarning
+}
+
 // ChangeFeedInfo describes the detail of a ChangeFeed
 type ChangeFeedInfo struct {
 	UpstreamID uint64    `json:"upstream-id"`

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -83,7 +83,7 @@ type FeedState string
 // All FeedStates
 const (
 	StateNormal   FeedState = "normal"
-	StateError    FeedState = "error"
+	StateWarning  FeedState = "warning"
 	StateFailed   FeedState = "failed"
 	StateStopped  FeedState = "stopped"
 	StateRemoved  FeedState = "removed"
@@ -95,7 +95,7 @@ func (s FeedState) ToInt() int {
 	switch s {
 	case StateNormal:
 		return 0
-	case StateError:
+	case StateWarning:
 		return 1
 	case StateFailed:
 		return 2
@@ -418,7 +418,7 @@ func (info *ChangeFeedInfo) fixState() {
 				if cerror.IsChangefeedFastFailErrorCode(errors.RFCErrorCode(info.Error.Code)) {
 					state = StateFailed
 				} else {
-					state = StateError
+					state = StateWarning
 				}
 			}
 		case AdminStop:

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -83,11 +83,12 @@ type FeedState string
 // All FeedStates
 const (
 	StateNormal   FeedState = "normal"
-	StateWarning  FeedState = "warning"
+	StatePending  FeedState = "pending"
 	StateFailed   FeedState = "failed"
 	StateStopped  FeedState = "stopped"
 	StateRemoved  FeedState = "removed"
 	StateFinished FeedState = "finished"
+	StateWarning  FeedState = "warning"
 )
 
 // ToInt return an int for each `FeedState`, only use this for metrics.
@@ -95,7 +96,7 @@ func (s FeedState) ToInt() int {
 	switch s {
 	case StateNormal:
 		return 0
-	case StateWarning:
+	case StatePending:
 		return 1
 	case StateFailed:
 		return 2
@@ -105,6 +106,8 @@ func (s FeedState) ToInt() int {
 		return 4
 	case StateRemoved:
 		return 5
+	case StateWarning:
+		return 6
 	}
 	// -1 for unknown feed state
 	return -1
@@ -122,6 +125,10 @@ func (s FeedState) IsNeeded(need string) bool {
 		case StateStopped:
 			return true
 		case StateFailed:
+			return true
+		case StateWarning:
+			return true
+		case StatePending:
 			return true
 		}
 	}

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -81,14 +81,18 @@ const (
 type FeedState string
 
 // All FeedStates
+// Only `StateNormal` and `StatePending` changefeed is running,
+// others are stopped.
 const (
-	StateNormal        FeedState = "normal"
-	StatePending       FeedState = "pending"
-	StateFailed        FeedState = "failed"
-	StateStopped       FeedState = "stopped"
-	StateRemoved       FeedState = "removed"
-	StateFinished      FeedState = "finished"
-	StateWarning       FeedState = "warning"
+	StateNormal   FeedState = "normal"
+	StatePending  FeedState = "pending"
+	StateFailed   FeedState = "failed"
+	StateStopped  FeedState = "stopped"
+	StateRemoved  FeedState = "removed"
+	StateFinished FeedState = "finished"
+	StateWarning  FeedState = "warning"
+	// StateUnInitialized is used for the changefeed that has not been initialized
+	// it only exists in memory for a short time and will not be persisted to storage
 	StateUnInitialized FeedState = ""
 )
 

--- a/cdc/model/changefeed.go
+++ b/cdc/model/changefeed.go
@@ -82,13 +82,14 @@ type FeedState string
 
 // All FeedStates
 const (
-	StateNormal   FeedState = "normal"
-	StatePending  FeedState = "pending"
-	StateFailed   FeedState = "failed"
-	StateStopped  FeedState = "stopped"
-	StateRemoved  FeedState = "removed"
-	StateFinished FeedState = "finished"
-	StateWarning  FeedState = "warning"
+	StateNormal        FeedState = "normal"
+	StatePending       FeedState = "pending"
+	StateFailed        FeedState = "failed"
+	StateStopped       FeedState = "stopped"
+	StateRemoved       FeedState = "removed"
+	StateFinished      FeedState = "finished"
+	StateWarning       FeedState = "warning"
+	StateUnInitialized FeedState = ""
 )
 
 // ToInt return an int for each `FeedState`, only use this for metrics.
@@ -108,6 +109,8 @@ func (s FeedState) ToInt() int {
 		return 5
 	case StateWarning:
 		return 6
+	case StateUnInitialized:
+		return 7
 	}
 	// -1 for unknown feed state
 	return -1

--- a/cdc/model/changefeed_test.go
+++ b/cdc/model/changefeed_test.go
@@ -575,7 +575,7 @@ func TestFixState(t *testing.T) {
 					Code: string(errors.ErrClusterIDMismatch.RFCCode()),
 				},
 			},
-			expectedState: StateError,
+			expectedState: StateWarning,
 		},
 		{
 			info: &ChangeFeedInfo{
@@ -585,7 +585,7 @@ func TestFixState(t *testing.T) {
 					Code: string(errors.ErrClusterIDMismatch.RFCCode()),
 				},
 			},
-			expectedState: StateError,
+			expectedState: StateWarning,
 		},
 		{
 			info: &ChangeFeedInfo{

--- a/cdc/model/errors.go
+++ b/cdc/model/errors.go
@@ -28,6 +28,16 @@ type RunningError struct {
 	Message string    `json:"message"`
 }
 
+// // 发生时间，发生地址，发生组件，错误码，错误信息
+// // 重试时间，发生时 CheckpointTs
+// func NewRunningError(err error) *RunningError {
+// 	return &RunningError{
+// 		Time:    time.Now(),
+// 		Code:    cerror.RFCCode(err),
+// 		Message: err.Error(),
+// 	}
+// }
+
 // IsChangefeedUnRetryableError return true if a running error contains a changefeed not retry error.
 func (r RunningError) IsChangefeedUnRetryableError() bool {
 	return cerror.IsChangefeedUnRetryableError(errors.New(r.Message + r.Code))

--- a/cdc/model/errors.go
+++ b/cdc/model/errors.go
@@ -28,15 +28,16 @@ type RunningError struct {
 	Message string    `json:"message"`
 }
 
-// // 发生时间，发生地址，发生组件，错误码，错误信息
-// // 重试时间，发生时 CheckpointTs
-// func NewRunningError(err error) *RunningError {
-// 	return &RunningError{
-// 		Time:    time.Now(),
-// 		Code:    cerror.RFCCode(err),
-// 		Message: err.Error(),
-// 	}
-// }
+// 发生时间，发生地址，发生组件，错误码，错误信息
+// 重试时间，发生时 CheckpointTs
+func NewRunningError(err error) *RunningError {
+	return &RunningError{
+		Time:    time.Now(),
+		Addr:    "test",
+		Code:    "test",
+		Message: err.Error(),
+	}
+}
 
 // IsChangefeedUnRetryableError return true if a running error contains a changefeed not retry error.
 func (r RunningError) IsChangefeedUnRetryableError() bool {

--- a/cdc/model/errors.go
+++ b/cdc/model/errors.go
@@ -28,8 +28,6 @@ type RunningError struct {
 	Message string    `json:"message"`
 }
 
-// 发生时间，发生地址，发生组件，错误码，错误信息
-// 重试时间，发生时 CheckpointTs
 func NewRunningError(err error) *RunningError {
 	return &RunningError{
 		Time:    time.Now(),

--- a/cdc/model/errors.go
+++ b/cdc/model/errors.go
@@ -28,15 +28,6 @@ type RunningError struct {
 	Message string    `json:"message"`
 }
 
-func NewRunningError(err error) *RunningError {
-	return &RunningError{
-		Time:    time.Now(),
-		Addr:    "test",
-		Code:    "test",
-		Message: err.Error(),
-	}
-}
-
 // IsChangefeedUnRetryableError return true if a running error contains a changefeed not retry error.
 func (r RunningError) IsChangefeedUnRetryableError() bool {
 	return cerror.IsChangefeedUnRetryableError(errors.New(r.Message + r.Code))

--- a/cdc/model/http_model_test.go
+++ b/cdc/model/http_model_test.go
@@ -42,7 +42,7 @@ func TestChangefeedCommonInfoMarshalJSON(t *testing.T) {
 	require.NotContains(t, string(cfInfoJSON), string(errors.ErrProcessorUnknown.RFCCode()))
 
 	// when state is not normal, the error code is exist
-	cfInfo.FeedState = StateError
+	cfInfo.FeedState = StateWarning
 	cfInfoJSON, err = json.Marshal(cfInfo)
 	require.Nil(t, err)
 	require.Contains(t, string(cfInfoJSON), string(errors.ErrProcessorUnknown.RFCCode()))
@@ -68,7 +68,7 @@ func TestChangefeedDetailMarshalJSON(t *testing.T) {
 	require.NotContains(t, string(cfInfoJSON), string(errors.ErrProcessorUnknown.RFCCode()))
 
 	// when state is not normal, the error code is exist
-	cfDetail.FeedState = StateError
+	cfDetail.FeedState = StateWarning
 	cfInfoJSON, err = json.Marshal(cfDetail)
 	require.Nil(t, err)
 	require.Contains(t, string(cfInfoJSON), string(errors.ErrProcessorUnknown.RFCCode()))

--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -295,7 +295,7 @@ func (c *changefeed) handleWarning(err error) {
 
 func (c *changefeed) checkStaleCheckpointTs(ctx cdcContext.Context, checkpointTs uint64) error {
 	state := c.state.Info.State
-	if state == model.StateNormal || state == model.StateStopped || state == model.StateError {
+	if state == model.StateNormal || state == model.StateStopped || state == model.StateWarning {
 		failpoint.Inject("InjectChangefeedFastFailError", func() error {
 			return cerror.ErrStartTsBeforeGC.FastGen("InjectChangefeedFastFailError")
 		})

--- a/cdc/owner/feed_state_manager.go
+++ b/cdc/owner/feed_state_manager.go
@@ -114,11 +114,7 @@ func (m *feedStateManager) Tick(state *orchestrator.ChangefeedReactorState) (adm
 	m.state = state
 	m.shouldBeRunning = true
 	defer func() {
-		if m.shouldBeRunning &&
-			m.state.Info.State != model.StatePending &&
-			m.state.Info.State != model.StateWarning {
-			m.patchState(model.StateNormal)
-		} else {
+		if !m.shouldBeRunning {
 			m.cleanUpTaskPositions()
 		}
 	}()

--- a/cdc/owner/feed_state_manager.go
+++ b/cdc/owner/feed_state_manager.go
@@ -269,8 +269,7 @@ func (m *feedStateManager) handleAdminJob() (jobsPending bool) {
 			zap.Uint64("checkpointTs", checkpointTs))
 	case model.AdminResume:
 		switch m.state.Info.State {
-		case model.StateFailed, model.StateWarning,
-			model.StateStopped, model.StateFinished, model.StatePending:
+		case model.StateFailed, model.StateStopped, model.StateFinished:
 		default:
 			log.Warn("can not resume the changefeed in the current state",
 				zap.String("namespace", m.state.ID.Namespace),

--- a/cdc/owner/feed_state_manager_test.go
+++ b/cdc/owner/feed_state_manager_test.go
@@ -62,8 +62,8 @@ func newFeedStateManager4Test(
 	f.errBackoff.Multiplier = multiplier
 	f.errBackoff.RandomizationFactor = 0
 
-	f.resetErrBackoff()
-	f.lastErrorTime = time.Unix(0, 0)
+	f.resetErrRetry()
+	f.lastErrorRetryTime = time.Unix(0, 0)
 
 	return f
 }
@@ -324,7 +324,7 @@ func TestHandleError(t *testing.T) {
 		manager.Tick(state)
 		tester.MustApplyPatches()
 		require.False(t, manager.ShouldRunning())
-		require.Equal(t, state.Info.State, model.StateError)
+		require.Equal(t, state.Info.State, model.StateWarning)
 		require.Equal(t, state.Info.AdminJobType, model.AdminStop)
 		require.Equal(t, state.Status.AdminJobType, model.AdminStop)
 		time.Sleep(d)
@@ -479,7 +479,7 @@ func TestChangefeedNotRetry(t *testing.T) {
 		return &model.ChangeFeedInfo{
 			SinkURI: "123",
 			Config:  &config.ReplicaConfig{},
-			State:   model.StateError,
+			State:   model.StateWarning,
 			Error: &model.RunningError{
 				Addr: "127.0.0.1",
 				Code: "CDC:ErrPipelineTryAgain",
@@ -497,7 +497,7 @@ func TestChangefeedNotRetry(t *testing.T) {
 		return &model.ChangeFeedInfo{
 			SinkURI: "123",
 			Config:  &config.ReplicaConfig{},
-			State:   model.StateError,
+			State:   model.StateWarning,
 			Error: &model.RunningError{
 				Addr:    "127.0.0.1",
 				Code:    "CDC:ErrExpressionColumnNotFound",
@@ -513,7 +513,7 @@ func TestChangefeedNotRetry(t *testing.T) {
 		return &model.ChangeFeedInfo{
 			SinkURI: "123",
 			Config:  &config.ReplicaConfig{},
-			State:   model.StateError,
+			State:   model.StateWarning,
 			Error: &model.RunningError{
 				Addr:    "127.0.0.1",
 				Code:    string(cerror.ErrExpressionColumnNotFound.RFCCode()),
@@ -530,7 +530,7 @@ func TestChangefeedNotRetry(t *testing.T) {
 		return &model.ChangeFeedInfo{
 			SinkURI: "123",
 			Config:  &config.ReplicaConfig{},
-			State:   model.StateError,
+			State:   model.StateWarning,
 			Error: &model.RunningError{
 				Addr:    "127.0.0.1",
 				Code:    string(cerror.ErrExpressionParseFailed.RFCCode()),
@@ -589,7 +589,7 @@ func TestBackoffStopsUnexpectedly(t *testing.T) {
 			tester.MustApplyPatches()
 			// If an error occurs, backing off from running the task.
 			require.False(t, manager.ShouldRunning())
-			require.Equal(t, state.Info.State, model.StateError)
+			require.Equal(t, state.Info.State, model.StateWarning)
 			require.Equal(t, state.Info.AdminJobType, model.AdminStop)
 			require.Equal(t, state.Status.AdminJobType, model.AdminStop)
 		}
@@ -637,7 +637,7 @@ func TestBackoffNeverStops(t *testing.T) {
 		manager.Tick(state)
 		tester.MustApplyPatches()
 		require.False(t, manager.ShouldRunning())
-		require.Equal(t, state.Info.State, model.StateError)
+		require.Equal(t, state.Info.State, model.StateWarning)
 		require.Equal(t, state.Info.AdminJobType, model.AdminStop)
 		require.Equal(t, state.Status.AdminJobType, model.AdminStop)
 		// 100ms is the backoff interval, so sleep 100ms and after a manager tick,
@@ -688,7 +688,7 @@ func TestUpdateChangefeedEpoch(t *testing.T) {
 		manager.Tick(state)
 		tester.MustApplyPatches()
 		require.False(t, manager.ShouldRunning())
-		require.Equal(t, state.Info.State, model.StateError)
+		require.Equal(t, state.Info.State, model.StateWarning)
 		require.Equal(t, state.Info.AdminJobType, model.AdminStop)
 		require.Equal(t, state.Status.AdminJobType, model.AdminStop)
 

--- a/cdc/owner/feed_state_manager_test.go
+++ b/cdc/owner/feed_state_manager_test.go
@@ -298,7 +298,9 @@ func TestHandleError(t *testing.T) {
 	})
 	state.PatchStatus(func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
 		require.Nil(t, status)
-		return &model.ChangeFeedStatus{}, true, nil
+		return &model.ChangeFeedStatus{
+			CheckpointTs: 200,
+		}, true, nil
 	})
 
 	tester.MustApplyPatches()
@@ -350,6 +352,13 @@ func TestHandleError(t *testing.T) {
 	manager.Tick(state)
 	tester.MustApplyPatches()
 	require.True(t, manager.ShouldRunning())
+	state.PatchStatus(
+		func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
+			status.CheckpointTs += 1
+			return status, true, nil
+		})
+	manager.Tick(state)
+	tester.MustApplyPatches()
 	require.Equal(t, model.StateNormal, state.Info.State)
 	require.Equal(t, model.AdminNone, state.Info.AdminJobType)
 	require.Equal(t, model.AdminNone, state.Status.AdminJobType)

--- a/cdc/owner/feed_state_manager_test.go
+++ b/cdc/owner/feed_state_manager_test.go
@@ -324,13 +324,35 @@ func TestHandleError(t *testing.T) {
 		manager.Tick(state)
 		tester.MustApplyPatches()
 		require.False(t, manager.ShouldRunning())
-		require.Equal(t, state.Info.State, model.StateWarning)
+		require.Equal(t, state.Info.State, model.StatePending)
 		require.Equal(t, state.Info.AdminJobType, model.AdminStop)
 		require.Equal(t, state.Status.AdminJobType, model.AdminStop)
 		time.Sleep(d)
 		manager.Tick(state)
 		tester.MustApplyPatches()
 	}
+
+	// no error tick, state should be transferred from pending to warning
+	manager.Tick(state)
+	require.True(t, manager.ShouldRunning())
+	require.Equal(t, model.StateWarning, state.Info.State)
+	require.Equal(t, model.AdminNone, state.Info.AdminJobType)
+	require.Equal(t, model.AdminNone, state.Status.AdminJobType)
+
+	// no error tick and checkpointTs is progressing,
+	// state should be transferred from warning to normal
+	state.PatchStatus(
+		func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
+			status.CheckpointTs += 1
+			return status, true, nil
+		})
+	tester.MustApplyPatches()
+	manager.Tick(state)
+	tester.MustApplyPatches()
+	require.True(t, manager.ShouldRunning())
+	require.Equal(t, model.StateNormal, state.Info.State)
+	require.Equal(t, model.AdminNone, state.Info.AdminJobType)
+	require.Equal(t, model.AdminNone, state.Status.AdminJobType)
 }
 
 func TestHandleFastFailError(t *testing.T) {
@@ -492,52 +514,52 @@ func TestChangefeedNotRetry(t *testing.T) {
 	manager.Tick(state)
 	require.True(t, manager.ShouldRunning())
 
-	// changefeed in error state and error can't be retried
-	state.PatchInfo(func(info *model.ChangeFeedInfo) (*model.ChangeFeedInfo, bool, error) {
-		return &model.ChangeFeedInfo{
-			SinkURI: "123",
-			Config:  &config.ReplicaConfig{},
-			State:   model.StateWarning,
-			Error: &model.RunningError{
-				Addr:    "127.0.0.1",
+	state.PatchTaskPosition("test",
+		func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+			if position == nil {
+				position = &model.TaskPosition{}
+			}
+			position.Error = &model.RunningError{
+				Time:    time.Now(),
+				Addr:    "test",
 				Code:    "CDC:ErrExpressionColumnNotFound",
 				Message: "what ever",
-			},
-		}, true, nil
-	})
+			}
+			return position, true, nil
+		})
 	tester.MustApplyPatches()
 	manager.Tick(state)
 	require.False(t, manager.ShouldRunning())
 
-	state.PatchInfo(func(info *model.ChangeFeedInfo) (*model.ChangeFeedInfo, bool, error) {
-		return &model.ChangeFeedInfo{
-			SinkURI: "123",
-			Config:  &config.ReplicaConfig{},
-			State:   model.StateWarning,
-			Error: &model.RunningError{
+	state.PatchTaskPosition("test",
+		func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+			if position == nil {
+				position = &model.TaskPosition{}
+			}
+			position.Error = &model.RunningError{
 				Addr:    "127.0.0.1",
 				Code:    string(cerror.ErrExpressionColumnNotFound.RFCCode()),
 				Message: cerror.ErrExpressionColumnNotFound.Error(),
-			},
-		}, true, nil
-	})
+			}
+			return position, true, nil
+		})
 	tester.MustApplyPatches()
 	manager.Tick(state)
 	// should be false
 	require.False(t, manager.ShouldRunning())
 
-	state.PatchInfo(func(info *model.ChangeFeedInfo) (*model.ChangeFeedInfo, bool, error) {
-		return &model.ChangeFeedInfo{
-			SinkURI: "123",
-			Config:  &config.ReplicaConfig{},
-			State:   model.StateWarning,
-			Error: &model.RunningError{
+	state.PatchTaskPosition("test",
+		func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+			if position == nil {
+				position = &model.TaskPosition{}
+			}
+			position.Error = &model.RunningError{
 				Addr:    "127.0.0.1",
 				Code:    string(cerror.ErrExpressionParseFailed.RFCCode()),
 				Message: cerror.ErrExpressionParseFailed.Error(),
-			},
-		}, true, nil
-	})
+			}
+			return position, true, nil
+		})
 	tester.MustApplyPatches()
 	manager.Tick(state)
 	// should be false
@@ -572,7 +594,11 @@ func TestBackoffStopsUnexpectedly(t *testing.T) {
 			require.Equal(t, state.Info.State, model.StateFailed)
 			require.False(t, manager.ShouldRunning())
 		} else {
-			require.Equal(t, state.Info.State, model.StateNormal)
+			if i == 1 {
+				require.Equal(t, model.StateNormal, state.Info.State)
+			} else {
+				require.Equal(t, model.StateWarning, state.Info.State)
+			}
 			require.True(t, manager.ShouldRunning())
 			state.PatchTaskPosition(ctx.GlobalVars().CaptureInfo.ID,
 				func(position *model.TaskPosition) (
@@ -589,7 +615,7 @@ func TestBackoffStopsUnexpectedly(t *testing.T) {
 			tester.MustApplyPatches()
 			// If an error occurs, backing off from running the task.
 			require.False(t, manager.ShouldRunning())
-			require.Equal(t, state.Info.State, model.StateWarning)
+			require.Equal(t, model.StatePending, state.Info.State)
 			require.Equal(t, state.Info.AdminJobType, model.AdminStop)
 			require.Equal(t, state.Status.AdminJobType, model.AdminStop)
 		}
@@ -623,7 +649,11 @@ func TestBackoffNeverStops(t *testing.T) {
 	tester.MustApplyPatches()
 
 	for i := 1; i <= 30; i++ {
-		require.Equal(t, state.Info.State, model.StateNormal)
+		if i == 1 {
+			require.Equal(t, model.StateNormal, state.Info.State)
+		} else {
+			require.Equal(t, model.StateWarning, state.Info.State)
+		}
 		require.True(t, manager.ShouldRunning())
 		state.PatchTaskPosition(ctx.GlobalVars().CaptureInfo.ID,
 			func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
@@ -637,7 +667,7 @@ func TestBackoffNeverStops(t *testing.T) {
 		manager.Tick(state)
 		tester.MustApplyPatches()
 		require.False(t, manager.ShouldRunning())
-		require.Equal(t, state.Info.State, model.StateWarning)
+		require.Equal(t, model.StatePending, state.Info.State)
 		require.Equal(t, state.Info.AdminJobType, model.AdminStop)
 		require.Equal(t, state.Status.AdminJobType, model.AdminStop)
 		// 100ms is the backoff interval, so sleep 100ms and after a manager tick,
@@ -688,7 +718,8 @@ func TestUpdateChangefeedEpoch(t *testing.T) {
 		manager.Tick(state)
 		tester.MustApplyPatches()
 		require.False(t, manager.ShouldRunning())
-		require.Equal(t, state.Info.State, model.StateWarning)
+		require.Equal(t, model.StatePending, state.Info.State, i)
+
 		require.Equal(t, state.Info.AdminJobType, model.AdminStop)
 		require.Equal(t, state.Status.AdminJobType, model.AdminStop)
 

--- a/cdc/owner/feed_state_manager_test.go
+++ b/cdc/owner/feed_state_manager_test.go
@@ -63,7 +63,6 @@ func newFeedStateManager4Test(
 	f.errBackoff.RandomizationFactor = 0
 
 	f.resetErrRetry()
-	f.lastErrorRetryTime = time.Unix(0, 0)
 
 	return f
 }

--- a/cdc/owner/owner.go
+++ b/cdc/owner/owner.go
@@ -735,7 +735,7 @@ func (o *ownerImpl) calculateGCSafepoint(state *orchestrator.GlobalReactorState)
 		}
 
 		switch changefeedState.Info.State {
-		case model.StateNormal, model.StateStopped, model.StateError:
+		case model.StateNormal, model.StateStopped, model.StateWarning:
 		case model.StateFailed:
 			if o.ignoreFailedChangeFeedWhenGC(changefeedState) {
 				continue

--- a/pkg/cmd/cli/cli_changefeed_list_test.go
+++ b/pkg/cmd/cli/cli_changefeed_list_test.go
@@ -43,7 +43,7 @@ func TestChangefeedListCli(t *testing.T) {
 			ID:             "error-1",
 			CheckpointTime: model.JSONTime{},
 			RunningError:   nil,
-			FeedState:      model.StateError,
+			FeedState:      model.StateWarning,
 		},
 		{
 			UpstreamID:     1,

--- a/pkg/cmd/cli/cli_changefeed_list_test.go
+++ b/pkg/cmd/cli/cli_changefeed_list_test.go
@@ -40,7 +40,7 @@ func TestChangefeedListCli(t *testing.T) {
 		{
 			UpstreamID:     1,
 			Namespace:      "default",
-			ID:             "error-1",
+			ID:             "pending-1",
 			CheckpointTime: model.JSONTime{},
 			RunningError:   nil,
 			FeedState:      model.StateWarning,
@@ -85,28 +85,38 @@ func TestChangefeedListCli(t *testing.T) {
 			RunningError:   nil,
 			FeedState:      model.StateStopped,
 		},
+		{
+			UpstreamID:     1,
+			Namespace:      "default",
+			ID:             "warning-7",
+			CheckpointTime: model.JSONTime{},
+			RunningError:   nil,
+			FeedState:      model.StateStopped,
+		},
 	}, nil).Times(2)
-	// when --all=false, should contains StateNormal, StateError, StateFailed, StateStopped changefeed
+	// when --all=false, should contains StateNormal, StateWarning, StateFailed, StateStopped changefeed
 	os.Args = []string{"list", "--all=false", "--namespace=default"}
 	require.Nil(t, cmd.Execute())
 	out, err := io.ReadAll(b)
 	require.Nil(t, err)
-	require.Contains(t, string(out), "error-1")
+	require.Contains(t, string(out), "pending-1")
 	require.Contains(t, string(out), "normal-2")
 	require.Contains(t, string(out), "stopped-6")
 	require.Contains(t, string(out), "failed-3")
+	require.Contains(t, string(out), "warning-7")
 
 	// when --all=true, should contains all changefeed
 	os.Args = []string{"list", "--all=true", "--namespace=default"}
 	require.Nil(t, cmd.Execute())
 	out, err = io.ReadAll(b)
 	require.Nil(t, err)
-	require.Contains(t, string(out), "error-1")
+	require.Contains(t, string(out), "pending-1")
 	require.Contains(t, string(out), "normal-2")
 	require.Contains(t, string(out), "failed-3")
 	require.Contains(t, string(out), "removed-4")
 	require.Contains(t, string(out), "finished-5")
 	require.Contains(t, string(out), "stopped-6")
+	require.Contains(t, string(out), "warning-7")
 
 	cf.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, errors.New("changefeed list test error"))

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -81,7 +81,7 @@ func TestMigration(t *testing.T) {
 	status1 := model.ChangeFeedStatus{CheckpointTs: 1}
 	info2 := model.ChangeFeedInfo{
 		SinkURI: "test1",
-		StartTs: 2, TargetTs: 200, State: model.StateError,
+		StartTs: 2, TargetTs: 200, State: model.StateWarning,
 	}
 	status2 := model.ChangeFeedStatus{CheckpointTs: 2}
 	cfg := config.GetDefaultReplicaConfig()
@@ -360,7 +360,7 @@ func TestMigrationNonDefaultCluster(t *testing.T) {
 	status1 := model.ChangeFeedStatus{CheckpointTs: 1}
 	info2 := model.ChangeFeedInfo{
 		SinkURI: "test1",
-		StartTs: 2, TargetTs: 200, State: model.StateError,
+		StartTs: 2, TargetTs: 200, State: model.StateWarning,
 	}
 	status2 := model.ChangeFeedStatus{CheckpointTs: 2}
 	info3 := model.ChangeFeedInfo{

--- a/tests/integration_tests/changefeed_error/run.sh
+++ b/tests/integration_tests/changefeed_error/run.sh
@@ -72,7 +72,7 @@ function run() {
 	ensure $MAX_RETRIES "check_etcd_meta_not_exist '/tidb/cdc/default/__cdc_meta__/owner' 'owner'"
 
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
-	ensure $MAX_RETRIES check_changefeed_state http://${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid} "error" "failpoint injected retriable error" ""
+	ensure $MAX_RETRIES check_changefeed_state http://${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid} "pending" "failpoint injected retriable error" ""
 
 	run_cdc_cli changefeed remove -c $changefeedid
 	ensure $MAX_RETRIES check_no_changefeed ${UP_PD_HOST_1}:${UP_PD_PORT_1}

--- a/tests/integration_tests/changefeed_error/run.sh
+++ b/tests/integration_tests/changefeed_error/run.sh
@@ -72,7 +72,7 @@ function run() {
 	ensure $MAX_RETRIES "check_etcd_meta_not_exist '/tidb/cdc/default/__cdc_meta__/owner' 'owner'"
 
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY
-	ensure $MAX_RETRIES check_changefeed_state http://${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid} "pending" "failpoint injected retriable error" ""
+	ensure $MAX_RETRIES check_changefeed_state http://${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid} "warning" "failpoint injected retriable error" ""
 
 	run_cdc_cli changefeed remove -c $changefeedid
 	ensure $MAX_RETRIES check_no_changefeed ${UP_PD_HOST_1}:${UP_PD_PORT_1}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #9273

### What is changed and how it works?
After this PR, the error status of changefeed will be removed, and the warning status will be added.
The changefeed status transition is shown in the following figure.

![image](https://github.com/pingcap/tiflow/assets/20351731/e7cb376a-b2da-41db-be9b-6d3564f72c69)

1. The user pauses changefeed, and changefeed enters the `stopped` state.
2. The user resumes changefeed, and changefeed returns to the `normal` state.
3. Changefeed encounters an error and enters the `warning` state. Changefeed automatically retries in the `warning` state.
4. If the changefeed retry is successful and the `CheckpointTs` advances beyond the `CheckpointTs` when the error occurred, the changefeed enters the `normal` state.
5. If the changefeed error retry exceeds the maximum retry time limit, it enters the `failed` state. After entering the `failed` state, the changefeed will block the GC of the upstream TiDB cluster. The default blocking time is `gc-ttl`. Users can manually recover the changefeed within the `gc-ttl` time.
6. If the changefeed encounters an unrecoverable error during the running process, it directly enters the `failed` state.
7. The changefeed  is complete, and the its progress has reached the preset `TargetTs`.
8. If the changefeed is in the stopped state for a time exceeding the duration specified by `gc-ttl`, it cannot be recovered.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
