### PR TITLE
capture(ticdc): remove reactor from owner and controller interface

### DIFF
--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -517,12 +517,12 @@ func (c *captureImpl) campaignOwner(ctx cdcContext.Context) error {
 		ctx, cancelOwner := context.WithCancel(ctx)
 		ownerCtx := cdcContext.NewContext(ctx, newGlobalVars)
 		g.Go(func() error {
-			return c.runEtcdWorker(ownerCtx, owner,
+			return c.runEtcdWorker(ownerCtx, owner.(orchestrator.Reactor),
 				orchestrator.NewGlobalState(c.EtcdClient.GetClusterID(), c.config.CaptureSessionTTL),
 				ownerFlushInterval, util.RoleOwner.String())
 		})
 		g.Go(func() error {
-			er := c.runEtcdWorker(ownerCtx, controller,
+			er := c.runEtcdWorker(ownerCtx, controller.(orchestrator.Reactor),
 				globalState,
 				// todo: do not use owner flush interval
 				ownerFlushInterval, util.RoleController.String())

--- a/cdc/controller/controller.go
+++ b/cdc/controller/controller.go
@@ -45,7 +45,6 @@ const versionInconsistentLogRate = 1
 
 // Controller is a manager to schedule changefeeds
 type Controller interface {
-	orchestrator.Reactor
 	AsyncStop()
 	GetChangefeedOwnerCaptureInfo(id model.ChangeFeedID) *model.CaptureInfo
 	GetAllChangeFeedInfo(ctx context.Context) (
@@ -63,7 +62,10 @@ type Controller interface {
 	) error
 }
 
-var _ Controller = &controllerImpl{}
+var (
+	_ orchestrator.Reactor = &controllerImpl{}
+	_ Controller           = &controllerImpl{}
+)
 
 type controllerImpl struct {
 	changefeeds     map[model.ChangeFeedID]*orchestrator.ChangefeedReactorState

--- a/cdc/controller/mock/controller_mock.go
+++ b/cdc/controller/mock/controller_mock.go
@@ -10,7 +10,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	model "github.com/pingcap/tiflow/cdc/model"
-	orchestrator "github.com/pingcap/tiflow/pkg/orchestrator"
 )
 
 // MockController is a mock of Controller interface.
@@ -149,19 +148,4 @@ func (m *MockController) IsChangefeedExists(ctx context.Context, id model.Change
 func (mr *MockControllerMockRecorder) IsChangefeedExists(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsChangefeedExists", reflect.TypeOf((*MockController)(nil).IsChangefeedExists), ctx, id)
-}
-
-// Tick mocks base method.
-func (m *MockController) Tick(ctx context.Context, state orchestrator.ReactorState) (orchestrator.ReactorState, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Tick", ctx, state)
-	ret0, _ := ret[0].(orchestrator.ReactorState)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Tick indicates an expected call of Tick.
-func (mr *MockControllerMockRecorder) Tick(ctx, state interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tick", reflect.TypeOf((*MockController)(nil).Tick), ctx, state)
 }

--- a/cdc/owner/mock/owner_mock.go
+++ b/cdc/owner/mock/owner_mock.go
@@ -13,7 +13,6 @@ import (
 	model "github.com/pingcap/tiflow/cdc/model"
 	owner "github.com/pingcap/tiflow/cdc/owner"
 	scheduler "github.com/pingcap/tiflow/cdc/scheduler"
-	orchestrator "github.com/pingcap/tiflow/pkg/orchestrator"
 )
 
 // MockOwner is a mock of Owner interface.
@@ -109,21 +108,6 @@ func (m *MockOwner) ScheduleTable(cfID model.ChangeFeedID, toCapture model.Captu
 func (mr *MockOwnerMockRecorder) ScheduleTable(cfID, toCapture, tableID, done interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleTable", reflect.TypeOf((*MockOwner)(nil).ScheduleTable), cfID, toCapture, tableID, done)
-}
-
-// Tick mocks base method.
-func (m *MockOwner) Tick(ctx context.Context, state orchestrator.ReactorState) (orchestrator.ReactorState, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Tick", ctx, state)
-	ret0, _ := ret[0].(orchestrator.ReactorState)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Tick indicates an expected call of Tick.
-func (mr *MockOwnerMockRecorder) Tick(ctx, state interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tick", reflect.TypeOf((*MockOwner)(nil).Tick), ctx, state)
 }
 
 // UpdateChangefeed mocks base method.

--- a/cdc/owner/owner.go
+++ b/cdc/owner/owner.go
@@ -81,7 +81,6 @@ type ownerJob struct {
 //
 // The interface is thread-safe, except for Tick, it's only used by etcd worker.
 type Owner interface {
-	orchestrator.Reactor
 	EnqueueJob(adminJob model.AdminJob, done chan<- error)
 	RebalanceTables(cfID model.ChangeFeedID, done chan<- error)
 	ScheduleTable(
@@ -132,7 +131,10 @@ type ownerImpl struct {
 	cfg *config.SchedulerConfig
 }
 
-var _ Owner = &ownerImpl{}
+var (
+	_ orchestrator.Reactor = &ownerImpl{}
+	_ Owner                = &ownerImpl{}
+)
 
 // NewOwner creates a new Owner
 func NewOwner(


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9930

### What is changed and how it works?
with meta store,  we can not have the reactor mode to tick the owner or controller,  so remove reactor from owner and controller interface



### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
 `None`.
```
