### PR TITLE
kafka(ticdc): add unit test to cover claim-check functionality and use uuid to generate object key

### DIFF
--- a/cdc/sink/dmlsink/mq/mq_dml_sink.go
+++ b/cdc/sink/dmlsink/mq/mq_dml_sink.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tiflow/pkg/sink"
 	"github.com/pingcap/tiflow/pkg/sink/codec"
 	"github.com/pingcap/tiflow/pkg/sink/kafka"
+	"github.com/pingcap/tiflow/pkg/sink/kafka/claimcheck"
 )
 
 // Assert EventSink[E event.TableEvent] implementation
@@ -73,7 +74,7 @@ func newDMLSink(
 	eventRouter *dispatcher.EventRouter,
 	encoderGroup codec.EncoderGroup,
 	protocol config.Protocol,
-	claimCheck *ClaimCheck,
+	claimCheck *claimcheck.ClaimCheck,
 	claimCheckEncoder codec.ClaimCheckLocationEncoder,
 	errCh chan error,
 ) *dmlSink {

--- a/cdc/sink/dmlsink/mq/worker.go
+++ b/cdc/sink/dmlsink/mq/worker.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tiflow/pkg/chann"
 	"github.com/pingcap/tiflow/pkg/config"
 	"github.com/pingcap/tiflow/pkg/sink/codec"
+	"github.com/pingcap/tiflow/pkg/sink/kafka/claimcheck"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -83,7 +84,7 @@ type worker struct {
 	// statistics is used to record DML metrics.
 	statistics *metrics.Statistics
 
-	claimCheck *ClaimCheck
+	claimCheck *claimcheck.ClaimCheck
 }
 
 // newWorker creates a new flush worker.
@@ -92,7 +93,7 @@ func newWorker(
 	protocol config.Protocol,
 	producer dmlproducer.DMLProducer,
 	encoderGroup codec.EncoderGroup,
-	claimCheck *ClaimCheck,
+	claimCheck *claimcheck.ClaimCheck,
 	claimCheckEncoder codec.ClaimCheckLocationEncoder,
 	statistics *metrics.Statistics,
 ) *worker {

--- a/cdc/sink/metrics/mq/metrics.go
+++ b/cdc/sink/metrics/mq/metrics.go
@@ -16,6 +16,7 @@ package mq
 import (
 	"github.com/pingcap/tiflow/pkg/sink/codec"
 	"github.com/pingcap/tiflow/pkg/sink/kafka"
+	"github.com/pingcap/tiflow/pkg/sink/kafka/claimcheck"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -47,25 +48,6 @@ var (
 			Help:      "Batch duration for MQ worker.",
 			Buckets:   prometheus.ExponentialBuckets(0.004, 2, 10), // 4ms ~ 2s
 		}, []string{"namespace", "changefeed"})
-
-	// ClaimCheckSendMessageDuration records the duration of send message to the external claim-check storage.
-	ClaimCheckSendMessageDuration = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: "ticdc",
-			Subsystem: "sink",
-			Name:      "mq_claim_check_send_message_duration",
-			Help:      "Duration(s) for MQ worker send message to the external claim-check storage.",
-			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 20), // 1ms~524s
-		}, []string{"namespace", "changefeed"})
-
-	// ClaimCheckSendMessageCount records the total count of messages sent to the external claim-check storage.
-	ClaimCheckSendMessageCount = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "ticdc",
-			Subsystem: "sink",
-			Name:      "mq_claim_check_send_message_count",
-			Help:      "The total count of messages sent to the external claim-check storage.",
-		}, []string{"namespace", "changefeed"})
 )
 
 // InitMetrics registers all metrics in this file.
@@ -73,8 +55,7 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(WorkerSendMessageDuration)
 	registry.MustRegister(WorkerBatchSize)
 	registry.MustRegister(WorkerBatchDuration)
-	registry.MustRegister(ClaimCheckSendMessageDuration)
-	registry.MustRegister(ClaimCheckSendMessageCount)
+	claimcheck.InitMetrics(registry)
 	codec.InitMetrics(registry)
 	kafka.InitMetrics(registry)
 }

