### PR TITLE
Removed String() call in favor of variable substitution.

### DIFF
--- a/dm/pkg/binlog/position.go
+++ b/dm/pkg/binlog/position.go
@@ -365,9 +365,14 @@ func IsFreshPosition(location Location, flavor string, cmpGTID bool) bool {
 //	-1, true if gSet1 is less than gSet2
 //
 // but if can't compare gSet1 and gSet2, will returns 0, false.
+var (
+ 	emptyMySQLGTIDSet, _   = gmysql.ParseMysqlGTIDSet("")
+ 	emptyMariaDBGTIDSet, _ = gmysql.ParseMariadbGTIDSet("")
+)
+
 func CompareGTID(gSet1, gSet2 gmysql.GTIDSet) (int, bool) {
-	gSetIsEmpty1 := gSet1 == nil || len(gSet1.String()) == 0
-	gSetIsEmpty2 := gSet2 == nil || len(gSet2.String()) == 0
+	gSetIsEmpty1 := gSet1 == nil || gSet1.Equal(emptyMySQLGTIDSet) || gSet1.Equal(emptyMariaDBGTIDSet)
+ 	gSetIsEmpty2 := gSet2 == nil || gSet2.Equal(emptyMySQLGTIDSet) || gSet2.Equal(emptyMariaDBGTIDSet)
 
 	switch {
 	case gSetIsEmpty1 && gSetIsEmpty2:

--- a/dm/pkg/binlog/position.go
+++ b/dm/pkg/binlog/position.go
@@ -366,13 +366,17 @@ func IsFreshPosition(location Location, flavor string, cmpGTID bool) bool {
 //
 // but if can't compare gSet1 and gSet2, will returns 0, false.
 var (
- 	emptyMySQLGTIDSet, _   = gmysql.ParseMysqlGTIDSet("")
- 	emptyMariaDBGTIDSet, _ = gmysql.ParseMariadbGTIDSet("")
+	emptyMySQLGTIDSet, _   = gmysql.ParseMysqlGTIDSet("")
+	emptyMariaDBGTIDSet, _ = gmysql.ParseMariadbGTIDSet("")
 )
 
+func CheckGTIDSetEmpty(gSet gmysql.GTIDSet) bool {
+	return gSet == nil || gSet.Equal(emptyMySQLGTIDSet) || gSet.Equal(emptyMariaDBGTIDSet)
+}
+
 func CompareGTID(gSet1, gSet2 gmysql.GTIDSet) (int, bool) {
-	gSetIsEmpty1 := gSet1 == nil || gSet1.Equal(emptyMySQLGTIDSet) || gSet1.Equal(emptyMariaDBGTIDSet)
- 	gSetIsEmpty2 := gSet2 == nil || gSet2.Equal(emptyMySQLGTIDSet) || gSet2.Equal(emptyMariaDBGTIDSet)
+	gSetIsEmpty1 := CheckGTIDSetEmpty(gSet1)
+	gSetIsEmpty2 := CheckGTIDSetEmpty(gSet2)
 
 	switch {
 	case gSetIsEmpty1 && gSetIsEmpty2:

--- a/dm/syncer/checkpoint.go
+++ b/dm/syncer/checkpoint.go
@@ -675,7 +675,7 @@ func (cp *RemoteCheckPoint) IsOlderThanTablePoint(table *filter.Table, location 
 	}
 	oldLocation := point.MySQLLocation()
 	// if we update enable-gtid = false to true, we need to compare binlog position instead of GTID before we save table point
-	cmpGTID := cp.cfg.EnableGTID && !(oldLocation.GTIDSetStr() == "" && binlog.ComparePosition(oldLocation.Position, binlog.MinPosition) > 0)
+	cmpGTID := cp.cfg.EnableGTID && !(oldLocation.GetGTID() == emptyMySQLGTIDSet && binlog.ComparePosition(oldLocation.Position, binlog.MinPosition) > 0)
 	cp.logCtx.L().Debug("compare table location whether is newer", zap.Stringer("location", location), zap.Stringer("old location", oldLocation), zap.Bool("cmpGTID", cmpGTID))
 
 	return binlog.CompareLocation(location, oldLocation, cmpGTID) <= 0

--- a/dm/syncer/checkpoint.go
+++ b/dm/syncer/checkpoint.go
@@ -675,7 +675,7 @@ func (cp *RemoteCheckPoint) IsOlderThanTablePoint(table *filter.Table, location 
 	}
 	oldLocation := point.MySQLLocation()
 	// if we update enable-gtid = false to true, we need to compare binlog position instead of GTID before we save table point
-	cmpGTID := cp.cfg.EnableGTID && !(oldLocation.GetGTID() == emptyMySQLGTIDSet && binlog.ComparePosition(oldLocation.Position, binlog.MinPosition) > 0)
+	cmpGTID := cp.cfg.EnableGTID && !(binlog.CheckGTIDSetEmpty(oldLocation.GetGTID()) && binlog.ComparePosition(oldLocation.Position, binlog.MinPosition) > 0)
 	cp.logCtx.L().Debug("compare table location whether is newer", zap.Stringer("location", location), zap.Stringer("old location", oldLocation), zap.Bool("cmpGTID", cmpGTID))
 
 	return binlog.CompareLocation(location, oldLocation, cmpGTID) <= 0

--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -72,6 +72,8 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
+
+	gmysql "github.com/go-mysql-org/go-mysql/mysql"
 )
 
 var (
@@ -3447,6 +3449,10 @@ func (s *Syncer) handleEventError(err error, startLocation, endLocation binlog.L
 	return terror.Annotatef(err, "startLocation: [%s], endLocation: [%s]", startLocation, endLocation)
 }
 
+var (
+	emptyMySQLGTIDSet, _ = gmysql.ParseMysqlGTIDSet("")
+)
+
 func (s *Syncer) adjustGlobalPointGTID(tctx *tcontext.Context) (bool, error) {
 	location := s.checkpoint.GlobalPoint()
 	// situations that don't need to adjust
@@ -3454,7 +3460,7 @@ func (s *Syncer) adjustGlobalPointGTID(tctx *tcontext.Context) (bool, error) {
 	// 2. location already has GTID position
 	// 3. location is totally new, has no position info
 	// 4. location is too early thus not a COMMIT location, which happens when it's reset by other logic
-	if !s.cfg.EnableGTID || location.GTIDSetStr() != "" || location.Position.Name == "" || location.Position.Pos == 4 {
+	if !s.cfg.EnableGTID || location.GetGTID() != emptyMySQLGTIDSet || location.Position.Name == "" || location.Position.Pos == 4 {
 		return false, nil
 	}
 	// set enableGTID to false for new streamerController

--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -72,8 +72,6 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
-
-	gmysql "github.com/go-mysql-org/go-mysql/mysql"
 )
 
 var (
@@ -3449,10 +3447,6 @@ func (s *Syncer) handleEventError(err error, startLocation, endLocation binlog.L
 	return terror.Annotatef(err, "startLocation: [%s], endLocation: [%s]", startLocation, endLocation)
 }
 
-var (
-	emptyMySQLGTIDSet, _ = gmysql.ParseMysqlGTIDSet("")
-)
-
 func (s *Syncer) adjustGlobalPointGTID(tctx *tcontext.Context) (bool, error) {
 	location := s.checkpoint.GlobalPoint()
 	// situations that don't need to adjust
@@ -3460,7 +3454,7 @@ func (s *Syncer) adjustGlobalPointGTID(tctx *tcontext.Context) (bool, error) {
 	// 2. location already has GTID position
 	// 3. location is totally new, has no position info
 	// 4. location is too early thus not a COMMIT location, which happens when it's reset by other logic
-	if !s.cfg.EnableGTID || location.GetGTID() != emptyMySQLGTIDSet || location.Position.Name == "" || location.Position.Pos == 4 {
+	if !s.cfg.EnableGTID || !binlog.CheckGTIDSetEmpty(location.GetGTID()) || location.Position.Name == "" || location.Position.Pos == 4 {
 		return false, nil
 	}
 	// set enableGTID to false for new streamerController


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9676 

### What is changed and how it works?

Substitute String() call for variable comparison:
emptyMySQLGTIDSet, _   = gmysql.ParseMysqlGTIDSet("")
emptyMariaDBGTIDSet, _ = gmysql.ParseMariadbGTIDSet("")
to speed up algorithm. 
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No.
##### Do you need to update user documentation, design documentation or monitoring documentation?
No.
### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
