### PR TITLE
engine: register loader metric

### DIFF
--- a/dm/loader/lightning.go
+++ b/dm/loader/lightning.go
@@ -81,6 +81,7 @@ type LightningLoader struct {
 	lastErr        error
 
 	speedRecorder *export.SpeedRecorder
+	metricProxies *metricProxies
 }
 
 // NewLightning creates a new Loader importing data with lightning.
@@ -135,6 +136,15 @@ func (l *LightningLoader) Type() pb.UnitType {
 	return pb.UnitType_Load
 }
 
+func (l *LightningLoader) initMetricProxies() {
+	if l.cfg.MetricsFactory != nil {
+		// running inside dataflow-engine and the factory is an auto register/deregister factory
+		l.metricProxies = newMetricProxies(l.cfg.MetricsFactory)
+	} else {
+		l.metricProxies = defaultMetricProxies
+	}
+}
+
 // Init initializes loader for a load task, but not start Process.
 // if fail, it should not call l.Close.
 func (l *LightningLoader) Init(ctx context.Context) (err error) {
@@ -142,6 +152,8 @@ func (l *LightningLoader) Init(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
+
+	l.initMetricProxies()
 
 	checkpointList := NewLightningCheckpointList(l.toDB, l.cfg.Name, l.cfg.SourceID, l.cfg.MetaSchema, l.logger)
 	err = checkpointList.Prepare(ctx)
@@ -483,7 +495,7 @@ func (l *LightningLoader) restore(ctx context.Context) error {
 
 func (l *LightningLoader) handleExitErrMetric(err *pb.ProcessError) {
 	resumable := fmt.Sprintf("%t", unit.IsResumableError(err))
-	loaderExitWithErrorCounter.WithLabelValues(l.cfg.Name, l.cfg.SourceID, resumable).Inc()
+	l.metricProxies.loaderExitWithErrorCounter.WithLabelValues(l.cfg.Name, l.cfg.SourceID, resumable).Inc()
 }
 
 // Process implements Unit.Process.
@@ -555,6 +567,7 @@ func (l *LightningLoader) IsFreshTask(ctx context.Context) (bool, error) {
 // Close does graceful shutdown.
 func (l *LightningLoader) Close() {
 	l.Pause()
+	l.removeLabelValuesWithTaskInMetrics(l.cfg.Name, l.cfg.SourceID)
 	l.checkPointList.Close()
 	l.closed.Store(true)
 }

--- a/dm/loader/lightning.go
+++ b/dm/loader/lightning.go
@@ -148,12 +148,12 @@ func (l *LightningLoader) initMetricProxies() {
 // Init initializes loader for a load task, but not start Process.
 // if fail, it should not call l.Close.
 func (l *LightningLoader) Init(ctx context.Context) (err error) {
+	l.initMetricProxies()
+
 	l.toDB, err = conn.GetDownstreamDB(&l.cfg.To)
 	if err != nil {
 		return err
 	}
-
-	l.initMetricProxies()
 
 	checkpointList := NewLightningCheckpointList(l.toDB, l.cfg.Name, l.cfg.SourceID, l.cfg.MetaSchema, l.logger)
 	err = checkpointList.Prepare(ctx)

--- a/dm/loader/lightning_test.go
+++ b/dm/loader/lightning_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tiflow/dm/config"
 	"github.com/pingcap/tiflow/dm/pkg/terror"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -71,4 +73,23 @@ func TestGetLightiningConfig(t *testing.T) {
 	lightningDefaultQuota := lcfg.NewConfig().TikvImporter.DiskQuota
 	// when we don't set dm loader disk quota, it should be equal to lightning's default quota
 	require.Equal(t, lightningDefaultQuota, conf.TikvImporter.DiskQuota)
+}
+
+func TestMetricProxies(t *testing.T) {
+	l := &LightningLoader{cfg: &config.SubTaskConfig{}}
+	l.initMetricProxies()
+	require.Equal(t, defaultMetricProxies, l.metricProxies)
+
+	registry := prometheus.NewRegistry()
+	l = &LightningLoader{cfg: &config.SubTaskConfig{MetricsFactory: promauto.With(registry)}}
+	l.initMetricProxies()
+	require.NotEqual(t, defaultMetricProxies, l.metricProxies)
+	l.metricProxies.loaderExitWithErrorCounter.WithLabelValues("test", "source", "false").Inc()
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+	require.Len(t, metricFamilies, 1)
+	l.removeLabelValuesWithTaskInMetrics("test", "source")
+	metricFamilies, err = registry.Gather()
+	require.NoError(t, err)
+	require.Len(t, metricFamilies, 0)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9359

### What is changed and how it works?
- register loader metric on engine, and remove useless metrics

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - [x] Unit test
 - Integration test
 - [x] Manual test (add detailed scripts or steps below)
start a job, see we can see metric of loader error
```
# TYPE dm_loader_exit_with_error_count counter
dm_loader_exit_with_error_count{job_id="1110282",project_id="73876",resumable_err="false",source_id="source-1290068",task="1110282",tenant="30073",worker_id="xxxx"} 6
# HELP dm_worker_task_state task state of dm worker in this job
# TYPE dm_worker_task_state gauge
dm_worker_task_state{job_id="1110282",project_id="73876",source_id="source-1290068",task="1110282",tenant="30073"} 15
```
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
