### PR TITLE
sqlmodel(dm): generate key in lower case

### DIFF
--- a/pkg/sqlmodel/causality.go
+++ b/pkg/sqlmodel/causality.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	timodel "github.com/pingcap/tidb/parser/model"
+	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tiflow/dm/pkg/log"
@@ -39,6 +40,19 @@ func (r *RowChange) CausalityKeys() []string {
 		ret = append(ret, r.getCausalityString(r.postValues)...)
 	}
 	return ret
+}
+
+func columnNeeds2LowerCase(col *timodel.ColumnInfo) bool {
+	switch col.GetType() {
+	case mysql.TypeVarchar, mysql.TypeString, mysql.TypeVarString, mysql.TypeTinyBlob,
+		mysql.TypeMediumBlob, mysql.TypeBlob, mysql.TypeLongBlob:
+		return collationNeeds2LowerCase(col.GetCollate())
+	}
+	return false
+}
+
+func collationNeeds2LowerCase(collation string) bool {
+	return !strings.HasSuffix(collation, "_bin")
 }
 
 func columnValue2String(value interface{}) string {
@@ -99,7 +113,12 @@ func genKeyString(
 			continue // ignore `null` value.
 		}
 		// one column key looks like:`column_val.column_name.`
-		buf.WriteString(columnValue2String(data))
+
+		val := columnValue2String(data)
+		if columnNeeds2LowerCase(columns[i]) {
+			val = strings.ToLower(val)
+		}
+		buf.WriteString(val)
 		buf.WriteString(".")
 		buf.WriteString(columns[i].Name.L)
 		buf.WriteString(".")
@@ -110,7 +129,7 @@ func genKeyString(
 		return "" // all values are `null`.
 	}
 	buf.WriteString(table)
-	return strings.ToLower(buf.String())
+	return buf.String()
 }
 
 // truncateIndexValues truncate prefix index from data.

--- a/pkg/sqlmodel/causality.go
+++ b/pkg/sqlmodel/causality.go
@@ -52,7 +52,7 @@ func columnNeeds2LowerCase(col *timodel.ColumnInfo) bool {
 }
 
 func collationNeeds2LowerCase(collation string) bool {
-	return !strings.HasSuffix(collation, "_bin")
+	return strings.HasSuffix(collation, "_ci")
 }
 
 func columnValue2String(value interface{}) string {

--- a/pkg/sqlmodel/causality.go
+++ b/pkg/sqlmodel/causality.go
@@ -110,7 +110,7 @@ func genKeyString(
 		return "" // all values are `null`.
 	}
 	buf.WriteString(table)
-	return buf.String()
+	return strings.ToLower(buf.String())
 }
 
 // truncateIndexValues truncate prefix index from data.

--- a/pkg/sqlmodel/causality_test.go
+++ b/pkg/sqlmodel/causality_test.go
@@ -156,6 +156,12 @@ func TestGetCausalityString(t *testing.T) {
 			keys:   []string{"16.a.db.tbl", "xyz.b.db.tbl"},
 		},
 		{
+			// case insensitive
+			schema: `create table t65(a int unique, b varchar(16) primary key)`,
+			values: []interface{}{16, "XyZ"},
+			keys:   []string{"16.a.db.tbl", "xyz.b.db.tbl"},
+		},
+		{
 			// primary key of multiple columns
 			schema: `create table t7(a int, b int, primary key(a, b))`,
 			values: []interface{}{59, 69},

--- a/pkg/sqlmodel/causality_test.go
+++ b/pkg/sqlmodel/causality_test.go
@@ -157,9 +157,15 @@ func TestGetCausalityString(t *testing.T) {
 		},
 		{
 			// case insensitive
-			schema: `create table t65(a int unique, b varchar(16) primary key)`,
+			schema: `create table t_ci(a int unique, b varchar(16) primary key)default charset=utf8 collate=utf8_unicode_ci`,
 			values: []interface{}{16, "XyZ"},
 			keys:   []string{"16.a.db.tbl", "xyz.b.db.tbl"},
+		},
+		{
+			// case sensitive
+			schema: `create table t_bin(a int unique, b varchar(16) primary key)default charset=utf8 collate=utf8_bin`,
+			values: []interface{}{16, "XyZ"},
+			keys:   []string{"16.a.db.tbl", "XyZ.b.db.tbl"},
 		},
 		{
 			// primary key of multiple columns

--- a/pkg/sqlmodel/row_change_test.go
+++ b/pkg/sqlmodel/row_change_test.go
@@ -34,6 +34,13 @@ func mockTableInfo(t *testing.T, sql string) *timodel.TableInfo {
 	node, err := p.ParseOneStmt(sql, "", "")
 	require.NoError(t, err)
 	ti, err := ddl.MockTableInfo(se, node.(*ast.CreateTableStmt), 1)
+	// for testing to be able to specify charset/collation, kind of hacky, ideally should add this to the MockTableInfo function in tidb
+	if tableCharset, tableCollate, err := ddl.GetCharsetAndCollateInTableOption(0, node.(*ast.CreateTableStmt).Options); err == nil {
+		for _, col := range ti.Columns {
+			col.SetCharset(tableCharset)
+			col.SetCollate(tableCollate)
+		}
+	}
 	require.NoError(t, err)
 	return ti
 }

--- a/pkg/sqlmodel/row_change_test.go
+++ b/pkg/sqlmodel/row_change_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/parser/ast"
+	"github.com/pingcap/tidb/parser/charset"
 	timodel "github.com/pingcap/tidb/parser/model"
 	timock "github.com/pingcap/tidb/util/mock"
 	cdcmodel "github.com/pingcap/tiflow/cdc/model"
@@ -33,14 +34,8 @@ func mockTableInfo(t *testing.T, sql string) *timodel.TableInfo {
 	se := timock.NewContext()
 	node, err := p.ParseOneStmt(sql, "", "")
 	require.NoError(t, err)
-	ti, err := ddl.MockTableInfo(se, node.(*ast.CreateTableStmt), 1)
-	// for testing to be able to specify charset/collation, kind of hacky, ideally should add this to the MockTableInfo function in tidb
-	if tableCharset, tableCollate, err := ddl.GetCharsetAndCollateInTableOption(0, node.(*ast.CreateTableStmt).Options); err == nil {
-		for _, col := range ti.Columns {
-			col.SetCharset(tableCharset)
-			col.SetCollate(tableCollate)
-		}
-	}
+	dbChs, dbColl := charset.GetDefaultCharsetAndCollate()
+	ti, err := ddl.BuildTableInfoWithStmt(se, node.(*ast.CreateTableStmt), dbChs, dbColl, nil)
 	require.NoError(t, err)
 	return ti
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9489 

### What is changed and how it works?
convert the key to lower case could detect case insensitive conflict, it may introduce fake conflict when the collation is case sensitive, but it won't affect the correctness of dm, because it only introduces a sync point

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - [x] Unit test
 - Integration test
 - [x] Manual test (add detailed scripts or steps below)

generate load with conflicting key of the schema mentioned in the issue, before the change the replication could be broken within tens of minutes, after the change, it has been running for over 10 hours without issue
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
