### PR TITLE
kv-client(ticdc): fix panic when close receiveFromStream

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -555,7 +555,14 @@ func (s *eventFeedSession) scheduleRegionRequest(ctx context.Context, sri single
 func (s *eventFeedSession) onRegionFail(ctx context.Context, errorInfo regionErrorInfo) {
 	s.rangeLock.UnlockRange(errorInfo.span.StartKey, errorInfo.span.EndKey,
 		errorInfo.verID.GetID(), errorInfo.verID.GetVer(), errorInfo.resolvedTs())
-	s.enqueueError(ctx, errorInfo)
+	log.Info("region failed", zap.Stringer("span", &errorInfo.span),
+		zap.Any("regionId", errorInfo.verID.GetID()),
+		zap.Error(errorInfo.err))
+	select {
+	case s.errCh.In() <- errorInfo:
+		s.errChSizeGauge.Inc()
+	case <-ctx.Done():
+	}
 }
 
 // requestRegionToStore gets singleRegionInfo from regionRouter, which is a token
@@ -657,7 +664,7 @@ func (s *eventFeedSession) requestRegionToStore(
 
 			g.Go(func() error {
 				defer s.deleteStream(storeAddr)
-				return s.receiveFromStream(ctx, g, storeAddr, storeID, stream.client, pendingRegions)
+				return s.receiveFromStream(ctx, storeAddr, storeID, stream.client, pendingRegions)
 			})
 		}
 
@@ -866,16 +873,6 @@ func (s *eventFeedSession) divideAndSendEventFeedToRegions(
 	}
 }
 
-// enqueueError sends error to the eventFeedSession's error channel in a none blocking way
-// TODO: refactor enqueueError to avoid too many goroutines spawned when a lot of regions meet error.
-func (s *eventFeedSession) enqueueError(ctx context.Context, errorInfo regionErrorInfo) {
-	select {
-	case s.errCh.In() <- errorInfo:
-		s.errChSizeGauge.Inc()
-	case <-ctx.Done():
-	}
-}
-
 // handleError handles error returned by a region. If some new EventFeed connection should be established, the region
 // info will be sent to `regionCh`. Note if region channel is full, this function will be blocked.
 // CAUTION: Note that this should only be invoked in a context that the region is not locked, otherwise use onRegionFail
