### PR TITLE
sink(ticdc): add more log and metrics to storage sink

### DIFF
--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -752,6 +752,7 @@ func (c *changefeed) releaseResources(ctx cdcContext.Context) {
 	c.cleanupMetrics()
 	c.schema = nil
 	c.barriers = nil
+	c.resolvedTs = 0
 	c.initialized = false
 	c.isReleased = true
 

--- a/cdc/sink/dmlsink/cloudstorage/cloud_storage_dml_sink.go
+++ b/cdc/sink/dmlsink/cloudstorage/cloud_storage_dml_sink.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/sink/dmlsink"
 	"github.com/pingcap/tiflow/cdc/sink/metrics"
@@ -36,6 +37,7 @@ import (
 	"github.com/pingcap/tiflow/pkg/sink/codec/builder"
 	"github.com/pingcap/tiflow/pkg/sink/codec/common"
 	putil "github.com/pingcap/tiflow/pkg/util"
+	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -208,6 +210,11 @@ func (s *DMLSink) run(ctx context.Context) error {
 			return worker.run(ctx)
 		})
 	}
+
+	log.Info("dml worker started", zap.String("namespace", s.changefeedID.Namespace),
+		zap.String("changefeed", s.changefeedID.ID),
+		zap.Int("workerCount", len(s.workers)),
+		zap.Any("config", s.workers[0].config))
 
 	return eg.Wait()
 }

