### PR TITLE
kafka(ticdc): claim check set the timeout default to 5m to prevent stuck too long if the external storage is unavailable.

### DIFF
--- a/cdc/sink/dmlsink/mq/kafka_dml_sink.go
+++ b/cdc/sink/dmlsink/mq/kafka_dml_sink.go
@@ -104,7 +104,7 @@ func NewKafkaDMLSink(
 
 	encoderBuilder, err := builder.NewRowEventEncoderBuilder(ctx, encoderConfig)
 	if err != nil {
-		return nil, cerror.WrapError(cerror.ErrKafkaInvalidConfig, err)
+		return nil, cerror.WrapError(cerror.ErrKafkaNewProducer, err)
 	}
 
 	failpointCh := make(chan error, 1)

--- a/pkg/sink/kafka/claimcheck/claim_check.go
+++ b/pkg/sink/kafka/claimcheck/claim_check.go
@@ -44,6 +44,10 @@ type ClaimCheck struct {
 
 // New return a new ClaimCheck.
 func New(ctx context.Context, storageURI string, changefeedID model.ChangeFeedID) (*ClaimCheck, error) {
+	log.Info("claim check enabled, start create the external storage",
+		zap.String("namespace", changefeedID.Namespace),
+		zap.String("changefeed", changefeedID.ID),
+		zap.String("storageURI", storageURI))
 	start := time.Now()
 	externalStorage, err := util.GetExternalStorageFromURI(ctx, storageURI)
 	if err != nil {

--- a/pkg/sink/kafka/claimcheck/claim_check.go
+++ b/pkg/sink/kafka/claimcheck/claim_check.go
@@ -51,23 +51,24 @@ func New(ctx context.Context, storageURI string, changefeedID model.ChangeFeedID
 	log.Info("claim check enabled, start create the external storage",
 		zap.String("namespace", changefeedID.Namespace),
 		zap.String("changefeed", changefeedID.ID),
-		zap.String("storageURI", storageURI))
+		zap.String("storageURI", util.MaskSensitiveDataInURI(storageURI)))
+
 	start := time.Now()
 	externalStorage, err := util.GetExternalStorageWithTimeout(ctx, storageURI, defaultTimeout)
 	if err != nil {
 		log.Error("create external storage failed",
 			zap.String("namespace", changefeedID.Namespace),
 			zap.String("changefeed", changefeedID.ID),
-			zap.String("storageURI", storageURI),
+			zap.String("storageURI", util.MaskSensitiveDataInURI(storageURI)),
 			zap.Duration("duration", time.Since(start)),
 			zap.Error(err))
 		return nil, errors.Trace(err)
 	}
-
+	
 	log.Info("claim-check create the external storage success",
 		zap.String("namespace", changefeedID.Namespace),
 		zap.String("changefeed", changefeedID.ID),
-		zap.String("storageURI", storageURI),
+		zap.String("storageURI", util.MaskSensitiveDataInURI(storageURI)),
 		zap.Duration("duration", time.Since(start)))
 
 	return &ClaimCheck{

--- a/pkg/sink/kafka/claimcheck/claim_check.go
+++ b/pkg/sink/kafka/claimcheck/claim_check.go
@@ -64,7 +64,7 @@ func New(ctx context.Context, storageURI string, changefeedID model.ChangeFeedID
 			zap.Error(err))
 		return nil, errors.Trace(err)
 	}
-	
+
 	log.Info("claim-check create the external storage success",
 		zap.String("namespace", changefeedID.Namespace),
 		zap.String("changefeed", changefeedID.ID),

--- a/pkg/sink/kafka/claimcheck/claim_check.go
+++ b/pkg/sink/kafka/claimcheck/claim_check.go
@@ -30,6 +30,10 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	defaultTimeout = 5 * time.Minute
+)
+
 // ClaimCheck manage send message to the claim-check external storage.
 type ClaimCheck struct {
 	storage storage.ExternalStorage
@@ -49,7 +53,7 @@ func New(ctx context.Context, storageURI string, changefeedID model.ChangeFeedID
 		zap.String("changefeed", changefeedID.ID),
 		zap.String("storageURI", storageURI))
 	start := time.Now()
-	externalStorage, err := util.GetExternalStorageFromURI(ctx, storageURI)
+	externalStorage, err := util.GetExternalStorageWithTimeout(ctx, storageURI, defaultTimeout)
 	if err != nil {
 		log.Error("create external storage failed",
 			zap.String("namespace", changefeedID.Namespace),

--- a/pkg/sink/kafka/claimcheck/claim_check.go
+++ b/pkg/sink/kafka/claimcheck/claim_check.go
@@ -48,13 +48,15 @@ func New(ctx context.Context, storageURI string, changefeedID model.ChangeFeedID
 	externalStorage, err := util.GetExternalStorageFromURI(ctx, storageURI)
 	if err != nil {
 		log.Error("create external storage failed",
+			zap.String("namespace", changefeedID.Namespace),
+			zap.String("changefeed", changefeedID.ID),
 			zap.String("storageURI", storageURI),
 			zap.Duration("duration", time.Since(start)),
 			zap.Error(err))
 		return nil, errors.Trace(err)
 	}
 
-	log.Info("claim-check enabled",
+	log.Info("claim-check create the external storage success",
 		zap.String("namespace", changefeedID.Namespace),
 		zap.String("changefeed", changefeedID.ID),
 		zap.String("storageURI", storageURI),

--- a/pkg/sink/kafka/claimcheck/claim_check.go
+++ b/pkg/sink/kafka/claimcheck/claim_check.go
@@ -44,15 +44,21 @@ type ClaimCheck struct {
 
 // New return a new ClaimCheck.
 func New(ctx context.Context, storageURI string, changefeedID model.ChangeFeedID) (*ClaimCheck, error) {
+	start := time.Now()
 	externalStorage, err := util.GetExternalStorageFromURI(ctx, storageURI)
 	if err != nil {
+		log.Error("create external storage failed",
+			zap.String("storageURI", storageURI),
+			zap.Duration("duration", time.Since(start)),
+			zap.Error(err))
 		return nil, errors.Trace(err)
 	}
 
 	log.Info("claim-check enabled",
 		zap.String("namespace", changefeedID.Namespace),
 		zap.String("changefeed", changefeedID.ID),
-		zap.String("storageURI", storageURI))
+		zap.String("storageURI", storageURI),
+		zap.Duration("duration", time.Since(start)))
 
 	return &ClaimCheck{
 		changefeedID:              changefeedID,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9737 

### What is changed and how it works?

* set the external storage timeout to 5m

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
