### PR TITLE
sink(cdc): fix the check about resolvedTs and checkpointTs

### DIFF
--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -771,7 +771,8 @@ func (m *SinkManager) UpdateReceivedSorterResolvedTs(span tablepb.Span, ts model
 func (m *SinkManager) UpdateBarrierTs(globalBarrierTs model.Ts, tableBarrier map[model.TableID]model.Ts) {
 	m.tableSinks.Range(func(span tablepb.Span, value interface{}) bool {
 		barrierTs := globalBarrierTs
-		if tableBarrierTs, ok := tableBarrier[span.TableID]; ok && tableBarrierTs > barrierTs {
+		if tableBarrierTs, ok := tableBarrier[span.TableID]; ok && tableBarrierTs < barrierTs {
+			// TODO: is it possible that table barrier is less than global barrier?
 			barrierTs = tableBarrierTs
 		}
 		value.(*tableSinkWrapper).updateBarrierTs(barrierTs)

--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -772,8 +772,10 @@ func (m *SinkManager) UpdateBarrierTs(globalBarrierTs model.Ts, tableBarrier map
 	m.tableSinks.Range(func(span tablepb.Span, value interface{}) bool {
 		barrierTs := globalBarrierTs
 		if tableBarrierTs, ok := tableBarrier[span.TableID]; ok && tableBarrierTs < barrierTs {
-			// TODO: is it possible that table barrier is less than global barrier?
-			barrierTs = tableBarrierTs
+			log.Panic("tableBarrierTs should be always greater than globalBarrierTs",
+				zap.String("namespace", m.changefeedID.Namespace),
+				zap.String("changefeed", m.changefeedID.ID),
+				zap.Stringer("span", &span))
 		}
 		value.(*tableSinkWrapper).updateBarrierTs(barrierTs)
 		return true

--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -768,30 +768,13 @@ func (m *SinkManager) UpdateReceivedSorterResolvedTs(span tablepb.Span, ts model
 }
 
 // UpdateBarrierTs update all tableSink's barrierTs in the SinkManager
-func (m *SinkManager) UpdateBarrierTs(
-	globalBarrierTs model.Ts,
-	tableBarrier map[model.TableID]model.Ts,
-) {
+func (m *SinkManager) UpdateBarrierTs(globalBarrierTs model.Ts, tableBarrier map[model.TableID]model.Ts) {
 	m.tableSinks.Range(func(span tablepb.Span, value interface{}) bool {
-		tableSink := value.(*tableSinkWrapper)
-		lastBarrierTs := tableSink.barrierTs.Load()
-		// It is safe to do not use compare and swap here.
-		// Only the processor will update the barrier ts.
-		// Other goroutines will only read the barrier ts.
-		// So it is safe to do not use compare and swap here, just Load and Store.
-		if tableBarrierTs, ok := tableBarrier[tableSink.span.TableID]; ok {
-			barrierTs := tableBarrierTs
-			if barrierTs > globalBarrierTs {
-				barrierTs = globalBarrierTs
-			}
-			if barrierTs > lastBarrierTs {
-				tableSink.barrierTs.Store(barrierTs)
-			}
-		} else {
-			if globalBarrierTs > lastBarrierTs {
-				tableSink.barrierTs.Store(globalBarrierTs)
-			}
+		barrierTs := globalBarrierTs
+		if tableBarrierTs, ok := tableBarrier[span.TableID]; ok && tableBarrierTs > barrierTs {
+			barrierTs = tableBarrierTs
 		}
+		value.(*tableSinkWrapper).updateBarrierTs(barrierTs)
 		return true
 	})
 }
@@ -1008,14 +991,14 @@ func (m *SinkManager) GetTableStats(span tablepb.Span) TableStats {
 		resolvedTs = tableSink.getReceivedSorterResolvedTs()
 	}
 
-	if resolvedTs < checkpointTs.ResolvedMark() {
-		log.Error("sinkManager: resolved ts should not less than checkpoint ts",
+	sinkUpperBound := tableSink.getUpperBoundTs()
+	if sinkUpperBound < checkpointTs.ResolvedMark() {
+		log.Panic("sinkManager: sink upperbound should not less than checkpoint ts",
 			zap.String("namespace", m.changefeedID.Namespace),
 			zap.String("changefeed", m.changefeedID.ID),
 			zap.Stringer("span", &span),
-			zap.Uint64("resolvedTs", resolvedTs),
-			zap.Any("checkpointTs", checkpointTs),
-			zap.Uint64("barrierTs", tableSink.barrierTs.Load()))
+			zap.Uint64("upperbound", sinkUpperBound),
+			zap.Any("checkpointTs", checkpointTs))
 	}
 	return TableStats{
 		CheckpointTs: checkpointTs.ResolvedMark(),

--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -771,11 +771,8 @@ func (m *SinkManager) UpdateReceivedSorterResolvedTs(span tablepb.Span, ts model
 func (m *SinkManager) UpdateBarrierTs(globalBarrierTs model.Ts, tableBarrier map[model.TableID]model.Ts) {
 	m.tableSinks.Range(func(span tablepb.Span, value interface{}) bool {
 		barrierTs := globalBarrierTs
-		if tableBarrierTs, ok := tableBarrier[span.TableID]; ok && tableBarrierTs < barrierTs {
-			log.Panic("tableBarrierTs should be always greater than globalBarrierTs",
-				zap.String("namespace", m.changefeedID.Namespace),
-				zap.String("changefeed", m.changefeedID.ID),
-				zap.Stringer("span", &span))
+		if tableBarrierTs, ok := tableBarrier[span.TableID]; ok && tableBarrierTs < globalBarrierTs {
+			barrierTs = tableBarrierTs
 		}
 		value.(*tableSinkWrapper).updateBarrierTs(barrierTs)
 		return true

--- a/cdc/processor/sinkmanager/table_sink_wrapper.go
+++ b/cdc/processor/sinkmanager/table_sink_wrapper.go
@@ -179,6 +179,15 @@ func (t *tableSinkWrapper) appendRowChangedEvents(events ...*model.RowChangedEve
 	return nil
 }
 
+func (t *tableSinkWrapper) updateBarrierTs(ts model.Ts) {
+	for {
+		old := t.barrierTs.Load()
+		if ts <= old || t.barrierTs.CompareAndSwap(old, ts) {
+			break
+		}
+	}
+}
+
 func (t *tableSinkWrapper) updateReceivedSorterResolvedTs(ts model.Ts) {
 	for {
 		old := t.receivedSorterResolvedTs.Load()

--- a/cdc/scheduler/internal/v3/agent/agent.go
+++ b/cdc/scheduler/internal/v3/agent/agent.go
@@ -270,6 +270,12 @@ func (a *agent) handleMessageHeartbeat(request *schedulepb.Heartbeat) (*schedule
 
 	allTables.Ascend(func(span tablepb.Span, table *tableSpan) bool {
 		status := table.getTableSpanStatus(request.CollectStats)
+		if status.Checkpoint.CheckpointTs > status.Checkpoint.ResolvedTs {
+			log.Warn("schedulerv3: CheckpointTs is greater than ResolvedTs",
+				zap.String("namespace", a.ChangeFeedID.Namespace),
+				zap.String("changefeed", a.ChangeFeedID.ID),
+				zap.String("span", span.String()))
+		}
 		if table.task != nil && table.task.IsRemove {
 			status.State = tablepb.TableStateStopping
 		}

--- a/cdc/scheduler/internal/v3/agent/agent.go
+++ b/cdc/scheduler/internal/v3/agent/agent.go
@@ -270,17 +270,6 @@ func (a *agent) handleMessage(msg []*schedulepb.Message) (
 }
 
 func (a *agent) handleMessageHeartbeat(request *schedulepb.Heartbeat) (*schedulepb.Message, *schedulepb.Barrier) {
-	// NOTE: for a given table, we don't check ResolvedTs should never less than CheckpointTs
-	// because if redo is enabled, the table's ResolvedTs can be less than the global Barrier.
-	// For example, consider such steps:
-	// 1. currently CheckpointTs is 90, and RedoMeta.ResolvedTs is 100. However,
-	//    there could be a table whose RedoResolvedTs has been advanced to 110.
-	// 2. then balance the table to another processor. StartTs and CheckpointTs of the table
-	//    will become 90.
-	// 3. then RedoResolvedTs can be advanced to 110, which will also advance global BarrierTs
-	//    to 110.
-	// 4. after the just re-scheduled table finds global BarrierTs has been advanced, it can
-	//    advance its CheckpointTs to 110, although its local RedoResolvedTs is still 90.
 	allTables := a.tableM.getAllTableSpans()
 	result := make([]tablepb.TableStatus, 0, allTables.Len())
 

--- a/cdc/scheduler/internal/v3/agent/agent.go
+++ b/cdc/scheduler/internal/v3/agent/agent.go
@@ -206,10 +206,7 @@ func (a *agent) Tick(ctx context.Context) (*schedulepb.Barrier, error) {
 		return nil, errors.Trace(err)
 	}
 
-	outboundMessages, barrier, err := a.handleMessage(inboundMessages)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	outboundMessages, barrier := a.handleMessage(inboundMessages)
 
 	responses, err := a.tableM.poll(ctx)
 	if err != nil {
@@ -237,9 +234,7 @@ func (a *agent) handleLivenessUpdate(liveness model.Liveness) {
 	}
 }
 
-func (a *agent) handleMessage(msg []*schedulepb.Message) (
-	result []*schedulepb.Message, barrier *schedulepb.Barrier, err error,
-) {
+func (a *agent) handleMessage(msg []*schedulepb.Message) (result []*schedulepb.Message, barrier *schedulepb.Barrier) {
 	for _, message := range msg {
 		ownerCaptureID := message.GetFrom()
 		header := message.GetHeader()

--- a/cdc/scheduler/internal/v3/agent/agent.go
+++ b/cdc/scheduler/internal/v3/agent/agent.go
@@ -254,10 +254,7 @@ func (a *agent) handleMessage(msg []*schedulepb.Message) (
 		switch message.GetMsgType() {
 		case schedulepb.MsgHeartbeat:
 			var reMsg *schedulepb.Message
-			reMsg, barrier, err = a.handleMessageHeartbeat(message.GetHeartbeat())
-			if err != nil {
-				return
-			}
+			reMsg, barrier = a.handleMessageHeartbeat(message.GetHeartbeat())
 			result = append(result, reMsg)
 		case schedulepb.MsgDispatchTableRequest:
 			a.handleMessageDispatchTableRequest(message.DispatchTableRequest, processorEpoch)
@@ -272,9 +269,7 @@ func (a *agent) handleMessage(msg []*schedulepb.Message) (
 	return
 }
 
-func (a *agent) handleMessageHeartbeat(request *schedulepb.Heartbeat) (
-	*schedulepb.Message, *schedulepb.Barrier, error,
-) {
+func (a *agent) handleMessageHeartbeat(request *schedulepb.Heartbeat) (*schedulepb.Message, *schedulepb.Barrier) {
 	// NOTE: for a given table, we don't check ResolvedTs should never less than CheckpointTs
 	// because if redo is enabled, the table's ResolvedTs can be less than the global Barrier.
 	// For example, consider such steps:
@@ -323,7 +318,7 @@ func (a *agent) handleMessageHeartbeat(request *schedulepb.Heartbeat) (
 		zap.String("changefeed", a.ChangeFeedID.ID),
 		zap.Any("message", message))
 
-	return message, request.GetBarrier(), nil
+	return message, request.GetBarrier()
 }
 
 type dispatchTableTaskStatus int32

--- a/cdc/scheduler/internal/v3/agent/agent_test.go
+++ b/cdc/scheduler/internal/v3/agent/agent_test.go
@@ -356,7 +356,7 @@ func TestAgentHandleMessageHeartbeat(t *testing.T) {
 		},
 	}
 
-	response, _, _ := a.handleMessage([]*schedulepb.Message{heartbeat})
+	response, _ := a.handleMessage([]*schedulepb.Message{heartbeat})
 	require.Len(t, response, 1)
 	require.Equal(t, model.LivenessCaptureAlive, response[0].GetHeartbeatResponse().Liveness)
 
@@ -376,7 +376,7 @@ func TestAgentHandleMessageHeartbeat(t *testing.T) {
 	}
 
 	a.tableM.tables.GetV(spanz.TableIDToComparableSpan(1)).task = &dispatchTableTask{IsRemove: true}
-	response, _, _ = a.handleMessage([]*schedulepb.Message{heartbeat})
+	response, _ = a.handleMessage([]*schedulepb.Message{heartbeat})
 	result = response[0].GetHeartbeatResponse().Tables
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].Span.TableID < result[j].Span.TableID
@@ -384,13 +384,13 @@ func TestAgentHandleMessageHeartbeat(t *testing.T) {
 	require.Equal(t, tablepb.TableStateStopping, result[1].State)
 
 	a.handleLivenessUpdate(model.LivenessCaptureStopping)
-	response, _, _ = a.handleMessage([]*schedulepb.Message{heartbeat})
+	response, _ = a.handleMessage([]*schedulepb.Message{heartbeat})
 	require.Len(t, response, 1)
 	require.Equal(t, model.LivenessCaptureStopping, response[0].GetHeartbeatResponse().Liveness)
 
 	a.handleLivenessUpdate(model.LivenessCaptureAlive)
 	heartbeat.Heartbeat.IsStopping = true
-	response, _, _ = a.handleMessage([]*schedulepb.Message{heartbeat})
+	response, _ = a.handleMessage([]*schedulepb.Message{heartbeat})
 	require.Equal(t, model.LivenessCaptureStopping, response[0].GetHeartbeatResponse().Liveness)
 	require.Equal(t, model.LivenessCaptureStopping, a.liveness.Load())
 }
@@ -577,7 +577,7 @@ func TestAgentHandleMessage(t *testing.T) {
 	}
 
 	// handle the first heartbeat, from the known owner.
-	response, _, _ := a.handleMessage([]*schedulepb.Message{heartbeat})
+	response, _ := a.handleMessage([]*schedulepb.Message{heartbeat})
 	require.Len(t, response, 1)
 
 	addTableRequest := &schedulepb.Message{
@@ -600,17 +600,17 @@ func TestAgentHandleMessage(t *testing.T) {
 		},
 	}
 	// wrong epoch, ignored
-	responses, _, _ := a.handleMessage([]*schedulepb.Message{addTableRequest})
+	responses, _ := a.handleMessage([]*schedulepb.Message{addTableRequest})
 	require.False(t, tableM.tables.Has(spanz.TableIDToComparableSpan(1)))
 	require.Len(t, responses, 0)
 
 	// correct epoch, processing.
 	addTableRequest.Header.ProcessorEpoch = a.Epoch
-	_, _, _ = a.handleMessage([]*schedulepb.Message{addTableRequest})
+	_, _ = a.handleMessage([]*schedulepb.Message{addTableRequest})
 	require.True(t, a.tableM.tables.Has(spanz.TableIDToComparableSpan(1)))
 
 	heartbeat.Header.OwnerRevision.Revision = 2
-	response, _, _ = a.handleMessage([]*schedulepb.Message{heartbeat})
+	response, _ = a.handleMessage([]*schedulepb.Message{heartbeat})
 	require.Len(t, response, 1)
 
 	// this should never happen in real world
@@ -624,12 +624,12 @@ func TestAgentHandleMessage(t *testing.T) {
 		From:    a.ownerInfo.ID,
 	}
 
-	response, _, _ = a.handleMessage([]*schedulepb.Message{unknownMessage})
+	response, _ = a.handleMessage([]*schedulepb.Message{unknownMessage})
 	require.Len(t, response, 0)
 
 	// staled message
 	heartbeat.Header.OwnerRevision.Revision = 1
-	response, _, _ = a.handleMessage([]*schedulepb.Message{heartbeat})
+	response, _ = a.handleMessage([]*schedulepb.Message{heartbeat})
 	require.Len(t, response, 0)
 }
 

--- a/cdc/scheduler/internal/v3/replication/replication_manager.go
+++ b/cdc/scheduler/internal/v3/replication/replication_manager.go
@@ -521,7 +521,7 @@ func (r *Manager) AdvanceCheckpoint(
 			zap.String("changefeed", r.changefeedID.ID),
 			zap.Uint64("flushedCheckpointTs", flushedMeta.CheckpointTs),
 			zap.Uint64("flushedResolvedTs", flushedMeta.ResolvedTs))
-		if flushedMeta.ResolvedTs != 0 && flushedMeta.ResolvedTs < newResolvedTs {
+		if flushedMeta.ResolvedTs < newResolvedTs {
 			newResolvedTs = flushedMeta.ResolvedTs
 		}
 

--- a/cdc/scheduler/internal/v3/replication/replication_manager.go
+++ b/cdc/scheduler/internal/v3/replication/replication_manager.go
@@ -573,6 +573,13 @@ func (r *Manager) AdvanceCheckpoint(
 		return true
 	})
 	if cannotProceed {
+		if redoMetaManager.Enabled() {
+			// If redo is enabled, GlobalBarrierTs should be limited by redo flushed meta.
+			flushedMeta := redoMetaManager.GetFlushedMeta()
+			if barrier.GlobalBarrierTs > flushedMeta.ResolvedTs {
+				barrier.GlobalBarrierTs = flushedMeta.ResolvedTs
+			}
+		}
 		return checkpointCannotProceed, checkpointCannotProceed
 	}
 	if slowestRange.TableID != 0 {

--- a/cdc/scheduler/internal/v3/replication/replication_manager.go
+++ b/cdc/scheduler/internal/v3/replication/replication_manager.go
@@ -595,6 +595,7 @@ func (r *Manager) AdvanceCheckpoint(
 	if cannotProceed {
 		if redoMetaManager.Enabled() {
 			// If redo is enabled, GlobalBarrierTs should be limited by redo flushed meta.
+			newResolvedTs = barrier.RedoBarrierTs
 			limitBarrierWithRedo(&newCheckpointTs, &newResolvedTs)
 		}
 		return checkpointCannotProceed, checkpointCannotProceed


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9769 

### What is changed and how it works?

* make owner scheduler broadcast correct ResolvedTs if redo is enbaled;
* correct the check about comparing resolvedTs and checkpointTs in processor;

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
