### PR TITLE
sink(cdc): avoid sinking redundant events in some rare cases with redo enabled

### DIFF
--- a/cdc/processor/sinkmanager/redo_cache.go
+++ b/cdc/processor/sinkmanager/redo_cache.go
@@ -157,7 +157,6 @@ func (e *eventAppender) pop(lowerBound, upperBound engine.Position) (res popResu
 			res.lowerBoundIfFail = e.lowerBound
 		} else {
 			res.lowerBoundIfFail = upperBound.Next()
-			res.lowerBoundIfFail = upperBound.Next()
 		}
 		return
 	}

--- a/cdc/processor/sinkmanager/redo_cache.go
+++ b/cdc/processor/sinkmanager/redo_cache.go
@@ -59,8 +59,13 @@ type popResult struct {
 	events      []*model.RowChangedEvent
 	size        uint64 // size of events.
 	releaseSize uint64 // size of all released events.
-	pushCount   int
-	success     bool
+
+	// many RowChangedEvent can come from one same PolymorphicEvent.
+	// pushCount indicates the count of raw PolymorphicEvents.
+	pushCount int
+
+	// success indicates whether there is a gap between cached events and required events.
+	success bool
 
 	// If success, upperBoundIfSuccess is the upperBound of poped events.
 	// The caller should fetch events (upperBoundIfSuccess, upperBound] from engine.

--- a/cdc/processor/sinkmanager/redo_cache.go
+++ b/cdc/processor/sinkmanager/redo_cache.go
@@ -61,9 +61,13 @@ type popResult struct {
 	releaseSize uint64 // size of all released events.
 	pushCount   int
 	success     bool
-	// If success, boundary is the upperBound of poped events.
-	// Otherwise, boundary is the lowerBound of cached events.
-	boundary engine.Position
+
+	// If success, upperBoundIfSuccess is the upperBound of poped events.
+	// The caller should fetch events (upperBoundIfSuccess, upperBound] from engine.
+	upperBoundIfSuccess engine.Position
+	// If fail, lowerBoundIfFail is the lowerBound of cached events.
+	// The caller should fetch events [lowerBound, lowerBoundIfFail) from engine.
+	lowerBoundIfFail engine.Position
 }
 
 // newRedoEventCache creates a redoEventCache instance.
@@ -150,26 +154,29 @@ func (e *eventAppender) pop(lowerBound, upperBound engine.Position) (res popResu
 		// NOTE: the caller will fetch events [lowerBound, res.boundary) from engine.
 		res.success = false
 		if e.lowerBound.Compare(upperBound.Next()) <= 0 {
-			res.boundary = e.lowerBound
+			res.lowerBoundIfFail = e.lowerBound
 		} else {
-			res.boundary = upperBound.Next()
+			res.lowerBoundIfFail = upperBound.Next()
+			res.lowerBoundIfFail = upperBound.Next()
 		}
 		return
 	}
+
 	if !e.upperBound.Valid() {
-		// if e.upperBound is invalid, it means there are no resolved transactions
-		// in the cache.
+		// It means there are no resolved cached transactions in the required range.
 		// NOTE: the caller will fetch events [lowerBound, res.boundary) from engine.
 		res.success = false
-		res.boundary = upperBound.Next()
+		res.lowerBoundIfFail = upperBound.Next()
 		return
 	}
 
 	res.success = true
-	if upperBound.Compare(e.upperBound) > 0 {
-		res.boundary = e.upperBound
+	if lowerBound.Compare(e.upperBound) > 0 {
+		res.upperBoundIfSuccess = lowerBound.Prev()
+	} else if upperBound.Compare(e.upperBound) > 0 {
+		res.upperBoundIfSuccess = e.upperBound
 	} else {
-		res.boundary = upperBound
+		res.upperBoundIfSuccess = upperBound
 	}
 
 	startIdx := sort.Search(e.readyCount, func(i int) bool {
@@ -181,28 +188,23 @@ func (e *eventAppender) pop(lowerBound, upperBound engine.Position) (res popResu
 		res.releaseSize += e.sizes[i]
 	}
 
-	var endIdx int
-	if startIdx == e.readyCount {
-		endIdx = startIdx
-	} else {
-		endIdx = sort.Search(e.readyCount, func(i int) bool {
-			pos := engine.Position{CommitTs: e.events[i].CommitTs, StartTs: e.events[i].StartTs}
-			return pos.Compare(res.boundary) > 0
-		})
-		res.events = e.events[startIdx:endIdx]
-		for i := startIdx; i < endIdx; i++ {
-			res.size += e.sizes[i]
-			res.pushCount += int(e.pushCounts[i])
-		}
-		res.releaseSize += res.size
+	endIdx := sort.Search(e.readyCount, func(i int) bool {
+		pos := engine.Position{CommitTs: e.events[i].CommitTs, StartTs: e.events[i].StartTs}
+		return pos.Compare(res.upperBoundIfSuccess) > 0
+	})
+	res.events = e.events[startIdx:endIdx]
+	for i := startIdx; i < endIdx; i++ {
+		res.size += e.sizes[i]
+		res.pushCount += int(e.pushCounts[i])
 	}
+	res.releaseSize += res.size
 
 	e.events = e.events[endIdx:]
 	e.sizes = e.sizes[endIdx:]
 	e.pushCounts = e.pushCounts[endIdx:]
 	e.readyCount -= endIdx
 	// Update boundaries. Set upperBound to invalid if the range has been drained.
-	e.lowerBound = res.boundary.Next()
+	e.lowerBound = res.upperBoundIfSuccess.Next()
 	if e.lowerBound.Compare(e.upperBound) > 0 {
 		e.upperBound = engine.Position{}
 	}

--- a/cdc/processor/sinkmanager/redo_cache_test.go
+++ b/cdc/processor/sinkmanager/redo_cache_test.go
@@ -147,4 +147,5 @@ func TestRedoEventCacheAllPopBranches(t *testing.T) {
 	require.Equal(t, 0, len(popRes.events))
 	require.Equal(t, engine.Position{StartTs: 500, CommitTs: 502}, popRes.upperBoundIfSuccess)
 	require.Equal(t, 0, appender.readyCount)
+	require.Equal(t, 0, len(appender.events))
 }

--- a/cdc/processor/sinkmanager/redo_cache_test.go
+++ b/cdc/processor/sinkmanager/redo_cache_test.go
@@ -48,14 +48,14 @@ func TestRedoEventCache(t *testing.T) {
 	// Try to pop [{0,1}, {0,4}], shoud fail. And the returned boundary should be {1,4}.
 	popRes = appender.pop(engine.Position{StartTs: 0, CommitTs: 1}, engine.Position{StartTs: 0, CommitTs: 4})
 	require.False(t, popRes.success)
-	require.Equal(t, uint64(1), popRes.boundary.StartTs)
-	require.Equal(t, uint64(4), popRes.boundary.CommitTs)
+	require.Equal(t, uint64(1), popRes.lowerBoundIfFail.StartTs)
+	require.Equal(t, uint64(4), popRes.lowerBoundIfFail.CommitTs)
 
 	// Try to pop [{0,2}, {0,4}], shoud fail. And the returned boundary should be {3,4}.
 	popRes = appender.pop(engine.Position{StartTs: 0, CommitTs: 1}, engine.Position{StartTs: 5, CommitTs: 6})
 	require.False(t, popRes.success)
-	require.Equal(t, uint64(3), popRes.boundary.StartTs)
-	require.Equal(t, uint64(4), popRes.boundary.CommitTs)
+	require.Equal(t, uint64(3), popRes.lowerBoundIfFail.StartTs)
+	require.Equal(t, uint64(4), popRes.lowerBoundIfFail.CommitTs)
 
 	// Try to pop [{3,4}, {3,4}], should success.
 	popRes = appender.pop(engine.Position{StartTs: 3, CommitTs: 4}, engine.Position{StartTs: 3, CommitTs: 4})
@@ -63,22 +63,22 @@ func TestRedoEventCache(t *testing.T) {
 	require.Equal(t, 2, len(popRes.events))
 	require.Equal(t, uint64(300), popRes.size)
 	require.Equal(t, 2, popRes.pushCount)
-	require.Equal(t, uint64(3), popRes.boundary.StartTs)
-	require.Equal(t, uint64(4), popRes.boundary.CommitTs)
+	require.Equal(t, uint64(3), popRes.upperBoundIfSuccess.StartTs)
+	require.Equal(t, uint64(4), popRes.upperBoundIfSuccess.CommitTs)
 
 	// Try to pop [{3,4}, {3,4}] again, shoud fail. And the returned boundary should be {4,4}.
 	popRes = appender.pop(engine.Position{StartTs: 3, CommitTs: 4}, engine.Position{StartTs: 3, CommitTs: 4})
 	require.False(t, popRes.success)
-	require.Equal(t, uint64(4), popRes.boundary.StartTs)
-	require.Equal(t, uint64(4), popRes.boundary.CommitTs)
+	require.Equal(t, uint64(4), popRes.lowerBoundIfFail.StartTs)
+	require.Equal(t, uint64(4), popRes.lowerBoundIfFail.CommitTs)
 
 	popRes = appender.pop(engine.Position{StartTs: 4, CommitTs: 4}, engine.Position{StartTs: 9, CommitTs: 10})
 	require.True(t, popRes.success)
 	require.Equal(t, 1, len(popRes.events))
 	require.Equal(t, uint64(300), popRes.size)
 	require.Equal(t, 1, popRes.pushCount)
-	require.Equal(t, uint64(5), popRes.boundary.StartTs)
-	require.Equal(t, uint64(6), popRes.boundary.CommitTs)
+	require.Equal(t, uint64(5), popRes.upperBoundIfSuccess.StartTs)
+	require.Equal(t, uint64(6), popRes.upperBoundIfSuccess.CommitTs)
 	require.Equal(t, 0, len(appender.events))
 	require.True(t, appender.broken)
 
@@ -106,15 +106,15 @@ func TestRedoEventCacheAllPopBranches(t *testing.T) {
 
 	popRes = appender.pop(engine.Position{StartTs: 1, CommitTs: 2}, engine.Position{StartTs: 3, CommitTs: 4})
 	require.False(t, popRes.success)
-	require.Equal(t, engine.Position{StartTs: 4, CommitTs: 4}, popRes.boundary)
+	require.Equal(t, engine.Position{StartTs: 4, CommitTs: 4}, popRes.lowerBoundIfFail)
 
 	popRes = appender.pop(engine.Position{StartTs: 1, CommitTs: 2}, engine.Position{StartTs: 300, CommitTs: 400})
 	require.False(t, popRes.success)
-	require.Equal(t, engine.Position{StartTs: 101, CommitTs: 111}, popRes.boundary)
+	require.Equal(t, engine.Position{StartTs: 101, CommitTs: 111}, popRes.lowerBoundIfFail)
 
 	popRes = appender.pop(engine.Position{StartTs: 1, CommitTs: 11}, engine.Position{StartTs: 2, CommitTs: 12})
 	require.False(t, popRes.success)
-	require.Equal(t, engine.Position{StartTs: 3, CommitTs: 12}, popRes.boundary)
+	require.Equal(t, engine.Position{StartTs: 3, CommitTs: 12}, popRes.lowerBoundIfFail)
 
 	batch = []*model.RowChangedEvent{{StartTs: 101, CommitTs: 111}, {StartTs: 101, CommitTs: 111}}
 	ok, _ = appender.pushBatch(batch, 0, engine.Position{StartTs: 101, CommitTs: 111})
@@ -127,7 +127,7 @@ func TestRedoEventCacheAllPopBranches(t *testing.T) {
 
 	popRes = appender.pop(engine.Position{StartTs: 101, CommitTs: 111}, engine.Position{StartTs: 102, CommitTs: 112})
 	require.True(t, popRes.success)
-	require.Equal(t, engine.Position{StartTs: 101, CommitTs: 111}, popRes.boundary)
+	require.Equal(t, engine.Position{StartTs: 101, CommitTs: 111}, popRes.upperBoundIfSuccess)
 	require.Equal(t, 2, len(popRes.events))
 	require.Equal(t, 1, popRes.pushCount)
 	require.Equal(t, uint64(101), popRes.events[1].StartTs)
@@ -135,5 +135,16 @@ func TestRedoEventCacheAllPopBranches(t *testing.T) {
 
 	popRes = appender.pop(engine.Position{StartTs: 102, CommitTs: 111}, engine.Position{StartTs: 102, CommitTs: 112})
 	require.False(t, popRes.success)
-	require.Equal(t, engine.Position{StartTs: 103, CommitTs: 112}, popRes.boundary)
+	require.Equal(t, engine.Position{StartTs: 103, CommitTs: 112}, popRes.lowerBoundIfFail)
+
+	batch = []*model.RowChangedEvent{&model.RowChangedEvent{StartTs: 102, CommitTs: 112}}
+	ok, _ = appender.pushBatch(batch, 0, engine.Position{StartTs: 102, CommitTs: 102})
+	require.True(t, ok)
+	require.Equal(t, 2, appender.readyCount)
+
+	popRes = appender.pop(engine.Position{StartTs: 501, CommitTs: 502}, engine.Position{StartTs: 701, CommitTs: 702})
+	require.True(t, popRes.success)
+	require.Equal(t, 0, len(popRes.events))
+	require.Equal(t, engine.Position{StartTs: 500, CommitTs: 502}, popRes.upperBoundIfSuccess)
+	require.Equal(t, 0, appender.readyCount)
 }

--- a/cdc/processor/sinkmanager/redo_cache_test.go
+++ b/cdc/processor/sinkmanager/redo_cache_test.go
@@ -137,7 +137,7 @@ func TestRedoEventCacheAllPopBranches(t *testing.T) {
 	require.False(t, popRes.success)
 	require.Equal(t, engine.Position{StartTs: 103, CommitTs: 112}, popRes.lowerBoundIfFail)
 
-	batch = []*model.RowChangedEvent{&model.RowChangedEvent{StartTs: 102, CommitTs: 112}}
+	batch = []*model.RowChangedEvent{{StartTs: 102, CommitTs: 112}}
 	ok, _ = appender.pushBatch(batch, 0, engine.Position{StartTs: 102, CommitTs: 102})
 	require.True(t, ok)
 	require.Equal(t, 2, appender.readyCount)

--- a/cdc/processor/sinkmanager/table_sink_worker.go
+++ b/cdc/processor/sinkmanager/table_sink_worker.go
@@ -201,13 +201,14 @@ func (w *sinkWorker) handleTask(ctx context.Context, task *sinkTask) (finalErr e
 		if err != nil {
 			return errors.Trace(err)
 		}
+		// NOTE: lowerBound can be updated by `fetchFromCache`, so `lastPos` should also be updated.
+		advancer.lastPos = lowerBound.Prev()
 		if drained {
 			// If drained is true it means we have drained all events from the cache,
 			// we can return directly instead of get events from the source manager again.
-			performCallback(lowerBound.Prev())
+			performCallback(advancer.lastPos)
 			return nil
 		}
-		advancer.lastPos = lowerBound.Prev()
 	}
 
 	// lowerBound and upperBound are both closed intervals.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10065 .

### What is changed and how it works?

Let's focus on file `cdc/processor/sinkmanager/table_sink_worker.go`. #10065 panics if

* redo is enabled;
* sink memory quota is almost full;
* there are transactions larger than 8M;
* when handling one large transaction, `fetchFromCache` returns `drained=false`;
* then the condition `for advancer.hasEnoughMem() && !task.isCanceled()` is broken immediately;
* changefeed is paused and then resumed, table sink is faster than redo.

After that, the variable `lastPos` can be less than `lowerBound.Prev()`, which is not expected.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
