### PR TITLE
metadata(cdc): implement sql UUID generator and refactor client

### DIFF
--- a/cdcv2/metadata/metadata.go
+++ b/cdcv2/metadata/metadata.go
@@ -24,7 +24,11 @@ import (
 // Querier is used to query information from metadata storage.
 type Querier interface {
 	// GetChangefeeds queries some or all changefeeds.
-	GetChangefeeds(...ChangefeedUUID) ([]*ChangefeedInfo, error)
+	GetChangefeed(...ChangefeedUUID) ([]*ChangefeedInfo, error)
+	// GetChangefeedState queries some or all changefeed states.
+	GetChangefeedState(...ChangefeedUUID) ([]*ChangefeedState, error)
+	// GetChangefeedProgress queries some or all changefeed progresses.
+	GetChangefeedProgress(...ChangefeedUUID) (map[ChangefeedUUID]ChangefeedProgress, error)
 }
 
 // -------------------- About owner schedule -------------------- //

--- a/cdcv2/metadata/metadata.go
+++ b/cdcv2/metadata/metadata.go
@@ -82,7 +82,10 @@ type CaptureObservation interface {
 	// OwnerChanges fetch owner modifications.
 	OwnerChanges() <-chan ScheduledChangefeed
 
-	// PostOwnerRemoved when an owner exits, inform the metadata storage.
+	// OnOwnerLaunched create an owner observation for a changefeed owner.
+	OnOwnerLaunched(cf ChangefeedUUID) OwnerObservation
+
+	// PostOwnerRemoved inform the metadata storage when an owner exits.
 	PostOwnerRemoved(cf ChangefeedUUID, taskPosition ChangefeedProgress) error
 }
 
@@ -120,7 +123,7 @@ type ControllerObservation interface {
 // All intrefaces are thread-safe and shares one same Context.
 type OwnerObservation interface {
 	// Self returns the changefeed info of the owner.
-	Self() *ChangefeedInfo
+	Self() ChangefeedUUID
 
 	// UpdateChangefeed updates changefeed metadata, must be called on a paused one.
 	UpdateChangefeed(*ChangefeedInfo) error

--- a/cdcv2/metadata/model.go
+++ b/cdcv2/metadata/model.go
@@ -148,16 +148,16 @@ func (s SchedState) toString() string {
 }
 
 // nolint
-func (s SchedState) fromString(str string) error {
+func (s *SchedState) fromString(str string) error {
 	switch str {
 	case "Launched":
-		s = SchedLaunched
+		*s = SchedLaunched
 	case "Removing":
-		s = SchedRemoving
+		*s = SchedRemoving
 	case "Removed":
-		s = SchedRemoved
+		*s = SchedRemoved
 	default:
-		s = SchedInvalid
+		*s = SchedInvalid
 		return errors.New("unreachable")
 	}
 	return nil

--- a/cdcv2/metadata/sql/client.go
+++ b/cdcv2/metadata/sql/client.go
@@ -181,8 +181,6 @@ type clientOptions struct {
 	maxExecTime time.Duration
 }
 
-type ClientOptionFunc func(*clientOptions)
-
 func setClientOptions(opts ...ClientOptionFunc) *clientOptions {
 	o := &clientOptions{
 		maxExecTime: defaultMaxExecTime,
@@ -193,6 +191,10 @@ func setClientOptions(opts ...ClientOptionFunc) *clientOptions {
 	return o
 }
 
+// ClientOptionFunc is the option function for the client.
+type ClientOptionFunc func(*clientOptions)
+
+// WithMaxExecTime sets the maximum execution time of the client.
 func WithMaxExecTime(d time.Duration) ClientOptionFunc {
 	return func(o *clientOptions) {
 		o.maxExecTime = d

--- a/cdcv2/metadata/sql/client.go
+++ b/cdcv2/metadata/sql/client.go
@@ -85,6 +85,7 @@ type changefeedStateClient[T TxnContext] interface {
 	queryChangefeedStates(tx T) ([]*ChangefeedStateDO, error)
 	queryChangefeedStatesByUpdateAt(tx T, lastUpdateAt time.Time) ([]*ChangefeedStateDO, error)
 	queryChangefeedStateByUUID(tx T, uuid uint64) (*ChangefeedStateDO, error)
+	queryChangefeedStateByUUIDs(tx T, uuid ...uint64) ([]*ChangefeedStateDO, error)
 	queryChangefeedStateByUUIDWithLock(tx T, uuid uint64) (*ChangefeedStateDO, error)
 }
 

--- a/cdcv2/metadata/sql/client_orm.go
+++ b/cdcv2/metadata/sql/client_orm.go
@@ -229,7 +229,8 @@ func (c *ormClient) queryChangefeedInfosByUUIDs(tx *gorm.DB, uuids ...uint64) ([
 	infos := []*ChangefeedInfoDO{}
 	ret := tx.Where("uuid in (?)", uuids).Find(&infos)
 	if err := handleSingleOpErr(ret, int64(len(uuids)), "QueryChangefeedInfosByUUIDs"); err != nil {
-		return nil, errors.Trace(err)
+		// TODO: optimize the behavior when some uuids are not found.
+		return infos, errors.Trace(err)
 	}
 	return infos, nil
 }
@@ -324,6 +325,18 @@ func (c *ormClient) queryChangefeedStateByUUID(tx *gorm.DB, uuid uint64) (*Chang
 		return nil, errors.Trace(err)
 	}
 	return state, nil
+}
+
+// queryChangefeedStateByUUIDs implements the changefeedStateClient interface.
+// nolint:unused
+func (c *ormClient) queryChangefeedStateByUUIDs(tx *gorm.DB, uuids ...uint64) ([]*ChangefeedStateDO, error) {
+	states := []*ChangefeedStateDO{}
+	ret := tx.Where("uuid in (?)", uuids).Find(&states)
+	if err := handleSingleOpErr(ret, int64(len(uuids)), "QueryChangefeedInfosByUUIDs"); err != nil {
+		// TODO: optimize the behavior when some uuids are not found.
+		return states, errors.Trace(err)
+	}
+	return states, nil
 }
 
 // queryChangefeedStateByUUIDWithLock implements the changefeedStateClient interface.

--- a/cdcv2/metadata/sql/client_orm.go
+++ b/cdcv2/metadata/sql/client_orm.go
@@ -55,7 +55,7 @@ func (c *ormClient) Txn(ctx context.Context, fn ormTxnAction) error {
 }
 
 // TxnWithOwnerLock executes the given transaction action in a transaction with owner lock.
-func (c *ormClient) TxnWithOwnerLock(ctx context.Context, uuid uint64, fn ormTxnAction) error {
+func (c *ormClient) TxnWithOwnerLock(ctx context.Context, uuid metadata.ChangefeedUUID, fn ormTxnAction) error {
 	return c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		sc := &ScheduleDO{}
 		ret := tx.Where("changefeed_uuid = ? and owner = ? and owner_state != ?", uuid, c.selfID, metadata.SchedRemoved).

--- a/cdcv2/metadata/sql/client_orm.go
+++ b/cdcv2/metadata/sql/client_orm.go
@@ -27,9 +27,8 @@ import (
 )
 
 var (
-	_ client[*gorm.DB] = &ormClient{}
+	_ checker[*gorm.DB] = &ormClient{}
 
-	_ checker[*gorm.DB]               = &ormClient{}
 	_ upstreamClient[*gorm.DB]        = &ormClient{}
 	_ changefeedInfoClient[*gorm.DB]  = &ormClient{}
 	_ changefeedStateClient[*gorm.DB] = &ormClient{}

--- a/cdcv2/metadata/sql/client_orm.go
+++ b/cdcv2/metadata/sql/client_orm.go
@@ -58,7 +58,7 @@ func (c *ormClient) Txn(ctx context.Context, fn ormTxnAction) error {
 func (c *ormClient) TxnWithOwnerLock(ctx context.Context, uuid uint64, fn ormTxnAction) error {
 	return c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		sc := &ScheduleDO{}
-		ret := tx.Where("changefeed_uuid = ? and owner = ? and owner_state != removed", uuid, c.selfID).
+		ret := tx.Where("changefeed_uuid = ? and owner = ? and owner_state != ?", uuid, c.selfID, metadata.SchedRemoved).
 			Clauses(clause.Locking{
 				Strength: "SHARE",
 				Table:    clause.Table{Name: clause.CurrentTable},

--- a/cdcv2/metadata/sql/observation.go
+++ b/cdcv2/metadata/sql/observation.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ngaut/log"
+	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdcv2/metadata"
 	ormUtil "github.com/pingcap/tiflow/engine/pkg/orm"

--- a/cdcv2/metadata/sql/uuid.go
+++ b/cdcv2/metadata/sql/uuid.go
@@ -14,17 +14,23 @@
 package sql
 
 import (
+	"context"
 	"hash"
 	"hash/crc64"
 	"hash/fnv"
+	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/pingcap/tiflow/cdcv2/metadata"
+	"github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type uuidGenerator interface {
-	GenChangefeedUUID() metadata.ChangefeedUUID
+	GenChangefeedUUID(ctx context.Context) (metadata.ChangefeedUUID, error)
 }
 
 // NewUUIDGenerator creates a new UUID generator.
@@ -50,8 +56,8 @@ func newMockUUIDGenerator() uuidGenerator {
 }
 
 // GenChangefeedUUID implements uuidGenerator interface.
-func (g *mockUUIDGenerator) GenChangefeedUUID() metadata.ChangefeedUUID {
-	return g.epoch.Add(1)
+func (g *mockUUIDGenerator) GenChangefeedUUID(ctx context.Context) (metadata.ChangefeedUUID, error) {
+	return g.epoch.Add(1), nil
 }
 
 type randomUUIDGenerator struct {
@@ -67,11 +73,82 @@ func newRandomUUIDGenerator(hasher hash.Hash64) uuidGenerator {
 }
 
 // GenChangefeedUUID implements uuidGenerator interface.
-func (g *randomUUIDGenerator) GenChangefeedUUID() metadata.ChangefeedUUID {
-	g.hasher = crc64.New(crc64.MakeTable(crc64.ISO))
+func (g *randomUUIDGenerator) GenChangefeedUUID(ctx context.Context) (metadata.ChangefeedUUID, error) {
 	g.hasher.Reset()
 	g.hasher.Write([]byte(g.uuidGen.NewString()))
-	return g.hasher.Sum64()
+	return g.hasher.Sum64(), nil
 }
 
 // TODO: implement sql based UUID generator.
+
+const tableNameLogicEpoch = "logic_epoch"
+const taskCDCChangefeedUUID = "cdc-changefeed-uuid"
+
+type logicEpochDO struct {
+	TaskID string `gorm:"column:task_id;type:varchar(128);primaryKey json:"task_id""`
+	Epoch  uint64 `gorm:"column:epoch;type:bigint(20) unsigned;not null" json:"epoch"`
+
+	CreatedAt time.Time `json:"created-at"`
+	UpdatedAt time.Time `json:"updated-at"`
+}
+
+func (l *logicEpochDO) TableName() string {
+	return tableNameLogicEpoch
+}
+
+type ormUUIDGenerator struct {
+	db     *gorm.DB
+	taskID string
+
+	once sync.Once
+}
+
+func newORMUUIDGenerator(taskID string, db *gorm.DB) uuidGenerator {
+	return &ormUUIDGenerator{
+		db:     db,
+		taskID: taskID,
+	}
+}
+
+func (g *ormUUIDGenerator) initlize(ctx context.Context) error {
+	// Do nothing on conflict
+	if err := g.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).
+		Create(&logicEpochDO{
+			TaskID: g.taskID,
+			Epoch:  0,
+		}).Error; err != nil {
+		return errors.WrapError(errors.ErrMetaOpFailed, err, "ormUUIDGeneratorInitlize")
+	}
+	return nil
+}
+
+func (g *ormUUIDGenerator) GenChangefeedUUID(ctx context.Context) (metadata.ChangefeedUUID, error) {
+	var err error
+	g.once.Do(func() {
+		err = g.initlize(ctx)
+	})
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+
+	var uuidDO *logicEpochDO
+	// every job owns its logic epoch
+	err = g.db.WithContext(ctx).
+		Where("task_id = ?", g.taskID).
+		Transaction(func(tx *gorm.DB) error {
+			if err := tx.Model(uuidDO).
+				Update("epoch", gorm.Expr("epoch + ?", 1)).Error; err != nil {
+				// return any error will rollback
+				return errors.WrapError(errors.ErrMetaOpFailed, err, "GenChangefeedUUID")
+			}
+
+			if err := tx.First(uuidDO).Error; err != nil {
+				return errors.WrapError(errors.ErrMetaOpFailed, err, "GenChangefeedUUID")
+			}
+			return nil
+		})
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	return uuidDO.Epoch, nil
+}

--- a/cdcv2/metadata/sql/uuid.go
+++ b/cdcv2/metadata/sql/uuid.go
@@ -81,8 +81,10 @@ func (g *randomUUIDGenerator) GenChangefeedUUID(ctx context.Context) (metadata.C
 
 // TODO: implement sql based UUID generator.
 
-const tableNameLogicEpoch = "logic_epoch"
-const taskCDCChangefeedUUID = "cdc-changefeed-uuid"
+const (
+	tableNameLogicEpoch   = "logic_epoch"
+	taskCDCChangefeedUUID = "cdc-changefeed-uuid"
+)
 
 type logicEpochDO struct {
 	TaskID string `gorm:"column:task_id;type:varchar(128);primaryKey json:"task_id""`

--- a/cdcv2/metadata/sql/uuid_test.go
+++ b/cdcv2/metadata/sql/uuid_test.go
@@ -1,0 +1,109 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-sql-driver/mysql"
+	"github.com/pingcap/tiflow/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestORMUUIDGeneratorInitFail(t *testing.T) {
+	t.Parallel()
+
+	backendDB, db, mock := newMockDB(t)
+	defer backendDB.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	// auto migrate
+	mock.ExpectQuery("SELECT SCHEMA_NAME from Information_schema.SCHEMATA " +
+		"where SCHEMA_NAME LIKE ? ORDER BY SCHEMA_NAME=? DESC limit 1").WillReturnRows(
+		sqlmock.NewRows([]string{"SCHEMA_NAME"}))
+	mock.ExpectExec("CREATE TABLE `logic_epoch` (`task_id` varchar(128),`epoch` bigint(20) unsigned NOT NULL," +
+		"`created_at` datetime(3) NULL,`updated_at` datetime(3) NULL,PRIMARY KEY (`task_id`))").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	// insert first record fail
+	mock.ExpectExec("INSERT INTO `logic_epoch` (`task_id`,`epoch`,`created_at`,`updated_at`) VALUES " +
+		"(?,?,?,?) ON DUPLICATE KEY UPDATE `task_id`=`task_id`").
+		WillReturnError(&mysql.MySQLError{Number: 1062, Message: "test error"})
+	gen := newORMUUIDGenerator(taskCDCChangefeedUUID, db)
+	uuid, err := gen.GenChangefeedUUID(ctx)
+	require.ErrorIs(t, err, errors.ErrMetaOpFailed)
+	require.ErrorContains(t, err, "test error")
+	require.Equal(t, uint64(0), uuid)
+
+	mock.ExpectClose()
+}
+
+func TestORMUUIDGenerator(t *testing.T) {
+	t.Parallel()
+
+	backendDB, db, mock := newMockDB(t)
+	defer backendDB.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	gen := newORMUUIDGenerator(taskCDCChangefeedUUID, db)
+
+	// auto migrate
+	mock.ExpectQuery("SELECT SCHEMA_NAME from Information_schema.SCHEMATA " +
+		"where SCHEMA_NAME LIKE ? ORDER BY SCHEMA_NAME=? DESC limit 1").WillReturnRows(
+		sqlmock.NewRows([]string{"SCHEMA_NAME"}))
+	mock.ExpectExec("CREATE TABLE `logic_epoch` (`task_id` varchar(128),`epoch` bigint(20) unsigned NOT NULL," +
+		"`created_at` datetime(3) NULL,`updated_at` datetime(3) NULL,PRIMARY KEY (`task_id`))").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	// insert first record
+	mock.ExpectExec("INSERT INTO `logic_epoch` (`task_id`,`epoch`,`created_at`,`updated_at`) VALUES " +
+		"(?,?,?,?) ON DUPLICATE KEY UPDATE `task_id`=`task_id`").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// case 1: update success
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE `logic_epoch` SET `epoch`=epoch + ?,`updated_at`=? WHERE task_id = ?").
+		WithArgs(1, sqlmock.AnyArg(), taskCDCChangefeedUUID).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// select
+	mock.ExpectQuery("SELECT `epoch` FROM `logic_epoch` WHERE task_id = ? LIMIT 1").
+		WithArgs(taskCDCChangefeedUUID).
+		WillReturnRows(sqlmock.NewRows([]string{"epoch"}).AddRow(11))
+	mock.ExpectCommit()
+
+	uuid, err := gen.GenChangefeedUUID(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(11), uuid)
+
+	// case 2: update fail
+	failedErr := errors.New("gen epoch error")
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE `logic_epoch` SET `epoch`=epoch + ?,`updated_at`=? WHERE task_id = ?").
+		WithArgs(1, sqlmock.AnyArg(), taskCDCChangefeedUUID).
+		WillReturnError(failedErr)
+	mock.ExpectRollback()
+	uuid, err = gen.GenChangefeedUUID(ctx)
+	require.ErrorContains(t, err, failedErr.Error())
+	require.Equal(t, uint64(0), uuid)
+
+	mock.ExpectClose()
+}

--- a/errors.toml
+++ b/errors.toml
@@ -1336,6 +1336,11 @@ error = '''
 meta operation fail
 '''
 
+["DFLOW:ErrMetaOpFailed"]
+error = '''
+meta operation %s is failed
+'''
+
 ["DFLOW:ErrMetaOptionConflict"]
 error = '''
 WithRange/WithPrefix/WithFromKey, more than one option are used

--- a/go.mod
+++ b/go.mod
@@ -276,7 +276,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/ncw/directio v1.0.5 // indirect
-	github.com/ngaut/log v0.0.0-20210830112240-0124ec040aeb
+	github.com/ngaut/log v0.0.0-20210830112240-0124ec040aeb // indirect
 	github.com/ngaut/pools v0.0.0-20180318154953-b7bc8c42aac7 // indirect
 	github.com/ngaut/sync2 v0.0.0-20141008032647-7a24ed77b2ef // indirect
 	github.com/opencontainers/runtime-spec v1.0.2 // indirect

--- a/pkg/errors/cdc_errors.go
+++ b/pkg/errors/cdc_errors.go
@@ -954,7 +954,7 @@ var (
 	)
 	ErrMetaOpFailed = errors.Normalize(
 		"meta operation %s is failed",
-		errors.RFCCodeText("DFLOW:ErrMetaOpFail"),
+		errors.RFCCodeText("DFLOW:ErrMetaOpFailed"),
 	)
 	ErrMetaInvalidState = errors.Normalize(
 		"meta state is invalid: %s",


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9871

### What is changed and how it works?
1. Extract [new client interface](https://github.com/pingcap/tiflow/pull/9864/files#diff-df5be604641b0a21457ede9555f4e6e1a3cc86cd74e2759ff48ca0d9700a0739R31-R34) to handle options, such as timeout.
2. Implement [sql-based uuid generator](https://github.com/pingcap/tiflow/pull/9864/files#diff-0147ec4c9f7b5b6ad61d76a4df8479b16bca88b8cf4db9922933bf03ec86929aR99-R154).
3. [Refactor querier interface](https://github.com/pingcap/tiflow/pull/9864/files#diff-a86fba1ff4e22021451169a4baf4122004d7fd5206fd1fafbe06a4ee4dec9175R27-R31).


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
