### PR TITLE
p2p(ticdc): remove etcd dependency from p2p agent

### DIFF
--- a/cdc/processor/manager.go
+++ b/cdc/processor/manager.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tiflow/pkg/config"
 	cdcContext "github.com/pingcap/tiflow/pkg/context"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
+	"github.com/pingcap/tiflow/pkg/etcd"
 	"github.com/pingcap/tiflow/pkg/orchestrator"
 	"github.com/pingcap/tiflow/pkg/upstream"
 	"github.com/prometheus/client_golang/prometheus"
@@ -74,6 +75,7 @@ type managerImpl struct {
 		*model.Liveness,
 		uint64,
 		*config.SchedulerConfig,
+		etcd.OwnerCaptureInfoClient,
 	) *processor
 	cfg *config.SchedulerConfig
 
@@ -129,7 +131,7 @@ func (m *managerImpl) Tick(stdCtx context.Context, state orchestrator.ReactorSta
 			p = m.newProcessor(
 				changefeedState.Info, changefeedState.Status,
 				m.captureInfo, changefeedID, up, m.liveness,
-				currentChangefeedEpoch, &cfg)
+				currentChangefeedEpoch, &cfg, ctx.GlobalVars().EtcdClient)
 			m.processors[changefeedID] = p
 		}
 		ctx := cdcContext.WithChangefeedVars(ctx, &cdcContext.ChangefeedVars{

--- a/cdc/processor/manager_test.go
+++ b/cdc/processor/manager_test.go
@@ -55,8 +55,9 @@ func NewManager4Test(
 		liveness *model.Liveness,
 		changefeedEpoch uint64,
 		cfg *config.SchedulerConfig,
+		client etcd.OwnerCaptureInfoClient,
 	) *processor {
-		return newProcessor4Test(t, info, status, captureInfo, m.liveness, cfg, false)
+		return newProcessor4Test(t, info, status, captureInfo, m.liveness, cfg, false, client)
 	}
 	return m
 }

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pingcap/tiflow/pkg/config"
 	cdcContext "github.com/pingcap/tiflow/pkg/context"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
+	"github.com/pingcap/tiflow/pkg/etcd"
 	"github.com/pingcap/tiflow/pkg/filter"
 	"github.com/pingcap/tiflow/pkg/pdutil"
 	"github.com/pingcap/tiflow/pkg/retry"
@@ -92,6 +93,7 @@ type processor struct {
 	lazyInit func(ctx cdcContext.Context) error
 	newAgent func(
 		context.Context, *model.Liveness, uint64, *config.SchedulerConfig,
+		etcd.OwnerCaptureInfoClient,
 	) (scheduler.Agent, error)
 	cfg *config.SchedulerConfig
 
@@ -105,6 +107,8 @@ type processor struct {
 	// we can refactor this step by step.
 	latestInfo   *model.ChangeFeedInfo
 	latestStatus *model.ChangeFeedStatus
+
+	ownerCaptureInfoClient etcd.OwnerCaptureInfoClient
 
 	metricSyncTableNumGauge      prometheus.Gauge
 	metricSchemaStorageGcTsGauge prometheus.Gauge
@@ -414,6 +418,7 @@ func NewProcessor(
 	liveness *model.Liveness,
 	changefeedEpoch uint64,
 	cfg *config.SchedulerConfig,
+	ownerCaptureInfoClient etcd.OwnerCaptureInfoClient,
 ) *processor {
 	p := &processor{
 		upstream:        up,
@@ -423,6 +428,8 @@ func NewProcessor(
 		changefeedEpoch: changefeedEpoch,
 		latestInfo:      info,
 		latestStatus:    status,
+
+		ownerCaptureInfoClient: ownerCaptureInfoClient,
 
 		metricSyncTableNumGauge: syncTableNumGauge.
 			WithLabelValues(changefeedID.Namespace, changefeedID.ID),
@@ -631,8 +638,7 @@ func (p *processor) lazyInitImpl(etcdCtx cdcContext.Context) (err error) {
 
 	// Bind them so that sourceManager can notify sinkManager.r.
 	p.sourceManager.r.OnResolve(p.sinkManager.r.UpdateReceivedSorterResolvedTs)
-
-	p.agent, err = p.newAgent(prcCtx, p.liveness, p.changefeedEpoch, p.cfg)
+	p.agent, err = p.newAgent(prcCtx, p.liveness, p.changefeedEpoch, p.cfg, p.ownerCaptureInfoClient)
 	if err != nil {
 		return err
 	}
@@ -651,14 +657,14 @@ func (p *processor) newAgentImpl(
 	liveness *model.Liveness,
 	changefeedEpoch uint64,
 	cfg *config.SchedulerConfig,
+	client etcd.OwnerCaptureInfoClient,
 ) (ret scheduler.Agent, err error) {
 	messageServer := p.globalVars.MessageServer
 	messageRouter := p.globalVars.MessageRouter
-	etcdClient := p.globalVars.EtcdClient
 	captureID := p.globalVars.CaptureInfo.ID
 	ret, err = scheduler.NewAgent(
 		ctx, captureID, liveness,
-		messageServer, messageRouter, etcdClient, p, p.changefeedID,
+		messageServer, messageRouter, client, p, p.changefeedID,
 		changefeedEpoch, cfg)
 	return ret, errors.Trace(err)
 }

--- a/cdc/processor/processor_test.go
+++ b/cdc/processor/processor_test.go
@@ -50,6 +50,7 @@ func newProcessor4Test(
 	liveness *model.Liveness,
 	cfg *config.SchedulerConfig,
 	enableRedo bool,
+	client etcd.OwnerCaptureInfoClient,
 ) *processor {
 	changefeedID := model.ChangeFeedID4Test("processor-test", "processor-test")
 	up := upstream.NewUpstream4Test(&sinkmanager.MockPD{})
@@ -57,7 +58,7 @@ func newProcessor4Test(
 		info,
 		status,
 		captureInfo,
-		changefeedID, up, liveness, 0, cfg)
+		changefeedID, up, liveness, 0, cfg, client)
 	// Some cases want to send errors to the processor without initializing it.
 	p.sinkManager.errors = make(chan error, 16)
 	p.lazyInit = func(ctx cdcContext.Context) error {
@@ -164,7 +165,7 @@ func initProcessor4Test(
 			etcd.DefaultClusterAndNamespacePrefix,
 			ctx.ChangefeedVars().ID.ID): `{"resolved-ts":0,"checkpoint-ts":0,"admin-job-type":0}`,
 	})
-	p := newProcessor4Test(t, changefeed.Info, changefeed.Status, captureInfo, liveness, cfg, enableRedo)
+	p := newProcessor4Test(t, changefeed.Info, changefeed.Status, captureInfo, liveness, cfg, enableRedo, nil)
 
 	return p, tester, changefeed
 }

--- a/cdc/scheduler/rexport.go
+++ b/cdc/scheduler/rexport.go
@@ -67,7 +67,7 @@ func NewAgent(
 	liveness *model.Liveness,
 	messageServer *p2p.MessageServer,
 	messageRouter p2p.MessageRouter,
-	etcdClient etcd.CDCEtcdClient,
+	ownerInfoClient etcd.OwnerCaptureInfoClient,
 	executor TableExecutor,
 	changefeedID model.ChangeFeedID,
 	changefeedEpoch uint64,
@@ -75,7 +75,7 @@ func NewAgent(
 ) (Agent, error) {
 	return v3agent.NewAgent(
 		ctx, captureID, liveness, changefeedID,
-		messageServer, messageRouter, etcdClient, executor, changefeedEpoch, cfg)
+		messageServer, messageRouter, ownerInfoClient, executor, changefeedEpoch, cfg)
 }
 
 // NewScheduler returns two-phase scheduler.

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -97,17 +97,22 @@ func MigrateBackupKey(version int, backupKey string) string {
 	return fmt.Sprintf("%s/%d/%s", migrateBackupPrefix, version, backupKey)
 }
 
-// CDCEtcdClient extracts CDCEtcdClients's method used for apiv2.
-type CDCEtcdClient interface {
-	GetClusterID() string
-
-	GetEtcdClient() *Client
-
+// OwnerCaptureInfoClient is the sub interface of CDCEtcdClient that used for get owner capture information
+type OwnerCaptureInfoClient interface {
 	GetOwnerID(context.Context) (model.CaptureID, error)
 
 	GetOwnerRevision(context.Context, model.CaptureID) (int64, error)
 
 	GetCaptures(context.Context) (int64, []*model.CaptureInfo, error)
+}
+
+// CDCEtcdClient extracts CDCEtcdClients's method used for apiv2.
+type CDCEtcdClient interface {
+	OwnerCaptureInfoClient
+
+	GetClusterID() string
+
+	GetEtcdClient() *Client
 
 	GetAllCDCInfo(ctx context.Context) ([]*mvccpb.KeyValue, error)
 

--- a/pkg/etcd/mock/etcd_client_mock.go
+++ b/pkg/etcd/mock/etcd_client_mock.go
@@ -15,6 +15,75 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
+// MockOwnerCaptureInfoClient is a mock of OwnerCaptureInfoClient interface.
+type MockOwnerCaptureInfoClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockOwnerCaptureInfoClientMockRecorder
+}
+
+// MockOwnerCaptureInfoClientMockRecorder is the mock recorder for MockOwnerCaptureInfoClient.
+type MockOwnerCaptureInfoClientMockRecorder struct {
+	mock *MockOwnerCaptureInfoClient
+}
+
+// NewMockOwnerCaptureInfoClient creates a new mock instance.
+func NewMockOwnerCaptureInfoClient(ctrl *gomock.Controller) *MockOwnerCaptureInfoClient {
+	mock := &MockOwnerCaptureInfoClient{ctrl: ctrl}
+	mock.recorder = &MockOwnerCaptureInfoClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockOwnerCaptureInfoClient) EXPECT() *MockOwnerCaptureInfoClientMockRecorder {
+	return m.recorder
+}
+
+// GetCaptures mocks base method.
+func (m *MockOwnerCaptureInfoClient) GetCaptures(arg0 context.Context) (int64, []*model.CaptureInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCaptures", arg0)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].([]*model.CaptureInfo)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetCaptures indicates an expected call of GetCaptures.
+func (mr *MockOwnerCaptureInfoClientMockRecorder) GetCaptures(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCaptures", reflect.TypeOf((*MockOwnerCaptureInfoClient)(nil).GetCaptures), arg0)
+}
+
+// GetOwnerID mocks base method.
+func (m *MockOwnerCaptureInfoClient) GetOwnerID(arg0 context.Context) (model.CaptureID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOwnerID", arg0)
+	ret0, _ := ret[0].(model.CaptureID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOwnerID indicates an expected call of GetOwnerID.
+func (mr *MockOwnerCaptureInfoClientMockRecorder) GetOwnerID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOwnerID", reflect.TypeOf((*MockOwnerCaptureInfoClient)(nil).GetOwnerID), arg0)
+}
+
+// GetOwnerRevision mocks base method.
+func (m *MockOwnerCaptureInfoClient) GetOwnerRevision(arg0 context.Context, arg1 model.CaptureID) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOwnerRevision", arg0, arg1)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOwnerRevision indicates an expected call of GetOwnerRevision.
+func (mr *MockOwnerCaptureInfoClientMockRecorder) GetOwnerRevision(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOwnerRevision", reflect.TypeOf((*MockOwnerCaptureInfoClient)(nil).GetOwnerRevision), arg0, arg1)
+}
+
 // MockCDCEtcdClient is a mock of CDCEtcdClient interface.
 type MockCDCEtcdClient struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9861

### What is changed and how it works?
1. define an interface to return owner-capture information
2. init processor with that interface


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
