### PR TITLE
cdc: Support schema for Debezium output protocol

### DIFF
--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -165,6 +165,9 @@ type SinkConfig struct {
 	// AdvanceTimeoutInSec is a duration in second. If a table sink progress hasn't been
 	// advanced for this given duration, the sink will be canceled and re-established.
 	AdvanceTimeoutInSec *uint `toml:"advance-timeout-in-sec" json:"advance-timeout-in-sec,omitempty"`
+
+	// Debezium only. Whether schema should be excluded in the output.
+	DebeziumDisableSchema *bool `toml:"debezium-disable-schema" json:"debezium-disable-schema,omitempty"`
 }
 
 // MaskSensitiveData masks sensitive data in SinkConfig

--- a/pkg/sink/codec/builder/encoder_builder.go
+++ b/pkg/sink/codec/builder/encoder_builder.go
@@ -49,7 +49,7 @@ func NewRowEventEncoderBuilder(
 	case config.ProtocolCraft:
 		return craft.NewBatchEncoderBuilder(cfg), nil
 	case config.ProtocolDebezium:
-		return debezium.NewBatchEncoderBuilder(cfg), nil
+		return debezium.NewBatchEncoderBuilder(cfg, config.GetGlobalServerConfig().ClusterID), nil
 	case config.ProtocolSimple:
 		return simple.NewBuilder(cfg), nil
 	default:

--- a/pkg/sink/codec/common/config.go
+++ b/pkg/sink/codec/common/config.go
@@ -79,7 +79,7 @@ type Config struct {
 	// Currently only Debezium protocol is aware of the time zone
 	TimeZone *time.Location
 
-	// Debezium only
+	// Debezium only. Whether schema should be excluded in the output.
 	DebeziumDisableSchema bool
 }
 
@@ -264,6 +264,9 @@ func mergeConfig(
 				dest.AvroDecimalHandlingMode = codecConfig.AvroDecimalHandlingMode
 				dest.AvroBigintUnsignedHandlingMode = codecConfig.AvroBigintUnsignedHandlingMode
 			}
+		}
+		if replicaConfig.Sink.DebeziumDisableSchema != nil {
+			dest.DebeziumDisableSchema = replicaConfig.Sink.DebeziumDisableSchema
 		}
 	}
 	if err := mergo.Merge(dest, urlParameters, mergo.WithOverride); err != nil {

--- a/pkg/sink/codec/common/config.go
+++ b/pkg/sink/codec/common/config.go
@@ -78,6 +78,9 @@ type Config struct {
 
 	// Currently only Debezium protocol is aware of the time zone
 	TimeZone *time.Location
+
+	// Debezium only
+	DebeziumDisableSchema bool
 }
 
 // NewConfig return a Config for codec
@@ -138,6 +141,8 @@ type urlConfig struct {
 	AvroSchemaRegistry       string `form:"schema-registry"`
 	OnlyOutputUpdatedColumns *bool  `form:"only-output-updated-columns"`
 	ContentCompatible        *bool  `form:"content-compatible"`
+
+	DebeziumDisableSchema *bool `form:"debezium-disable-schema"`
 }
 
 // Apply fill the Config
@@ -228,6 +233,10 @@ func (c *Config) Apply(sinkURI *url.URL, replicaConfig *config.ReplicaConfig) er
 		if c.ContentCompatible {
 			c.OnlyOutputUpdatedColumns = true
 		}
+	}
+
+	if urlParameter.DebeziumDisableSchema != nil {
+		c.DebeziumDisableSchema = *urlParameter.DebeziumDisableSchema
 	}
 
 	return nil

--- a/pkg/sink/codec/debezium/codec.go
+++ b/pkg/sink/codec/debezium/codec.go
@@ -14,12 +14,15 @@
 package debezium
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"time"
 
