### PR TITLE
processor(ticdc): decouple processor from reactor

### DIFF
--- a/cdc/processor/manager.go
+++ b/cdc/processor/manager.go
@@ -93,7 +93,7 @@ func NewManager(
 		processors:                   make(map[model.ChangeFeedID]*processor),
 		commandQueue:                 make(chan *command, 4),
 		upstreamManager:              upstreamManager,
-		newProcessor:                 newProcessor,
+		newProcessor:                 NewProcessor,
 		metricProcessorCloseDuration: processorCloseDuration,
 		cfg:                          cfg,
 	}

--- a/cdc/processor/manager.go
+++ b/cdc/processor/manager.go
@@ -155,7 +155,7 @@ func (m *managerImpl) Tick(stdCtx context.Context, state orchestrator.ReactorSta
 		}
 		err, warning := p.Tick(ctx, changefeedState.Info, changefeedState.Status)
 		if warning != nil {
-			patchWarning(err, p.captureInfo, changefeedState)
+			patchWarning(warning, p.captureInfo, changefeedState)
 		}
 		if err != nil {
 			handleProcessorErr(p, err, changefeedState)

--- a/cdc/processor/manager.go
+++ b/cdc/processor/manager.go
@@ -193,7 +193,8 @@ func checkChangefeedNormal(changefeed *orchestrator.ChangefeedReactorState) bool
 // createTaskPosition will create a new task position if a task position does not exist.
 // task position not exist only when the processor is running first in the first tick.
 func createTaskPosition(changefeed *orchestrator.ChangefeedReactorState,
-	captureInfo *model.CaptureInfo) (skipThisTick bool) {
+	captureInfo *model.CaptureInfo,
+) (skipThisTick bool) {
 	if _, exist := changefeed.TaskPositions[captureInfo.ID]; exist {
 		return false
 	}
@@ -208,7 +209,8 @@ func createTaskPosition(changefeed *orchestrator.ChangefeedReactorState,
 }
 
 func handleProcessorErr(p *processor, err error,
-	changefeed *orchestrator.ChangefeedReactorState) {
+	changefeed *orchestrator.ChangefeedReactorState,
+) {
 	if isProcessorIgnorableError(err) {
 		log.Info("processor exited",
 			zap.String("capture", p.captureInfo.ID),
@@ -247,7 +249,8 @@ func handleProcessorErr(p *processor, err error,
 
 func patchWarning(err error,
 	captureInfo *model.CaptureInfo,
-	changefeed *orchestrator.ChangefeedReactorState) {
+	changefeed *orchestrator.ChangefeedReactorState,
+) {
 	var code string
 	if rfcCode, ok := cerror.RFCCode(err); ok {
 		code = string(rfcCode)

--- a/cdc/processor/manager_test.go
+++ b/cdc/processor/manager_test.go
@@ -47,7 +47,8 @@ func NewManager4Test(
 	cfg := config.NewDefaultSchedulerConfig()
 	m := NewManager(captureInfo, upstream.NewManager4Test(nil), liveness, cfg).(*managerImpl)
 	m.newProcessor = func(
-		state *orchestrator.ChangefeedReactorState,
+		info *model.ChangeFeedInfo,
+		status *model.ChangeFeedStatus,
 		captureInfo *model.CaptureInfo,
 		changefeedID model.ChangeFeedID,
 		up *upstream.Upstream,
@@ -55,7 +56,7 @@ func NewManager4Test(
 		changefeedEpoch uint64,
 		cfg *config.SchedulerConfig,
 	) *processor {
-		return newProcessor4Test(t, state, captureInfo, m.liveness, cfg, false)
+		return newProcessor4Test(t, info, status, captureInfo, m.liveness, cfg, false)
 	}
 	return m
 }

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -470,7 +470,8 @@ func isProcessorIgnorableError(err error) bool {
 // maintain table components, error handling, etc.
 //
 // It can be called in etcd ticks, so it should never be blocked.
-func (p *processor) Tick(ctx cdcContext.Context,
+func (p *processor) Tick(
+    ctx cdcContext.Context,
 	info *model.ChangeFeedInfo, status *model.ChangeFeedStatus,
 ) (error, error) {
 	p.latestInfo = info

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -471,7 +471,7 @@ func isProcessorIgnorableError(err error) bool {
 //
 // It can be called in etcd ticks, so it should never be blocked.
 func (p *processor) Tick(
-    ctx cdcContext.Context,
+	ctx cdcContext.Context,
 	info *model.ChangeFeedInfo, status *model.ChangeFeedStatus,
 ) (error, error) {
 	p.latestInfo = info

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -99,6 +99,10 @@ type processor struct {
 	agent           scheduler.Agent
 	changefeedEpoch uint64
 
+	// The latest changefeed info and status from meta storage. they are updated in every Tick.
+	// processor implements TableExecutor interface, so we need to add these two fields here to use them
+	// in `AddTableSpan` and `RemoveTableSpan`, otherwise we need to adjust the interface.
+	// we can refactor this step by step.
 	latestInfo   *model.ChangeFeedInfo
 	latestStatus *model.ChangeFeedStatus
 

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -453,7 +453,8 @@ func isProcessorIgnorableError(err error) bool {
 //
 // It can be called in etcd ticks, so it should never be blocked.
 func (p *processor) Tick(ctx cdcContext.Context,
-	info *model.ChangeFeedInfo, status *model.ChangeFeedStatus) (error, error) {
+	info *model.ChangeFeedInfo, status *model.ChangeFeedStatus,
+) (error, error) {
 	p.latestInfo = info
 	p.latestStatus = status
 

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -478,6 +478,7 @@ func (p *processor) Tick(ctx cdcContext.Context,
 
 	// check upstream error first
 	if err := p.upstream.Error(); err != nil {
+		p.metricProcessorErrorCounter.Inc()
 		return err, nil
 	}
 	if p.upstream.IsClosed() {
@@ -513,8 +514,9 @@ func (p *processor) Tick(ctx cdcContext.Context,
 	// otherwise the function called below may panic.
 	if err == nil {
 		p.refreshMetrics()
+	} else {
+		p.metricProcessorErrorCounter.Inc()
 	}
-
 	return err, warning
 }
 

--- a/cdc/processor/processor_test.go
+++ b/cdc/processor/processor_test.go
@@ -110,7 +110,7 @@ func newProcessor4Test(
 
 func initProcessor4Test(
 	ctx cdcContext.Context, t *testing.T, liveness *model.Liveness, enableRedo bool,
-) (*processor, *orchestrator.ReactorStateTester) {
+) (*processor, *orchestrator.ReactorStateTester, *orchestrator.ChangefeedReactorState) {
 	changefeedInfo := `
 {
     "sink-uri": "blackhole://",
@@ -150,11 +150,10 @@ func initProcessor4Test(
 		etcd.DefaultCDCClusterID, ctx.ChangefeedVars().ID)
 	captureInfo := &model.CaptureInfo{ID: "capture-test", AdvertiseAddr: "127.0.0.1:0000"}
 	cfg := config.NewDefaultSchedulerConfig()
-	p := newProcessor4Test(t, changefeed.Info, changefeed.Status, captureInfo, liveness, cfg, enableRedo)
 
 	captureID := ctx.GlobalVars().CaptureInfo.ID
 	changefeedID := ctx.ChangefeedVars().ID
-	return p, orchestrator.NewReactorStateTester(t, p.changefeed, map[string]string{
+	tester := orchestrator.NewReactorStateTester(t, changefeed, map[string]string{
 		fmt.Sprintf("%s/capture/%s",
 			etcd.DefaultClusterAndMetaPrefix,
 			captureID): `{"id":"` + captureID + `","address":"127.0.0.1:8300"}`,
@@ -165,6 +164,9 @@ func initProcessor4Test(
 			etcd.DefaultClusterAndNamespacePrefix,
 			ctx.ChangefeedVars().ID.ID): `{"resolved-ts":0,"checkpoint-ts":0,"admin-job-type":0}`,
 	})
+	p := newProcessor4Test(t, changefeed.Info, changefeed.Status, captureInfo, liveness, cfg, enableRedo)
+
+	return p, tester, changefeed
 }
 
 type mockSchemaStorage struct {
@@ -212,20 +214,20 @@ func (a *mockAgent) Close() error {
 func TestTableExecutorAddingTableIndirectly(t *testing.T) {
 	ctx := cdcContext.NewBackendContext4Test(true)
 	liveness := model.LivenessCaptureAlive
-	p, tester := initProcessor4Test(ctx, t, &liveness, false)
+	p, tester, changefeed := initProcessor4Test(ctx, t, &liveness, false)
 
 	// init tick
-	err := p.Tick(ctx)
-	require.Nil(t, err)
+	checkChangefeedNormal(changefeed)
+	createTaskPosition(changefeed, p.captureInfo)
 	tester.MustApplyPatches()
-	p.changefeed.PatchStatus(func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
+	changefeed.PatchStatus(func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
 		status.CheckpointTs = 20
 		return status, true, nil
 	})
 	tester.MustApplyPatches()
 
 	// no operation
-	err = p.Tick(ctx)
+	err, _ := p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 
@@ -260,7 +262,7 @@ func TestTableExecutorAddingTableIndirectly(t *testing.T) {
 		}}...,
 	)
 
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 
@@ -283,7 +285,7 @@ func TestTableExecutorAddingTableIndirectly(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 
@@ -300,20 +302,20 @@ func TestTableExecutorAddingTableIndirectly(t *testing.T) {
 func TestTableExecutorAddingTableIndirectlyWithRedoEnabled(t *testing.T) {
 	ctx := cdcContext.NewBackendContext4Test(true)
 	liveness := model.LivenessCaptureAlive
-	p, tester := initProcessor4Test(ctx, t, &liveness, true)
+	p, tester, changefeed := initProcessor4Test(ctx, t, &liveness, true)
 
 	// init tick
-	err := p.Tick(ctx)
-	require.Nil(t, err)
+	checkChangefeedNormal(changefeed)
+	createTaskPosition(changefeed, p.captureInfo)
 	tester.MustApplyPatches()
-	p.changefeed.PatchStatus(func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
+	changefeed.PatchStatus(func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
 		status.CheckpointTs = 20
 		return status, true, nil
 	})
 	tester.MustApplyPatches()
 
 	// no operation
-	err = p.Tick(ctx)
+	err, _ := p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 
@@ -348,7 +350,7 @@ func TestTableExecutorAddingTableIndirectlyWithRedoEnabled(t *testing.T) {
 		}}...,
 	)
 
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 
@@ -381,7 +383,7 @@ func TestTableExecutorAddingTableIndirectlyWithRedoEnabled(t *testing.T) {
 	require.Equal(t, model.Ts(60), stats.ResolvedTs)
 	require.Equal(t, model.Ts(50), stats.BarrierTs)
 
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 
@@ -398,38 +400,43 @@ func TestTableExecutorAddingTableIndirectlyWithRedoEnabled(t *testing.T) {
 func TestProcessorError(t *testing.T) {
 	ctx := cdcContext.NewBackendContext4Test(true)
 	liveness := model.LivenessCaptureAlive
-	p, tester := initProcessor4Test(ctx, t, &liveness, false)
+	p, tester, changefeed := initProcessor4Test(ctx, t, &liveness, false)
+
 	// init tick
-	err := p.Tick(ctx)
+	err, _ := p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
+	createTaskPosition(changefeed, p.captureInfo)
 	tester.MustApplyPatches()
 
 	// send a abnormal error
 	p.sinkManager.errors <- cerror.ErrSinkURIInvalid
-	err = p.Tick(ctx)
-	tester.MustApplyPatches()
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Error(t, err)
-	require.Equal(t, p.changefeed.TaskPositions[p.captureInfo.ID], &model.TaskPosition{
+	handleProcessorErr(p, err, changefeed)
+	tester.MustApplyPatches()
+	require.Equal(t, changefeed.TaskPositions[p.captureInfo.ID], &model.TaskPosition{
 		Error: &model.RunningError{
-			Time:    p.changefeed.TaskPositions[p.captureInfo.ID].Error.Time,
+			Time:    changefeed.TaskPositions[p.captureInfo.ID].Error.Time,
 			Addr:    "127.0.0.1:0000",
 			Code:    "CDC:ErrSinkURIInvalid",
 			Message: "[CDC:ErrSinkURIInvalid]sink uri invalid '%s'",
 		},
 	})
 
-	p, tester = initProcessor4Test(ctx, t, &liveness, false)
+	p, tester, changefeed = initProcessor4Test(ctx, t, &liveness, false)
 	// init tick
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
+	createTaskPosition(changefeed, p.captureInfo)
 	tester.MustApplyPatches()
 
 	// send a normal error
 	p.sinkManager.errors <- context.Canceled
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
+	handleProcessorErr(p, err, changefeed)
 	tester.MustApplyPatches()
 	require.True(t, cerror.ErrReactorFinished.Equal(errors.Cause(err)))
-	require.Equal(t, p.changefeed.TaskPositions[p.captureInfo.ID], &model.TaskPosition{
+	require.Equal(t, changefeed.TaskPositions[p.captureInfo.ID], &model.TaskPosition{
 		Error: nil,
 	})
 }
@@ -437,23 +444,23 @@ func TestProcessorError(t *testing.T) {
 func TestProcessorExit(t *testing.T) {
 	ctx := cdcContext.NewBackendContext4Test(true)
 	liveness := model.LivenessCaptureAlive
-	p, tester := initProcessor4Test(ctx, t, &liveness, false)
+	p, tester, changefeed := initProcessor4Test(ctx, t, &liveness, false)
 	var err error
 	// init tick
-	err = p.Tick(ctx)
-	require.Nil(t, err)
+	checkChangefeedNormal(changefeed)
+	createTaskPosition(changefeed, p.captureInfo)
 	tester.MustApplyPatches()
 
 	// stop the changefeed
-	p.changefeed.PatchStatus(func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
+	changefeed.PatchStatus(func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
 		status.AdminJobType = model.AdminStop
 		return status, true, nil
 	})
 	tester.MustApplyPatches()
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.True(t, cerror.ErrReactorFinished.Equal(errors.Cause(err)))
 	tester.MustApplyPatches()
-	require.Equal(t, p.changefeed.TaskPositions[p.captureInfo.ID], &model.TaskPosition{
+	require.Equal(t, changefeed.TaskPositions[p.captureInfo.ID], &model.TaskPosition{
 		Error: nil,
 	})
 }
@@ -461,14 +468,14 @@ func TestProcessorExit(t *testing.T) {
 func TestProcessorClose(t *testing.T) {
 	ctx := cdcContext.NewBackendContext4Test(true)
 	liveness := model.LivenessCaptureAlive
-	p, tester := initProcessor4Test(ctx, t, &liveness, false)
+	p, tester, changefeed := initProcessor4Test(ctx, t, &liveness, false)
 	// init tick
-	err := p.Tick(ctx)
-	require.Nil(t, err)
+	checkChangefeedNormal(changefeed)
+	createTaskPosition(changefeed, p.captureInfo)
 	tester.MustApplyPatches()
 
 	// Do a no operation tick to lazy init the processor.
-	err = p.Tick(ctx)
+	err, _ := p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 
@@ -480,19 +487,19 @@ func TestProcessorClose(t *testing.T) {
 	require.Nil(t, err)
 	require.True(t, done)
 
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 
 	// push the resolvedTs and checkpointTs
-	p.changefeed.PatchStatus(func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
+	changefeed.PatchStatus(func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
 		return status, true, nil
 	})
 	tester.MustApplyPatches()
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
-	require.Contains(t, p.changefeed.TaskPositions, p.captureInfo.ID)
+	require.Contains(t, changefeed.TaskPositions, p.captureInfo.ID)
 
 	require.Nil(t, p.Close())
 	tester.MustApplyPatches()
@@ -500,14 +507,14 @@ func TestProcessorClose(t *testing.T) {
 	require.Nil(t, p.sourceManager.r)
 	require.Nil(t, p.agent)
 
-	p, tester = initProcessor4Test(ctx, t, &liveness, false)
+	p, tester, changefeed = initProcessor4Test(ctx, t, &liveness, false)
 	// init tick
-	err = p.Tick(ctx)
-	require.Nil(t, err)
+	checkChangefeedNormal(changefeed)
+	createTaskPosition(changefeed, p.captureInfo)
 	tester.MustApplyPatches()
 
 	// Do a no operation tick to lazy init the processor.
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 
@@ -518,20 +525,20 @@ func TestProcessorClose(t *testing.T) {
 	done, err = p.AddTableSpan(ctx, spanz.TableIDToComparableSpan(2), tablepb.Checkpoint{CheckpointTs: 30}, false)
 	require.Nil(t, err)
 	require.True(t, done)
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 
 	// send error
 	p.sinkManager.errors <- cerror.ErrSinkURIInvalid
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Error(t, err)
 	tester.MustApplyPatches()
 
 	require.Nil(t, p.Close())
 	tester.MustApplyPatches()
-	require.Equal(t, p.changefeed.TaskPositions[p.captureInfo.ID].Error, &model.RunningError{
-		Time:    p.changefeed.TaskPositions[p.captureInfo.ID].Error.Time,
+	require.Equal(t, changefeed.TaskPositions[p.captureInfo.ID].Error, &model.RunningError{
+		Time:    changefeed.TaskPositions[p.captureInfo.ID].Error.Time,
 		Addr:    "127.0.0.1:0000",
 		Code:    "CDC:ErrSinkURIInvalid",
 		Message: "[CDC:ErrSinkURIInvalid]sink uri invalid '%s'",
@@ -544,15 +551,15 @@ func TestProcessorClose(t *testing.T) {
 func TestPositionDeleted(t *testing.T) {
 	ctx := cdcContext.NewBackendContext4Test(true)
 	liveness := model.LivenessCaptureAlive
-	p, tester := initProcessor4Test(ctx, t, &liveness, false)
+	p, tester, changefeed := initProcessor4Test(ctx, t, &liveness, false)
 	// init tick
-	err := p.Tick(ctx)
-	require.Nil(t, err)
+	checkChangefeedNormal(changefeed)
+	createTaskPosition(changefeed, p.captureInfo)
 	tester.MustApplyPatches()
-	require.Contains(t, p.changefeed.TaskPositions, p.captureInfo.ID)
+	require.Contains(t, changefeed.TaskPositions, p.captureInfo.ID)
 
 	// Do a no operation tick to lazy init the processor.
-	err = p.Tick(ctx)
+	err, _ := p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 
@@ -565,18 +572,18 @@ func TestPositionDeleted(t *testing.T) {
 	require.True(t, done)
 
 	// some others delete the task position
-	p.changefeed.PatchTaskPosition(p.captureInfo.ID,
+	changefeed.PatchTaskPosition(p.captureInfo.ID,
 		func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 			return nil, true, nil
 		})
 	tester.MustApplyPatches()
 
 	// position created again
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
-	require.Equal(t, &model.TaskPosition{}, p.changefeed.TaskPositions[p.captureInfo.ID])
-	require.Contains(t, p.changefeed.TaskPositions, p.captureInfo.ID)
+	require.Equal(t, &model.TaskPosition{}, changefeed.TaskPositions[p.captureInfo.ID])
+	require.Contains(t, changefeed.TaskPositions, p.captureInfo.ID)
 
 	require.Nil(t, p.Close())
 	tester.MustApplyPatches()
@@ -585,18 +592,18 @@ func TestPositionDeleted(t *testing.T) {
 func TestSchemaGC(t *testing.T) {
 	ctx := cdcContext.NewBackendContext4Test(true)
 	liveness := model.LivenessCaptureAlive
-	p, tester := initProcessor4Test(ctx, t, &liveness, false)
+	p, tester, changefeed := initProcessor4Test(ctx, t, &liveness, false)
 
 	var err error
 	// init tick
-	err = p.Tick(ctx)
-	require.Nil(t, err)
+	checkChangefeedNormal(changefeed)
+	createTaskPosition(changefeed, p.captureInfo)
 	tester.MustApplyPatches()
 
 	updateChangeFeedPosition(t, tester,
 		model.DefaultChangeFeedID("changefeed-id-test"),
 		50)
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 
@@ -647,21 +654,21 @@ func TestIgnorableError(t *testing.T) {
 func TestUpdateBarrierTs(t *testing.T) {
 	ctx := cdcContext.NewBackendContext4Test(true)
 	liveness := model.LivenessCaptureAlive
-	p, tester := initProcessor4Test(ctx, t, &liveness, false)
-	p.changefeed.PatchStatus(func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
+	p, tester, changefeed := initProcessor4Test(ctx, t, &liveness, false)
+	changefeed.PatchStatus(func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
 		status.CheckpointTs = 5
 		return status, true, nil
 	})
 	p.ddlHandler.r.schemaStorage.(*mockSchemaStorage).resolvedTs = 10
 
 	// init tick
-	err := p.Tick(ctx)
-	require.Nil(t, err)
+	checkChangefeedNormal(changefeed)
+	createTaskPosition(changefeed, p.captureInfo)
 	tester.MustApplyPatches()
-	require.Contains(t, p.changefeed.TaskPositions, p.captureInfo.ID)
+	require.Contains(t, changefeed.TaskPositions, p.captureInfo.ID)
 
 	// Do a no operation tick to lazy init the processor.
-	err = p.Tick(ctx)
+	err, _ := p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 
@@ -669,15 +676,15 @@ func TestUpdateBarrierTs(t *testing.T) {
 	done, err := p.AddTableSpan(ctx, span, tablepb.Checkpoint{CheckpointTs: 5}, false)
 	require.True(t, done)
 	require.Nil(t, err)
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 
 	// Global resolved ts has advanced while schema storage stalls.
-	p.changefeed.PatchStatus(func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
+	changefeed.PatchStatus(func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
 		return status, true, nil
 	})
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 	p.updateBarrierTs(&schedulepb.Barrier{GlobalBarrierTs: 20, TableBarriers: nil})
@@ -686,7 +693,7 @@ func TestUpdateBarrierTs(t *testing.T) {
 
 	// Schema storage has advanced too.
 	p.ddlHandler.r.schemaStorage.(*mockSchemaStorage).resolvedTs = 15
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 	p.updateBarrierTs(&schedulepb.Barrier{GlobalBarrierTs: 20, TableBarriers: nil})
@@ -700,15 +707,15 @@ func TestUpdateBarrierTs(t *testing.T) {
 func TestProcessorLiveness(t *testing.T) {
 	ctx := cdcContext.NewBackendContext4Test(true)
 	liveness := model.LivenessCaptureAlive
-	p, tester := initProcessor4Test(ctx, t, &liveness, false)
+	p, tester, changefeed := initProcessor4Test(ctx, t, &liveness, false)
 
 	// First tick for creating position.
-	err := p.Tick(ctx)
+	err, _ := p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 
 	// Second tick for init.
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 
 	// Changing p.liveness affects p.agent liveness.
@@ -735,19 +742,19 @@ func TestProcessorDostNotStuckInInit(t *testing.T) {
 
 	ctx := cdcContext.NewBackendContext4Test(true)
 	liveness := model.LivenessCaptureAlive
-	p, tester := initProcessor4Test(ctx, t, &liveness, false)
+	p, tester, changefeed := initProcessor4Test(ctx, t, &liveness, false)
 
 	// First tick for creating position.
-	err := p.Tick(ctx)
+	err, _ := p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()
 
 	// Second tick for init.
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 
 	// TODO(qupeng): third tick for handle a warning.
-	err = p.Tick(ctx)
+	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 
 	require.Nil(t, p.Close())

--- a/cdc/processor/processor_test.go
+++ b/cdc/processor/processor_test.go
@@ -412,7 +412,7 @@ func TestProcessorError(t *testing.T) {
 	p.sinkManager.errors <- cerror.ErrSinkURIInvalid
 	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Error(t, err)
-	handleProcessorErr(p, err, changefeed)
+	patchProcessorErr(p.captureInfo, changefeed, err)
 	tester.MustApplyPatches()
 	require.Equal(t, changefeed.TaskPositions[p.captureInfo.ID], &model.TaskPosition{
 		Error: &model.RunningError{
@@ -435,7 +435,7 @@ func TestProcessorError(t *testing.T) {
 	// send a normal error
 	p.sinkManager.errors <- context.Canceled
 	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
-	handleProcessorErr(p, err, changefeed)
+	patchProcessorErr(p.captureInfo, changefeed, err)
 	tester.MustApplyPatches()
 	require.True(t, cerror.ErrReactorFinished.Equal(errors.Cause(err)))
 	require.Equal(t, changefeed.TaskPositions[p.captureInfo.ID], &model.TaskPosition{
@@ -538,7 +538,7 @@ func TestProcessorClose(t *testing.T) {
 	p.sinkManager.errors <- cerror.ErrSinkURIInvalid
 	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Error(t, err)
-	handleProcessorErr(p, err, changefeed)
+	patchProcessorErr(p.captureInfo, changefeed, err)
 	tester.MustApplyPatches()
 
 	require.Nil(t, p.Close())

--- a/cdc/processor/processor_test.go
+++ b/cdc/processor/processor_test.go
@@ -422,6 +422,8 @@ func TestProcessorError(t *testing.T) {
 			Message: "[CDC:ErrSinkURIInvalid]sink uri invalid '%s'",
 		},
 	})
+	require.Nil(t, p.Close())
+	tester.MustApplyPatches()
 
 	p, tester, changefeed = initProcessor4Test(ctx, t, &liveness, false)
 	// init tick
@@ -439,6 +441,8 @@ func TestProcessorError(t *testing.T) {
 	require.Equal(t, changefeed.TaskPositions[p.captureInfo.ID], &model.TaskPosition{
 		Error: nil,
 	})
+	require.Nil(t, p.Close())
+	tester.MustApplyPatches()
 }
 
 func TestProcessorExit(t *testing.T) {
@@ -462,6 +466,8 @@ func TestProcessorExit(t *testing.T) {
 	require.Equal(t, changefeed.TaskPositions[p.captureInfo.ID], &model.TaskPosition{
 		Error: nil,
 	})
+	require.Nil(t, p.Close())
+	tester.MustApplyPatches()
 }
 
 func TestProcessorClose(t *testing.T) {

--- a/cdc/processor/processor_test.go
+++ b/cdc/processor/processor_test.go
@@ -449,7 +449,7 @@ func TestProcessorExit(t *testing.T) {
 	ctx := cdcContext.NewBackendContext4Test(true)
 	liveness := model.LivenessCaptureAlive
 	p, tester, changefeed := initProcessor4Test(ctx, t, &liveness, false)
-	//var err error
+	// var err error
 	// init tick
 	checkChangefeedNormal(changefeed)
 	createTaskPosition(changefeed, p.captureInfo)

--- a/cdc/processor/processor_test.go
+++ b/cdc/processor/processor_test.go
@@ -445,7 +445,7 @@ func TestProcessorExit(t *testing.T) {
 	ctx := cdcContext.NewBackendContext4Test(true)
 	liveness := model.LivenessCaptureAlive
 	p, tester, changefeed := initProcessor4Test(ctx, t, &liveness, false)
-	var err error
+	//var err error
 	// init tick
 	checkChangefeedNormal(changefeed)
 	createTaskPosition(changefeed, p.captureInfo)
@@ -457,8 +457,7 @@ func TestProcessorExit(t *testing.T) {
 		return status, true, nil
 	})
 	tester.MustApplyPatches()
-	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
-	require.True(t, cerror.ErrReactorFinished.Equal(errors.Cause(err)))
+	require.False(t, checkChangefeedNormal(changefeed))
 	tester.MustApplyPatches()
 	require.Equal(t, changefeed.TaskPositions[p.captureInfo.ID], &model.TaskPosition{
 		Error: nil,
@@ -533,6 +532,7 @@ func TestProcessorClose(t *testing.T) {
 	p.sinkManager.errors <- cerror.ErrSinkURIInvalid
 	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Error(t, err)
+	handleProcessorErr(p, err, changefeed)
 	tester.MustApplyPatches()
 
 	require.Nil(t, p.Close())
@@ -579,6 +579,8 @@ func TestPositionDeleted(t *testing.T) {
 	tester.MustApplyPatches()
 
 	// position created again
+	checkChangefeedNormal(changefeed)
+	createTaskPosition(changefeed, p.captureInfo)
 	err, _ = p.Tick(ctx, changefeed.Info, changefeed.Status)
 	require.Nil(t, err)
 	tester.MustApplyPatches()

--- a/cdc/processor/processor_test.go
+++ b/cdc/processor/processor_test.go
@@ -53,7 +53,7 @@ func newProcessor4Test(
 ) *processor {
 	changefeedID := model.ChangeFeedID4Test("processor-test", "processor-test")
 	up := upstream.NewUpstream4Test(&sinkmanager.MockPD{})
-	p := newProcessor(
+	p := NewProcessor(
 		info,
 		status,
 		captureInfo,

--- a/cdc/processor/processor_test.go
+++ b/cdc/processor/processor_test.go
@@ -44,7 +44,8 @@ import (
 
 func newProcessor4Test(
 	t *testing.T,
-	state *orchestrator.ChangefeedReactorState,
+	info *model.ChangeFeedInfo,
+	status *model.ChangeFeedStatus,
 	captureInfo *model.CaptureInfo,
 	liveness *model.Liveness,
 	cfg *config.SchedulerConfig,
@@ -53,7 +54,8 @@ func newProcessor4Test(
 	changefeedID := model.ChangeFeedID4Test("processor-test", "processor-test")
 	up := upstream.NewUpstream4Test(&sinkmanager.MockPD{})
 	p := newProcessor(
-		state,
+		info,
+		status,
 		captureInfo,
 		changefeedID, up, liveness, 0, cfg)
 	// Some cases want to send errors to the processor without initializing it.
@@ -84,7 +86,7 @@ func newProcessor4Test(
 
 		p.agent = &mockAgent{executor: p, liveness: liveness}
 		p.sinkManager.r, p.sourceManager.r, _ = sinkmanager.NewManagerWithMemEngine(
-			t, changefeedID, state.Info, p.redo.r)
+			t, changefeedID, info, p.redo.r)
 		p.sinkManager.name = "SinkManager"
 		p.sinkManager.changefeedID = changefeedID
 		p.sinkManager.spawn(ctx)
@@ -148,7 +150,7 @@ func initProcessor4Test(
 		etcd.DefaultCDCClusterID, ctx.ChangefeedVars().ID)
 	captureInfo := &model.CaptureInfo{ID: "capture-test", AdvertiseAddr: "127.0.0.1:0000"}
 	cfg := config.NewDefaultSchedulerConfig()
-	p := newProcessor4Test(t, changefeed, captureInfo, liveness, cfg, enableRedo)
+	p := newProcessor4Test(t, changefeed.Info, changefeed.Status, captureInfo, liveness, cfg, enableRedo)
 
 	captureID := ctx.GlobalVars().CaptureInfo.ID
 	changefeedID := ctx.ChangefeedVars().ID


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9780

### What is changed and how it works?
1. make the processor tick logic not depend on the reactor anymore.
2. add Processor interface


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