--- a/pkg/sink/codec/canal/canal_json_decoder.go
+++ b/pkg/sink/codec/canal/canal_json_decoder.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -128,7 +129,8 @@ func (b *batchDecoder) assembleClaimCheckRowChangedEvent(ctx context.Context, cl
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	data, err := b.storage.ReadFile(ctx, claimCheckLocation)
+	_, claimCheckFileName := filepath.Split(claimCheckLocation)
+	data, err := b.storage.ReadFile(ctx, claimCheckFileName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sink/codec/canal/canal_json_row_event_encoder.go
+++ b/pkg/sink/codec/canal/canal_json_row_event_encoder.go
@@ -262,7 +262,7 @@ func newJSONMessageForDML(
 			if config.LargeMessageHandle.EnableClaimCheck() {
 				out.RawByte(',')
 				out.RawString("\"claimCheckLocation\":")
-				out.String(common.NewClaimCheckFileName(e))
+				out.String(common.NewClaimCheckFileName(config.LargeMessageHandle.ClaimCheckStorageURI))
 			}
 		}
 		out.RawByte('}')
@@ -415,7 +415,7 @@ func (c *JSONRowEventEncoder) AppendRowChangedEvent(
 
 		if c.config.LargeMessageHandle.EnableClaimCheck() {
 			m.Event = e
-			m.ClaimCheckFileName = common.NewClaimCheckFileName(e)
+			m.ClaimCheckFileName = common.NewClaimCheckFileName(c.config.LargeMessageHandle.ClaimCheckStorageURI)
 		}
 	}
 

--- a/pkg/sink/codec/canal/canal_json_row_event_encoder.go
+++ b/pkg/sink/codec/canal/canal_json_row_event_encoder.go
@@ -416,7 +416,7 @@ func (c *JSONRowEventEncoder) AppendRowChangedEvent(
 
 		if c.config.LargeMessageHandle.EnableClaimCheck() {
 			m.Event = e
-			m.ClaimCheckFileName = common.NewClaimCheckFileName(c.config.LargeMessageHandle.ClaimCheckStorageURI)
+			m.ClaimCheckFileName = common.NewClaimCheckFileName()
 		}
 	}
 
@@ -426,7 +426,8 @@ func (c *JSONRowEventEncoder) AppendRowChangedEvent(
 
 // NewClaimCheckLocationMessage implements the ClaimCheckLocationEncoder interface
 func (c *JSONRowEventEncoder) NewClaimCheckLocationMessage(origin *common.Message) (*common.Message, error) {
-	value, err := newJSONMessageForDML(c.builder, origin.Event, c.config, true, origin.ClaimCheckFileName)
+	claimCheckLocation := common.ClaimCheckFileNameWithPrefix(c.config.LargeMessageHandle.ClaimCheckStorageURI, origin.ClaimCheckFileName)
+	value, err := newJSONMessageForDML(c.builder, origin.Event, c.config, true, claimCheckLocation)
 	if err != nil {
 		return nil, cerror.WrapError(cerror.ErrCanalEncodeFailed, err)
 	}

--- a/pkg/sink/codec/canal/canal_json_row_event_encoder.go
+++ b/pkg/sink/codec/canal/canal_json_row_event_encoder.go
@@ -26,6 +26,7 @@ import (
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/sink/codec"
 	"github.com/pingcap/tiflow/pkg/sink/codec/common"
+	"github.com/pingcap/tiflow/pkg/sink/kafka/claimcheck"
 	"go.uber.org/zap"
 )
 
@@ -416,7 +417,7 @@ func (c *JSONRowEventEncoder) AppendRowChangedEvent(
 
 		if c.config.LargeMessageHandle.EnableClaimCheck() {
 			m.Event = e
-			m.ClaimCheckFileName = common.NewClaimCheckFileName()
+			m.ClaimCheckFileName = claimcheck.NewFileName()
 		}
 	}
 
@@ -426,7 +427,7 @@ func (c *JSONRowEventEncoder) AppendRowChangedEvent(
 
 // NewClaimCheckLocationMessage implements the ClaimCheckLocationEncoder interface
 func (c *JSONRowEventEncoder) NewClaimCheckLocationMessage(origin *common.Message) (*common.Message, error) {
-	claimCheckLocation := common.ClaimCheckFileNameWithPrefix(c.config.LargeMessageHandle.ClaimCheckStorageURI, origin.ClaimCheckFileName)
+	claimCheckLocation := claimcheck.FileNameWithPrefix(c.config.LargeMessageHandle.ClaimCheckStorageURI, origin.ClaimCheckFileName)
 	value, err := newJSONMessageForDML(c.builder, origin.Event, c.config, true, claimCheckLocation)
 	if err != nil {
 		return nil, cerror.WrapError(cerror.ErrCanalEncodeFailed, err)

--- a/pkg/sink/codec/canal/canal_json_txn_event_encoder.go
+++ b/pkg/sink/codec/canal/canal_json_txn_event_encoder.go
@@ -50,7 +50,7 @@ func (j *JSONTxnEventEncoder) AppendTxnEvent(
 	callback func(),
 ) error {
 	for _, row := range txn.Rows {
-		value, err := newJSONMessageForDML(j.builder, row, j.config, false)
+		value, err := newJSONMessageForDML(j.builder, row, j.config, false, "")
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/pkg/sink/codec/common/message.go
+++ b/pkg/sink/codec/common/message.go
@@ -17,13 +17,10 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"path"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/pingcap/tiflow/cdc/model"
-	"github.com/pingcap/tiflow/engine/pkg/clock"
 	"github.com/pingcap/tiflow/pkg/config"
 	"github.com/tikv/client-go/v2/oracle"
 )
@@ -172,30 +169,10 @@ func UnmarshalClaimCheckMessage(data []byte) (*ClaimCheckMessage, error) {
 	return &m, err
 }
 
-// NewClaimCheckFileName return file name for sent the message to claim check storage.
-// make sure the file name can identify one event uniquely.
-// {date}/{schema}-{table}-{commitTs}-{startTs}-{handleKeys}.json
-// the files is organized by date, it's easy to clean up those objects by removing the whole directory.
-func NewClaimCheckFileName(e *model.RowChangedEvent) string {
-	// according to the https://docs.pingcap.com/tidb/stable/tidb-limitations#limitations-on-identifier-length
-	// schema and table maximum length is 64 characters, and the string representation of the commit ts is 20 bytes.
-	date := clock.New().Now().Format("2006-01-02")
-
-	elements := []string{
-		e.Table.Schema, e.Table.Table,
-		strconv.FormatUint(e.CommitTs, 10), strconv.FormatUint(e.StartTs, 10),
-	}
-	elements = append(elements, e.GetHandleKeyColumnValues()...)
-	fileName := strings.Join(elements, "-")
-	fileName += ".json"
-
-	fileName = path.Join(date, fileName)
-
-	// the maximum length of the S3 object key is 1024 bytes,
-	// ref https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
-	if len(fileName) > 1024 {
-		// randomly generated uuid has 122 bits, it should be within the length limit with the prefix.
-		fileName = path.Join(date, uuid.New().String()+".json")
-	}
-	return fileName
+// NewClaimCheckFileName return the file name for the message which is delivered to the external storage system.
+// UUID V4 is used to generate random and unique file names.
+// This should not exceed the S3 object name length limit.
+// ref https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+func NewClaimCheckFileName(prefix string) string {
+	return path.Join(prefix, uuid.NewString()+".json")
 }

--- a/pkg/sink/codec/common/message.go
+++ b/pkg/sink/codec/common/message.go
@@ -16,7 +16,7 @@ package common
 import (
 	"encoding/binary"
 	"encoding/json"
-	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/google/uuid"
@@ -45,6 +45,7 @@ type Message struct {
 	Callback  func()            // Callback function will be called when the message is sent to the sink.
 
 	// ClaimCheckFileName is set if the message should be sent to the claim check storage.
+	// it's only the file name, since the claim check storage writer know the path.
 	ClaimCheckFileName string
 
 	Event *model.RowChangedEvent
@@ -173,6 +174,11 @@ func UnmarshalClaimCheckMessage(data []byte) (*ClaimCheckMessage, error) {
 // UUID V4 is used to generate random and unique file names.
 // This should not exceed the S3 object name length limit.
 // ref https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
-func NewClaimCheckFileName(prefix string) string {
-	return path.Join(prefix, uuid.NewString()+".json")
+func NewClaimCheckFileName() string {
+	return uuid.NewString() + ".json"
+}
+
+// ClaimCheckFileNameWithPrefix returns the file name with prefix, the full path.
+func ClaimCheckFileNameWithPrefix(prefix, fileName string) string {
+	return filepath.Join(prefix, fileName)
 }

--- a/pkg/sink/codec/common/message.go
+++ b/pkg/sink/codec/common/message.go
@@ -16,10 +16,8 @@ package common
 import (
 	"encoding/binary"
 	"encoding/json"
-	"path/filepath"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/pkg/config"
 	"github.com/tikv/client-go/v2/oracle"
@@ -168,17 +166,4 @@ func UnmarshalClaimCheckMessage(data []byte) (*ClaimCheckMessage, error) {
 	var m ClaimCheckMessage
 	err := json.Unmarshal(data, &m)
 	return &m, err
-}
-
-// NewClaimCheckFileName return the file name for the message which is delivered to the external storage system.
-// UUID V4 is used to generate random and unique file names.
-// This should not exceed the S3 object name length limit.
-// ref https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
-func NewClaimCheckFileName() string {
-	return uuid.NewString() + ".json"
-}
-
-// ClaimCheckFileNameWithPrefix returns the file name with prefix, the full path.
-func ClaimCheckFileNameWithPrefix(prefix, fileName string) string {
-	return filepath.Join(prefix, fileName)
 }

--- a/pkg/sink/codec/open/open_protocol_encoder.go
+++ b/pkg/sink/codec/open/open_protocol_encoder.go
@@ -245,7 +245,8 @@ func (d *BatchEncoder) NewClaimCheckLocationMessage(origin *common.Message) (*co
 	}
 
 	keyMsg.OnlyHandleKey = false
-	keyMsg.ClaimCheckLocation = origin.ClaimCheckFileName
+	claimCheckLocation := common.ClaimCheckFileNameWithPrefix(d.config.LargeMessageHandle.ClaimCheckStorageURI, origin.ClaimCheckFileName)
+	keyMsg.ClaimCheckLocation = claimCheckLocation
 	key, err := keyMsg.Encode()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -285,7 +286,7 @@ func (d *BatchEncoder) appendSingleLargeMessage4ClaimCheck(key, value []byte, e 
 	message.Schema = &e.Table.Schema
 	message.Table = &e.Table.Table
 	// ClaimCheckFileName must be set to indicate this message should be sent to the external storage.
-	message.ClaimCheckFileName = common.NewClaimCheckFileName(d.config.LargeMessageHandle.ClaimCheckStorageURI)
+	message.ClaimCheckFileName = common.NewClaimCheckFileName()
 	message.Event = e
 	message.IncRowsCount()
 	if callback != nil {

--- a/pkg/sink/codec/open/open_protocol_encoder.go
+++ b/pkg/sink/codec/open/open_protocol_encoder.go
@@ -25,6 +25,7 @@ import (
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/sink/codec"
 	"github.com/pingcap/tiflow/pkg/sink/codec/common"
+	"github.com/pingcap/tiflow/pkg/sink/kafka/claimcheck"
 	"go.uber.org/zap"
 )
 
@@ -245,7 +246,7 @@ func (d *BatchEncoder) NewClaimCheckLocationMessage(origin *common.Message) (*co
 	}
 
 	keyMsg.OnlyHandleKey = false
-	claimCheckLocation := common.ClaimCheckFileNameWithPrefix(d.config.LargeMessageHandle.ClaimCheckStorageURI, origin.ClaimCheckFileName)
+	claimCheckLocation := claimcheck.FileNameWithPrefix(d.config.LargeMessageHandle.ClaimCheckStorageURI, origin.ClaimCheckFileName)
 	keyMsg.ClaimCheckLocation = claimCheckLocation
 	key, err := keyMsg.Encode()
 	if err != nil {
@@ -286,7 +287,7 @@ func (d *BatchEncoder) appendSingleLargeMessage4ClaimCheck(key, value []byte, e 
 	message.Schema = &e.Table.Schema
 	message.Table = &e.Table.Table
 	// ClaimCheckFileName must be set to indicate this message should be sent to the external storage.
-	message.ClaimCheckFileName = common.NewClaimCheckFileName()
+	message.ClaimCheckFileName = claimcheck.NewFileName()
 	message.Event = e
 	message.IncRowsCount()
 	if callback != nil {

--- a/pkg/sink/codec/open/open_protocol_encoder.go
+++ b/pkg/sink/codec/open/open_protocol_encoder.go
@@ -285,7 +285,7 @@ func (d *BatchEncoder) appendSingleLargeMessage4ClaimCheck(key, value []byte, e 
 	message.Schema = &e.Table.Schema
 	message.Table = &e.Table.Table
 	// ClaimCheckFileName must be set to indicate this message should be sent to the external storage.
-	message.ClaimCheckFileName = common.NewClaimCheckFileName(e)
+	message.ClaimCheckFileName = common.NewClaimCheckFileName(d.config.LargeMessageHandle.ClaimCheckStorageURI)
 	message.Event = e
 	message.IncRowsCount()
 	if callback != nil {

--- a/pkg/sink/kafka/claimcheck/claim_check.go
+++ b/pkg/sink/kafka/claimcheck/claim_check.go
@@ -1,4 +1,4 @@
-// Copyright 2022 PingCAP, Inc.
+// Copyright 2023 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/sink/kafka/claimcheck/claim_check.go
+++ b/pkg/sink/kafka/claimcheck/claim_check.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mq
+package claimcheck
 
 import (
 	"bytes"
@@ -24,7 +24,6 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tiflow/cdc/model"
-	"github.com/pingcap/tiflow/cdc/sink/metrics/mq"
 	"github.com/pingcap/tiflow/pkg/config"
 	"github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/sink/codec/common"
@@ -46,8 +45,8 @@ type ClaimCheck struct {
 	metricSendMessageCount    prometheus.Counter
 }
 
-// NewClaimCheck return a new ClaimCheck.
-func NewClaimCheck(ctx context.Context, config *config.LargeMessageHandleConfig, changefeedID model.ChangeFeedID) (*ClaimCheck, error) {
+// New return a new ClaimCheck.
+func New(ctx context.Context, config *config.LargeMessageHandleConfig, changefeedID model.ChangeFeedID) (*ClaimCheck, error) {
 	storage, err := util.GetExternalStorageFromURI(ctx, config.ClaimCheckStorageURI)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -63,8 +62,8 @@ func NewClaimCheck(ctx context.Context, config *config.LargeMessageHandleConfig,
 		changefeedID:              changefeedID,
 		storage:                   storage,
 		compression:               config.ClaimCheckCompression,
-		metricSendMessageDuration: mq.ClaimCheckSendMessageDuration.WithLabelValues(changefeedID.Namespace, changefeedID.ID),
-		metricSendMessageCount:    mq.ClaimCheckSendMessageCount.WithLabelValues(changefeedID.Namespace, changefeedID.ID),
+		metricSendMessageDuration: claimCheckSendMessageDuration.WithLabelValues(changefeedID.Namespace, changefeedID.ID),
+		metricSendMessageCount:    claimCheckSendMessageCount.WithLabelValues(changefeedID.Namespace, changefeedID.ID),
 	}, nil
 }
 
@@ -106,6 +105,6 @@ func (c *ClaimCheck) WriteMessage(ctx context.Context, message *common.Message) 
 
 // Close the claim check by clean up the metrics.
 func (c *ClaimCheck) Close() {
-	mq.ClaimCheckSendMessageDuration.DeleteLabelValues(c.changefeedID.Namespace, c.changefeedID.ID)
-	mq.ClaimCheckSendMessageCount.DeleteLabelValues(c.changefeedID.Namespace, c.changefeedID.ID)
+	claimCheckSendMessageDuration.DeleteLabelValues(c.changefeedID.Namespace, c.changefeedID.ID)
+	claimCheckSendMessageCount.DeleteLabelValues(c.changefeedID.Namespace, c.changefeedID.ID)
 }

--- a/pkg/sink/kafka/claimcheck/metrics.go
+++ b/pkg/sink/kafka/claimcheck/metrics.go
@@ -1,3 +1,16 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package claimcheck
 
 import "github.com/prometheus/client_golang/prometheus"

--- a/pkg/sink/kafka/claimcheck/metrics.go
+++ b/pkg/sink/kafka/claimcheck/metrics.go
@@ -1,0 +1,30 @@
+package claimcheck
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	// claimCheckSendMessageDuration records the duration of send message to the external claim-check storage.
+	claimCheckSendMessageDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "ticdc",
+			Subsystem: "sink",
+			Name:      "mq_claim_check_send_message_duration",
+			Help:      "Duration(s) for MQ worker send message to the external claim-check storage.",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 20), // 1ms~524s
+		}, []string{"namespace", "changefeed"})
+
+	// claimCheckSendMessageCount records the total count of messages sent to the external claim-check storage.
+	claimCheckSendMessageCount = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "ticdc",
+			Subsystem: "sink",
+			Name:      "mq_claim_check_send_message_count",
+			Help:      "The total count of messages sent to the external claim-check storage.",
+		}, []string{"namespace", "changefeed"})
+)
+
+// InitMetrics registers all claim check related metrics
+func InitMetrics(registry *prometheus.Registry) {
+	registry.MustRegister(claimCheckSendMessageDuration)
+	registry.MustRegister(claimCheckSendMessageCount)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9528, close #9529

### What is changed and how it works?

* use `uuid` to generate object key for claim check large message
* add e2e unit test to cover claim-check functionality for both open-protocol and canal-json

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
