### PR TITLE
config(ticdc): handle key only not allow force-replicate

### DIFF
--- a/pkg/sink/codec/common/config.go
+++ b/pkg/sink/codec/common/config.go
@@ -151,6 +151,7 @@ func (c *Config) Apply(sinkURI *url.URL, replicaConfig *config.ReplicaConfig) er
 		c.MaxMessageBytes = *urlParameter.MaxMessageBytes
 	}
 
+	// avro related
 	if urlParameter.AvroDecimalHandlingMode != nil &&
 		*urlParameter.AvroDecimalHandlingMode != "" {
 		c.AvroDecimalHandlingMode = *urlParameter.AvroDecimalHandlingMode
@@ -164,9 +165,12 @@ func (c *Config) Apply(sinkURI *url.URL, replicaConfig *config.ReplicaConfig) er
 			c.AvroEnableWatermark = *urlParameter.AvroEnableWatermark
 		}
 	}
-
 	if urlParameter.AvroSchemaRegistry != "" {
 		c.AvroSchemaRegistry = urlParameter.AvroSchemaRegistry
+	}
+	if c.Protocol == config.ProtocolAvro && replicaConfig.ForceReplicate {
+		return cerror.ErrCodecInvalidConfig.GenWithStack(
+			`force-replicate must be disabled, when using avro protocol`)
 	}
 
 	if replicaConfig.Sink != nil {

--- a/pkg/sink/codec/common/config.go
+++ b/pkg/sink/codec/common/config.go
@@ -181,6 +181,10 @@ func (c *Config) Apply(sinkURI *url.URL, replicaConfig *config.ReplicaConfig) er
 		if replicaConfig.Sink.KafkaConfig != nil {
 			c.LargeMessageHandle = replicaConfig.Sink.KafkaConfig.LargeMessageHandle
 		}
+		if c.LargeMessageHandle.HandleKeyOnly() && replicaConfig.ForceReplicate {
+			return cerror.ErrCodecInvalidConfig.GenWithStack(
+				`force-replicate must be disabled, when the large message handle option is set to "handle-key-only"`)
+		}
 	}
 	if urlParameter.OnlyOutputUpdatedColumns != nil {
 		c.OnlyOutputUpdatedColumns = *urlParameter.OnlyOutputUpdatedColumns
@@ -197,6 +201,10 @@ func (c *Config) Apply(sinkURI *url.URL, replicaConfig *config.ReplicaConfig) er
 	}
 
 	c.DeleteOnlyHandleKeyColumns = util.GetOrZero(replicaConfig.Sink.DeleteOnlyOutputHandleKeyColumns)
+	if c.DeleteOnlyHandleKeyColumns && replicaConfig.ForceReplicate {
+		return cerror.ErrCodecInvalidConfig.GenWithStack(
+			`force-replicate must be disabled when configuration "delete-only-output-handle-key-columns" is true.`)
+	}
 	return nil
 }
 

--- a/pkg/sink/codec/common/config_test.go
+++ b/pkg/sink/codec/common/config_test.go
@@ -235,6 +235,21 @@ func TestDeleteHandleKeyOnly(t *testing.T) {
 	require.ErrorIs(t, err, cerror.ErrCodecInvalidConfig)
 }
 
+func TestAvroForceReplicate(t *testing.T) {
+	t.Parallel()
+
+	replicaConfig := config.GetDefaultReplicaConfig()
+	replicaConfig.ForceReplicate = true
+
+	uri := "kafka://127.0.0.1:9092/abc?protocol=avro"
+	sinkURI, err := url.Parse(uri)
+	require.NoError(t, err)
+
+	codecConfig := NewConfig(config.ProtocolAvro)
+	err = codecConfig.Apply(sinkURI, replicaConfig)
+	require.ErrorIs(t, err, cerror.ErrCodecInvalidConfig)
+}
+
 func TestConfigApplyValidate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9478 

### What is changed and how it works?

* disallow changefeed enable `force-replicate` when using `delete-only-output-handle-key-columns`
* disallow changefeed enable `force-replicate` when using handle-key-only
* disallow changefeed enable `force-replicate` when using avro protocol.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
