### PR TITLE
sink to csv: output old value to CSV files

### DIFF
--- a/cdc/api/v2/model.go
+++ b/cdc/api/v2/model.go
@@ -919,7 +919,7 @@ type CSVConfig struct {
 	NullString           string `json:"null"`
 	IncludeCommitTs      bool   `json:"include_commit_ts"`
 	BinaryEncodingMethod string `json:"binary_encoding_method"`
-	EnableOldValue       bool   `json:"enable_old_value"`
+	OutputOldValue       bool   `json:"output_old_value"`
 }
 
 // LargeMessageHandleConfig denotes the large message handling config

--- a/cdc/api/v2/model.go
+++ b/cdc/api/v2/model.go
@@ -919,6 +919,7 @@ type CSVConfig struct {
 	NullString           string `json:"null"`
 	IncludeCommitTs      bool   `json:"include_commit_ts"`
 	BinaryEncodingMethod string `json:"binary_encoding_method"`
+	EnableOldValue       bool   `json:"enable_old_value"`
 }
 
 // LargeMessageHandleConfig denotes the large message handling config

--- a/pkg/cmd/util/changefeed_storage_sink.toml
+++ b/pkg/cmd/util/changefeed_storage_sink.toml
@@ -15,3 +15,6 @@ quote = '"'
 null = '\N'
 # Include commit-ts in the row data. The default value is false.
 include-commit-ts = false
+# Enable Old Value, update statement will be replaced by a pair of delete and insert
+# in the CSV files.
+enable-old-value = false

--- a/pkg/cmd/util/changefeed_storage_sink.toml
+++ b/pkg/cmd/util/changefeed_storage_sink.toml
@@ -15,6 +15,6 @@ quote = '"'
 null = '\N'
 # Include commit-ts in the row data. The default value is false.
 include-commit-ts = false
-# Enable Old Value, update statement will be replaced by a pair of delete and insert
-# in the CSV files.
-enable-old-value = false
+# Ouptut Old Value, for example update statement will be replaced by a pair of delete and insert
+# in the CSV files to output the old value.
+output-old-value = false

