### PR TITLE
sink(ticdc): fix csv delimiter

### DIFF
--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -210,15 +210,20 @@ func (c *CSVConfig) validateAndAdjust() error {
 	}
 
 	// validate delimiter
-	if len(c.Delimiter) == 0 {
+	switch len(c.Delimiter) {
+	case 0:
 		return cerror.WrapError(cerror.ErrSinkInvalidConfig,
 			errors.New("csv config delimiter cannot be empty"))
-	}
-	if strings.ContainsRune(c.Delimiter, CR) ||
-		strings.ContainsRune(c.Delimiter, LF) {
+	case 1:
+		if strings.ContainsRune(c.Delimiter, CR) || strings.ContainsRune(c.Delimiter, LF) {
+			return cerror.WrapError(cerror.ErrSinkInvalidConfig,
+				errors.New("csv config delimiter contains line break characters"))
+		}
+	default:
 		return cerror.WrapError(cerror.ErrSinkInvalidConfig,
-			errors.New("csv config delimiter contains line break characters"))
+			errors.New("csv config delimiter contains more than one character"))
 	}
+
 	if len(c.Quote) > 0 && strings.Contains(c.Delimiter, c.Quote) {
 		return cerror.WrapError(cerror.ErrSinkInvalidConfig,
 			errors.New("csv config quote and delimiter cannot be the same"))

--- a/pkg/config/sink_test.go
+++ b/pkg/config/sink_test.go
@@ -350,6 +350,14 @@ func TestValidateAndAdjustCSVConfig(t *testing.T) {
 			wantErr: "csv config delimiter contains line break characters",
 		},
 		{
+			name: "delimiter contains more than one character",
+			config: &CSVConfig{
+				Quote:     "'",
+				Delimiter: "\r\t",
+			},
+			wantErr: "csv config delimiter contains more than one character",
+		},
+		{
 			name: "delimiter and quote are same",
 			config: &CSVConfig{
 				Quote:     "'",


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9609

### What is changed and how it works?
limit delimiter to single character.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`Fix the issue of delimiter could be configured as multiple characters in the csv protocol`
```
