### PR TITLE
csv(cdc): delimiter supports at most 3 characters

### DIFF
--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -221,14 +221,14 @@ func (c *CSVConfig) validateAndAdjust() error {
 	case 0:
 		return cerror.WrapError(cerror.ErrSinkInvalidConfig,
 			errors.New("csv config delimiter cannot be empty"))
-	case 1, 2:
+	case 1, 2, 3:
 		if strings.ContainsRune(c.Delimiter, CR) || strings.ContainsRune(c.Delimiter, LF) {
 			return cerror.WrapError(cerror.ErrSinkInvalidConfig,
 				errors.New("csv config delimiter contains line break characters"))
 		}
 	default:
 		return cerror.WrapError(cerror.ErrSinkInvalidConfig,
-			errors.New("csv config delimiter contains more than two character, note that escape "+
+			errors.New("csv config delimiter contains more than three characters, note that escape "+
 				"sequences can only be used in double quotes in toml configuration items."))
 	}
 

--- a/pkg/config/sink_test.go
+++ b/pkg/config/sink_test.go
@@ -343,6 +343,15 @@ func TestValidateAndAdjustCSVConfig(t *testing.T) {
 			wantErr: "",
 		},
 		{
+			name: "valid delimiter with 3 characters",
+			config: &CSVConfig{
+				Quote:                "\"",
+				Delimiter:            "|@|",
+				BinaryEncodingMethod: BinaryEncodingHex,
+			},
+			wantErr: "",
+		},
+		{
 			name: "delimiter is empty",
 			config: &CSVConfig{
 				Quote:     "'",
@@ -359,12 +368,12 @@ func TestValidateAndAdjustCSVConfig(t *testing.T) {
 			wantErr: "csv config delimiter contains line break characters",
 		},
 		{
-			name: "delimiter contains more than two characters",
+			name: "delimiter contains more than three characters",
 			config: &CSVConfig{
 				Quote:     "'",
-				Delimiter: "FEF",
+				Delimiter: "FEFA",
 			},
-			wantErr: "csv config delimiter contains more than two character, note that escape " +
+			wantErr: "csv config delimiter contains more than three characters, note that escape " +
 				"sequences can only be used in double quotes in toml configuration items.",
 		},
 		{


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #9969 

### What is changed and how it works?
Some customers use separator like `|@|` in their env. So we need to relief the delimiter restriction further to support at most 3 characters.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
