### PR TITLE
(CDC/redo) speedup TestGCAndCleanup from several hundreds seconds to few seconds

### DIFF
--- a/cdc/redo/meta_manager_test.go
+++ b/cdc/redo/meta_manager_test.go
@@ -252,7 +252,7 @@ func TestGCAndCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	checkGC := func(checkpointTs uint64) {
-		time.Sleep(time.Duration(redo.DefaultGCIntervalInMs) * time.Millisecond * 20)
+		time.Sleep(time.Duration(redo.MinGCIntervalInMs) * time.Millisecond * 20)
 		checkEqual := false
 		extStorage.WalkDir(ctx, nil, func(path string, size int64) error {
 			if strings.HasSuffix(path, redo.MetaEXT) {
@@ -292,6 +292,7 @@ func TestGCAndCleanup(t *testing.T) {
 		MetaFlushIntervalInMs: redo.MinFlushIntervalInMs,
 		EncodingWorkerNum:     redo.DefaultEncodingWorkerNum,
 		FlushWorkerNum:        redo.DefaultFlushWorkerNum,
+		GCIntervalInMs:        int64(redo.MinGCIntervalInMs),
 	}
 
 	m := NewMetaManager(changefeedID, cfg, startTs)

--- a/pkg/config/consistent.go
+++ b/pkg/config/consistent.go
@@ -34,6 +34,7 @@ type ConsistentConfig struct {
 	Storage               string `toml:"storage" json:"storage"`
 	UseFileBackend        bool   `toml:"use-file-backend" json:"use-file-backend"`
 	Compression           string `toml:"compression" json:"compression"`
+	GCIntervalInMs        int64  `toml:"gc-interval" json:"gc-interval"`
 }
 
 // ValidateAndAdjust validates the consistency config and adjusts it if necessary.
@@ -53,6 +54,14 @@ func (c *ConsistentConfig) ValidateAndAdjust() error {
 		return cerror.ErrInvalidReplicaConfig.FastGenByArgs(
 			fmt.Sprintf("The consistent.flush-interval:%d must be equal or greater than %d",
 				c.FlushIntervalInMs, redo.MinFlushIntervalInMs))
+	}
+	if c.GCIntervalInMs == 0 {
+		c.GCIntervalInMs = int64(redo.DefaultGCIntervalInMs)
+	}
+	if c.GCIntervalInMs < int64(redo.MinGCIntervalInMs) {
+		return cerror.ErrInvalidReplicaConfig.FastGenByArgs(
+			fmt.Sprintf("The consistent.gc-interval:%d must be equal or greater than %d",
+				c.GCIntervalInMs, redo.MinGCIntervalInMs))
 	}
 
 	if c.MetaFlushIntervalInMs == 0 {

--- a/pkg/redo/config.go
+++ b/pkg/redo/config.go
@@ -30,6 +30,8 @@ import (
 var (
 	// DefaultGCIntervalInMs defines GC interval in meta manager, which can be changed in tests.
 	DefaultGCIntervalInMs = 5000 // 5 seconds
+	// MinGCIntervalInMs defines the minimum GC interval in meta manager.
+	MinGCIntervalInMs = 10 // 10 milliseconds
 	// DefaultMaxLogSize is the default max size of log file
 	DefaultMaxLogSize = int64(64)
 )


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/10214

### What is changed and how it works?
Use configurable GC interval for redo Manager, so `TestGCAndCleanup` doesn't need to wait hundreds seconds https://github.com/pingcap/tiflow/blob/master/cdc/redo/meta_manager_test.go#L255

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
