### PR TITLE
sorter(cdc): fix panics of accessing sort engine

### DIFF
--- a/cdc/processor/sinkmanager/table_sink_worker.go
+++ b/cdc/processor/sinkmanager/table_sink_worker.go
@@ -255,10 +255,7 @@ func (w *sinkWorker) handleTask(ctx context.Context, task *sinkTask) (finalErr e
 			allEventSize += size
 		}
 
-		if err := advancer.tryAdvanceAndAcquireMem(
-			false,
-			pos.Valid(),
-		); err != nil {
+		if err := advancer.tryAdvanceAndAcquireMem(false, pos.Valid()); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/cdc/processor/sinkmanager/table_sink_wrapper.go
+++ b/cdc/processor/sinkmanager/table_sink_wrapper.go
@@ -62,10 +62,12 @@ type tableSinkWrapper struct {
 
 	// state used to control the lifecycle of the table.
 	state *tablepb.TableState
+
 	// startTs is the start ts of the table.
 	startTs model.Ts
 	// targetTs is the upper bound of the table sink.
 	targetTs model.Ts
+
 	// barrierTs is the barrier bound of the table sink.
 	barrierTs atomic.Uint64
 	// receivedSorterResolvedTs is the resolved ts received from the sorter.

--- a/cdc/processor/sourcemanager/engine/pebble/event_sorter_test.go
+++ b/cdc/processor/sourcemanager/engine/pebble/event_sorter_test.go
@@ -179,6 +179,6 @@ func TestCleanData(t *testing.T) {
 
 	span := spanz.TableIDToComparableSpan(1)
 	s.AddTable(span, 0)
-	require.Nil(t, s.CleanByTable(spanz.TableIDToComparableSpan(2), engine.Position{}))
+	require.NoError(t, s.CleanByTable(spanz.TableIDToComparableSpan(2), engine.Position{}))
 	require.Nil(t, s.CleanByTable(span, engine.Position{}))
 }

--- a/cdc/processor/sourcemanager/engine/pebble/event_sorter_test.go
+++ b/cdc/processor/sourcemanager/engine/pebble/event_sorter_test.go
@@ -179,8 +179,6 @@ func TestCleanData(t *testing.T) {
 
 	span := spanz.TableIDToComparableSpan(1)
 	s.AddTable(span, 0)
-	require.Panics(t, func() {
-		s.CleanByTable(spanz.TableIDToComparableSpan(2), engine.Position{})
-	})
+	require.Nil(t, s.CleanByTable(spanz.TableIDToComparableSpan(2), engine.Position{}))
 	require.Nil(t, s.CleanByTable(span, engine.Position{}))
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9849

### What is changed and how it works?

#### Why it panics?

When removing a table, the table can be cleared from `SortEngine` but there is still a task in `tableSinkWorker`. When it tries to create an iterator to access table data, it panics.

#### How to resolve?

When creates an iterator on an unexist table, just returns an empty iterator.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
