### PR TITLE
kafka(ticdc): claim check do not use filepath join to build the full file path.

### DIFF
--- a/pkg/sink/codec/open/open_protocol_encoder_test.go
+++ b/pkg/sink/codec/open/open_protocol_encoder_test.go
@@ -462,7 +462,7 @@ func TestE2EClaimCheckMessage(t *testing.T) {
 	ctx := context.Background()
 	topic := ""
 
-	a := 241
+	a := 244
 	codecConfig := common.NewConfig(config.ProtocolOpen).WithMaxMessageBytes(a)
 	codecConfig.LargeMessageHandle.LargeMessageHandleOption = config.LargeMessageHandleOptionClaimCheck
 	codecConfig.LargeMessageHandle.LargeMessageHandleCompression = compression.LZ4

--- a/pkg/sink/kafka/claimcheck/claim_check.go
+++ b/pkg/sink/kafka/claimcheck/claim_check.go
@@ -16,6 +16,7 @@ package claimcheck
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -101,7 +102,7 @@ func (c *ClaimCheck) WriteMessage(ctx context.Context, key, value []byte, fileNa
 
 // FileNameWithPrefix returns the file name with prefix, the full path.
 func (c *ClaimCheck) FileNameWithPrefix(fileName string) string {
-	return c.storage.URI() + "/" + fileName
+	return strings.TrimSuffix(c.storage.URI(), "/") + "/" + fileName
 }
 
 // CleanMetrics the claim check by clean up the metrics.

--- a/pkg/sink/kafka/claimcheck/claim_check.go
+++ b/pkg/sink/kafka/claimcheck/claim_check.go
@@ -16,7 +16,6 @@ package claimcheck
 import (
 	"context"
 	"encoding/json"
-	"path/filepath"
 	"time"
 
 	"github.com/google/uuid"
@@ -102,7 +101,7 @@ func (c *ClaimCheck) WriteMessage(ctx context.Context, key, value []byte, fileNa
 
 // FileNameWithPrefix returns the file name with prefix, the full path.
 func (c *ClaimCheck) FileNameWithPrefix(fileName string) string {
-	return filepath.Join(c.storage.URI(), fileName)
+	return c.storage.URI() + "/" + fileName
 }
 
 // CleanMetrics the claim check by clean up the metrics.

--- a/pkg/sink/kafka/claimcheck/claim_check_test.go
+++ b/pkg/sink/kafka/claimcheck/claim_check_test.go
@@ -1,0 +1,34 @@
+// Copyright 2023 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package claimcheck
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pingcap/tiflow/cdc/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaimCheckFileName(t *testing.T) {
+	ctx := context.Background()
+	storageURI := "file:///tmp/abc/"
+	changefeedID := model.DefaultChangeFeedID("test")
+
+	claimCheck, err := New(ctx, storageURI, changefeedID)
+	require.NoError(t, err)
+
+	fileName := claimCheck.FileNameWithPrefix("file.json")
+	require.Equal(t, "file:////tmp/abc/file.json", fileName)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10036

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
