### PR TITLE
server(ticdc): fix panic issue if capture is not initialized

### DIFF
--- a/cdc/server/server.go
+++ b/cdc/server/server.go
@@ -371,6 +371,11 @@ func (s *server) run(ctx context.Context) (err error) {
 // Drain removes tables in the current TiCDC instance.
 // It's part of graceful shutdown, should be called before Close.
 func (s *server) Drain() <-chan struct{} {
+	if s.capture == nil {
+		done := make(chan struct{})
+		close(done)
+		return done
+	}
 	return s.capture.Drain()
 }
 

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -131,8 +131,7 @@ func (o *options) run(cmd *cobra.Command) error {
 		return errors.Trace(err)
 	}
 	// Drain the server before shutdown.
-	shutdownNotify := func() <-chan struct{} { return server.Drain() }
-	util.InitSignalHandling(shutdownNotify, cancel)
+	util.InitSignalHandling(server.Drain, cancel)
 
 	// Run TiCDC server.
 	err = server.Run(ctx)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9745

### What is changed and how it works?
check if the capture is nil or not when Drain capture


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