@@ -963,8 +960,7 @@ func (s *eventFeedSession) getRPCContextForRegion(ctx context.Context, id tikv.R
 //  2. pending regions: call `s.onRegionFail` for each pending region before this
 //     routine exits to establish these regions.
 func (s *eventFeedSession) receiveFromStream(
-	ctx context.Context,
-	g *errgroup.Group,
+	parentCtx context.Context,
 	addr string,
 	storeID uint64,
 	stream cdcpb.ChangeData_EventFeedClient,
@@ -993,7 +989,7 @@ func (s *eventFeedSession) receiveFromStream(
 		remainingRegions := pendingRegions.takeAll()
 		for _, state := range remainingRegions {
 			errInfo := newRegionErrorInfo(state.sri, cerror.ErrPendingRegionCancel.FastGenByArgs())
-			s.onRegionFail(ctx, errInfo)
+			s.onRegionFail(parentCtx, errInfo)
 		}
 	}()
 
@@ -1002,121 +998,146 @@ func (s *eventFeedSession) receiveFromStream(
 
 	// always create a new region worker, because `receiveFromStream` is ensured
 	// to call exactly once from outer code logic
-	worker := newRegionWorker(s.changefeed, s, addr)
+	worker := newRegionWorker(parentCtx, s.changefeed, s, addr)
 
-	defer worker.evictAllRegions()
+	ctx, cancel := context.WithCancel(parentCtx)
+	var retErr error
+	once := sync.Once{}
+	handleExit := func(err error) error {
+		once.Do(func() {
+			cancel()
+			retErr = err
+		})
+		return err
+	}
 
-	g.Go(func() error {
-		return worker.run(ctx)
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		err := handleExit(worker.run())
+		if err != nil {
+			log.Error("region worker exited with error", zap.Error(err),
+				zap.Any("changefeed", s.changefeed),
+				zap.Any("addr", addr),
+				zap.Any("storeID", storeID))
+		}
+		return err
 	})
 
-	maxCommitTs := model.Ts(0)
-	for {
-		cevent, err := stream.Recv()
+	receiveEvents := func() error {
+		maxCommitTs := model.Ts(0)
+		for {
+			cevent, err := stream.Recv()
 
-		failpoint.Inject("kvClientRegionReentrantError", func(op failpoint.Value) {
-			if op.(string) == "error" {
-				_ = worker.sendEvents(ctx, []*regionStatefulEvent{nil})
+			failpoint.Inject("kvClientRegionReentrantError", func(op failpoint.Value) {
+				if op.(string) == "error" {
+					_ = worker.sendEvents(ctx, []*regionStatefulEvent{nil})
+				}
+			})
+			failpoint.Inject("kvClientStreamRecvError", func(msg failpoint.Value) {
+				errStr := msg.(string)
+				if errStr == io.EOF.Error() {
+					err = io.EOF
+				} else {
+					err = errors.New(errStr)
+				}
+			})
+			if err != nil {
+				if status.Code(errors.Cause(err)) == codes.Canceled {
+					log.Debug(
+						"receive from stream canceled",
+						zap.String("namespace", s.changefeed.Namespace),
+						zap.String("changefeed", s.changefeed.ID),
+						zap.String("addr", addr),
+						zap.Uint64("storeID", storeID),
+					)
+				} else {
+					log.Warn(
+						"failed to receive from stream",
+						zap.String("namespace", s.changefeed.Namespace),
+						zap.String("changefeed", s.changefeed.ID),
+						zap.String("addr", addr),
+						zap.Uint64("storeID", storeID),
+						zap.Error(err),
+					)
+					// Note that pd need at lease 10s+ to tag a kv node as disconnect if kv node down
+					// tikv raft need wait (raft-base-tick-interval * raft-election-timeout-ticks) 10s to start a new
+					// election
+				}
+
+				// Use the same delay mechanism as `stream.Send` error handling, since
+				// these two errors often mean upstream store suffers an accident, which
+				// needs time to recover, kv client doesn't need to retry frequently.
+				// TODO: add a better retry backoff or rate limitter
+				time.Sleep(time.Millisecond * time.Duration(rand.Intn(100)))
+
+				// TODO: better to closes the send direction of the stream to notify
+				// the other side, but it is not safe to call CloseSend concurrently
+				// with SendMsg, in future refactor we should refine the recv loop
+				s.deleteStream(addr)
+
+				// send nil regionStatefulEvent to signal worker exit
+				err = worker.sendEvents(ctx, []*regionStatefulEvent{nil})
+				if err != nil {
+					return err
+				}
+
+				// Do no return error but gracefully stop the goroutine here. Then the whole job will not be canceled and
+				// connection will be retried.
+				return nil
 			}
-		})
-		failpoint.Inject("kvClientStreamRecvError", func(msg failpoint.Value) {
-			errStr := msg.(string)
-			if errStr == io.EOF.Error() {
-				err = io.EOF
-			} else {
-				err = errors.New(errStr)
-			}
-		})
-		if err != nil {
-			if status.Code(errors.Cause(err)) == codes.Canceled {
-				log.Debug(
-					"receive from stream canceled",
+
+			size := cevent.Size()
+			if size > warnRecvMsgSizeThreshold {
+				regionCount := 0
+				if cevent.ResolvedTs != nil {
+					regionCount = len(cevent.ResolvedTs.Regions)
+				}
+				log.Warn("change data event size too large",
 					zap.String("namespace", s.changefeed.Namespace),
 					zap.String("changefeed", s.changefeed.ID),
-					zap.String("addr", addr),
-					zap.Uint64("storeID", storeID),
-				)
-			} else {
-				log.Warn(
-					"failed to receive from stream",
-					zap.String("namespace", s.changefeed.Namespace),
-					zap.String("changefeed", s.changefeed.ID),
-					zap.String("addr", addr),
-					zap.Uint64("storeID", storeID),
-					zap.Error(err),
-				)
-				// Note that pd need at lease 10s+ to tag a kv node as disconnect if kv node down
-				// tikv raft need wait (raft-base-tick-interval * raft-election-timeout-ticks) 10s to start a new
-				// election
+					zap.Int("size", size), zap.Int("eventLen", len(cevent.Events)),
+					zap.Int("resolvedRegionCount", regionCount))
 			}
 
-			// Use the same delay mechanism as `stream.Send` error handling, since
-			// these two errors often mean upstream store suffers an accident, which
-			// needs time to recover, kv client doesn't need to retry frequently.
-			// TODO: add a better retry backoff or rate limitter
-			time.Sleep(time.Millisecond * time.Duration(rand.Intn(100)))
-
-			// TODO: better to closes the send direction of the stream to notify
-			// the other side, but it is not safe to call CloseSend concurrently
-			// with SendMsg, in future refactor we should refine the recv loop
-			s.deleteStream(addr)
-
-			// send nil regionStatefulEvent to signal worker exit
-			err = worker.sendEvents(ctx, []*regionStatefulEvent{nil})
+			if len(cevent.Events) != 0 {
+				if entries, ok := cevent.Events[0].Event.(*cdcpb.Event_Entries_); ok {
+					commitTs := entries.Entries.Entries[0].CommitTs
+					if maxCommitTs < commitTs {
+						maxCommitTs = commitTs
+					}
+				}
+			}
+			err = s.sendRegionChangeEvents(ctx, cevent.Events, worker, pendingRegions, addr)
 			if err != nil {
 				return err
 			}
-
-			// Do no return error but gracefully stop the goroutine here. Then the whole job will not be canceled and
-			// connection will be retried.
-			return nil
-		}
-
-		size := cevent.Size()
-		if size > warnRecvMsgSizeThreshold {
-			regionCount := 0
 			if cevent.ResolvedTs != nil {
-				regionCount = len(cevent.ResolvedTs.Regions)
-			}
-			log.Warn("change data event size too large",
-				zap.String("namespace", s.changefeed.Namespace),
-				zap.String("changefeed", s.changefeed.ID),
-				zap.Int("size", size), zap.Int("eventLen", len(cevent.Events)),
-				zap.Int("resolvedRegionCount", regionCount))
-		}
-
-		if len(cevent.Events) != 0 {
-			if entries, ok := cevent.Events[0].Event.(*cdcpb.Event_Entries_); ok {
-				commitTs := entries.Entries.Entries[0].CommitTs
-				if maxCommitTs < commitTs {
-					maxCommitTs = commitTs
+				metricSendEventBatchResolvedSize.Observe(float64(len(cevent.ResolvedTs.Regions)))
+				err = s.sendResolvedTs(ctx, cevent.ResolvedTs, worker)
+				if err != nil {
+					return err
+				}
+				// NOTE(qupeng): what if all regions are removed from the store?
+				// TiKV send resolved ts events every second by default.
+				// We check and update region count here to save CPU.
+				tsStat.regionCount.Store(uint64(worker.statesManager.regionCount()))
+				tsStat.resolvedTs.Store(cevent.ResolvedTs.Ts)
+				if maxCommitTs == 0 {
+					// In case, there is no write for the table,
+					// we use resolved ts as maxCommitTs to make the stats meaningful.
+					tsStat.commitTs.Store(cevent.ResolvedTs.Ts)
+				} else {
+					tsStat.commitTs.Store(maxCommitTs)
 				}
 			}
 		}
-		err = s.sendRegionChangeEvents(ctx, cevent.Events, worker, pendingRegions, addr)
-		if err != nil {
-			return err
-		}
-		if cevent.ResolvedTs != nil {
-			metricSendEventBatchResolvedSize.Observe(float64(len(cevent.ResolvedTs.Regions)))
-			err = s.sendResolvedTs(ctx, cevent.ResolvedTs, worker)
-			if err != nil {
-				return err
-			}
-			// NOTE(qupeng): what if all regions are removed from the store?
-			// TiKV send resolved ts events every second by default.
-			// We check and update region count here to save CPU.
-			tsStat.regionCount.Store(uint64(worker.statesManager.regionCount()))
-			tsStat.resolvedTs.Store(cevent.ResolvedTs.Ts)
-			if maxCommitTs == 0 {
-				// In case, there is no write for the table,
-				// we use resolved ts as maxCommitTs to make the stats meaningful.
-				tsStat.commitTs.Store(cevent.ResolvedTs.Ts)
-			} else {
-				tsStat.commitTs.Store(maxCommitTs)
-			}
-		}
 	}
+	eg.Go(func() error {
+		return handleExit(receiveEvents())
+	})
+
+	_ = eg.Wait()
+	return retErr
 }
 
 func (s *eventFeedSession) sendRegionChangeEvents(

--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -114,7 +114,7 @@ type regionWorker struct {
 }
 
 func newRegionWorker(
-	changefeedID model.ChangeFeedID, s *eventFeedSession, addr string,
+	ctx context.Context, changefeedID model.ChangeFeedID, s *eventFeedSession, addr string,
 ) *regionWorker {
 	metrics := &regionWorkerMetrics{}
 	metrics.metricReceivedEventSize = eventSize.WithLabelValues("received")
@@ -139,6 +139,7 @@ func newRegionWorker(
 		WithLabelValues("committed", changefeedID.Namespace, changefeedID.ID)
 
 	return &regionWorker{
+		parentCtx:     ctx,
 		session:       s,
 		inputCh:       make(chan []*regionStatefulEvent, regionWorkerInputChanSize),
 		outputCh:      s.eventCh,
@@ -347,6 +348,12 @@ func (w *regionWorker) resolveLock(ctx context.Context) error {
 }
 
 func (w *regionWorker) processEvent(ctx context.Context, event *regionStatefulEvent) error {
+	// event.state is nil when resolvedTsEvent is not nil
+	skipEvent := event.state != nil && event.state.isStopped()
+	if skipEvent {
+		return nil
+	}
+
 	if event.finishedCallbackCh != nil {
 		event.finishedCallbackCh <- struct{}{}
 		return nil
@@ -409,41 +416,40 @@ func (w *regionWorker) onHandleExit(err error) {
 }
 
 func (w *regionWorker) eventHandler(ctx context.Context) error {
-	preprocess := func(event *regionStatefulEvent, ok bool) (
-		exitEventHandler bool,
-		skipEvent bool,
-	) {
-		// event == nil means the region worker should exit and re-establish
-		// all existing regions.
-		if !ok || event == nil {
+	pollEvents := func() ([]*regionStatefulEvent, error) {
+		exitFn := func() error {
 			log.Info("region worker closed by error",
 				zap.String("namespace", w.session.client.changefeed.Namespace),
 				zap.String("changefeed", w.session.client.changefeed.ID))
-			exitEventHandler = true
-			return
+			return cerror.ErrRegionWorkerExit.GenWithStackByArgs()
 		}
-		// event.state is nil when resolvedTsEvent is not nil
-		if event.state != nil && event.state.isStopped() {
-			skipEvent = true
-		}
-		return
-	}
-	pollEvents := func() (events []*regionStatefulEvent, ok bool, err error) {
+
 		select {
 		case <-ctx.Done():
-			err = errors.Trace(ctx.Err())
-		case err = <-w.errorCh:
-		case events, ok = <-w.inputCh:
-			if ok && len(events) == 0 {
+			return nil, errors.Trace(ctx.Err())
+		case err := <-w.errorCh:
+			return nil, errors.Trace(err)
+		case events, ok := <-w.inputCh:
+			if !ok {
+				return nil, exitFn()
+			}
+			if len(events) == 0 {
 				log.Panic("regionWorker.inputCh doesn't accept empty slice")
 			}
+			for _, event := range events {
+				// event == nil means the region worker should exit and re-establish
+				// all existing regions.
+				if event == nil {
+					return nil, exitFn()
+				}
+			}
+			return events, nil
 		}
-		return
 	}
 
 	highWatermarkMet := false
 	for {
-		events, ok, err := pollEvents()
+		events, err := pollEvents()
 		if err != nil {
 			return err
 		}
@@ -497,15 +503,9 @@ func (w *regionWorker) eventHandler(ctx context.Context) error {
 			// throughput. Otherwise, we process event in local region worker to
 			// ensure low processing latency.
 			for _, event := range events {
-				exitEventHandler, skipEvent := preprocess(event, ok)
-				if exitEventHandler {
-					return cerror.ErrRegionWorkerExit.GenWithStackByArgs()
-				}
-				if !skipEvent {
-					err = w.processEvent(ctx, event)
-					if err != nil {
-						return err
-					}
+				err = w.processEvent(ctx, event)
+				if err != nil {
+					return err
 				}
 			}
 		}
@@ -567,14 +567,14 @@ func (w *regionWorker) cancelStream(delay time.Duration) {
 	}
 }
 
-func (w *regionWorker) run(parentCtx context.Context) error {
+func (w *regionWorker) run() error {
 	defer func() {
 		for _, h := range w.handles {
 			h.Unregister()
 		}
+		w.evictAllRegions()
 	}()
-	w.parentCtx = parentCtx
-	ctx, cancel := context.WithCancel(parentCtx)
+	ctx, cancel := context.WithCancel(w.parentCtx)
 	wg, ctx := errgroup.WithContext(ctx)
 	w.initPoolHandles()
 
@@ -687,19 +687,7 @@ func handleEventEntry(
 			state.matcher.putPrewriteRow(entry)
 		case cdcpb.Event_COMMIT:
 			metrics.metricPullEventCommitCounter.Inc()
-			// NOTE: state.getLastResolvedTs() will never less than startTs.
-			resolvedTs := state.getLastResolvedTs()
-			// TiKV can send events with StartTs/CommitTs less than startTs.
-			isStaleEvent := entry.CommitTs <= startTs
-			if entry.CommitTs <= resolvedTs && !isStaleEvent {
-				logPanic("The CommitTs must be greater than the resolvedTs",
-					zap.String("EventType", "COMMIT"),
-					zap.Uint64("CommitTs", entry.CommitTs),
-					zap.Uint64("resolvedTs", resolvedTs),
-					zap.Uint64("regionID", regionID))
-				return errUnreachable
-			}
-
+			// NOTE: matchRow should always be called even if the event is stale.
 			if !state.matcher.matchRow(entry, state.isInitialized()) {
 				if !state.isInitialized() {
 					state.matcher.cacheCommitRow(entry)
@@ -711,16 +699,31 @@ func handleEventEntry(
 					entry.GetType(), entry.GetOpType())
 			}
 
-			if !isStaleEvent {
-				revent, err := assembleRowEvent(regionID, entry)
-				if err != nil {
-					return errors.Trace(err)
-				}
-				if !emit(revent) {
-					return nil
-				}
-				metrics.metricSendEventCommitCounter.Inc()
+			// TiKV can send events with StartTs/CommitTs less than startTs.
+			isStaleEvent := entry.CommitTs <= startTs
+			if isStaleEvent {
+				continue
 			}
+
+			// NOTE: state.getLastResolvedTs() will never less than startTs.
+			resolvedTs := state.getLastResolvedTs()
+			if entry.CommitTs <= resolvedTs {
+				logPanic("The CommitTs must be greater than the resolvedTs",
+					zap.String("EventType", "COMMIT"),
+					zap.Uint64("CommitTs", entry.CommitTs),
+					zap.Uint64("resolvedTs", resolvedTs),
+					zap.Uint64("regionID", regionID))
+				return errUnreachable
+			}
+
+			revent, err := assembleRowEvent(regionID, entry)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if !emit(revent) {
+				return nil
+			}
+			metrics.metricSendEventCommitCounter.Inc()
 		case cdcpb.Event_ROLLBACK:
 			metrics.metricPullEventRollbackCounter.Inc()
 			if !state.isInitialized() {

--- a/cdc/kv/region_worker_test.go
+++ b/cdc/kv/region_worker_test.go
@@ -159,7 +159,7 @@ func TestRegionWokerHandleEventEntryEventOutOfOrder(t *testing.T) {
 		&tikv.RPCContext{}), 0)
 	state.sri.lockedRange = &regionlock.LockedRange{}
 	state.start()
-	worker := newRegionWorker(model.ChangeFeedID{}, s, "")
+	worker := newRegionWorker(ctx, model.ChangeFeedID{}, s, "")
 	require.Equal(t, 2, cap(worker.outputCh))
 
 	// Receive prewrite2 with empty value.
@@ -322,7 +322,7 @@ func TestRegionWorkerHandleEventsBeforeStartTs(t *testing.T) {
 	s1.sri.lockedRange = &regionlock.LockedRange{}
 	s1.sri.lockedRange.CheckpointTs.Store(9)
 	s1.start()
-	w := newRegionWorker(model.ChangeFeedID{}, s, "")
+	w := newRegionWorker(ctx, model.ChangeFeedID{}, s, "")
 
 	err := w.handleResolvedTs(ctx, &resolvedTsEvent{
 		resolvedTs: 5,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9520

### What is changed and how it works?
1. reafactor some codes
2. wait worker exit before evictAllRegions in `eventFeedSession.receiveFromStream`

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`Fix the issue that caused panic when rebuilding grpc connections to tikv`.
```
