### PR TITLE
client(cdc): use a small backoff to load regions

### DIFF
--- a/cdc/kv/shared_client.go
+++ b/cdc/kv/shared_client.go
@@ -444,7 +444,7 @@ func (s *SharedClient) divideAndScheduleRegions(
 	backoffBeforeLoad := false
 	for {
 		if backoffBeforeLoad {
-			if err := util.Hang(ctx, 5*time.Second); err != nil {
+			if err := util.Hang(ctx, loadRegionRetryInterval); err != nil {
 				return err
 			}
 			backoffBeforeLoad = false
@@ -794,6 +794,7 @@ var (
 )
 
 const (
-	resolveLockMinInterval time.Duration  = 10 * time.Second
-	invalidSubscriptionID  SubscriptionID = SubscriptionID(0)
+	loadRegionRetryInterval time.Duration  = 100 * time.Millisecond
+	resolveLockMinInterval  time.Duration  = 10 * time.Second
+	invalidSubscriptionID   SubscriptionID = SubscriptionID(0)
 )

--- a/cdc/kv/shared_stream.go
+++ b/cdc/kv/shared_stream.go
@@ -104,6 +104,10 @@ func newStream(ctx context.Context, c *SharedClient, g *errgroup.Group, r *reque
 			// Why we need to re-schedule pending regions? This because the store can
 			// fail forever, and all regions are scheduled to other stores.
 			for _, sri := range stream.clearPendingRegions() {
+				if sri.lockedRange == nil {
+					// It means it's a special task for stopping the table.
+					continue
+				}
 				c.onRegionFail(newRegionErrorInfo(sri, &sendRequestToStoreErr{}))
 			}
 			if err := util.Hang(ctx, time.Second); err != nil {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9841 

### What is changed and how it works?

* reduce backoff of loading regions from `5s` to `100ms`;
* fix a nil pointer panic;

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
