### PR TITLE
ddl(ticdc): async exec add index ddl

### DIFF
--- a/cdc/sink/ddlsink/mysql/mysql_ddl_sink.go
+++ b/cdc/sink/ddlsink/mysql/mysql_ddl_sink.go
@@ -84,6 +84,11 @@ func NewDDLSink(
 		return nil, err
 	}
 
+	cfg.IsTiDB, err = pmysql.CheckIsTiDB(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
 	m := &DDLSink{
 		id:         changefeedID,
 		db:         db,
@@ -99,7 +104,7 @@ func NewDDLSink(
 
 // WriteDDLEvent writes a DDL event to the mysql database.
 func (m *DDLSink) WriteDDLEvent(ctx context.Context, ddl *model.DDLEvent) error {
-	if ddl.Type == timodel.ActionAddIndex {
+	if ddl.Type == timodel.ActionAddIndex && m.cfg.IsTiDB {
 		return m.asyncExecAddIndexDDLIfTimeout(ctx, ddl)
 	}
 	return m.execDDLWithMaxRetries(ctx, ddl)

--- a/cdc/sink/ddlsink/mysql/mysql_ddl_sink.go
+++ b/cdc/sink/ddlsink/mysql/mysql_ddl_sink.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"database/sql"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/pingcap/failpoint"
@@ -25,6 +26,7 @@ import (
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/sink/ddlsink"
 	"github.com/pingcap/tiflow/cdc/sink/metrics"
+	"github.com/pingcap/tiflow/pkg/chann"
 	"github.com/pingcap/tiflow/pkg/config"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/errorutil"
@@ -59,6 +61,13 @@ type DDLSink struct {
 	// statistics is the statistics of this sink.
 	// We use it to record the DDL count.
 	statistics *metrics.Statistics
+
+	async struct {
+		ctx    context.Context
+		cancel func()
+		ddlCh  *chann.DrainableChann[*model.DDLEvent]
+		ddlMap sync.Map
+	}
 }
 
 // NewDDLSink creates a new DDLSink.
@@ -84,22 +93,62 @@ func NewDDLSink(
 		return nil, err
 	}
 
+	asyncCtx, cancel := context.WithCancel(ctx)
 	m := &DDLSink{
 		id:         changefeedID,
 		db:         db,
 		cfg:        cfg,
 		statistics: metrics.NewStatistics(ctx, changefeedID, sink.TxnSink),
+		async: struct {
+			ctx    context.Context
+			cancel func()
+			ddlCh  *chann.DrainableChann[*model.DDLEvent]
+			ddlMap sync.Map
+		}{
+			ctx:    asyncCtx,
+			cancel: cancel,
+			ddlCh:  chann.NewAutoDrainChann[*model.DDLEvent](chann.Cap(-1)),
+			ddlMap: sync.Map{},
+		},
 	}
 
+	go func() {
+		m.asyncExec()
+	}()
 	log.Info("MySQL DDL sink is created",
 		zap.String("namespace", m.id.Namespace),
 		zap.String("changefeed", m.id.ID))
 	return m, nil
 }
 
+func (m *DDLSink) waitAsyncDDLFinished(ctx context.Context, ddl *model.DDLEvent) {
+	v, ok := m.async.ddlMap.Load(ddl.TableInfo.ID)
+	if !ok {
+		return
+	}
+	select {
+	case <-ctx.Done():
+	case <-v.(chan struct{}):
+		return
+	}
+}
+
 // WriteDDLEvent writes a DDL event to the mysql database.
 func (m *DDLSink) WriteDDLEvent(ctx context.Context, ddl *model.DDLEvent) error {
-	return m.execDDLWithMaxRetries(ctx, ddl)
+	switch ddl.Type {
+	case timodel.ActionAddIndex:
+		m.waitAsyncDDLFinished(ctx, ddl)
+		m.async.ddlCh.In() <- ddl
+		m.async.ddlMap.Store(ddl.TableInfo.ID, make(chan struct{}))
+		return nil
+	case timodel.ActionDropIndex,
+		timodel.ActionMultiSchemaChange,
+		timodel.ActionRenameIndex, timodel.ActionAlterIndexVisibility:
+		m.waitAsyncDDLFinished(ctx, ddl)
+		return m.execDDLWithMaxRetries(ctx, ddl)
+	default:
+		return m.execDDLWithMaxRetries(ctx, ddl)
+	}
 }
 
 func (m *DDLSink) execDDLWithMaxRetries(ctx context.Context, ddl *model.DDLEvent) error {
@@ -235,6 +284,7 @@ func (m *DDLSink) WriteCheckpointTs(_ context.Context, _ uint64, _ []*model.Tabl
 
 // Close closes the database connection.
 func (m *DDLSink) Close() {
+	m.async.cancel()
 	if m.statistics != nil {
 		m.statistics.Close()
 	}
@@ -244,6 +294,41 @@ func (m *DDLSink) Close() {
 				zap.String("namespace", m.id.Namespace),
 				zap.String("changefeed", m.id.ID),
 				zap.Error(err))
+		}
+	}
+}
+
+// Run loop.
+func (m *DDLSink) asyncExec() error {
+	log.Info("async ddl worker starts",
+		zap.String("changefeedID", m.id.String()))
+	for {
+		select {
+		case <-m.async.ctx.Done():
+			log.Info("async ddl worker exits as canceled",
+				zap.String("changefeedID", m.id.String()))
+			return nil
+		case ddlEvent := <-m.async.ddlCh.Out():
+			if ddlEvent != nil {
+				if err := m.execDDLWithMaxRetries(m.async.ctx, ddlEvent); err != nil {
+					log.Error("async exec ddl failed",
+						zap.String("changefeedID", m.id.String()),
+						zap.Uint64("commitTs", ddlEvent.CommitTs),
+						zap.String("ddl", ddlEvent.Query))
+				}
+				ch, ok := m.async.ddlMap.LoadAndDelete(ddlEvent.TableInfo.ID)
+				if !ok {
+					log.Error("load ddl from map failed",
+						zap.String("changefeedID", m.id.String()),
+						zap.Uint64("commitTs", ddlEvent.CommitTs),
+						zap.String("ddl", ddlEvent.Query))
+				}
+				close(ch.(chan struct{}))
+				log.Error("async exec ddl done",
+					zap.String("changefeedID", m.id.String()),
+					zap.Uint64("commitTs", ddlEvent.CommitTs),
+					zap.String("ddl", ddlEvent.Query))
+			}
 		}
 	}
 }

--- a/cdc/sink/ddlsink/mysql/mysql_ddl_sink.go
+++ b/cdc/sink/ddlsink/mysql/mysql_ddl_sink.go
@@ -112,9 +112,7 @@ func NewDDLSink(
 		},
 	}
 
-	go func() {
-		m.asyncExec()
-	}()
+	go m.asyncExec()
 	log.Info("MySQL DDL sink is created",
 		zap.String("namespace", m.id.Namespace),
 		zap.String("changefeed", m.id.ID))
@@ -303,7 +301,7 @@ func (m *DDLSink) Close() {
 }
 
 // Run loop.
-func (m *DDLSink) asyncExec() error {
+func (m *DDLSink) asyncExec() {
 	defer func() {
 		m.async.ddlMap.Range(func(key, value interface{}) bool {
 			log.Warn("ddl is skip due async worker exits",
@@ -320,7 +318,7 @@ func (m *DDLSink) asyncExec() error {
 		case <-m.async.ctx.Done():
 			log.Info("async ddl worker exits as canceled",
 				zap.String("changefeedID", m.id.String()))
-			return nil
+			return
 		case ddlEvent := <-m.async.ddlCh.Out():
 			if ddlEvent != nil {
 				if err := m.execDDLWithMaxRetries(m.async.ctx, ddlEvent); err != nil {

--- a/cdc/sink/ddlsink/mysql/mysql_ddl_sink.go
+++ b/cdc/sink/ddlsink/mysql/mysql_ddl_sink.go
@@ -268,6 +268,7 @@ func (m *DDLSink) asyncExecAddIndexDDLIfTimeout(ctx context.Context, ddl *model.
 				zap.Uint64("commitTs", ddl.CommitTs),
 				zap.String("ddl", ddl.Query))
 			done <- err
+			return
 		}
 		log.Info("async exec ddl done",
 			zap.String("changefeedID", m.id.String()),
@@ -279,14 +280,15 @@ func (m *DDLSink) asyncExecAddIndexDDLIfTimeout(ctx context.Context, ddl *model.
 		case <-ctx.Done():
 			log.Info("async ddl exits as canceled",
 				zap.String("changefeedID", m.id.String()),
-				zap.Uint64("commitTs", ddl.CommitTs))
-			return nil
+				zap.Uint64("commitTs", ddl.CommitTs),
+				zap.String("ddl", ddl.Query))
 		case err := <-done:
 			return err
 		case <-tick.C:
 			log.Info("async ddl is still running",
 				zap.String("changefeedID", m.id.String()),
-				zap.Uint64("commitTs", ddl.CommitTs))
+				zap.Uint64("commitTs", ddl.CommitTs),
+				zap.String("ddl", ddl.Query))
 			return nil
 		}
 	}

--- a/cdc/sink/ddlsink/mysql/mysql_ddl_sink_test.go
+++ b/cdc/sink/ddlsink/mysql/mysql_ddl_sink_test.go
@@ -46,6 +46,8 @@ func TestWriteDDLEvent(t *testing.T) {
 		// normal db
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.Nil(t, err)
+		mock.ExpectQuery("select tidb_version()").
+			WillReturnRows(sqlmock.NewRows([]string{"tidb_version()"}).AddRow("5.7.25-TiDB-v4.0.0-beta-191-ga1b3e3b"))
 		mock.ExpectBegin()
 		mock.ExpectExec("USE `test`;").WillReturnResult(sqlmock.NewResult(1, 1))
 		mock.ExpectExec("ALTER TABLE test.t1 ADD COLUMN a int").WillReturnResult(sqlmock.NewResult(1, 1))

--- a/cdc/sink/ddlsink/mysql/mysql_ddl_sink_test.go
+++ b/cdc/sink/ddlsink/mysql/mysql_ddl_sink_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"database/sql"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -148,12 +149,12 @@ func TestAsyncExecAddIndex(t *testing.T) {
 	t.Parallel()
 
 	ddlExecutionTime := time.Millisecond * 3000
-	dbIndex := 0
+	var dbIndex int32 = 0
 	GetDBConnImpl = func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		defer func() {
-			dbIndex++
+			atomic.AddInt32(&dbIndex, 1)
 		}()
-		if dbIndex == 0 {
+		if atomic.LoadInt32(&dbIndex) == 0 {
 			// test db
 			db, err := pmysql.MockTestDB(true)
 			require.Nil(t, err)

--- a/cdc/sink/ddlsink/mysql/mysql_ddl_sink_test.go
+++ b/cdc/sink/ddlsink/mysql/mysql_ddl_sink_test.go
@@ -32,8 +32,6 @@ import (
 )
 
 func TestWriteDDLEvent(t *testing.T) {
-	t.Parallel()
-
 	dbIndex := 0
 	GetDBConnImpl = func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		defer func() {
@@ -146,8 +144,6 @@ func TestNeedSwitchDB(t *testing.T) {
 }
 
 func TestAsyncExecAddIndex(t *testing.T) {
-	t.Parallel()
-
 	ddlExecutionTime := time.Millisecond * 3000
 	var dbIndex int32 = 0
 	GetDBConnImpl = func(ctx context.Context, dsnStr string) (*sql.DB, error) {

--- a/cdc/sink/ddlsink/mysql/mysql_ddl_sink_test.go
+++ b/cdc/sink/ddlsink/mysql/mysql_ddl_sink_test.go
@@ -147,7 +147,7 @@ func TestNeedSwitchDB(t *testing.T) {
 func TestAsyncExecAddIndex(t *testing.T) {
 	t.Parallel()
 
-	ddlExecutionTime := time.Millisecond * 2000
+	ddlExecutionTime := time.Millisecond * 3000
 	dbIndex := 0
 	GetDBConnImpl = func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		defer func() {
@@ -201,6 +201,6 @@ func TestAsyncExecAddIndex(t *testing.T) {
 	err = sink.WriteDDLEvent(ctx, ddl1)
 	require.Nil(t, err)
 	require.True(t, time.Since(start) < ddlExecutionTime)
-	require.True(t, time.Since(start) >= time.Second)
+	require.True(t, time.Since(start) >= 2*time.Second)
 	sink.Close()
 }

--- a/cdc/sink/ddlsink/mysql/mysql_ddl_sink_test.go
+++ b/cdc/sink/ddlsink/mysql/mysql_ddl_sink_test.go
@@ -162,6 +162,8 @@ func TestAsyncExecAddIndex(t *testing.T) {
 		// normal db
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.Nil(t, err)
+		mock.ExpectQuery("select tidb_version()").
+			WillReturnRows(sqlmock.NewRows([]string{"tidb_version()"}).AddRow("5.7.25-TiDB-v4.0.0-beta-191-ga1b3e3b"))
 		mock.ExpectBegin()
 		mock.ExpectExec("USE `test`;").
 			WillReturnResult(sqlmock.NewResult(1, 1))

--- a/pkg/applier/redo_test.go
+++ b/pkg/applier/redo_test.go
@@ -241,6 +241,10 @@ func getMockDB(t *testing.T) *sql.DB {
 		Number:  1305,
 		Message: "FUNCTION test.tidb_version does not exist",
 	})
+	mock.ExpectQuery("select tidb_version()").WillReturnError(&mysql.MySQLError{
+		Number:  1305,
+		Message: "FUNCTION test.tidb_version does not exist",
+	})
 
 	mock.ExpectBegin()
 	mock.ExpectExec("USE `test`;").WillReturnResult(sqlmock.NewResult(1, 1))


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9644

### What is changed and how it works?

After this pull request, the "add index" DDL will be executed asynchronously, and it will no longer block the progression of DML replication. There is a risk associated with executing the "add index" DDL in this manner: If an error occurs during the execution of the "add index" DDL in downstream TiDB, the DDL may be lost. However, the likelihood of this situation occurring is low since the DDL was executed successfully upstream, and it will not impact the data correctness downstream.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
TiCDC exec adding index DDL  asynchronously and does not block checkpoint ts
```
