### PR TITLE
sqlmodel(*): optimize O(N*N) generated column check to O(N)

### DIFF
--- a/pkg/sqlmodel/multirow.go
+++ b/pkg/sqlmodel/multirow.go
@@ -129,12 +129,16 @@ func GenUpdateSQL(changes ...*RowChange) (string, []any) {
 		whenCaseStmts[i] = whereBuf.String()
 	}
 
+	// Build gegerated columns lower name set to accelerate the following check
+	targetGeneratedColSet := generatedColumnsNameSet(first.targetTableInfo.Columns)
+
 	// Generate `ColumnName`=CASE WHEN .. THEN .. END
 	// Use this value in order to identify which is the first CaseWhenThen line,
 	// because generated column can happen any where and it will be skipped.
 	isFirstCaseWhenThenLine := true
 	for _, column := range first.targetTableInfo.Columns {
-		if isGenerated(first.targetTableInfo.Columns, column.Name) {
+		// skip generated columns
+		if _, ok := targetGeneratedColSet[column.Name.L]; ok {
 			continue
 		}
 		if !isFirstCaseWhenThenLine {
@@ -166,7 +170,7 @@ func GenUpdateSQL(changes ...*RowChange) (string, []any) {
 	var assignValueColumnCount int
 	var skipColIdx []int
 	for i, col := range first.sourceTableInfo.Columns {
-		if isGenerated(first.targetTableInfo.Columns, col.Name) {
+		if _, ok := targetGeneratedColSet[col.Name.L]; ok {
 			skipColIdx = append(skipColIdx, i)
 			continue
 		}
@@ -235,8 +239,11 @@ func GenInsertSQL(tp DMLType, changes ...*RowChange) (string, []interface{}) {
 	buf.WriteString(" (")
 	columnNum := 0
 	var skipColIdx []int
+
+	// build gegerated columns lower name set to accelerate the following check
+	generatedColumns := generatedColumnsNameSet(first.targetTableInfo.Columns)
 	for i, col := range first.sourceTableInfo.Columns {
-		if isGenerated(first.targetTableInfo.Columns, col.Name) {
+		if _, ok := generatedColumns[col.Name.L]; ok {
 			skipColIdx = append(skipColIdx, i)
 			continue
 		}

--- a/pkg/sqlmodel/row_change.go
+++ b/pkg/sqlmodel/row_change.go
@@ -307,10 +307,12 @@ func (r *RowChange) genUpdateSQL() (string, []interface{}) {
 	buf.WriteString(r.targetTable.QuoteString())
 	buf.WriteString(" SET ")
 
+	// Build target generated columns lower names set to accelerate following check
+	generatedColumns := generatedColumnsNameSet(r.targetTableInfo.Columns)
 	args := make([]interface{}, 0, len(r.preValues)+len(r.postValues))
 	writtenFirstCol := false
 	for i, col := range r.sourceTableInfo.Columns {
-		if isGenerated(r.targetTableInfo.Columns, col.Name) {
+		if _, ok := generatedColumns[col.Name.L]; ok {
 			continue
 		}
 

--- a/pkg/sqlmodel/utils.go
+++ b/pkg/sqlmodel/utils.go
@@ -50,15 +50,6 @@ func valuesHolder(n int) string {
 	return builder.String()
 }
 
-func isGenerated(columns []*timodel.ColumnInfo, name timodel.CIStr) bool {
-	for _, col := range columns {
-		if col.Name.L == name.L {
-			return col.IsGenerated()
-		}
-	}
-	return false
-}
-
 // generatedColumnsNameSet returns a set of generated columns' name.
 func generatedColumnsNameSet(columns []*timodel.ColumnInfo) map[string]struct{} {
 	m := make(map[string]struct{})

--- a/pkg/sqlmodel/utils.go
+++ b/pkg/sqlmodel/utils.go
@@ -59,6 +59,17 @@ func isGenerated(columns []*timodel.ColumnInfo, name timodel.CIStr) bool {
 	return false
 }
 
+// generatedColumnsNameSet returns a set of generated columns' name.
+func generatedColumnsNameSet(columns []*timodel.ColumnInfo) map[string]struct{} {
+	m := make(map[string]struct{})
+	for _, col := range columns {
+		if col.IsGenerated() {
+			m[col.Name.L] = struct{}{}
+		}
+	}
+	return m
+}
+
 // ColValAsStr convert column value as string
 func ColValAsStr(v interface{}) string {
 	switch dv := v.(type) {

--- a/pkg/sqlmodel/utils_test.go
+++ b/pkg/sqlmodel/utils_test.go
@@ -16,6 +16,7 @@ package sqlmodel
 import (
 	"testing"
 
+	timodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 )
@@ -39,4 +40,33 @@ func TestValidatorGenColData(t *testing.T) {
 	require.Equal(t, "\x01\x02\x03", res)
 	res = ColValAsStr(decimal.NewFromInt(222123123))
 	require.Equal(t, "222123123", res)
+}
+
+func TestGeneratedColumnsNameSet(t *testing.T) {
+	t.Parallel()
+
+	cols := []*timodel.ColumnInfo{
+		{
+			Name:                timodel.CIStr{O: "A", L: "a"},
+			GeneratedExprString: "generated_expr",
+		},
+		{
+			Name: timodel.CIStr{O: "B", L: "b"},
+		},
+		{
+			Name:                timodel.CIStr{O: "C", L: "c"},
+			GeneratedExprString: "generated_expr",
+		},
+		{
+			Name:                timodel.CIStr{O: "D", L: "d"},
+			GeneratedExprString: "generated_expr",
+		},
+	}
+
+	m := generatedColumnsNameSet(cols)
+	require.Equal(t, map[string]struct{}{
+		"a": {},
+		"c": {},
+		"d": {},
+	}, m)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/10313

### What is changed and how it works?
Optimize O(N*N) time complexity generated column check to O(N) by building generated columns name set.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
