### PR TITLE
Makefile(ticdc): support build cdc in fips mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ### Makefile for tiflow
-.PHONY: build test check clean fmt cdc kafka_consumer storage_consumer coverage \
+.PHONY: build test check clean fmt cdc cdc_fips kafka_consumer storage_consumer coverage \
 	integration_test_build integration_test integration_test_mysql integration_test_kafka bank \
 	kafka_docker_integration_test kafka_docker_integration_test_with_build \
 	clean_integration_test_containers \
@@ -42,6 +42,7 @@ DM_TEST_DIR := /tmp/dm_test
 ENGINE_TEST_DIR := /tmp/engine_test
 
 GO       := GO111MODULE=on go
+
 ifeq (${CDC_ENABLE_VENDOR}, 1)
 GOVENDORFLAG := -mod=vendor
 endif
@@ -59,6 +60,7 @@ else ifeq (${OS}, "darwin")
 endif
 
 GOBUILD  := CGO_ENABLED=$(CGO) $(GO) build $(BUILD_FLAG) -trimpath $(GOVENDORFLAG)
+GOBUILDFIPS  := CGO_ENABLED=1 GOEXPERIMENT=boringcrypto $(GO) build -tags boringcrypto $(BUILD_FLAG) -trimpath $(GOVENDORFLAG)
 GOBUILDNOVENDOR  := CGO_ENABLED=0 $(GO) build $(BUILD_FLAG) -trimpath
 GOTEST   := CGO_ENABLED=1 $(GO) test -p $(P) --race --tags=intest
 GOTESTNORACE := CGO_ENABLED=1 $(GO) test -p $(P)
@@ -156,6 +158,9 @@ build-cdc-with-failpoint: ## Build cdc with failpoint enabled.
 
 cdc:
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/cdc ./cmd/cdc/main.go
+
+cdc_fips:
+	$(GOBUILDFIPS) -ldflags '$(LDFLAGS)' -o bin/cdc ./cmd/cdc
 
 kafka_consumer:
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/cdc_kafka_consumer ./cmd/kafka-consumer/main.go

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ DM_TEST_DIR := /tmp/dm_test
 ENGINE_TEST_DIR := /tmp/engine_test
 
 GO       := GO111MODULE=on go
-
 ifeq (${CDC_ENABLE_VENDOR}, 1)
 GOVENDORFLAG := -mod=vendor
 endif

--- a/cmd/cdc/fips.go
+++ b/cmd/cdc/fips.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	_ "crypto/tls/fipsonly"
-
+	//
 	"github.com/pingcap/tiflow/pkg/version"
 )
 

--- a/cmd/cdc/fips.go
+++ b/cmd/cdc/fips.go
@@ -1,0 +1,27 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build boringcrypto
+// +build boringcrypto
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+
+	"github.com/pingcap/tiflow/pkg/version"
+)
+
+func init() {
+	version.ReleaseVersion += "-fips"
+}

--- a/pkg/version/check.go
+++ b/pkg/version/check.go
@@ -67,6 +67,7 @@ func SanitizeVersion(v string) string {
 		return v
 	}
 	v = versionHash.ReplaceAllLiteralString(v, "")
+	v = strings.TrimSuffix(v, "-fips")
 	v = strings.TrimSuffix(v, "-dirty")
 	return strings.TrimPrefix(v, "v")
 }

