### PR TITLE
changefeed (ticdc): don't set changefeed to failed state when error retry reach limit

### DIFF
--- a/cdc/owner/feed_state_manager.go
+++ b/cdc/owner/feed_state_manager.go
@@ -463,7 +463,7 @@ func (m *feedStateManager) handleError(errs ...*model.RunningError) {
 			log.Warn("changefeed will not be restarted because it has been failing for a long time period",
 				zap.Duration("maxElapsedTime", m.errBackoff.MaxElapsedTime))
 			m.shouldBeRunning = false
-			m.patchState(model.StateFailed)
+			m.patchState(model.StateError)
 		} else {
 			log.Info("changefeed restart backoff interval is changed",
 				zap.String("namespace", m.state.ID.Namespace),

--- a/cdc/owner/feed_state_manager_test.go
+++ b/cdc/owner/feed_state_manager_test.go
@@ -204,7 +204,7 @@ func TestHandleError(t *testing.T) {
 
 	require.False(t, manager.ShouldRunning())
 	require.False(t, manager.ShouldRemoved())
-	require.Equal(t, state.Info.State, model.StateFailed)
+	require.Equal(t, state.Info.State, model.StateError)
 	require.Equal(t, state.Info.AdminJobType, model.AdminStop)
 	require.Equal(t, state.Status.AdminJobType, model.AdminStop)
 

--- a/pkg/txnutil/gc/gc_manager.go
+++ b/pkg/txnutil/gc/gc_manager.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/cdc/model"

--- a/pkg/txnutil/gc/gc_manager.go
+++ b/pkg/txnutil/gc/gc_manager.go
@@ -113,11 +113,7 @@ func (m *gcManager) CheckStaleCheckpointTs(
 ) error {
 	gcSafepointUpperBound := checkpointTs - 1
 	if m.isTiCDCBlockGC {
-		pdTime, err := m.pdClock.CurrentTime()
-		// TODO: should we return err here, or just log it?
-		if err != nil {
-			return errors.Trace(err)
-		}
+		pdTime, _ := m.pdClock.CurrentTime()
 		if pdTime.Sub(oracle.GetTimeFromTS(gcSafepointUpperBound)) > time.Duration(m.gcTTL)*time.Second {
 			return cerror.ErrGCTTLExceeded.GenWithStackByArgs(checkpointTs, changefeedID)
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #5647 close #8382 close #9388

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