--- a/pkg/config/config_test_data.go
+++ b/pkg/config/config_test_data.go
@@ -217,7 +217,8 @@ const (
       "quote": "\"",
       "null": "\\N",
       "include-commit-ts": true,
-      "binary-encoding-method":"base64"
+      "binary-encoding-method":"base64",
+      "output-old-value": false
     },
     "date-separator": "month",
     "enable-partition-separator": true,

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -192,8 +192,8 @@ type CSVConfig struct {
 	IncludeCommitTs bool `toml:"include-commit-ts" json:"include-commit-ts"`
 	// encoding method of binary type
 	BinaryEncodingMethod string `toml:"binary-encoding-method" json:"binary-encoding-method"`
-	// enable old value
-	EnableOldValue bool `toml:"enable-old-value" json:"enable-old-value"`
+	// output old value
+	OutputOldValue bool `toml:"output-old-value" json:"output-old-value"`
 }
 
 func (c *CSVConfig) validateAndAdjust() error {

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -192,6 +192,8 @@ type CSVConfig struct {
 	IncludeCommitTs bool `toml:"include-commit-ts" json:"include-commit-ts"`
 	// encoding method of binary type
 	BinaryEncodingMethod string `toml:"binary-encoding-method" json:"binary-encoding-method"`
+	// enable old value
+	EnableOldValue bool `toml:"enable-old-value" json:"enable-old-value"`
 }
 
 func (c *CSVConfig) validateAndAdjust() error {

--- a/pkg/sink/codec/common/config.go
+++ b/pkg/sink/codec/common/config.go
@@ -70,7 +70,7 @@ type Config struct {
 	IncludeCommitTs      bool
 	Terminator           string
 	BinaryEncodingMethod string
-	EnableOldValue       bool
+	OutputOldValue       bool
 
 	// for open protocol
 	OnlyOutputUpdatedColumns bool
@@ -192,7 +192,7 @@ func (c *Config) Apply(sinkURI *url.URL, replicaConfig *config.ReplicaConfig) er
 			c.NullString = replicaConfig.Sink.CSVConfig.NullString
 			c.IncludeCommitTs = replicaConfig.Sink.CSVConfig.IncludeCommitTs
 			c.BinaryEncodingMethod = replicaConfig.Sink.CSVConfig.BinaryEncodingMethod
-			c.EnableOldValue = replicaConfig.Sink.CSVConfig.EnableOldValue
+			c.OutputOldValue = replicaConfig.Sink.CSVConfig.OutputOldValue
 		}
 		if replicaConfig.Sink.KafkaConfig != nil && replicaConfig.Sink.KafkaConfig.LargeMessageHandle != nil {
 			c.LargeMessageHandle = replicaConfig.Sink.KafkaConfig.LargeMessageHandle

--- a/pkg/sink/codec/common/config.go
+++ b/pkg/sink/codec/common/config.go
@@ -70,6 +70,7 @@ type Config struct {
 	IncludeCommitTs      bool
 	Terminator           string
 	BinaryEncodingMethod string
+	EnableOldValue       bool
 
 	// for open protocol
 	OnlyOutputUpdatedColumns bool
@@ -191,6 +192,7 @@ func (c *Config) Apply(sinkURI *url.URL, replicaConfig *config.ReplicaConfig) er
 			c.NullString = replicaConfig.Sink.CSVConfig.NullString
 			c.IncludeCommitTs = replicaConfig.Sink.CSVConfig.IncludeCommitTs
 			c.BinaryEncodingMethod = replicaConfig.Sink.CSVConfig.BinaryEncodingMethod
+			c.EnableOldValue = replicaConfig.Sink.CSVConfig.EnableOldValue
 		}
 		if replicaConfig.Sink.KafkaConfig != nil && replicaConfig.Sink.KafkaConfig.LargeMessageHandle != nil {
 			c.LargeMessageHandle = replicaConfig.Sink.KafkaConfig.LargeMessageHandle

--- a/pkg/sink/codec/csv/csv_message.go
+++ b/pkg/sink/codec/csv/csv_message.go
@@ -82,6 +82,7 @@ type csvMessage struct {
 	schemaName string
 	commitTs   uint64
 	columns    []any
+	preColumns []any
 	// newRecord indicates whether we encounter a new record.
 	newRecord bool
 }
@@ -101,17 +102,36 @@ func newCSVMessage(config *common.Config) *csvMessage {
 // Col5-n: one or more columns that represent the data to be changed.
 func (c *csvMessage) encode() []byte {
 	strBuilder := new(strings.Builder)
-	c.formatValue(c.opType.String(), strBuilder)
-	c.formatValue(c.tableName, strBuilder)
-	c.formatValue(c.schemaName, strBuilder)
-	if c.config.IncludeCommitTs {
-		c.formatValue(c.commitTs, strBuilder)
+	if c.opType == operationUpdate && c.config.EnableOldValue && len(c.preColumns) != 0 {
+		// Encode the old value first as a dedicated row.
+		c.encodeMeta("D", strBuilder)
+		c.encodeColumns(c.preColumns, strBuilder)
+
+		// Encode the after value as a dedicated row.
+		c.newRecord = true // reset newRecord to true, so that the first column will not start with delimiter.
+		c.encodeMeta("I", strBuilder)
+		c.encodeColumns(c.columns, strBuilder)
+	} else {
+		c.encodeMeta(c.opType.String(), strBuilder)
+		c.encodeColumns(c.columns, strBuilder)
 	}
-	for _, col := range c.columns {
-		c.formatValue(col, strBuilder)
-	}
-	strBuilder.WriteString(c.config.Terminator)
 	return []byte(strBuilder.String())
+}
+
+func (c *csvMessage) encodeMeta(opType string, b *strings.Builder) {
+	c.formatValue(opType, b)
+	c.formatValue(c.tableName, b)
+	c.formatValue(c.schemaName, b)
+	if c.config.IncludeCommitTs {
+		c.formatValue(c.commitTs, b)
+	}
+}
+
+func (c *csvMessage) encodeColumns(columns []any, b *strings.Builder) {
+	for _, col := range columns {
+		c.formatValue(col, b)
+	}
+	b.WriteString(c.config.Terminator)
 }
 
 func (c *csvMessage) decode(datums []types.Datum) error {
@@ -348,14 +368,30 @@ func rowChangedEvent2CSVMsg(csvConfig *common.Config, e *model.RowChangedEvent) 
 		}
 	} else {
 		if e.PreColumns == nil {
+			// This is a insert operation.
 			csvMsg.opType = operationInsert
+			csvMsg.columns, err = rowChangeColumns2CSVColumns(csvConfig, e.Columns, e.ColInfos)
+			if err != nil {
+				return nil, err
+			}
 		} else {
+			// This is a update operation.
 			csvMsg.opType = operationUpdate
-		}
-		// for insert and update operation, we only record the after columns.
-		csvMsg.columns, err = rowChangeColumns2CSVColumns(csvConfig, e.Columns, e.ColInfos)
-		if err != nil {
-			return nil, err
+			if csvConfig.EnableOldValue {
+				if len(e.PreColumns) != len(e.Columns) {
+					return nil, cerror.WrapError(cerror.ErrCSVDecodeFailed,
+						fmt.Errorf("the column length of preColumns %d doesn't equal to that of columns %d",
+							len(e.PreColumns), len(e.Columns)))
+				}
+				csvMsg.preColumns, err = rowChangeColumns2CSVColumns(csvConfig, e.PreColumns, e.ColInfos)
+				if err != nil {
+					return nil, err
+				}
+			}
+			csvMsg.columns, err = rowChangeColumns2CSVColumns(csvConfig, e.Columns, e.ColInfos)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	return csvMsg, nil

--- a/pkg/sink/codec/csv/csv_message.go
+++ b/pkg/sink/codec/csv/csv_message.go
@@ -102,7 +102,7 @@ func newCSVMessage(config *common.Config) *csvMessage {
 // Col5-n: one or more columns that represent the data to be changed.
 func (c *csvMessage) encode() []byte {
 	strBuilder := new(strings.Builder)
-	if c.opType == operationUpdate && c.config.EnableOldValue && len(c.preColumns) != 0 {
+	if c.opType == operationUpdate && c.config.OutputOldValue && len(c.preColumns) != 0 {
 		// Encode the old value first as a dedicated row.
 		c.encodeMeta("D", strBuilder)
 		c.encodeColumns(c.preColumns, strBuilder)
@@ -377,7 +377,7 @@ func rowChangedEvent2CSVMsg(csvConfig *common.Config, e *model.RowChangedEvent) 
 		} else {
 			// This is a update operation.
 			csvMsg.opType = operationUpdate
-			if csvConfig.EnableOldValue {
+			if csvConfig.OutputOldValue {
 				if len(e.PreColumns) != len(e.Columns) {
 					return nil, cerror.WrapError(cerror.ErrCSVDecodeFailed,
 						fmt.Errorf("the column length of preColumns %d doesn't equal to that of columns %d",

--- a/pkg/sink/codec/csv/csv_message_test.go
+++ b/pkg/sink/codec/csv/csv_message_test.go
@@ -795,7 +795,7 @@ func TestCSVMessageEncode(t *testing.T) {
 					Terminator:      "\n",
 					NullString:      "\\N",
 					IncludeCommitTs: true,
-					EnableOldValue:  true,
+					OutputOldValue:  true,
 				},
 				opType:     operationUpdate,
 				tableName:  "table2",

--- a/pkg/sink/codec/csv/csv_message_test.go
+++ b/pkg/sink/codec/csv/csv_message_test.go
@@ -742,6 +742,7 @@ func TestCSVMessageEncode(t *testing.T) {
 		tableName  string
 		schemaName string
 		commitTs   uint64
+		preColumns []any
 		columns    []any
 	}
 	testCases := []struct {
@@ -784,6 +785,27 @@ func TestCSVMessageEncode(t *testing.T) {
 				columns:    []any{"a!b!c", "def"},
 			},
 			want: []byte(`U!table2!test!435661838416609281!a\!b\!c!def` + "\n"),
+		},
+		{
+			name: "csv encode values containing single-character delimter string, without quote mark, update with old value",
+			fields: fields{
+				config: &common.Config{
+					Delimiter:       "!",
+					Quote:           "",
+					Terminator:      "\n",
+					NullString:      "\\N",
+					IncludeCommitTs: true,
+					EnableOldValue:  true,
+				},
+				opType:     operationUpdate,
+				tableName:  "table2",
+				schemaName: "test",
+				commitTs:   435661838416609281,
+				preColumns: []any{"a!b!c", "abc"},
+				columns:    []any{"a!b!c", "def"},
+			},
+			want: []byte(`D!table2!test!435661838416609281!a\!b\!c!abc` + "\n" +
+				`I!table2!test!435661838416609281!a\!b\!c!def` + "\n"),
 		},
 		{
 			name: "csv encode values containing single-character delimter string, with quote mark",
@@ -903,6 +925,7 @@ func TestCSVMessageEncode(t *testing.T) {
 				schemaName: tc.fields.schemaName,
 				commitTs:   tc.fields.commitTs,
 				columns:    tc.fields.columns,
+				preColumns: tc.fields.preColumns,
 				newRecord:  true,
 			}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/10167

### What is changed and how it works?

When changefeed configuration set:
```
[sink.csv]
output-old-value = true
```
As https://github.com/pingcap/tiflow/issues/10167 described, sink to csv replace update with a pair of delete and insert, in this way to record the old value for UPDATE statement, so it is possible to generate undo DML for some data repairing cases.

Before this change, the CSV output statement of `update schema.table set name="def" where id=1 and name="abc"` is
```
U, table, schema, [commit-ts], 1, def
```
After this change, the CSV output looks like:
```
D, table, schema, [commit-ts], 1, abc
I, table, schema, [commit-ts], 1, def
```


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
After set `[sink.csv] output-old-value = true` configuration for the sink to storage changefeed, for each UPDATE statement there will be 2 rows of data in the output CSV file. The output CSV files size is larger than before if there are many UPDATE statements.

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
TiCDC sink to CSV files: support output old values for csv files, this is helpful for data repairing scenario.
```
