### PR TITLE
syncer(dm): Improve logging of ignored TableMap/FormatDesc

### DIFF
--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -2442,6 +2442,13 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 			if needContinue {
 				continue
 			}
+		case *replication.TableMapEvent:
+			s.tctx.L().Info("unhandled TableMap event",
+				zap.String("schema", string(ev.Schema)),
+				zap.String("table", string(ev.Table)),
+			)
+		case *replication.FormatDescriptionEvent:
+			s.tctx.L().Info("unhandled FormatDescription event")
 		default:
 			s.tctx.L().Warn("unhandled event", zap.String("type", fmt.Sprintf("%T", ev)))
 		}

--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -2436,12 +2436,7 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 					eventType = "XID"
 					needContinue, err2 = funcCommit()
 				case *replication.TableMapEvent:
-					s.tctx.L().Info("unhandled TableMap event from transaction payload",
-						zap.String("schema", string(tpevt.Schema)),
-						zap.String("table", string(tpevt.Table)),
-					)
 				case *replication.FormatDescriptionEvent:
-					s.tctx.L().Info("unhandled FormatDescription event from transaction payload")
 				default:
 					s.tctx.L().Warn("unhandled event from transaction payload", zap.String("type", fmt.Sprintf("%T", tpevt)))
 				}
@@ -2450,12 +2445,7 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 				continue
 			}
 		case *replication.TableMapEvent:
-			s.tctx.L().Info("unhandled TableMap event",
-				zap.String("schema", string(ev.Schema)),
-				zap.String("table", string(ev.Table)),
-			)
 		case *replication.FormatDescriptionEvent:
-			s.tctx.L().Info("unhandled FormatDescription event")
 		default:
 			s.tctx.L().Warn("unhandled event", zap.String("type", fmt.Sprintf("%T", ev)))
 		}

--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -2435,6 +2435,13 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 				case *replication.XIDEvent:
 					eventType = "XID"
 					needContinue, err2 = funcCommit()
+				case *replication.TableMapEvent:
+					s.tctx.L().Info("unhandled TableMap event from transaction payload",
+						zap.String("schema", string(tpevt.Schema)),
+						zap.String("table", string(tpevt.Table)),
+					)
+				case *replication.FormatDescriptionEvent:
+					s.tctx.L().Info("unhandled FormatDescription event from transaction payload")
 				default:
 					s.tctx.L().Warn("unhandled event from transaction payload", zap.String("type", fmt.Sprintf("%T", tpevt)))
 				}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10204 

### What is changed and how it works?

This makes the logging on the warning level less noisy and adds detail to the TableMap event logs.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Logging of `TableMapEvent` and `FormatDescriptionEvent` was changed from the warning level to the info level.
```
