### PR TITLE
puller(cdc): improve benchmarks about frontier

### DIFF
--- a/cdc/puller/frontier/frontier_bench_test.go
+++ b/cdc/puller/frontier/frontier_bench_test.go
@@ -73,7 +73,7 @@ func benchmarkSpanForwardAndFrontier(b *testing.B, order string, regions, rounds
 			offset := offsets[i]
 			span := spans[offset]
 			if spanz.IsSubSpan(span, totalSpan) {
-				f.Forward(offset, span, offset)
+				f.Forward(offset, span, uint64(1))
 				if i%regions == 0 {
 					f.Frontier()
 				}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

Benchmark results:
```bash
goos: linux
goarch: amd64
pkg: github.com/pingcap/tiflow/cdc/puller/frontier
cpu: Intel(R) Xeon(R) Gold 6240 CPU @ 2.60GHz
BenchmarkSpanForwardAndFrontier/900000(region)-10(round)-16                    1        17700041191 ns/op
BenchmarkSpanForwardAndFrontier/400000(region)-10(round)-16                    1        6722656192 ns/op
```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
