### PR TITLE
Fix tiflash block-cache size && remove useless config

### DIFF
--- a/tests/integration_tests/_utils/start_tidb_cluster_impl
+++ b/tests/integration_tests/_utils/start_tidb_cluster_impl
@@ -296,7 +296,6 @@ run_sql "FLUSH privileges" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 cat - >"$OUT_DIR/tiflash-config.toml" <<EOF
 tmp_path = "${OUT_DIR}/tiflash/tmp"
 display_name = "TiFlash"
-default_profile = "default"
 users_config = "${OUT_DIR}/tiflash/users.toml"
 path = "${OUT_DIR}/tiflash/db"
 mark_cache_size = 5368709120
@@ -308,13 +307,6 @@ interserver_http_port = 5500
 [flash]
 tidb_status_addr = "127.0.0.1:8500"
 service_addr = "127.0.0.1:9500"
-overlap_threshold = 0.6
-
-[flash.flash_cluster]
-master_ttl = 60
-refresh_interval = 20
-update_rule_interval = 5
-cluster_manager_path = "${CUR}/../../bin/flash_cluster_manager"
 
 [flash.proxy]
 addr = "127.0.0.1:9000"
@@ -334,10 +326,7 @@ count = 10
 runAsDaemon = true
 
 [raft]
-kvstore_path = "${OUT_DIR}/tiflash/kvstore"
 pd_addr = "${UP_PD_HOST_1}:${UP_PD_PORT_1}"
-ignore_databases = "system,default"
-storage_engine = "dt"
 EOF
 
 cat - >"$OUT_DIR/tiflash-proxy.toml" <<EOF
@@ -357,13 +346,13 @@ wal-dir = ""
 max-open-files = 1000
 
 [rocksdb.defaultcf]
-block-cache-size = "10GB"
+block-cache-size = "1GB"
 
 [rocksdb.lockcf]
-block-cache-size = "4GB"
+block-cache-size = "1GB"
 
 [rocksdb.writecf]
-block-cache-size = "4GB"
+block-cache-size = "1GB"
 
 [raftdb]
 max-open-files = 1000


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/9425

### What is changed and how it works?

Reduce the total block-cache size of TiFlash proxy from 19GB to 4GB

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