--- a/cdc/sink/dmlsink/cloudstorage/dml_worker.go
+++ b/cdc/sink/dmlsink/cloudstorage/dml_worker.go
@@ -16,6 +16,7 @@ import (
 	"bytes"
 	"context"
 	"path"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -42,13 +43,16 @@ type dmlWorker struct {
 	storage      storage.ExternalStorage
 	config       *cloudstorage.Config
 	// flushNotifyCh is used to notify that several tables can be flushed.
-	flushNotifyCh     chan dmlTask
-	inputCh           *chann.DrainableChann[eventFragment]
-	isClosed          uint64
-	statistics        *metrics.Statistics
-	filePathGenerator *cloudstorage.FilePathGenerator
-	metricWriteBytes  prometheus.Gauge
-	metricFileCount   prometheus.Gauge
+	flushNotifyCh          chan dmlTask
+	inputCh                *chann.DrainableChann[eventFragment]
+	isClosed               uint64
+	statistics             *metrics.Statistics
+	filePathGenerator      *cloudstorage.FilePathGenerator
+	metricWriteBytes       prometheus.Gauge
+	metricFileCount        prometheus.Gauge
+	metricWriteDuration    prometheus.Observer
+	metricFlushDuration    prometheus.Observer
+	metricsWorkerBusyRatio prometheus.Counter
 }
 
 // dmlTask defines a task containing the tables to be flushed.
@@ -119,6 +123,12 @@ func newDMLWorker(
 			WithLabelValues(changefeedID.Namespace, changefeedID.ID),
 		metricFileCount: mcloudstorage.CloudStorageFileCountGauge.
 			WithLabelValues(changefeedID.Namespace, changefeedID.ID),
+		metricWriteDuration: mcloudstorage.CloudStorageWriteDurationHistogram.
+			WithLabelValues(changefeedID.Namespace, changefeedID.ID),
+		metricFlushDuration: mcloudstorage.CloudStorageFlushDurationHistogram.
+			WithLabelValues(changefeedID.Namespace, changefeedID.ID),
+		metricsWorkerBusyRatio: mcloudstorage.CloudStorageWorkerBusyRatioCounter.
+			WithLabelValues(changefeedID.Namespace, changefeedID.ID, strconv.Itoa(id)),
 	}
 
 	return d
@@ -145,14 +155,25 @@ func (d *dmlWorker) run(ctx context.Context) error {
 // flushMessages flush messages from active tables to cloud storage.
 // active means that a table has events since last flushing.
 func (d *dmlWorker) flushMessages(ctx context.Context) error {
+	var flushTimeSlice, totalTimeSlice time.Duration
+	overseerTicker := time.NewTicker(d.config.FlushInterval * 2)
+	defer overseerTicker.Stop()
+	startToWork := time.Now()
 	for {
 		select {
 		case <-ctx.Done():
 			return errors.Trace(ctx.Err())
+		case now := <-overseerTicker.C:
+			totalTimeSlice = now.Sub(startToWork)
+			busyRatio := flushTimeSlice.Seconds() / totalTimeSlice.Seconds() * 1000
+			d.metricsWorkerBusyRatio.Add(busyRatio)
+			startToWork = now
+			flushTimeSlice = 0
 		case task := <-d.flushNotifyCh:
 			if atomic.LoadUint64(&d.isClosed) == 1 {
 				return nil
 			}
+			start := time.Now()
 			for table, task := range task.tasks {
 				if len(task.msgs) == 0 {
 					continue
@@ -217,12 +238,15 @@ func (d *dmlWorker) flushMessages(ctx context.Context) error {
 					zap.String("path", dataFilePath),
 				)
 			}
+			flushTimeSlice += time.Since(start)
 		}
 	}
 }
 
 func (d *dmlWorker) writeIndexFile(ctx context.Context, path, content string) error {
+	start := time.Now()
 	err := d.storage.WriteFile(ctx, path, []byte(content))
+	d.metricFlushDuration.Observe(time.Since(start).Seconds())
 	return err
 }
 
@@ -239,10 +263,13 @@ func (d *dmlWorker) writeDataFile(ctx context.Context, path string, task *single
 	}
 
 	if err := d.statistics.RecordBatchExecution(func() (int, int64, error) {
+		start := time.Now()
+
 		err := d.storage.WriteFile(ctx, path, buf.Bytes())
 		if err != nil {
 			return 0, 0, err
 		}
+		d.metricFlushDuration.Observe(time.Since(start).Seconds())
 		return rowsCnt, bytesCnt, nil
 	}); err != nil {
 		return err

--- a/cdc/sink/metrics/cloudstorage/metrics.go
+++ b/cdc/sink/metrics/cloudstorage/metrics.go
@@ -36,10 +36,40 @@ var (
 		Name:      "cloud_storage_file_count",
 		Help:      "Total number of files managed by a cloud storage sink",
 	}, []string{"namespace", "changefeed"})
+
+	// CloudStorageWriteDurationHistogram records the latency distributions of writeLog.
+	CloudStorageWriteDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "cloud_storage_write_duration_seconds",
+		Help:      "The latency distributions of write storage by a cloud storage sink",
+		Buckets:   prometheus.ExponentialBuckets(0.001, 2.0, 13),
+	}, []string{"namespace", "changefeed"})
+
+	// CloudStorageFlushDurationHistogram records the latency distributions of flushLog.
+	CloudStorageFlushDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "cloud_storage_flush_duration_seconds",
+		Help:      "The latency distributions of flush storage by a cloud storage sink",
+		Buckets:   prometheus.ExponentialBuckets(0.001, 2.0, 13),
+	}, []string{"namespace", "changefeed"})
+
+	// CloudStorageWorkerBusyRatio records the busy ratio of CloudStorage bgUpdateLog worker.
+	CloudStorageWorkerBusyRatioCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "cloud_storage_worker_busy_ratio",
+			Help:      "Busy ratio (X ms in 1s) for cloud storage sink dml worker.",
+		}, []string{"namespace", "changefeed", "id"})
 )
 
 // InitMetrics registers all metrics in this file.
 func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(CloudStorageWriteBytesGauge)
 	registry.MustRegister(CloudStorageFileCountGauge)
+	registry.MustRegister(CloudStorageWriteDurationHistogram)
+	registry.MustRegister(CloudStorageFlushDurationHistogram)
+	registry.MustRegister(CloudStorageWorkerBusyRatioCounter)
 }

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -224,7 +224,8 @@ func (c *CSVConfig) validateAndAdjust() error {
 		}
 	default:
 		return cerror.WrapError(cerror.ErrSinkInvalidConfig,
-			errors.New("csv config delimiter contains more than one character"))
+			errors.New("csv config delimiter contains more than one character, note that escape "+
+				"sequences can only be used in double quotes in toml configuration items."))
 	}
 
 	if len(c.Quote) > 0 && strings.Contains(c.Delimiter, c.Quote) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10115

### What is changed and how it works?
 add more log and metrics to storage sink, the write duration panel will take effect after #9954 is merged.
![image](https://github.com/pingcap/tiflow/assets/61726649/7615060b-da58-4c9e-98b7-bb6141fd11c6)


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