--- a/pkg/version/check_test.go
+++ b/pkg/version/check_test.go
@@ -266,6 +266,10 @@ func TestCompareVersion(t *testing.T) {
 	dirtyVersion := semver.New(SanitizeVersion("v6.3.0-dirty"))
 	require.Equal(t, 1, dirtyVersion.Compare(*MinTiCDCVersion))
 	require.Equal(t, 0, dirtyVersion.Compare(*semver.New("6.3.0")))
+
+	dirtyVersionWithFIPS := semver.New(SanitizeVersion("v6.3.0-dirty-fips"))
+	require.Equal(t, 1, dirtyVersionWithFIPS.Compare(*MinTiCDCVersion))
+	require.Equal(t, 0, dirtyVersionWithFIPS.Compare(*semver.New("6.3.0")))
 }
 
 func TestReleaseSemver(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9962 

### What is changed and how it works?
1. add support to build FIPS-ready cdc binary following the info shown in https://github.com/pingcap/tidb/pull/47949
2. add `-fips` in the release version of FIPS-ready binary
![image](https://github.com/pingcap/tiflow/assets/47731263/6da8ec4f-d5ce-4d60-a151-ea734f4407a4)
3. support sanitize version with `-fips` suffix when do version check


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
    Make sure the version sanitize process works with `-fips` suffix;
 - Manual test (add detailed scripts or steps below)
```
ENABLE_FIPS=1 make cdc
go tool nm bin/cdc | grep boring
```
Check the boringcrypto linked via cgo, some function names like:
```
 6d3aa60 t local.crypto/internal/boring._Cfunc__goboringcrypto_AES_cbc_encrypt.abi0
 6d3abc0 t local.crypto/internal/boring._Cfunc__goboringcrypto_AES_ctr128_encrypt.abi0
 6d3ad20 t local.crypto/internal/boring._Cfunc__goboringcrypto_AES_decrypt.abi0
 6d3ade0 t local.crypto/internal/boring._Cfunc__goboringcrypto_AES_encrypt.abi0
 6d3aea0 t local.crypto/internal/boring._Cfunc__goboringcrypto_AES_set_decrypt_key.abi0
 6d3af80 t local.crypto/internal/boring._Cfunc__goboringcrypto_AES_set_encrypt_key.abi0
 6d3b060 t local.crypto/internal/boring._Cfunc__goboringcrypto_BN_bin2bn.abi0
 6d3b140 t local.crypto/internal/boring._Cfunc__goboringcrypto_BN_bn2bin_padded.abi0
 6d3b220 t local.crypto/internal/boring._Cfunc__goboringcrypto_BN_bn2le_padded.abi0
 6d4cec0 t local.crypto/internal/boring._Cfunc__goboringcrypto_BN_free
 6d3b300 t local.crypto/internal/boring._Cfunc__goboringcrypto_BN_free.abi0
 6d3b380 t local.crypto/internal/boring._Cfunc__goboringcrypto_BN_le2bn.abi0
 6d3b460 t local.crypto/internal/boring._Cfunc__goboringcrypto_BN_new.abi0
 6d3b4c0 t local.crypto/internal/boring._Cfunc__goboringcrypto_BN_num_bytes.abi0
 6d3b540 t local.crypto/internal/boring._Cfunc__goboringcrypto_BORINGSSL_bcm_power_on_self_test.abi0
 6d3b5a0 t local.crypto/internal/boring._Cfunc__goboringcrypto_ECDSA_sign.abi0
 6d3b700 t local.crypto/internal/boring._Cfunc__goboringcrypto_ECDSA_size.abi0
 6d3b780 t local.crypto/internal/boring._Cfunc__goboringcrypto_ECDSA_verify.abi0
 6d4cf00 t local.crypto/internal/boring._Cfunc__goboringcrypto_EC_GROUP_free
 6d3b8e0 t local.crypto/internal/boring._Cfunc__goboringcrypto_EC_GROUP_free.abi0
 6d3b960 t local.crypto/internal/boring._Cfunc__goboringcrypto_EC_GROUP_new_by_curve_name.abi0
 6d4cf40 t local.crypto/internal/boring._Cfunc__goboringcrypto_EC_KEY_free
 6d3ba00 t local.crypto/internal/boring._Cfunc__goboringcrypto_EC_KEY_free.abi0
 6d3ba80 t local.crypto/internal/boring._Cfunc__goboringcrypto_EC_KEY_generate_key_fips.abi0
 6d3bb00 t local.crypto/internal/boring._Cfunc__goboringcrypto_EC_KEY_get0_group.abi0
 6d3bb80 t local.crypto/internal/boring._Cfunc__goboringcrypto_EC_KEY_get0_private_key.abi0
 6d3bc00 t local.crypto/internal/boring._Cfunc__goboringcrypto_EC_KEY_get0_public_key.abi0
 6d3bc80 t local.crypto/internal/boring._Cfunc__goboringcrypto_EC_KEY_new_by_curve_name.abi0
 6d3bd20 t local.crypto/internal/boring._Cfunc__goboringcrypto_EC_KEY_set_private_key.abi0
 6d3bde0 t local.crypto/internal/boring._Cfunc__goboringcrypto_EC_KEY_set_public_key.abi0
 6d4cf80 t local.crypto/internal/boring._Cfunc__goboringcrypto_EC_POINT_free
 6d3bea0 t local.crypto/internal/boring._Cfunc__goboringcrypto_EC_POINT_free.abi0
```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
The original binary should not be affected. But the binary build with FIPS support is expected to be slower.

##### Do you need to update user documentation, design documentation or monitoring documentation?
Need to add contents about the support for FIPS-ready binary and how to download it later;

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Support build fips-ready cdc binary
```
