### PR TITLE
scheduler(ticdc): Updating ReplicationSet.stats only when stats is not empty

### DIFF
--- a/cdc/scheduler/internal/v3/replication/replication_set.go
+++ b/cdc/scheduler/internal/v3/replication/replication_set.go
@@ -1020,7 +1020,13 @@ func (r *ReplicationSet) updateCheckpointAndStats(
 			zap.Any("checkpointTs", r.Checkpoint.CheckpointTs),
 			zap.Any("resolvedTs", r.Checkpoint.ResolvedTs))
 	}
-	r.Stats = stats
+
+	// we only update stats when stats is not empty, due to we only collect stats every 10s.
+	// refer https://github.com/pingcap/tiflow/blob/bbf2d87f467313bf06f1f123b5409ebbac469647 \
+	// /cdc/scheduler/internal/v3/member/capture_manager.go#L176
+	if stats.Size() > 0 {
+		r.Stats = stats
+	}
 }
 
 // SetHeap is a max-heap, it implements heap.Interface.

--- a/cdc/scheduler/internal/v3/replication/replication_set.go
+++ b/cdc/scheduler/internal/v3/replication/replication_set.go
@@ -1021,9 +1021,7 @@ func (r *ReplicationSet) updateCheckpointAndStats(
 			zap.Any("resolvedTs", r.Checkpoint.ResolvedTs))
 	}
 
-	// we only update stats when stats is not empty, due to we only collect stats every 10s.
-	// refer https://github.com/pingcap/tiflow/blob/bbf2d87f467313bf06f1f123b5409ebbac469647 \
-	// /cdc/scheduler/internal/v3/member/capture_manager.go#L176
+	// we only update stats when stats is not empty, because we only collect stats every 10s.
 	if stats.Size() > 0 {
 		r.Stats = stats
 	}


### PR DESCRIPTION
Issue Number: close https://github.com/pingcap/tiflow/issues/10224

### What is changed and how it works?
update stats only when it's not empty to make metrics updating normally
![image](https://github.com/pingcap/tiflow/assets/26538495/414a13e0-85b3-4564-aafe-7c11ee7824b7)


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
