### PR TITLE
kv-client(ticdc): evictAllRegions after close receiveEvents goroutine

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -999,6 +999,7 @@ func (s *eventFeedSession) receiveFromStream(
 	// always create a new region worker, because `receiveFromStream` is ensured
 	// to call exactly once from outer code logic
 	worker := newRegionWorker(parentCtx, s.changefeed, s, addr)
+	defer worker.evictAllRegions()
 
 	ctx, cancel := context.WithCancel(parentCtx)
 	var retErr error

--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -572,7 +572,6 @@ func (w *regionWorker) run() error {
 		for _, h := range w.handles {
 			h.Unregister()
 		}
-		w.evictAllRegions()
 	}()
 	ctx, cancel := context.WithCancel(w.parentCtx)
 	wg, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9595

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
