### PR TITLE
sink-to-mysql(cdc) set `time_zone` session variable explicitly

### DIFF
--- a/cdc/model/schema_storage.go
+++ b/cdc/model/schema_storage.go
@@ -281,8 +281,8 @@ func IsColCDCVisible(col *model.ColumnInfo) bool {
 	return true
 }
 
-// ExistTableUniqueColumn returns whether the table has a unique column
-func (ti *TableInfo) ExistTableUniqueColumn() bool {
+// HasUniqueColumn returns whether the table has a unique column
+func (ti *TableInfo) HasUniqueColumn() bool {
 	return ti.hasUniqueColumn
 }
 
@@ -299,7 +299,7 @@ func (ti *TableInfo) IsEligible(forceReplicate bool) bool {
 	if ti.IsView() {
 		return true
 	}
-	return ti.ExistTableUniqueColumn()
+	return ti.HasUniqueColumn()
 }
 
 // IsIndexUnique returns whether the index is unique

--- a/cdc/model/schema_storage_test.go
+++ b/cdc/model/schema_storage_test.go
@@ -190,7 +190,7 @@ func TestTableInfoGetterFuncs(t *testing.T) {
 	require.Equal(t, 3, len(fts))
 	require.Equal(t, 3, len(colInfos))
 
-	require.True(t, info.ExistTableUniqueColumn())
+	require.True(t, info.HasUniqueColumn())
 
 	// check IsEligible
 	require.True(t, info.IsEligible(false))

--- a/cdc/sink/dmlsink/txn/mysql/mysql.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql.go
@@ -888,7 +888,7 @@ func (s *mysqlBackend) setDMLMaxRetry(maxRetry uint64) {
 
 func (s *mysqlBackend) setSessionVariables(ctx context.Context, txn *sql.Tx) error {
 	// set time zone before executing the transaction.
-	query := fmt.Sprintf("SET time_zone = %s", s.cfg.Timezone)
+	query := fmt.Sprintf("SET SESSION time_zone = %s", s.cfg.Timezone)
 	_, err := txn.ExecContext(ctx, query)
 	return err
 }

--- a/cdc/sink/dmlsink/txn/mysql/mysql.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql.go
@@ -888,7 +888,7 @@ func (s *mysqlBackend) setDMLMaxRetry(maxRetry uint64) {
 
 func (s *mysqlBackend) setSessionVariables(ctx context.Context, txn *sql.Tx) error {
 	// set time zone before executing the transaction.
-	query := fmt.Sprintf("SET time_zone = '%s'", s.cfg.Timezone)
+	query := fmt.Sprintf("SET time_zone = %s", s.cfg.Timezone)
 	_, err := txn.ExecContext(ctx, query)
 	return err
 }

--- a/cdc/sink/dmlsink/txn/mysql/mysql.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql.go
@@ -764,6 +764,19 @@ func (s *mysqlBackend) execDMLWithMaxRetries(pctx context.Context, dmls *prepare
 			}
 
 			// Set session variables first and then execute the transaction.
+			// ref to https://github.com/pingcap/tiflow/issues/10393
+			if err = s.setSessionVariables(pctx, tx); err != nil {
+				err := logDMLTxnErr(
+					cerror.WrapError(cerror.ErrMySQLTxnError, err),
+					start, s.changefeed, "SET SESSION VARIABLES", dmls.rowCount, dmls.startTs)
+				if rbErr := tx.Rollback(); rbErr != nil {
+					if errors.Cause(rbErr) != context.Canceled {
+						log.Warn("failed to rollback txn", zap.String("changefeed", s.changefeed), zap.Error(rbErr))
+					}
+				}
+				return 0, 0, err
+			}
+
 			// we try to set write source for each txn,
 			// so we can use it to trace the data source
 			if err = s.setWriteSource(pctx, tx); err != nil {
@@ -871,6 +884,13 @@ func getSQLErrCode(err error) (errors.ErrCode, bool) {
 // Only for testing.
 func (s *mysqlBackend) setDMLMaxRetry(maxRetry uint64) {
 	s.dmlMaxRetry = maxRetry
+}
+
+func (s *mysqlBackend) setSessionVariables(ctx context.Context, txn *sql.Tx) error {
+	// set time zone before executing the transaction.
+	query := fmt.Sprintf("SET time_zone = '%s'", s.cfg.Timezone)
+	_, err := txn.ExecContext(ctx, query)
+	return err
 }
 
 // setWriteSource sets write source for the transaction.

--- a/cdc/sink/dmlsink/txn/mysql/mysql_test.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql_test.go
@@ -304,6 +304,7 @@ func TestNewMySQLBackendExecDML(t *testing.T) {
 		// normal db
 		db, mock := newTestMockDB(t)
 		mock.ExpectBegin()
+		mock.ExpectExec("SET SESSION time_zone = \"UTC\"").WillReturnResult(sqlmock.NewResult(0, 0))
 		mock.ExpectExec("INSERT INTO `s1`.`t1` (`a`,`b`) VALUES (?,?),(?,?)").
 			WithArgs(1, "test", 2, "test").
 			WillReturnResult(sqlmock.NewResult(2, 2))
@@ -430,6 +431,7 @@ func TestExecDMLRollbackErrDatabaseNotExists(t *testing.T) {
 		// normal db
 		db, mock := newTestMockDB(t)
 		mock.ExpectBegin()
+		mock.ExpectExec("SET SESSION time_zone = \"UTC\"").WillReturnResult(sqlmock.NewResult(0, 0))
 		mock.ExpectExec("REPLACE INTO `s1`.`t1` (`a`) VALUES (?),(?)").
 			WithArgs(1, 2).
 			WillReturnError(errDatabaseNotExists)
@@ -501,6 +503,7 @@ func TestExecDMLRollbackErrTableNotExists(t *testing.T) {
 		// normal db
 		db, mock := newTestMockDB(t)
 		mock.ExpectBegin()
+		mock.ExpectExec("SET SESSION time_zone = \"UTC\"").WillReturnResult(sqlmock.NewResult(0, 0))
 		mock.ExpectExec("REPLACE INTO `s1`.`t1` (`a`) VALUES (?),(?)").
 			WithArgs(1, 2).
 			WillReturnError(errTableNotExists)
@@ -573,6 +576,7 @@ func TestExecDMLRollbackErrRetryable(t *testing.T) {
 		db, mock := newTestMockDB(t)
 		for i := 0; i < 2; i++ {
 			mock.ExpectBegin()
+			mock.ExpectExec("SET SESSION time_zone = \"UTC\"").WillReturnResult(sqlmock.NewResult(0, 0))
 			mock.ExpectExec("REPLACE INTO `s1`.`t1` (`a`) VALUES (?),(?)").
 				WithArgs(1, 2).
 				WillReturnError(errLockDeadlock)
@@ -635,6 +639,7 @@ func TestMysqlSinkNotRetryErrDupEntry(t *testing.T) {
 		// normal db
 		db, mock := newTestMockDB(t)
 		mock.ExpectBegin()
+		mock.ExpectExec("SET SESSION time_zone = \"UTC\"").WillReturnResult(sqlmock.NewResult(0, 0))
 		mock.ExpectExec("INSERT INTO `s1`.`t1` (`a`) VALUES (?)").
 			WithArgs(1).
 			WillReturnResult(sqlmock.NewResult(1, 1))
@@ -813,6 +818,7 @@ func TestMySQLSinkExecDMLError(t *testing.T) {
 		// normal db
 		db, mock := newTestMockDB(t)
 		mock.ExpectBegin()
+		mock.ExpectExec("SET SESSION time_zone = \"UTC\"").WillReturnResult(sqlmock.NewResult(0, 0))
 		mock.ExpectExec("INSERT INTO `s1`.`t1` (`a`,`b`) VALUES (?,?),(?,?)").WillDelayFor(1 * time.Second).
 			WillReturnError(&dmysql.MySQLError{Number: mysql.ErrNoSuchTable})
 		mock.ExpectClose()


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/10393 

### What is changed and how it works?

Set `time_zone` session variable explicitly before execute DML SQL to make sure `TIMESTAMP` column values are correct when doing cross region replication.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Set `time_zone` session variable explicitly before execute DML SQL to make sure `TIMESTAMP` column values are correct when doing cross region replication.
```