+	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/hack"
@@ -29,6 +32,7 @@ import (
 	"github.com/pingcap/tiflow/pkg/sink/codec/common"
 	"github.com/pingcap/tiflow/pkg/util"
 	"github.com/tikv/client-go/v2/oracle"
+	"go.uber.org/zap"
 )
 
 type dbzCodec struct {
@@ -37,11 +41,16 @@ type dbzCodec struct {
 	nowFunc   func() time.Time
 }
 
-func (c *dbzCodec) writeColumnsAsField(writer *util.JSONWriter, fieldName string, cols []*model.Column, colInfos []rowcodec.ColInfo) error {
+func (c *dbzCodec) writeDebeziumFieldValues(
+	writer *util.JSONWriter,
+	fieldName string,
+	cols []*model.Column,
+	colInfos []rowcodec.ColInfo,
+) error {
 	var err error
 	writer.WriteObjectField(fieldName, func() {
 		for i, col := range cols {
-			err = c.writeDebeziumField(writer, col, colInfos[i].Ft)
+			err = c.writeDebeziumFieldValue(writer, col, colInfos[i].Ft)
 			if err != nil {
 				break
 			}
@@ -50,25 +59,229 @@ func (c *dbzCodec) writeColumnsAsField(writer *util.JSONWriter, fieldName string
 	return err
 }
 
+func (c *dbzCodec) writeDebeziumFieldSchema(
+	writer *util.JSONWriter,
+	col *model.Column,
+	ft *types.FieldType,
+) error {
+	switch col.Type {
+	case mysql.TypeBit:
+		n := ft.GetFlen()
+		if n == 1 {
+			writer.WriteObjectElement(func() {
+				writer.WriteStringField("type", "boolean")
+				writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+				writer.WriteStringField("field", col.Name)
+			})
+		} else {
+			writer.WriteObjectElement(func() {
+				writer.WriteStringField("type", "bytes")
+				writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+				writer.WriteStringField("name", "io.debezium.data.Bits")
+				writer.WriteIntField("version", 1)
+				writer.WriteObjectField("parameters", func() {
+					writer.WriteStringField("length", fmt.Sprintf("%d", n))
+				})
+				writer.WriteStringField("field", col.Name)
+			})
+		}
+
+	case mysql.TypeVarchar, mysql.TypeString, mysql.TypeVarString, mysql.TypeTinyBlob,
+		mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeBlob:
+		writer.WriteObjectElement(func() {
+			writer.WriteStringField("type", "string")
+			writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+			writer.WriteStringField("field", col.Name)
+		})
+
+	case mysql.TypeEnum:
+		writer.WriteObjectElement(func() {
+			writer.WriteStringField("type", "string")
+			writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+			writer.WriteStringField("name", "io.debezium.data.Enum")
+			writer.WriteIntField("version", 1)
+			writer.WriteObjectField("parameters", func() {
+				writer.WriteStringField("allowed", strings.Join(ft.GetElems(), ","))
+			})
+			writer.WriteStringField("field", col.Name)
+		})
+
+	case mysql.TypeSet:
+		writer.WriteObjectElement(func() {
+			writer.WriteStringField("type", "string")
+			writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+			writer.WriteStringField("name", "io.debezium.data.EnumSet")
+			writer.WriteIntField("version", 1)
+			writer.WriteObjectField("parameters", func() {
+				writer.WriteStringField("allowed", strings.Join(ft.GetElems(), ","))
+			})
+			writer.WriteStringField("field", col.Name)
+		})
+
+	case mysql.TypeNewDecimal:
+		writer.WriteObjectElement(func() {
+			writer.WriteStringField("type", "double")
+			writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+			writer.WriteStringField("field", col.Name)
+		})
+
+	case mysql.TypeDate, mysql.TypeNewDate:
+		writer.WriteObjectElement(func() {
+			writer.WriteStringField("type", "int32")
+			writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+			writer.WriteStringField("name", "io.debezium.time.Date")
+			writer.WriteIntField("version", 1)
+			writer.WriteStringField("field", col.Name)
+		})
+
+	case mysql.TypeDatetime:
+		writer.WriteObjectElement(func() {
+			writer.WriteStringField("type", "int64")
+			writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+			if ft.GetDecimal() <= 3 {
+				writer.WriteStringField("name", "io.debezium.time.Timestamp")
+			} else {
+				writer.WriteStringField("name", "io.debezium.time.MicroTimestamp")
+			}
+			writer.WriteIntField("version", 1)
+			writer.WriteStringField("field", col.Name)
+		})
+
+	case mysql.TypeTimestamp:
+		writer.WriteObjectElement(func() {
+			writer.WriteStringField("type", "string")
+			writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+			writer.WriteStringField("name", "io.debezium.time.ZonedTimestamp")
+			writer.WriteIntField("version", 1)
+			writer.WriteStringField("field", col.Name)
+		})
+
+	case mysql.TypeDuration:
+		writer.WriteObjectElement(func() {
+			writer.WriteStringField("type", "int64")
+			writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+			writer.WriteStringField("name", "io.debezium.time.MicroTime")
+			writer.WriteIntField("version", 1)
+			writer.WriteStringField("field", col.Name)
+		})
+
+	case mysql.TypeJSON:
+		writer.WriteObjectElement(func() {
+			writer.WriteStringField("type", "string")
+			writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+			writer.WriteStringField("name", "io.debezium.data.Json")
+			writer.WriteIntField("version", 1)
+			writer.WriteStringField("field", col.Name)
+		})
+
+	case mysql.TypeTiny: // TINYINT
+		writer.WriteObjectElement(func() {
+			writer.WriteStringField("type", "int16")
+			writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+			writer.WriteStringField("field", col.Name)
+		})
+
+	case mysql.TypeShort: // SMALLINT
+		writer.WriteObjectElement(func() {
+			if mysql.HasUnsignedFlag(ft.GetFlag()) {
+				writer.WriteStringField("type", "int32")
+			} else {
+				writer.WriteStringField("type", "int16")
+			}
+			writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+			writer.WriteStringField("field", col.Name)
+		})
+
+	case mysql.TypeInt24: // MEDIUMINT
+		writer.WriteObjectElement(func() {
+			writer.WriteStringField("type", "int32")
+			writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+			writer.WriteStringField("field", col.Name)
+		})
+
+	case mysql.TypeLong: // INT
+		writer.WriteObjectElement(func() {
+			if mysql.HasUnsignedFlag(ft.GetFlag()) {
+				writer.WriteStringField("type", "int64")
+			} else {
+				writer.WriteStringField("type", "int32")
+			}
+			writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+			writer.WriteStringField("field", col.Name)
+		})
+
+	case mysql.TypeLonglong: // BIGINT
+		writer.WriteObjectElement(func() {
+			writer.WriteStringField("type", "int64")
+			writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+			writer.WriteStringField("field", col.Name)
+		})
+
+	case mysql.TypeFloat:
+		writer.WriteObjectElement(func() {
+			writer.WriteStringField("type", "float")
+			writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+			writer.WriteStringField("field", col.Name)
+		})
+
+	case mysql.TypeDouble:
+		writer.WriteObjectElement(func() {
+			writer.WriteStringField("type", "double")
+			writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+			writer.WriteStringField("field", col.Name)
+		})
+
+	case mysql.TypeYear:
+		writer.WriteObjectElement(func() {
+			writer.WriteStringField("type", "int32")
+			writer.WriteBoolField("optional", !mysql.HasNotNullFlag(ft.GetFlag()))
+			writer.WriteStringField("name", "io.debezium.time.Year")
+			writer.WriteIntField("version", 1)
+			writer.WriteStringField("field", col.Name)
+		})
+
+	default:
+		log.Warn(
+			"meet unsupported field type",
+			zap.Any("fieldType", col.Type),
+			zap.Any("column", col.Name),
+		)
+	}
+
+	return nil
+}
+
 // See https://debezium.io/documentation/reference/stable/connectors/mysql.html#mysql-data-types
-func (c *dbzCodec) writeDebeziumField(writer *util.JSONWriter, col *model.Column, ft *types.FieldType) error {
+//
+//revive:disable indent-error-flow
+func (c *dbzCodec) writeDebeziumFieldValue(
+	writer *util.JSONWriter,
+	col *model.Column,
+	ft *types.FieldType,
+) error {
 	if col.Value == nil {
 		writer.WriteNullField(col.Name)
 		return nil
 	}
 	switch col.Type {
 	case mysql.TypeBit:
-		if v, ok := col.Value.(uint64); ok {
-			// Debezium behavior:
-			// BIT(1) → BOOLEAN
-			// BIT(>1) → BYTES		The byte[] contains the bits in little-endian form and is sized to
-			//						contain the specified number of bits.
-			n := ft.GetFlen()
-			if n == 1 {
-				writer.WriteBoolField(col.Name, v != 0)
-				return nil
-			}
+		v, ok := col.Value.(uint64)
+		if !ok {
+			return cerror.ErrDebeziumEncodeFailed.GenWithStack(
+				"unexpected column value type %T for bit column %s",
+				col.Value,
+				col.Name)
+		}
 
+		// Debezium behavior:
+		// BIT(1) → BOOLEAN
+		// BIT(>1) → BYTES		The byte[] contains the bits in little-endian form and is sized to
+		//						contain the specified number of bits.
+		n := ft.GetFlen()
+		if n == 1 {
+			writer.WriteBoolField(col.Name, v != 0)
+			return nil
+		} else {
 			var buf [8]byte
 			binary.LittleEndian.PutUint64(buf[:], v)
 			numBytes := n / 8
@@ -78,123 +291,142 @@ func (c *dbzCodec) writeDebeziumField(writer *util.JSONWriter, col *model.Column
 			c.writeBinaryField(writer, col.Name, buf[:numBytes])
 			return nil
 		}
-		return cerror.ErrDebeziumEncodeFailed.GenWithStack(
-			"unexpected column value type %T for bit column %s",
-			col.Value,
-			col.Name)
+
 	case mysql.TypeVarchar, mysql.TypeString, mysql.TypeVarString, mysql.TypeTinyBlob,
 		mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeBlob:
-		if col.Flag.IsBinary() {
-			if v, ok := col.Value.([]byte); ok {
-				c.writeBinaryField(writer, col.Name, v)
-				return nil
-			}
+		v, ok := col.Value.([]byte)
+		if !ok {
 			return cerror.ErrDebeziumEncodeFailed.GenWithStack(
-				"unexpected column value type %T for binary string column %s",
+				"unexpected column value type %T for string column %s",
 				col.Value,
 				col.Name)
 		}
-		if v, ok := col.Value.([]byte); ok {
+
+		if col.Flag.IsBinary() {
+			c.writeBinaryField(writer, col.Name, v)
+			return nil
+		} else {
 			writer.WriteStringField(col.Name, string(hack.String(v)))
 			return nil
 		}
-		return cerror.ErrDebeziumEncodeFailed.GenWithStack(
-			"unexpected column value type %T for non-binary string column %s",
-			col.Value,
-			col.Name)
+
 	case mysql.TypeEnum:
-		if v, ok := col.Value.(uint64); ok {
-			enumVar, err := types.ParseEnumValue(ft.GetElems(), v)
-			if err != nil {
-				// Invalid enum value inserted in non-strict mode.
-				writer.WriteStringField(col.Name, "")
-				return nil
-			}
-			writer.WriteStringField(col.Name, enumVar.Name)
+		v, ok := col.Value.(uint64)
+		if !ok {
+			return cerror.ErrDebeziumEncodeFailed.GenWithStack(
+				"unexpected column value type %T for enum column %s",
+				col.Value,
+				col.Name)
+		}
+
+		enumVar, err := types.ParseEnumValue(ft.GetElems(), v)
+		if err != nil {
+			// Invalid enum value inserted in non-strict mode.
+			writer.WriteStringField(col.Name, "")
 			return nil
 		}
-		return cerror.ErrDebeziumEncodeFailed.GenWithStack(
-			"unexpected column value type %T for enum column %s",
-			col.Value,
-			col.Name)
+
+		writer.WriteStringField(col.Name, enumVar.Name)
+		return nil
+
 	case mysql.TypeSet:
-		if v, ok := col.Value.(uint64); ok {
-			setVar, err := types.ParseSetValue(ft.GetElems(), v)
-			if err != nil {
-				// Invalid enum value inserted in non-strict mode.
-				writer.WriteStringField(col.Name, "")
-				return nil
-			}
-			writer.WriteStringField(col.Name, setVar.Name)
+		v, ok := col.Value.(uint64)
+		if !ok {
+			return cerror.ErrDebeziumEncodeFailed.GenWithStack(
+				"unexpected column value type %T for set column %s",
+				col.Value,
+				col.Name)
+
+		}
+
+		setVar, err := types.ParseSetValue(ft.GetElems(), v)
+		if err != nil {
+			// Invalid enum value inserted in non-strict mode.
+			writer.WriteStringField(col.Name, "")
 			return nil
 		}
-		return cerror.ErrDebeziumEncodeFailed.GenWithStack(
-			"unexpected column value type %T for set column %s",
-			col.Value,
-			col.Name)
+
+		writer.WriteStringField(col.Name, setVar.Name)
+		return nil
+
 	case mysql.TypeNewDecimal:
-		if v, ok := col.Value.(string); ok {
-			floatV, err := strconv.ParseFloat(v, 64)
-			if err != nil {
-				return cerror.WrapError(
-					cerror.ErrDebeziumEncodeFailed,
-					err)
-			}
-			writer.WriteFloat64Field(col.Name, floatV)
-			return nil
+		v, ok := col.Value.(string)
+		if !ok {
+			return cerror.ErrDebeziumEncodeFailed.GenWithStack(
+				"unexpected column value type %T for decimal column %s",
+				col.Value,
+				col.Name)
 		}
-		return cerror.ErrDebeziumEncodeFailed.GenWithStack(
-			"unexpected column value type %T for decimal column %s",
-			col.Value,
-			col.Name)
+
+		floatV, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return cerror.WrapError(
+				cerror.ErrDebeziumEncodeFailed,
+				err)
+		}
+
+		writer.WriteFloat64Field(col.Name, floatV)
+		return nil
+
 	case mysql.TypeDate, mysql.TypeNewDate:
-		if v, ok := col.Value.(string); ok {
-			t, err := time.Parse("2006-01-02", v)
-			if err != nil {
-				// For example, time may be invalid like 1000-00-00
-				// return nil, nil
-				if mysql.HasNotNullFlag(ft.GetFlag()) {
-					writer.WriteInt64Field(col.Name, 0)
-					return nil
-				}
+		v, ok := col.Value.(string)
+		if !ok {
+			return cerror.ErrDebeziumEncodeFailed.GenWithStack(
+				"unexpected column value type %T for date column %s",
+				col.Value,
+				col.Name)
+		}
+
+		t, err := time.Parse("2006-01-02", v)
+		if err != nil {
+			// For example, time may be invalid like 1000-00-00
+			// return nil, nil
+			if mysql.HasNotNullFlag(ft.GetFlag()) {
+				writer.WriteInt64Field(col.Name, 0)
+				return nil
+			} else {
 				writer.WriteNullField(col.Name)
 				return nil
 			}
-			writer.WriteInt64Field(col.Name, t.Unix()/60/60/24)
-			return nil
 		}
-		return cerror.ErrDebeziumEncodeFailed.GenWithStack(
-			"unexpected column value type %T for date column %s",
-			col.Value,
-			col.Name)
+
+		writer.WriteInt64Field(col.Name, t.Unix()/60/60/24)
+		return nil
+
 	case mysql.TypeDatetime:
 		// Debezium behavior from doc:
 		// > Such columns are converted into epoch milliseconds or microseconds based on the
 		// > column's precision by using UTC.
 
 		// TODO: For Default Value = CURRENT_TIMESTAMP, the result is incorrect.
-		if v, ok := col.Value.(string); ok {
-			t, err := time.Parse("2006-01-02 15:04:05.999999", v)
-			if err != nil {
-				// For example, time may be 1000-00-00
-				if mysql.HasNotNullFlag(ft.GetFlag()) {
-					writer.WriteInt64Field(col.Name, 0)
-					return nil
-				}
+		v, ok := col.Value.(string)
+		if !ok {
+			return cerror.ErrDebeziumEncodeFailed.GenWithStack(
+				"unexpected column value type %T for datetime column %s",
+				col.Value,
+				col.Name)
+		}
+
+		t, err := time.Parse("2006-01-02 15:04:05.999999", v)
+		if err != nil {
+			// For example, time may be 1000-00-00
+			if mysql.HasNotNullFlag(ft.GetFlag()) {
+				writer.WriteInt64Field(col.Name, 0)
+				return nil
+			} else {
 				writer.WriteNullField(col.Name)
 				return nil
 			}
-			if ft.GetDecimal() <= 3 {
-				writer.WriteInt64Field(col.Name, t.UnixMilli())
-				return nil
-			}
+		}
+
+		if ft.GetDecimal() <= 3 {
+			writer.WriteInt64Field(col.Name, t.UnixMilli())
+			return nil
+		} else {
 			writer.WriteInt64Field(col.Name, t.UnixMicro())
 			return nil
 		}
-		return cerror.ErrDebeziumEncodeFailed.GenWithStack(
-			"unexpected column value type %T for datetime column %s",
-			col.Value,
-			col.Name)
+
 	case mysql.TypeTimestamp:
 		// Debezium behavior from doc:
 		// > The TIMESTAMP type represents a timestamp without time zone information.
@@ -205,64 +437,72 @@ func (c *dbzCodec) writeDebeziumField(writer *util.JSONWriter, col *model.Column
 		// > based on the server (or session's) current time zone. The time zone will be queried from
 		// > the server by default. If this fails, it must be specified explicitly by the database
 		// > connectionTimeZone MySQL configuration option.
-		if v, ok := col.Value.(string); ok {
-			t, err := time.ParseInLocation("2006-01-02 15:04:05.999999", v, c.config.TimeZone)
-			if err != nil {
-				// For example, time may be invalid like 1000-00-00
-				if mysql.HasNotNullFlag(ft.GetFlag()) {
-					t = time.Unix(0, 0)
-				} else {
-					writer.WriteNullField(col.Name)
-					return nil
-				}
-			}
-
-			str := t.UTC().Format("2006-01-02T15:04:05")
-			fsp := ft.GetDecimal()
-			if fsp > 0 {
-				tmp := fmt.Sprintf(".%06d", t.Nanosecond()/1000)
-				str = str + tmp[:1+fsp]
-			}
-			str += "Z"
-
-			writer.WriteStringField(col.Name, str)
-			return nil
+		v, ok := col.Value.(string)
+		if !ok {
+			return cerror.ErrDebeziumEncodeFailed.GenWithStack(
+				"unexpected column value type %T for timestamp column %s",
+				col.Value,
+				col.Name)
 		}
-		return cerror.ErrDebeziumEncodeFailed.GenWithStack(
-			"unexpected column value type %T for timestamp column %s",
-			col.Value,
-			col.Name)
+
+		t, err := time.ParseInLocation("2006-01-02 15:04:05.999999", v, c.config.TimeZone)
+		if err != nil {
+			// For example, time may be invalid like 1000-00-00
+			if mysql.HasNotNullFlag(ft.GetFlag()) {
+				t = time.Unix(0, 0)
+			} else {
+				writer.WriteNullField(col.Name)
+				return nil
+			}
+		}
+
+		str := t.UTC().Format("2006-01-02T15:04:05")
+		fsp := ft.GetDecimal()
+		if fsp > 0 {
+			tmp := fmt.Sprintf(".%06d", t.Nanosecond()/1000)
+			str = str + tmp[:1+fsp]
+		}
+		str += "Z"
+
+		writer.WriteStringField(col.Name, str)
+		return nil
+
 	case mysql.TypeDuration:
 		// Debezium behavior from doc:
 		// > Represents the time value in microseconds and does not include
 		// > time zone information. MySQL allows M to be in the range of 0-6.
-		if v, ok := col.Value.(string); ok {
-			d, _, _, err := types.StrToDuration(types.DefaultStmtNoWarningContext, v, ft.GetDecimal())
-			if err != nil {
-				return cerror.WrapError(
-					cerror.ErrDebeziumEncodeFailed,
-					err)
-			}
-
-			writer.WriteInt64Field(col.Name, d.Microseconds())
-			return nil
+		v, ok := col.Value.(string)
+		if !ok {
+			return cerror.ErrDebeziumEncodeFailed.GenWithStack(
+				"unexpected column value type %T for time column %s",
+				col.Value,
+				col.Name)
 		}
-		return cerror.ErrDebeziumEncodeFailed.GenWithStack(
-			"unexpected column value type %T for time column %s",
-			col.Value,
-			col.Name)
+
+		d, _, _, err := types.StrToDuration(types.DefaultStmtNoWarningContext, v, ft.GetDecimal())
+		if err != nil {
+			return cerror.WrapError(
+				cerror.ErrDebeziumEncodeFailed,
+				err)
+		}
+
+		writer.WriteInt64Field(col.Name, d.Microseconds())
+		return nil
+
 	case mysql.TypeLonglong:
 		if col.Flag.IsUnsigned() {
 			// Handle with BIGINT UNSIGNED.
 			// Debezium always produce INT64 instead of UINT64 for BIGINT.
-			if v, ok := col.Value.(uint64); ok {
-				writer.WriteInt64Field(col.Name, int64(v))
-				return nil
+			v, ok := col.Value.(uint64)
+			if !ok {
+				return cerror.ErrDebeziumEncodeFailed.GenWithStack(
+					"unexpected column value type %T for unsigned bigint column %s",
+					col.Value,
+					col.Name)
 			}
-			return cerror.ErrDebeziumEncodeFailed.GenWithStack(
-				"unexpected column value type %T for unsigned bigint column %s",
-				col.Value,
-				col.Name)
+
+			writer.WriteInt64Field(col.Name, int64(v))
+			return nil
 		}
 
 		// Note: Although Debezium's doc claims to use INT32 for INT, but it
@@ -299,7 +539,8 @@ func (c *dbzCodec) EncodeRowChangedEvent(
 				// ts_ms: In the source object, ts_ms indicates the time that the change was made in the database.
 				// https://debezium.io/documentation/reference/stable/connectors/mysql.html#mysql-create-events
 				jWriter.WriteInt64Field("ts_ms", commitTime.UnixMilli())
-				jWriter.WriteBoolField("snapshot", false)
+				// snapshot field is a string of true,last,false,incremental
+				jWriter.WriteStringField("snapshot", "false")
 				jWriter.WriteStringField("db", e.Table.Schema)
 				jWriter.WriteStringField("table", e.Table.Table)
 				jWriter.WriteInt64Field("server_id", 0)
@@ -339,18 +580,202 @@ func (c *dbzCodec) EncodeRowChangedEvent(
 				// after: An optional field that specifies the state of the row after the event occurred.
 				// Optional field that specifies the state of the row after the event occurred.
 				// In a delete event value, the after field is null, signifying that the row no longer exists.
-				err = c.writeColumnsAsField(jWriter, "after", e.Columns, e.ColInfos)
+				err = c.writeDebeziumFieldValues(jWriter, "after", e.Columns, e.ColInfos)
 			} else if e.IsDelete() {
 				jWriter.WriteStringField("op", "d")
 				jWriter.WriteNullField("after")
-				err = c.writeColumnsAsField(jWriter, "before", e.PreColumns, e.ColInfos)
+				err = c.writeDebeziumFieldValues(jWriter, "before", e.PreColumns, e.ColInfos)
 			} else if e.IsUpdate() {
 				jWriter.WriteStringField("op", "u")
-				err = c.writeColumnsAsField(jWriter, "before", e.PreColumns, e.ColInfos)
+				err = c.writeDebeziumFieldValues(jWriter, "before", e.PreColumns, e.ColInfos)
 				if err == nil {
-					err = c.writeColumnsAsField(jWriter, "after", e.Columns, e.ColInfos)
+					err = c.writeDebeziumFieldValues(jWriter, "after", e.Columns, e.ColInfos)
 				}
 			}
+		})
+
+		jWriter.WriteObjectField("schema", func() {
+			jWriter.WriteStringField("type", "struct")
+			jWriter.WriteBoolField("optional", false)
+			jWriter.WriteStringField("name", fmt.Sprintf("%s.%s.%s.Envelope", c.clusterID, e.Table.Schema, e.Table.Table))
+			jWriter.WriteIntField("version", 1)
+			jWriter.WriteArrayField("fields", func() {
+				// schema is the same for `before` and `after`. So we build a new buffer to
+				// build the JSON, so that content can be reused.
+				var fieldsJSON string
+				{
+					fieldsBuf := &bytes.Buffer{}
+					fieldsWriter := util.BorrowJSONWriter(fieldsBuf)
+					var validCols []*model.Column
+					if e.IsInsert() {
+						validCols = e.Columns
+					} else if e.IsDelete() {
+						validCols = e.PreColumns
+					} else if e.IsUpdate() {
+						validCols = e.Columns
+					}
+					for i, col := range validCols {
+						err = c.writeDebeziumFieldSchema(fieldsWriter, col, e.ColInfos[i].Ft)
+						if err != nil {
+							return
+						}
+					}
+					util.ReturnJSONWriter(fieldsWriter)
+					fieldsJSON = fieldsBuf.String()
+				}
+				jWriter.WriteObjectElement(func() {
+					jWriter.WriteStringField("type", "struct")
+					jWriter.WriteBoolField("optional", true)
+					jWriter.WriteStringField("name", fmt.Sprintf("%s.%s.%s.Value", c.clusterID, e.Table.Schema, e.Table.Table))
+					jWriter.WriteStringField("field", "before")
+					jWriter.WriteArrayField("fields", func() {
+						jWriter.WriteRaw(fieldsJSON)
+					})
+				})
+				jWriter.WriteObjectElement(func() {
+					jWriter.WriteStringField("type", "struct")
+					jWriter.WriteBoolField("optional", true)
+					jWriter.WriteStringField("name", fmt.Sprintf("%s.%s.%s.Value", c.clusterID, e.Table.Schema, e.Table.Table))
+					jWriter.WriteStringField("field", "after")
+					jWriter.WriteArrayField("fields", func() {
+						jWriter.WriteRaw(fieldsJSON)
+					})
+				})
+				jWriter.WriteObjectElement(func() {
+					jWriter.WriteStringField("type", "struct")
+					jWriter.WriteArrayField("fields", func() {
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "string")
+							jWriter.WriteBoolField("optional", false)
+							jWriter.WriteStringField("field", "version")
+						})
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "string")
+							jWriter.WriteBoolField("optional", false)
+							jWriter.WriteStringField("field", "connector")
+						})
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "string")
+							jWriter.WriteBoolField("optional", false)
+							jWriter.WriteStringField("field", "name")
+						})
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "int64")
+							jWriter.WriteBoolField("optional", false)
+							jWriter.WriteStringField("field", "ts_ms")
+						})
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "string")
+							jWriter.WriteBoolField("optional", true)
+							jWriter.WriteStringField("name", "io.debezium.data.Enum")
+							jWriter.WriteIntField("version", 1)
+							jWriter.WriteObjectField("parameters", func() {
+								jWriter.WriteStringField("allowed", "true,last,false,incremental")
+							})
+							jWriter.WriteStringField("default", "false")
+							jWriter.WriteStringField("field", "snapshot")
+						})
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "string")
+							jWriter.WriteBoolField("optional", false)
+							jWriter.WriteStringField("field", "db")
+						})
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "string")
+							jWriter.WriteBoolField("optional", true)
+							jWriter.WriteStringField("field", "sequence")
+						})
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "string")
+							jWriter.WriteBoolField("optional", true)
+							jWriter.WriteStringField("field", "table")
+						})
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "int64")
+							jWriter.WriteBoolField("optional", false)
+							jWriter.WriteStringField("field", "server_id")
+						})
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "string")
+							jWriter.WriteBoolField("optional", true)
+							jWriter.WriteStringField("field", "gtid")
+						})
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "string")
+							jWriter.WriteBoolField("optional", false)
+							jWriter.WriteStringField("field", "file")
+						})
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "int64")
+							jWriter.WriteBoolField("optional", false)
+							jWriter.WriteStringField("field", "pos")
+						})
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "int32")
+							jWriter.WriteBoolField("optional", false)
+							jWriter.WriteStringField("field", "row")
+						})
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "int64")
+							jWriter.WriteBoolField("optional", true)
+							jWriter.WriteStringField("field", "thread")
+						})
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "string")
+							jWriter.WriteBoolField("optional", true)
+							jWriter.WriteStringField("field", "query")
+						})
+						// Below are extra TiDB fields
+						// jWriter.WriteObjectElement(func() {
+						// 	jWriter.WriteStringField("type", "int64")
+						// 	jWriter.WriteBoolField("optional", false)
+						// 	jWriter.WriteStringField("field", "commit_ts")
+						// })
+						// jWriter.WriteObjectElement(func() {
+						// 	jWriter.WriteStringField("type", "string")
+						// 	jWriter.WriteBoolField("optional", false)
+						// 	jWriter.WriteStringField("field", "cluster_id")
+						// })
+					})
+					jWriter.WriteBoolField("optional", false)
+					jWriter.WriteStringField("name", "io.debezium.connector.mysql.Source")
+					jWriter.WriteStringField("field", "source")
+				})
+				jWriter.WriteObjectElement(func() {
+					jWriter.WriteStringField("type", "string")
+					jWriter.WriteBoolField("optional", false)
+					jWriter.WriteStringField("field", "op")
+				})
+				jWriter.WriteObjectElement(func() {
+					jWriter.WriteStringField("type", "int64")
+					jWriter.WriteBoolField("optional", true)
+					jWriter.WriteStringField("field", "ts_ms")
+				})
+				jWriter.WriteObjectElement(func() {
+					jWriter.WriteStringField("type", "struct")
+					jWriter.WriteArrayField("fields", func() {
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "string")
+							jWriter.WriteBoolField("optional", false)
+							jWriter.WriteStringField("field", "id")
+						})
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "int64")
+							jWriter.WriteBoolField("optional", false)
+							jWriter.WriteStringField("field", "total_order")
+						})
+						jWriter.WriteObjectElement(func() {
+							jWriter.WriteStringField("type", "int64")
+							jWriter.WriteBoolField("optional", false)
+							jWriter.WriteStringField("field", "data_collection_order")
+						})
+					})
+					jWriter.WriteBoolField("optional", true)
+					jWriter.WriteStringField("name", "event.block")
+					jWriter.WriteIntField("version", 1)
+					jWriter.WriteStringField("field", "transaction")
+				})
+			})
 		})
 	})
 

