### PR TITLE
puller(cdc): enlarge table resolved ts buffer size

### DIFF
--- a/cdc/puller/multiplexing_puller.go
+++ b/cdc/puller/multiplexing_puller.go
@@ -35,6 +35,10 @@ import (
 const (
 	resolveLockFence        time.Duration = 20 * time.Second
 	resolveLockTickInterval time.Duration = 10 * time.Second
+
+	// Suppose there are 50K tables, total size of `resolvedEventsCache`s will be
+	// unsafe.SizeOf(kv.MultiplexingEvent) * 50K * 256 = 800M.
+	tableResolvedTsBufferSize int = 256
 )
 
 type tableProgress struct {
@@ -150,7 +154,7 @@ func (p *MultiplexingPuller) subscribe(spans []tablepb.Span, startTs model.Ts, t
 		startTs:    startTs,
 		tableName:  tableName,
 
-		resolvedEventsCache: make(chan kv.MultiplexingEvent, 16),
+		resolvedEventsCache: make(chan kv.MultiplexingEvent, tableResolvedTsBufferSize),
 		tsTracker:           frontier.NewFrontier(0, spans...),
 	}
 	progress.initialized.Store(false)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9815 .

### What is changed and how it works?

Enlarge table resolved ts buffer size from `16` to `256`. It will be enough for most cases, even if the table contains 100K regions.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
