### PR TITLE
kafka(ticdc):  fix panic issue when sasl enabled by config file

### DIFF
--- a/cdc/sink/codec/common/config_test.go
+++ b/cdc/sink/codec/common/config_test.go
@@ -313,3 +313,20 @@ func TestOpenProtocolHandleKeyOnly(t *testing.T) {
 	err = codecConfig.Validate()
 	require.NoError(t, err)
 }
+
+func TestKafkaConfigWithoutHandleKey(t *testing.T) {
+	t.Parallel()
+
+	// handle-key-only not enabled, always no error
+	replicaConfig := config.GetDefaultReplicaConfig()
+	replicaConfig.Sink.KafkaConfig = &config.KafkaConfig{}
+
+	uri := "kafka://127.0.0.1:9092/canal-json?protocol=canal-json"
+	sinkURI, err := url.Parse(uri)
+	require.NoError(t, err)
+
+	codecConfig := NewConfig(config.ProtocolCanalJSON)
+	err = codecConfig.Apply(sinkURI, replicaConfig)
+	require.NoError(t, err)
+	require.False(t, codecConfig.LargeMessageHandle.HandleKeyOnly())
+}

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -500,10 +500,16 @@ func (c *LargeMessageHandleConfig) Validate(protocol Protocol, enableTiDBExtensi
 
 // HandleKeyOnly returns true if handle large message by encoding handle key only.
 func (c *LargeMessageHandleConfig) HandleKeyOnly() bool {
+	if c == nil {
+		return false
+	}
 	return c.LargeMessageHandleOption == LargeMessageHandleOptionHandleKeyOnly
 }
 
 // Disabled returns true if disable large message handle.
 func (c *LargeMessageHandleConfig) Disabled() bool {
+	if c == nil {
+		return true
+	}
 	return c.LargeMessageHandleOption == LargeMessageHandleOptionNone
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9669

### What is changed and how it works?
check if the LargeMessageHandleConfig is nil first


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
 `None`.
```
