### PR TITLE
cdc: disable kv-client.enable-multiplexing by default

### DIFF
--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -160,7 +160,7 @@ func TestParseCfg(t *testing.T) {
 			CertAllowedCN: []string{"dd", "ee"},
 		},
 		KVClient: &config.KVClientConfig{
-			EnableMultiplexing:   true,
+			EnableMultiplexing:   false,
 			WorkerConcurrent:     8,
 			GrpcStreamConcurrent: 1,
 			FrontierConcurrent:   8,
@@ -300,7 +300,7 @@ check-balance-interval = "10s"
 		},
 		Security: &config.SecurityConfig{},
 		KVClient: &config.KVClientConfig{
-			EnableMultiplexing:   true,
+			EnableMultiplexing:   false,
 			WorkerConcurrent:     8,
 			GrpcStreamConcurrent: 1,
 			FrontierConcurrent:   8,
@@ -430,7 +430,7 @@ cert-allowed-cn = ["dd","ee"]
 			CertAllowedCN: []string{"dd", "ee"},
 		},
 		KVClient: &config.KVClientConfig{
-			EnableMultiplexing:   true,
+			EnableMultiplexing:   false,
 			WorkerConcurrent:     8,
 			GrpcStreamConcurrent: 1,
 			FrontierConcurrent:   8,

--- a/pkg/config/config_test_data.go
+++ b/pkg/config/config_test_data.go
@@ -119,7 +119,7 @@ const (
   },
   "per-table-memory-quota": 0,
   "kv-client": {
-    "enable-multiplexing": true,
+    "enable-multiplexing": false,
     "worker-concurrent": 8,
     "grpc-stream-concurrent": 1,
     "frontier-concurrent": 8,

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -111,7 +111,7 @@ var defaultServerConfig = &ServerConfig{
 	},
 	Security: &SecurityConfig{},
 	KVClient: &KVClientConfig{
-		EnableMultiplexing:   true,
+		EnableMultiplexing:   false,
 		WorkerConcurrent:     8,
 		GrpcStreamConcurrent: 1,
 		FrontierConcurrent:   8,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9673 

### What is changed and how it works?

Disable kv-client.enable-multiplexing by default.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
