### PR TITLE
dm: fix lag keeps growing when failed ddl is skipped and no following ddl

### DIFF
--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -222,9 +222,21 @@ type Syncer struct {
 	// `lower_case_table_names` setting of upstream db
 	SourceTableNamesFlavor conn.LowerCaseTableNamesFlavor
 
-	tsOffset                  atomic.Int64    // time offset between upstream and syncer, DM's timestamp - MySQL's timestamp
-	secondsBehindMaster       atomic.Int64    // current task delay second behind upstream
-	workerJobTSArray          []*atomic.Int64 // worker's sync job TS array, note that idx=0 is skip idx and idx=1 is ddl idx,sql worker job idx=(queue id + 2)
+	// time difference between upstream and DM nodes: time of DM - time of upstream.
+	// we use this to calculate replication lag more accurately when clock is not synced
+	// on either upstream or DM nodes.
+	tsOffset atomic.Int64
+	// this field measures the time difference in seconds between current time of DM and
+	// the minimal timestamp of currently processing binlog events.
+	// this lag will consider time difference between upstream and DM nodes
+	secondsBehindMaster atomic.Int64
+	// stores the last job TS(binlog event timestamp) of each worker,
+	// if there's no active job, the corresponding worker's TS is reset to 0.
+	// since DML worker runs jobs in batch, the TS is the TS of the first job in the batch.
+	// 	- 0 is not used here, it's the idx for skip jobs, see skipJobIdx
+	// 	- 1 is ddl worker
+	// 	- 2+ is for DML worker job idx=(queue id + 2)
+	workerJobTSArray          []*atomic.Int64
 	lastCheckpointFlushedTime time.Time
 
 	firstMeetBinlogTS *int64
@@ -607,6 +619,10 @@ func (s *Syncer) reset() {
 	if s.streamerController != nil {
 		s.streamerController.Close()
 	}
+	s.secondsBehindMaster.Store(0)
+	for _, jobTS := range s.workerJobTSArray {
+		jobTS.Store(0)
+	}
 	// create new job chans
 	s.newJobChans()
 	s.checkpoint.DiscardPendingSnapshots()
@@ -880,7 +896,7 @@ func (s *Syncer) calcReplicationLag(headerTS int64) int64 {
 
 // updateReplicationJobTS store job TS, it is called after every batch dml job / one skip job / one ddl job is added and committed.
 func (s *Syncer) updateReplicationJobTS(job *job, jobIdx int) {
-	// when job is nil mean no job in this bucket, need do reset this bucket job ts to 0
+	// when job is nil mean no job in this bucket, need to reset this bucket job ts to 0
 	if job == nil {
 		s.workerJobTSArray[jobIdx].Store(0)
 	} else {
@@ -913,11 +929,6 @@ func (s *Syncer) updateReplicationLagMetric() {
 			s.tctx.L().Info("ShowLagInLog", zap.Int64("lag", lag))
 		}
 	})
-
-	// reset skip job TS in case of skip job TS is never updated
-	if minTS == s.workerJobTSArray[skipJobIdx].Load() {
-		s.workerJobTSArray[skipJobIdx].Store(0)
-	}
 }
 
 func (s *Syncer) saveTablePoint(table *filter.Table, location binlog.Location) {
@@ -1089,7 +1100,6 @@ func (s *Syncer) handleJob(job *job) (added2Queue bool, err error) {
 			// is the last binlog in source db
 			s.saveGlobalPoint(job.location)
 		}
-		s.updateReplicationJobTS(job, skipJobIdx)
 		return
 	}
 

--- a/dm/syncer/syncer_test.go
+++ b/dm/syncer/syncer_test.go
@@ -964,7 +964,11 @@ func (s *testSyncerSuite) TestRun(c *C) {
 	ctx, cancel = context.WithCancel(context.Background())
 	resultCh = make(chan pb.ProcessResult)
 	// simulate `syncer.Resume` here, but doesn't reset database conns
+	syncer.secondsBehindMaster.Store(100)
+	syncer.workerJobTSArray[ddlJobIdx].Store(100)
 	syncer.reset()
+	c.Assert(syncer.secondsBehindMaster.Load(), Equals, int64(0))
+	c.Assert(syncer.workerJobTSArray[ddlJobIdx].Load(), Equals, int64(0))
 	mockStreamerProducer = &MockStreamProducer{s.generateEvents(events2, c)}
 	mockStreamer, err = mockStreamerProducer.GenerateStreamFrom(binlog.MustZeroLocation(mysql.MySQLFlavor))
 	c.Assert(err, IsNil)

--- a/dm/worker/subtask.go
+++ b/dm/worker/subtask.go
@@ -575,7 +575,7 @@ func (st *SubTask) Kill() {
 	st.validator = nil
 }
 
-// Pause pauses a running sub task or a sub task paused by error.
+// Pause pauses a running subtask or a subtask paused by error.
 func (st *SubTask) Pause() error {
 	if st.markResultCanceled() {
 		return nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9605

### What is changed and how it works?
- reset recorded ts on syncer restart

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - [x] Unit test
 - Integration test
 - [x] Manual test (add detailed scripts or steps below)
  - test using  steps in the issue, before the change, lag keeps growing, became 0 after this pr
```
before 

➜  dm curl -s "127.0.0.1:8361/metrics" | grep -v '#'| grep dm_syncer_replication_lag_gauge
dm_syncer_replication_lag_gauge{source_id="mysql-3307",task="test",worker="worker-1"} 303
➜  dm curl -s "127.0.0.1:8361/metrics" | grep -v '#'| grep dm_syncer_replication_lag_gauge
dm_syncer_replication_lag_gauge{source_id="mysql-3307",task="test",worker="worker-1"} 313


after
➜  dm curl -s "127.0.0.1:8361/metrics" | grep -v '#'| grep dm_syncer_replication_lag_gauge
dm_syncer_replication_lag_gauge{source_id="mysql-3307",task="test",worker="worker-1"} 0
➜  dm curl -s "127.0.0.1:8361/metrics" | grep -v '#'| grep dm_syncer_replication_lag_gauge
dm_syncer_replication_lag_gauge{source_id="mysql-3307",task="test",worker="worker-1"} 0
```

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
fix lag keeps growing when failed ddl is skipped and no following ddl
```
