### PR TITLE
dm: sync partition DDL even if upstream schema is not equal in optimistic mode

### DIFF
--- a/dm/master/shardddl/optimist_test.go
+++ b/dm/master/shardddl/optimist_test.go
@@ -760,7 +760,7 @@ func (t *testOptimistSuite) TestOptimistLockConflict() {
 	case <-time.After(watchTimeout):
 		t.T().Fatal("timeout")
 	case op3 := <-opCh:
-		require.Equal(t.T(), []string{}, op3.DDLs)
+		require.Equal(t.T(), DDLs1, op3.DDLs)
 		require.Equal(t.T(), optimism.ConflictNone, op3.ConflictStage)
 	}
 	cancel2()

--- a/dm/pkg/shardddl/optimism/lock.go
+++ b/dm/pkg/shardddl/optimism/lock.go
@@ -848,7 +848,7 @@ func (l *Lock) trySyncForOneDDL(source, schema, table string, prevTable, postTab
 
 	// Normal DDL
 	if tableErr == nil {
-		log.L().Debug("receive a normal DDL", zap.String("source", source), zap.String("schema", schema), zap.String("table", table), zap.Stringer("prevTable", prevTable), zap.Stringer("postTable", postTable))
+		log.L().Info("receive a normal DDL", zap.String("source", source), zap.String("schema", schema), zap.String("table", table), zap.Stringer("prevTable", prevTable), zap.Stringer("postTable", postTable))
 		oldJoined, oldErr := l.joinNormalTables()
 
 		l.tables[source][schema][table] = postTable
@@ -883,7 +883,8 @@ func (l *Lock) trySyncForOneDDL(source, schema, table string, prevTable, postTab
 			// oldJoined != newJoined
 			// postTable == oldJoined (CREATE TABLE)
 			// prevTable < postTable
-			return (joinedErr != nil || joinedCmp != 0) || (err2 == nil && cmp == 0) || tableCmp < 0, ConflictNone
+			// prevTable == postTable(Partition/Sequence)
+			return (joinedErr != nil || joinedCmp != 0) || (err2 == nil && cmp == 0) || tableCmp <= 0, ConflictNone
 		}
 	}
 
@@ -920,7 +921,7 @@ func (l *Lock) trySyncForOneDDL(source, schema, table string, prevTable, postTab
 
 		return true, ConflictNone
 	}
-	log.L().Debug("conflict hasn't been resolved", zap.String("source", source), zap.String("schema", schema), zap.String("table", table), zap.Stringer("prevTable", prevTable), zap.Stringer("postTable", postTable))
+	log.L().Info("conflict hasn't been resolved", zap.String("source", source), zap.String("schema", schema), zap.String("table", table), zap.Stringer("prevTable", prevTable), zap.Stringer("postTable", postTable))
 	return false, ConflictSkipWaitRedirect
 }
 

--- a/dm/pkg/shardddl/optimism/lock_test.go
+++ b/dm/pkg/shardddl/optimism/lock_test.go
@@ -2738,6 +2738,11 @@ func (t *testLock) TestTrySyncForOneDDL(c *C) {
 	c.Assert(schemaChanged, IsTrue)
 	c.Assert(conflictStage, Equals, ConflictNone)
 
+	// check create partition, no changed since https://github.com/pingcap/tidb-tools/blob/d671b0840063bc2532941f02e02e12627402844c/pkg/schemacmp/table.go#L251
+	schemaChanged, conflictStage = l.trySyncForOneDDL(source, schema, table1, t0, t1)
+	c.Assert(schemaChanged, IsTrue)
+	c.Assert(conflictStage, Equals, ConflictNone)
+
 	// check alter table drop column
 	schemaChanged, conflictStage = l.trySyncForOneDDL(source, schema, table2, t0, t2)
 	c.Assert(schemaChanged, IsFalse)

--- a/dm/tests/shardddl2/run.sh
+++ b/dm/tests/shardddl2/run.sh
@@ -507,6 +507,24 @@ function DM_DropAddColumn() {
 	done
 }
 
+function DM_ADD_DROP_PARTITIONS_CASE() {
+	run_sql_source1 "insert into ${shardddl1}.${tb1} values(1);"
+	run_sql_source2 "insert into ${shardddl1}.${tb1} values(2);"
+	run_sql_source1 "alter table ${shardddl1}.${tb1} add column new_col1 int;"
+	run_sql_source1 "insert into ${shardddl1}.${tb1} values(3,3);"
+	run_sql_source2 "insert into ${shardddl1}.${tb1} values(4);"
+
+	run_sql_source1 "ALTER TABLE ${shardddl1}.${tb1} ADD PARTITION (partition p1 VALUES LESS THAN (10000))"
+	run_sql_tidb_with_retry "show create table ${shardddl}.${tb}" "PARTITION \`p1\`"
+}
+
+function DM_ADD_DROP_PARTITIONS() {
+	run_case ADD_DROP_PARTITIONS "double-source-optimistic" \
+		"run_sql_source1 \"create table ${shardddl1}.${tb1} (a int) PARTITION BY RANGE (a) (PARTITION p0 VALUES LESS THAN (100));\"; \
+     run_sql_source2 \"create table ${shardddl1}.${tb1} (a int) PARTITION BY RANGE (a) (PARTITION p0 VALUES LESS THAN (100));\";" \
+		"clean_table" "optimistic"
+}
+
 function run() {
 	init_cluster
 	init_database
@@ -515,6 +533,7 @@ function run() {
 	DM_DROP_COLUMN_ALL_DONE
 	DM_RECOVER_LOCK
 	DM_DropAddColumn
+	DM_ADD_DROP_PARTITIONS
 	start=36
 	end=45
 	except=(042 044 045)

--- a/dm/tests/shardddl2/run.sh
+++ b/dm/tests/shardddl2/run.sh
@@ -515,7 +515,10 @@ function DM_ADD_DROP_PARTITIONS_CASE() {
 	run_sql_source2 "insert into ${shardddl1}.${tb1} values(4);"
 
 	run_sql_source1 "ALTER TABLE ${shardddl1}.${tb1} ADD PARTITION (partition p1 VALUES LESS THAN (10000))"
-	run_sql_tidb_with_retry "show create table ${shardddl}.${tb}" "PARTITION \`p1\`"
+	run_sql_tidb_with_retry "SELECT count(1) FROM information_schema.partitions WHERE TABLE_SCHEMA='${shardddl}' AND TABLE_NAME = '${tb}' AND PARTITION_NAME IS NOT NULL;" "count(1): 2"
+
+	run_sql_source1 "ALTER TABLE ${shardddl1}.${tb1} DROP PARTITION p1;"
+	run_sql_tidb_with_retry "SELECT count(1) FROM information_schema.partitions WHERE TABLE_SCHEMA='${shardddl}' AND TABLE_NAME = '${tb}' AND PARTITION_NAME IS NOT NULL;" "count(1): 1"
 }
 
 function DM_ADD_DROP_PARTITIONS() {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9788

### What is changed and how it works?
- if a DDL not effect table schema, sync it directly

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