--- a/pkg/sink/codec/debezium/codec.go
+++ b/pkg/sink/codec/debezium/codec.go
@@ -334,7 +334,6 @@ func (c *dbzCodec) writeDebeziumFieldValue(
 				"unexpected column value type %T for set column %s",
 				col.Value,
 				col.Name)
-
 		}
 
 		setVar, err := types.ParseSetValue(ft.GetElems(), v)

--- a/pkg/sink/codec/debezium/codec_test.go
+++ b/pkg/sink/codec/debezium/codec_test.go
@@ -34,6 +34,7 @@ func TestEncodeInsert(t *testing.T) {
 		clusterID: "test-cluster",
 		nowFunc:   func() time.Time { return time.Unix(1701326309, 0) },
 	}
+	codec.config.DebeziumDisableSchema = true
 
 	e := &model.RowChangedEvent{
 		CommitTs: 1,
@@ -53,7 +54,8 @@ func TestEncodeInsert(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	err := codec.EncodeRowChangedEvent(e, buf)
 	require.Nil(t, err)
-	require.JSONEq(t, `{
+	require.JSONEq(t, `
+	{
 		"payload": {
 			"before": null,
 			"after": {
@@ -74,14 +76,120 @@ func TestEncodeInsert(t *testing.T) {
 				"query": null,
 				"row": 0,
 				"server_id": 0,
-				"snapshot": false,
+				"snapshot": "false",
 				"thread": 0,
 				"version": "2.4.0.Final"
 			},
 			"ts_ms": 1701326309000,
 			"transaction": null
 		}
-	}`, buf.String())
+	}
+	`, buf.String())
+
+	codec.config.DebeziumDisableSchema = false
+	buf.Reset()
+	err = codec.EncodeRowChangedEvent(e, buf)
+	require.Nil(t, err)
+	require.JSONEq(t, `
+	{
+		"payload": {
+			"source": {
+				"version": "2.4.0.Final",
+				"connector": "TiCDC",
+				"name": "test-cluster",
+				"ts_ms": 0,
+				"snapshot": "false",
+				"db": "test",
+				"table": "table1",
+				"server_id": 0,
+				"gtid": null,
+				"file": "",
+				"pos": 0,
+				"row": 0,
+				"thread": 0,
+				"query": null,
+				"commit_ts": 1,
+				"cluster_id": "test-cluster"
+			},
+			"ts_ms": 1701326309000,
+			"transaction": null,
+			"op": "c",
+			"before": null,
+			"after": { "tiny": 1 }
+		},
+		"schema": {
+			"type": "struct",
+			"optional": false,
+			"name": "test-cluster.test.table1.Envelope",
+			"version": 1,
+			"fields": [
+				{
+					"type": "struct",
+					"optional": true,
+					"name": "test-cluster.test.table1.Value",
+					"field": "before",
+					"fields": [{ "type": "int16", "optional": true, "field": "tiny" }]
+				},
+				{
+					"type": "struct",
+					"optional": true,
+					"name": "test-cluster.test.table1.Value",
+					"field": "after",
+					"fields": [{ "type": "int16", "optional": true, "field": "tiny" }]
+				},
+				{
+					"type": "struct",
+					"fields": [
+						{ "type": "string", "optional": false, "field": "version" },
+						{ "type": "string", "optional": false, "field": "connector" },
+						{ "type": "string", "optional": false, "field": "name" },
+						{ "type": "int64", "optional": false, "field": "ts_ms" },
+						{
+							"type": "string",
+							"optional": true,
+							"name": "io.debezium.data.Enum",
+							"version": 1,
+							"parameters": { "allowed": "true,last,false,incremental" },
+							"default": "false",
+							"field": "snapshot"
+						},
+						{ "type": "string", "optional": false, "field": "db" },
+						{ "type": "string", "optional": true, "field": "sequence" },
+						{ "type": "string", "optional": true, "field": "table" },
+						{ "type": "int64", "optional": false, "field": "server_id" },
+						{ "type": "string", "optional": true, "field": "gtid" },
+						{ "type": "string", "optional": false, "field": "file" },
+						{ "type": "int64", "optional": false, "field": "pos" },
+						{ "type": "int32", "optional": false, "field": "row" },
+						{ "type": "int64", "optional": true, "field": "thread" },
+						{ "type": "string", "optional": true, "field": "query" }
+					],
+					"optional": false,
+					"name": "io.debezium.connector.mysql.Source",
+					"field": "source"
+				},
+				{ "type": "string", "optional": false, "field": "op" },
+				{ "type": "int64", "optional": true, "field": "ts_ms" },
+				{
+					"type": "struct",
+					"fields": [
+						{ "type": "string", "optional": false, "field": "id" },
+						{ "type": "int64", "optional": false, "field": "total_order" },
+						{
+							"type": "int64",
+							"optional": false,
+							"field": "data_collection_order"
+						}
+					],
+					"optional": true,
+					"name": "event.block",
+					"version": 1,
+					"field": "transaction"
+				}
+			]
+		}
+	}
+	`, buf.String())
 }
 
 func TestEncodeUpdate(t *testing.T) {
@@ -90,6 +198,7 @@ func TestEncodeUpdate(t *testing.T) {
 		clusterID: "test-cluster",
 		nowFunc:   func() time.Time { return time.Unix(1701326309, 0) },
 	}
+	codec.config.DebeziumDisableSchema = true
 
 	e := &model.RowChangedEvent{
 		CommitTs: 1,
@@ -113,7 +222,8 @@ func TestEncodeUpdate(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	err := codec.EncodeRowChangedEvent(e, buf)
 	require.Nil(t, err)
-	require.JSONEq(t, `{
+	require.JSONEq(t, `
+	{
 		"payload": {
 			"before": {
 				"tiny": 2
@@ -136,14 +246,120 @@ func TestEncodeUpdate(t *testing.T) {
 				"query": null,
 				"row": 0,
 				"server_id": 0,
-				"snapshot": false,
+				"snapshot": "false",
 				"thread": 0,
 				"version": "2.4.0.Final"
 			},
 			"ts_ms": 1701326309000,
 			"transaction": null
 		}
-	}`, buf.String())
+	}
+	`, buf.String())
+
+	codec.config.DebeziumDisableSchema = false
+	buf.Reset()
+	err = codec.EncodeRowChangedEvent(e, buf)
+	require.Nil(t, err)
+	require.JSONEq(t, `
+	{
+		"payload": {
+			"source": {
+				"version": "2.4.0.Final",
+				"connector": "TiCDC",
+				"name": "test-cluster",
+				"ts_ms": 0,
+				"snapshot": "false",
+				"db": "test",
+				"table": "table1",
+				"server_id": 0,
+				"gtid": null,
+				"file": "",
+				"pos": 0,
+				"row": 0,
+				"thread": 0,
+				"query": null,
+				"commit_ts": 1,
+				"cluster_id": "test-cluster"
+			},
+			"ts_ms": 1701326309000,
+			"transaction": null,
+			"op": "u",
+			"before": { "tiny": 2 },
+			"after": { "tiny": 1 }
+		},
+		"schema": {
+			"type": "struct",
+			"optional": false,
+			"name": "test-cluster.test.table1.Envelope",
+			"version": 1,
+			"fields": [
+				{
+					"type": "struct",
+					"optional": true,
+					"name": "test-cluster.test.table1.Value",
+					"field": "before",
+					"fields": [{ "type": "int16", "optional": true, "field": "tiny" }]
+				},
+				{
+					"type": "struct",
+					"optional": true,
+					"name": "test-cluster.test.table1.Value",
+					"field": "after",
+					"fields": [{ "type": "int16", "optional": true, "field": "tiny" }]
+				},
+				{
+					"type": "struct",
+					"fields": [
+						{ "type": "string", "optional": false, "field": "version" },
+						{ "type": "string", "optional": false, "field": "connector" },
+						{ "type": "string", "optional": false, "field": "name" },
+						{ "type": "int64", "optional": false, "field": "ts_ms" },
+						{
+							"type": "string",
+							"optional": true,
+							"name": "io.debezium.data.Enum",
+							"version": 1,
+							"parameters": { "allowed": "true,last,false,incremental" },
+							"default": "false",
+							"field": "snapshot"
+						},
+						{ "type": "string", "optional": false, "field": "db" },
+						{ "type": "string", "optional": true, "field": "sequence" },
+						{ "type": "string", "optional": true, "field": "table" },
+						{ "type": "int64", "optional": false, "field": "server_id" },
+						{ "type": "string", "optional": true, "field": "gtid" },
+						{ "type": "string", "optional": false, "field": "file" },
+						{ "type": "int64", "optional": false, "field": "pos" },
+						{ "type": "int32", "optional": false, "field": "row" },
+						{ "type": "int64", "optional": true, "field": "thread" },
+						{ "type": "string", "optional": true, "field": "query" }
+					],
+					"optional": false,
+					"name": "io.debezium.connector.mysql.Source",
+					"field": "source"
+				},
+				{ "type": "string", "optional": false, "field": "op" },
+				{ "type": "int64", "optional": true, "field": "ts_ms" },
+				{
+					"type": "struct",
+					"fields": [
+						{ "type": "string", "optional": false, "field": "id" },
+						{ "type": "int64", "optional": false, "field": "total_order" },
+						{
+							"type": "int64",
+							"optional": false,
+							"field": "data_collection_order"
+						}
+					],
+					"optional": true,
+					"name": "event.block",
+					"version": 1,
+					"field": "transaction"
+				}
+			]
+		}
+	}
+	`, buf.String())
 }
 
 func TestEncodeDelete(t *testing.T) {
@@ -152,6 +368,7 @@ func TestEncodeDelete(t *testing.T) {
 		clusterID: "test-cluster",
 		nowFunc:   func() time.Time { return time.Unix(1701326309, 0) },
 	}
+	codec.config.DebeziumDisableSchema = true
 
 	e := &model.RowChangedEvent{
 		CommitTs: 1,
@@ -171,7 +388,8 @@ func TestEncodeDelete(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	err := codec.EncodeRowChangedEvent(e, buf)
 	require.Nil(t, err)
-	require.JSONEq(t, `{
+	require.JSONEq(t, `
+	{
 		"payload": {
 			"before": {
 				"tiny": 2
@@ -192,14 +410,120 @@ func TestEncodeDelete(t *testing.T) {
 				"query": null,
 				"row": 0,
 				"server_id": 0,
-				"snapshot": false,
+				"snapshot": "false",
 				"thread": 0,
 				"version": "2.4.0.Final"
 			},
 			"ts_ms": 1701326309000,
 			"transaction": null
 		}
-	}`, buf.String())
+	}
+	`, buf.String())
+
+	codec.config.DebeziumDisableSchema = false
+	buf.Reset()
+	err = codec.EncodeRowChangedEvent(e, buf)
+	require.Nil(t, err)
+	require.JSONEq(t, `
+	{
+		"payload": {
+			"source": {
+				"version": "2.4.0.Final",
+				"connector": "TiCDC",
+				"name": "test-cluster",
+				"ts_ms": 0,
+				"snapshot": "false",
+				"db": "test",
+				"table": "table1",
+				"server_id": 0,
+				"gtid": null,
+				"file": "",
+				"pos": 0,
+				"row": 0,
+				"thread": 0,
+				"query": null,
+				"commit_ts": 1,
+				"cluster_id": "test-cluster"
+			},
+			"ts_ms": 1701326309000,
+			"transaction": null,
+			"op": "d",
+			"after": null,
+			"before": { "tiny": 2 }
+		},
+		"schema": {
+			"type": "struct",
+			"optional": false,
+			"name": "test-cluster.test.table1.Envelope",
+			"version": 1,
+			"fields": [
+				{
+					"type": "struct",
+					"optional": true,
+					"name": "test-cluster.test.table1.Value",
+					"field": "before",
+					"fields": [{ "type": "int16", "optional": true, "field": "tiny" }]
+				},
+				{
+					"type": "struct",
+					"optional": true,
+					"name": "test-cluster.test.table1.Value",
+					"field": "after",
+					"fields": [{ "type": "int16", "optional": true, "field": "tiny" }]
+				},
+				{
+					"type": "struct",
+					"fields": [
+						{ "type": "string", "optional": false, "field": "version" },
+						{ "type": "string", "optional": false, "field": "connector" },
+						{ "type": "string", "optional": false, "field": "name" },
+						{ "type": "int64", "optional": false, "field": "ts_ms" },
+						{
+							"type": "string",
+							"optional": true,
+							"name": "io.debezium.data.Enum",
+							"version": 1,
+							"parameters": { "allowed": "true,last,false,incremental" },
+							"default": "false",
+							"field": "snapshot"
+						},
+						{ "type": "string", "optional": false, "field": "db" },
+						{ "type": "string", "optional": true, "field": "sequence" },
+						{ "type": "string", "optional": true, "field": "table" },
+						{ "type": "int64", "optional": false, "field": "server_id" },
+						{ "type": "string", "optional": true, "field": "gtid" },
+						{ "type": "string", "optional": false, "field": "file" },
+						{ "type": "int64", "optional": false, "field": "pos" },
+						{ "type": "int32", "optional": false, "field": "row" },
+						{ "type": "int64", "optional": true, "field": "thread" },
+						{ "type": "string", "optional": true, "field": "query" }
+					],
+					"optional": false,
+					"name": "io.debezium.connector.mysql.Source",
+					"field": "source"
+				},
+				{ "type": "string", "optional": false, "field": "op" },
+				{ "type": "int64", "optional": true, "field": "ts_ms" },
+				{
+					"type": "struct",
+					"fields": [
+						{ "type": "string", "optional": false, "field": "id" },
+						{ "type": "int64", "optional": false, "field": "total_order" },
+						{
+							"type": "int64",
+							"optional": false,
+							"field": "data_collection_order"
+						}
+					],
+					"optional": true,
+					"name": "event.block",
+					"version": 1,
+					"field": "transaction"
+				}
+			]
+		}
+	}
+	`, buf.String())
 }
 
 func BenchmarkEncodeOneTinyColumn(b *testing.B) {
@@ -208,6 +532,7 @@ func BenchmarkEncodeOneTinyColumn(b *testing.B) {
 		clusterID: "test-cluster",
 		nowFunc:   func() time.Time { return time.Unix(1701326309, 0) },
 	}
+	codec.config.DebeziumDisableSchema = true
 
 	e := &model.RowChangedEvent{
 		CommitTs: 1,
@@ -239,6 +564,7 @@ func BenchmarkEncodeLargeText(b *testing.B) {
 		clusterID: "test-cluster",
 		nowFunc:   func() time.Time { return time.Unix(1701326309, 0) },
 	}
+	codec.config.DebeziumDisableSchema = true
 
 	e := &model.RowChangedEvent{
 		CommitTs: 1,
@@ -270,6 +596,7 @@ func BenchmarkEncodeLargeBinary(b *testing.B) {
 		clusterID: "test-cluster",
 		nowFunc:   func() time.Time { return time.Unix(1701326309, 0) },
 	}
+	codec.config.DebeziumDisableSchema = true
 
 	e := &model.RowChangedEvent{
 		CommitTs: 1,

--- a/pkg/sink/codec/debezium/debezium_test.go
+++ b/pkg/sink/codec/debezium/debezium_test.go
@@ -132,7 +132,7 @@ func (h *SQLTestHelper) ScanTable() []*model.RowChangedEvent {
 func requireDebeziumJSONEq(t *testing.T, dbzOutput []byte, tiCDCOutput []byte) {
 	var (
 		ignoredRecordPaths = map[string]bool{
-			`{map[string]any}["schema"]`:                             true,
+			// `{map[string]any}["schema"]`:                             true,
 			`{map[string]any}["payload"].(map[string]any)["source"]`: true,
 			`{map[string]any}["payload"].(map[string]any)["ts_ms"]`:  true,
 		}
@@ -178,7 +178,7 @@ func TestDataTypes(t *testing.T) {
 	rows := helper.ScanTable()
 	cfg := common.NewConfig(config.ProtocolDebezium)
 	cfg.TimeZone = time.UTC
-	encoder := NewBatchEncoderBuilder(cfg).Build()
+	encoder := NewBatchEncoderBuilder(cfg, "dbserver1").Build()
 	for _, row := range rows {
 		err := encoder.AppendRowChangedEvent(context.Background(), "", row, nil)
 		require.Nil(t, err)

--- a/pkg/sink/codec/debezium/encoder.go
+++ b/pkg/sink/codec/debezium/encoder.go
@@ -95,13 +95,13 @@ func (d *BatchEncoder) Build() []*common.Message {
 }
 
 // newBatchEncoder creates a new Debezium BatchEncoder.
-func newBatchEncoder(c *common.Config) codec.RowEventEncoder {
+func newBatchEncoder(c *common.Config, clusterID string) codec.RowEventEncoder {
 	batch := &BatchEncoder{
 		messages: nil,
 		config:   c,
 		codec: &dbzCodec{
 			config:    c,
-			clusterID: config.GetGlobalServerConfig().ClusterID,
+			clusterID: clusterID,
 			nowFunc:   time.Now,
 		},
 	}
@@ -109,19 +109,21 @@ func newBatchEncoder(c *common.Config) codec.RowEventEncoder {
 }
 
 type batchEncoderBuilder struct {
-	config *common.Config
+	config    *common.Config
+	clusterID string
 }
 
 // NewBatchEncoderBuilder creates a Debezium batchEncoderBuilder.
-func NewBatchEncoderBuilder(config *common.Config) codec.RowEventEncoderBuilder {
+func NewBatchEncoderBuilder(config *common.Config, clusterID string) codec.RowEventEncoderBuilder {
 	return &batchEncoderBuilder{
-		config: config,
+		config:    config,
+		clusterID: clusterID,
 	}
 }
 
 // Build a `BatchEncoder`
 func (b *batchEncoderBuilder) Build() codec.RowEventEncoder {
-	return newBatchEncoder(b.config)
+	return newBatchEncoder(b.config, b.clusterID)
 }
 
 // CleanMetrics do nothing

--- a/pkg/util/json_writer.go
+++ b/pkg/util/json_writer.go
@@ -85,6 +85,10 @@ func (w *JSONWriter) Buffer() []byte {
 	return w.stream.Buffer()
 }
 
+func (w *JSONWriter) WriteRaw(b string) {
+	w.stream.WriteRaw(b)
+}
+
 // WriteBase64String writes a base64 string like "<value>".
 func (w *JSONWriter) WriteBase64String(b []byte) {
 	if w.out == nil {
@@ -112,6 +116,15 @@ func (w *JSONWriter) WriteObject(objectFieldsWriteFn func()) {
 	w.stream.WriteObjectStart()
 	objectFieldsWriteFn()
 	w.stream.WriteObjectEnd()
+	w.needPrependComma = lastNeedPrependComma
+}
+
+func (w *JSONWriter) WriteArray(arrayElementsWriteFn func()) {
+	lastNeedPrependComma := w.needPrependComma
+	w.needPrependComma = false
+	w.stream.WriteArrayStart()
+	arrayElementsWriteFn()
+	w.stream.WriteArrayEnd()
 	w.needPrependComma = lastNeedPrependComma
 }
 
@@ -214,6 +227,16 @@ func (w *JSONWriter) WriteObjectField(fieldName string, objectFieldsWriteFn func
 	w.WriteObject(objectFieldsWriteFn)
 }
 
+func (w *JSONWriter) WriteArrayField(fieldName string, arrayElementsWriteFn func()) {
+	if w.needPrependComma {
+		w.stream.WriteMore()
+	} else {
+		w.needPrependComma = true
+	}
+	w.stream.WriteObjectField(fieldName)
+	w.WriteArray(arrayElementsWriteFn)
+}
+
 // WriteNullField writes a array field like "<fieldName>":null.
 func (w *JSONWriter) WriteNullField(fieldName string) {
 	if w.needPrependComma {
@@ -222,5 +245,104 @@ func (w *JSONWriter) WriteNullField(fieldName string) {
 		w.needPrependComma = true
 	}
 	w.stream.WriteObjectField(fieldName)
+	w.stream.WriteNil()
+}
+
+func (w *JSONWriter) WriteBoolElement(value bool) {
+	if w.needPrependComma {
+		w.stream.WriteMore()
+	} else {
+		w.needPrependComma = true
+	}
+	w.stream.WriteBool(value)
+}
+
+func (w *JSONWriter) WriteIntElement(value int) {
+	if w.needPrependComma {
+		w.stream.WriteMore()
+	} else {
+		w.needPrependComma = true
+	}
+	w.stream.WriteInt(value)
+}
+
+func (w *JSONWriter) WriteInt64Element(value int64) {
+	if w.needPrependComma {
+		w.stream.WriteMore()
+	} else {
+		w.needPrependComma = true
+	}
+	w.stream.WriteInt64(value)
+}
+
+func (w *JSONWriter) WriteUint64Element(value uint64) {
+	if w.needPrependComma {
+		w.stream.WriteMore()
+	} else {
+		w.needPrependComma = true
+	}
+	w.stream.WriteUint64(value)
+}
+
+func (w *JSONWriter) WriteFloat64Element(value float64) {
+	if w.needPrependComma {
+		w.stream.WriteMore()
+	} else {
+		w.needPrependComma = true
+	}
+	w.stream.WriteFloat64(value)
+}
+
+func (w *JSONWriter) WriteStringElement(value string) {
+	if w.needPrependComma {
+		w.stream.WriteMore()
+	} else {
+		w.needPrependComma = true
+	}
+	w.stream.WriteString(value)
+}
+
+func (w *JSONWriter) WriteBase64StringElement(b []byte) {
+	if w.needPrependComma {
+		w.stream.WriteMore()
+	} else {
+		w.needPrependComma = true
+	}
+	w.WriteBase64String(b)
+}
+
+func (w *JSONWriter) WriteAnyElement(value any) {
+	if w.needPrependComma {
+		w.stream.WriteMore()
+	} else {
+		w.needPrependComma = true
+	}
+	w.stream.WriteVal(value)
+}
+
+func (w *JSONWriter) WriteObjectElement(objectFieldsWriteFn func()) {
+	if w.needPrependComma {
+		w.stream.WriteMore()
+	} else {
+		w.needPrependComma = true
+	}
+	w.WriteObject(objectFieldsWriteFn)
+}
+
+func (w *JSONWriter) WriteArrayElement(arrayElementsWriteFn func()) {
+	if w.needPrependComma {
+		w.stream.WriteMore()
+	} else {
+		w.needPrependComma = true
+	}
+	w.WriteArray(arrayElementsWriteFn)
+}
+
+func (w *JSONWriter) WriteNullElement() {
+	if w.needPrependComma {
+		w.stream.WriteMore()
+	} else {
+		w.needPrependComma = true
+	}
 	w.stream.WriteNil()
 }

--- a/pkg/util/json_writer.go
+++ b/pkg/util/json_writer.go
@@ -85,6 +85,7 @@ func (w *JSONWriter) Buffer() []byte {
 	return w.stream.Buffer()
 }
 
+// WriteRaw writes a raw string directly into the output.
 func (w *JSONWriter) WriteRaw(b string) {
 	w.stream.WriteRaw(b)
 }
@@ -119,6 +120,7 @@ func (w *JSONWriter) WriteObject(objectFieldsWriteFn func()) {
 	w.needPrependComma = lastNeedPrependComma
 }
 
+// WriteArray writes [......].
 func (w *JSONWriter) WriteArray(arrayElementsWriteFn func()) {
 	lastNeedPrependComma := w.needPrependComma
 	w.needPrependComma = false
@@ -227,6 +229,7 @@ func (w *JSONWriter) WriteObjectField(fieldName string, objectFieldsWriteFn func
 	w.WriteObject(objectFieldsWriteFn)
 }
 
+// WriteArrayField writes a array field like "<fieldName>":[......].
 func (w *JSONWriter) WriteArrayField(fieldName string, arrayElementsWriteFn func()) {
 	if w.needPrependComma {
 		w.stream.WriteMore()
@@ -237,7 +240,7 @@ func (w *JSONWriter) WriteArrayField(fieldName string, arrayElementsWriteFn func
 	w.WriteArray(arrayElementsWriteFn)
 }
 
-// WriteNullField writes a array field like "<fieldName>":null.
+// WriteNullField writes a null field like "<fieldName>":null.
 func (w *JSONWriter) WriteNullField(fieldName string) {
 	if w.needPrependComma {
 		w.stream.WriteMore()
@@ -248,6 +251,7 @@ func (w *JSONWriter) WriteNullField(fieldName string) {
 	w.stream.WriteNil()
 }
 
+// WriteBoolElement writes a bool array element like ,<value>.
 func (w *JSONWriter) WriteBoolElement(value bool) {
 	if w.needPrependComma {
 		w.stream.WriteMore()
@@ -257,6 +261,7 @@ func (w *JSONWriter) WriteBoolElement(value bool) {
 	w.stream.WriteBool(value)
 }
 
+// WriteIntElement writes a int array element like ,<value>.
 func (w *JSONWriter) WriteIntElement(value int) {
 	if w.needPrependComma {
 		w.stream.WriteMore()
@@ -266,6 +271,7 @@ func (w *JSONWriter) WriteIntElement(value int) {
 	w.stream.WriteInt(value)
 }
 
+// WriteInt64Element writes a int64 array element like ,<value>.
 func (w *JSONWriter) WriteInt64Element(value int64) {
 	if w.needPrependComma {
 		w.stream.WriteMore()
@@ -275,6 +281,7 @@ func (w *JSONWriter) WriteInt64Element(value int64) {
 	w.stream.WriteInt64(value)
 }
 
+// WriteUint64Element writes a uint64 array element like ,<value>.
 func (w *JSONWriter) WriteUint64Element(value uint64) {
 	if w.needPrependComma {
 		w.stream.WriteMore()
@@ -284,6 +291,7 @@ func (w *JSONWriter) WriteUint64Element(value uint64) {
 	w.stream.WriteUint64(value)
 }
 
+// WriteFloat64Element writes a float64 array element like ,<value>.
 func (w *JSONWriter) WriteFloat64Element(value float64) {
 	if w.needPrependComma {
 		w.stream.WriteMore()
@@ -293,6 +301,7 @@ func (w *JSONWriter) WriteFloat64Element(value float64) {
 	w.stream.WriteFloat64(value)
 }
 
+// WriteStringElement writes a string array element like ,"<value>".
 func (w *JSONWriter) WriteStringElement(value string) {
 	if w.needPrependComma {
 		w.stream.WriteMore()
@@ -302,6 +311,7 @@ func (w *JSONWriter) WriteStringElement(value string) {
 	w.stream.WriteString(value)
 }
 
+// WriteBase64StringElement writes a base64 string array element like ,"<value>".
 func (w *JSONWriter) WriteBase64StringElement(b []byte) {
 	if w.needPrependComma {
 		w.stream.WriteMore()
@@ -311,6 +321,7 @@ func (w *JSONWriter) WriteBase64StringElement(b []byte) {
 	w.WriteBase64String(b)
 }
 
+// WriteAnyElement writes a array element like ,<value>.
 func (w *JSONWriter) WriteAnyElement(value any) {
 	if w.needPrependComma {
 		w.stream.WriteMore()
@@ -320,6 +331,7 @@ func (w *JSONWriter) WriteAnyElement(value any) {
 	w.stream.WriteVal(value)
 }
 
+// WriteObjectElement writes a object array element like ,{......}.
 func (w *JSONWriter) WriteObjectElement(objectFieldsWriteFn func()) {
 	if w.needPrependComma {
 		w.stream.WriteMore()
@@ -329,6 +341,7 @@ func (w *JSONWriter) WriteObjectElement(objectFieldsWriteFn func()) {
 	w.WriteObject(objectFieldsWriteFn)
 }
 
+// WriteArrayElement writes a array array element like ,[......].
 func (w *JSONWriter) WriteArrayElement(arrayElementsWriteFn func()) {
 	if w.needPrependComma {
 		w.stream.WriteMore()
@@ -338,6 +351,7 @@ func (w *JSONWriter) WriteArrayElement(arrayElementsWriteFn func()) {
 	w.WriteArray(arrayElementsWriteFn)
 }
 
+// WriteNullElement writes a null array element like ,null.
 func (w *JSONWriter) WriteNullElement() {
 	if w.needPrependComma {
 		w.stream.WriteMore()

--- a/pkg/util/json_writer_test.go
+++ b/pkg/util/json_writer_test.go
@@ -136,6 +136,172 @@ func (suite *JSONWriterTestSuite) TestObject() {
 	suite.Require().Equal(`{"foo":{"foo1":{"abc":null},"bar1":{}},"bar":{"foo2":{},"bar2":{}}}`, s)
 }
 
+func (suite *JSONWriterTestSuite) TestArray() {
+	var s string
+
+	s = suite.writeJSON(func(w *JSONWriter) {
+		w.WriteArray(func() {})
+	})
+	suite.Require().Equal(`[]`, s)
+
+	s = suite.writeJSON(func(w *JSONWriter) {
+		w.WriteArray(func() {
+			w.WriteUint64Element(1)
+		})
+	})
+	suite.Require().Equal(`[1]`, s)
+
+	s = suite.writeJSON(func(w *JSONWriter) {
+		w.WriteArray(func() {
+			w.WriteUint64Element(1)
+			w.WriteUint64Element(2)
+		})
+	})
+	suite.Require().Equal(`[1,2]`, s)
+
+	s = suite.writeJSON(func(w *JSONWriter) {
+		w.WriteArray(func() {
+			w.WriteArrayElement(func() {})
+		})
+	})
+	suite.Require().Equal(`[[]]`, s)
+
+	s = suite.writeJSON(func(w *JSONWriter) {
+		w.WriteArray(func() {
+			w.WriteArrayElement(func() {})
+			w.WriteArrayElement(func() {})
+		})
+	})
+	suite.Require().Equal(`[[],[]]`, s)
+
+	s = suite.writeJSON(func(w *JSONWriter) {
+		w.WriteArray(func() {
+			w.WriteArrayElement(func() {
+				w.WriteArrayElement(func() {})
+			})
+			w.WriteArrayElement(func() {
+				w.WriteArrayElement(func() {})
+			})
+		})
+	})
+	suite.Require().Equal(`[[[]],[[]]]`, s)
+
+	s = suite.writeJSON(func(w *JSONWriter) {
+		w.WriteArray(func() {
+			w.WriteArrayElement(func() {
+				w.WriteArrayElement(func() {})
+				w.WriteArrayElement(func() {})
+			})
+			w.WriteArrayElement(func() {
+				w.WriteArrayElement(func() {})
+			})
+		})
+	})
+	suite.Require().Equal(`[[[],[]],[[]]]`, s)
+
+	s = suite.writeJSON(func(w *JSONWriter) {
+		w.WriteArray(func() {
+			w.WriteArrayElement(func() {
+				w.WriteArrayElement(func() {})
+				w.WriteArrayElement(func() {})
+			})
+			w.WriteArrayElement(func() {
+				w.WriteArrayElement(func() {})
+				w.WriteArrayElement(func() {})
+			})
+		})
+	})
+	suite.Require().Equal(`[[[],[]],[[],[]]]`, s)
+
+	s = suite.writeJSON(func(w *JSONWriter) {
+		w.WriteArray(func() {
+			w.WriteArrayElement(func() {
+				w.WriteArrayElement(func() {
+					w.WriteNullElement()
+				})
+				w.WriteArrayElement(func() {})
+			})
+			w.WriteArrayElement(func() {
+				w.WriteArrayElement(func() {})
+				w.WriteArrayElement(func() {})
+			})
+		})
+	})
+	suite.Require().Equal(`[[[null],[]],[[],[]]]`, s)
+
+	s = suite.writeJSON(func(w *JSONWriter) {
+		w.WriteArray(func() {
+			w.WriteObjectElement(func() {})
+		})
+	})
+	suite.Require().Equal(`[{}]`, s)
+
+	s = suite.writeJSON(func(w *JSONWriter) {
+		w.WriteArray(func() {
+			w.WriteObjectElement(func() {
+				w.WriteUint64Field("foo", 1)
+			})
+		})
+	})
+	suite.Require().Equal(`[{"foo":1}]`, s)
+
+	s = suite.writeJSON(func(w *JSONWriter) {
+		w.WriteArray(func() {
+			w.WriteObjectElement(func() {
+				w.WriteUint64Field("foo", 1)
+				w.WriteUint64Field("bar", 2)
+			})
+		})
+	})
+	suite.Require().Equal(`[{"foo":1,"bar":2}]`, s)
+
+	s = suite.writeJSON(func(w *JSONWriter) {
+		w.WriteArray(func() {
+			w.WriteObjectElement(func() {
+				w.WriteUint64Field("foo", 1)
+				w.WriteUint64Field("bar", 2)
+			})
+			w.WriteObjectElement(func() {
+				w.WriteUint64Field("The world is just a stage", 1)
+				w.WriteUint64Field("It's better to laugh than to cry", 2)
+			})
+		})
+	})
+	suite.Require().Equal(`[{"foo":1,"bar":2},{"The world is just a stage":1,"It's better to laugh than to cry":2}]`, s)
+
+	s = suite.writeJSON(func(w *JSONWriter) {
+		w.WriteObject(func() {
+			w.WriteArrayField("values", func() {
+				w.WriteUint64Element(1)
+				w.WriteUint64Element(2)
+			})
+		})
+	})
+	suite.Require().Equal(`{"values":[1,2]}`, s)
+
+	s = suite.writeJSON(func(w *JSONWriter) {
+		w.WriteObject(func() {
+			w.WriteArrayField("values", func() {
+				w.WriteUint64Element(1)
+				w.WriteUint64Element(2)
+			})
+			w.WriteUint64Field("foo", 1)
+		})
+	})
+	suite.Require().Equal(`{"values":[1,2],"foo":1}`, s)
+
+	s = suite.writeJSON(func(w *JSONWriter) {
+		w.WriteObject(func() {
+			w.WriteUint64Field("foo", 1)
+			w.WriteArrayField("values", func() {
+				w.WriteUint64Element(1)
+				w.WriteUint64Element(2)
+			})
+		})
+	})
+	suite.Require().Equal(`{"foo":1,"values":[1,2]}`, s)
+}
+
 func (suite *JSONWriterTestSuite) TestBase64() {
 	var s string
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tiflow/issues/1799

### What is changed and how it works?

- [x] JSONWriter supports output array
- [x] Output Debezium schemas
- [x] Config to enable or disable schema output

Benchmark (with schema):

```
BenchmarkEncodeOneTinyColumn-10    	  425042	      2734 ns/op	     256 B/op	      12 allocs/op
BenchmarkEncodeLargeText-10        	  342390	      3566 ns/op	     256 B/op	      12 allocs/op
BenchmarkEncodeLargeBinary-10      	  319641	      3497 ns/op	    1410 B/op	      15 allocs/op
```

Benchmark (without schema):

```
BenchmarkEncodeOneTinyColumn-10    	 2771671	       430.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkEncodeLargeText-10        	  974575	      1250 ns/op	       0 B/op	       0 allocs/op
BenchmarkEncodeLargeBinary-10      	  978442	      1143 ns/op	    1154 B/op	       3 allocs/op
```


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
