### PR TITLE
owner, metrics(ticdc): fix metrics

### DIFF
--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -687,8 +687,8 @@ LOOP2:
 	c.initMetrics()
 
 	c.initialized = true
-	c.metricsChangefeedCreateTimeGuage.Set(float64(c.latestInfo.CreateTime.Second()))
-	c.metricsChangefeedRestartTimeGauge.SetToCurrentTime()
+	c.metricsChangefeedCreateTimeGuage.Set(float64(oracle.GetPhysical(c.latestInfo.CreateTime)))
+	c.metricsChangefeedRestartTimeGauge.Set(float64(oracle.GetPhysical(time.Now())))
 	log.Info("changefeed initialized",
 		zap.String("namespace", c.id.Namespace),
 		zap.String("changefeed", c.id.ID),

--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -140,6 +140,9 @@ type changefeed struct {
 	metricsChangefeedBarrierTsGauge prometheus.Gauge
 	metricsChangefeedTickDuration   prometheus.Observer
 
+	metricsChangefeedCreateTimeGuage  prometheus.Gauge
+	metricsChangefeedRestartTimeGauge prometheus.Gauge
+
 	downstreamObserver observer.Observer
 	observerLastTick   *atomic.Time
 
@@ -684,6 +687,8 @@ LOOP2:
 	c.initMetrics()
 
 	c.initialized = true
+	c.metricsChangefeedCreateTimeGuage.Set(float64(c.latestInfo.CreateTime.Second()))
+	c.metricsChangefeedRestartTimeGauge.SetToCurrentTime()
 	log.Info("changefeed initialized",
 		zap.String("namespace", c.id.Namespace),
 		zap.String("changefeed", c.id.ID),
@@ -715,10 +720,16 @@ func (c *changefeed) initMetrics() {
 		WithLabelValues(c.id.Namespace, c.id.ID)
 	c.metricsChangefeedTickDuration = changefeedTickDuration.
 		WithLabelValues(c.id.Namespace, c.id.ID)
+
+	c.metricsChangefeedCreateTimeGuage = changefeedStartTimeGauge.
+		WithLabelValues(c.id.Namespace, c.id.ID, "create")
+	c.metricsChangefeedRestartTimeGauge = changefeedStartTimeGauge.
+		WithLabelValues(c.id.Namespace, c.id.ID, "restart")
 }
 
 // releaseResources is idempotent.
 func (c *changefeed) releaseResources(ctx cdcContext.Context) {
+	c.cleanupMetrics()
 	if c.isReleased {
 		return
 	}
@@ -756,7 +767,6 @@ func (c *changefeed) releaseResources(ctx cdcContext.Context) {
 		_ = c.downstreamObserver.Close()
 	}
 
-	c.cleanupMetrics()
 	c.schema = nil
 	c.barriers = nil
 	c.resolvedTs = 0
@@ -794,6 +804,8 @@ func (c *changefeed) cleanupMetrics() {
 
 	if c.isRemoved {
 		changefeedStatusGauge.DeleteLabelValues(c.id.Namespace, c.id.ID)
+		changefeedCheckpointTsGauge.DeleteLabelValues(c.id.Namespace, c.id.ID, "create")
+		changefeedCheckpointTsLagGauge.DeleteLabelValues(c.id.Namespace, c.id.ID, "restart")
 	}
 }
 

--- a/cdc/owner/metrics.go
+++ b/cdc/owner/metrics.go
@@ -113,6 +113,13 @@ var (
 			Help:      "Bucketed histogram of owner close changefeed reactor time (s).",
 			Buckets:   prometheus.ExponentialBuckets(0.01 /* 10 ms */, 2, 18),
 		})
+	changefeedStartTimeGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "ticdc",
+			Subsystem: "owner",
+			Name:      "changefeed_start_time",
+			Help:      "The start time of changefeeds",
+		}, []string{"namespace", "changefeed", "type"})
 )
 
 const (
@@ -142,6 +149,7 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(changefeedStatusGauge)
 	registry.MustRegister(changefeedTickDuration)
 	registry.MustRegister(changefeedCloseDuration)
+	registry.MustRegister(changefeedStartTimeGauge)
 }
 
 // lagBucket returns the lag buckets for prometheus metric

--- a/metrics/grafana/TiCDC-Monitor-Summary.json
+++ b/metrics/grafana/TiCDC-Monitor-Summary.json
@@ -130,8 +130,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 29,
-  "iteration": 1671613058905,
+  "id": null,
+  "iteration": 1705047462154,
   "links": [],
   "panels": [
     {
@@ -1026,7 +1026,7 @@
           "hiddenSeries": false,
           "id": 218,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
@@ -1082,7 +1082,8 @@
           },
           "yaxes": [
             {
-              "format": "none",
+              "$$hashKey": "object:234",
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -1090,6 +1091,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:235",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -1127,7 +1129,7 @@
           "hiddenSeries": false,
           "id": 229,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
@@ -1228,7 +1230,7 @@
           "hiddenSeries": false,
           "id": 228,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
@@ -1284,7 +1286,8 @@
           },
           "yaxes": [
             {
-              "format": "none",
+              "$$hashKey": "object:279",
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -1292,6 +1295,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:280",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -1329,7 +1333,7 @@
           "hiddenSeries": false,
           "id": 220,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
@@ -1430,7 +1434,7 @@
           "hiddenSeries": false,
           "id": 219,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
@@ -1486,7 +1490,8 @@
           },
           "yaxes": [
             {
-              "format": "none",
+              "$$hashKey": "object:344",
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -1494,6 +1499,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:345",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -1531,7 +1537,7 @@
           "hiddenSeries": false,
           "id": 224,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
@@ -1632,7 +1638,7 @@
           "hiddenSeries": false,
           "id": 664,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
@@ -1691,7 +1697,8 @@
           },
           "yaxes": [
             {
-              "format": "none",
+              "$$hashKey": "object:389",
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -1699,6 +1706,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:390",
               "format": "none",
               "label": null,
               "logBase": 1,
@@ -1736,7 +1744,7 @@
           "hiddenSeries": false,
           "id": 665,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
@@ -1848,7 +1856,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 4
+            "y": 20
           },
           "hiddenSeries": false,
           "id": 635,
@@ -1953,7 +1961,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 4
+            "y": 20
           },
           "hiddenSeries": false,
           "id": 620,
@@ -2853,12 +2861,7 @@
     "list": [
       {
         "allValue": null,
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
+        "current": {},
         "datasource": "${DS_TEST-CLUSTER}",
         "definition": "",
         "description": null,
@@ -2885,12 +2888,7 @@
       },
       {
         "allValue": null,
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
+        "current": {},
         "datasource": "${DS_TEST-CLUSTER}",
         "definition": "",
         "description": null,
@@ -2917,15 +2915,7 @@
       },
       {
         "allValue": ".*",
-        "current": {
-          "selected": true,
-          "text": [
-            "default"
-          ],
-          "value": [
-            "default"
-          ]
-        },
+        "current": {},
         "datasource": "${DS_TEST-CLUSTER}",
         "definition": "label_values(ticdc_processor_processor_tick_duration_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}, namespace)",
         "description": null,
@@ -2952,11 +2942,7 @@
       },
       {
         "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": "${DS_TEST-CLUSTER}",
         "definition": "label_values(ticdc_processor_resolved_ts{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}, changefeed)",
         "description": null,
@@ -2983,11 +2969,7 @@
       },
       {
         "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": "${DS_TEST-CLUSTER}",
         "definition": "label_values(process_start_time_seconds{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", job=\"ticdc\"}, instance)",
         "description": null,
@@ -3014,11 +2996,7 @@
       },
       {
         "allValue": ".*",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": "${DS_TEST-CLUSTER}",
         "definition": "label_values(tikv_engine_size_bytes{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}, instance)",
         "description": null,
@@ -3100,11 +3078,7 @@
       },
       {
         "allValue": "",
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": "${DS_TEST-CLUSTER}",
         "definition": "label_values(process_start_time_seconds{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", job=\"ticdc\"}, instance)",
         "description": null,
@@ -3131,11 +3105,7 @@
       },
       {
         "allValue": null,
-        "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
         "datasource": "${DS_TEST-CLUSTER}",
         "definition": "label_values(ticdc_actor_number_of_workers{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", job=\"ticdc\"}, name)",
         "description": null,

--- a/metrics/grafana/ticdc.json
+++ b/metrics/grafana/ticdc.json
@@ -131,7 +131,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1699845194714,
+  "iteration": 1705029240982,
   "links": [],
   "panels": [
     {
@@ -4448,7 +4448,7 @@
           "hiddenSeries": false,
           "id": 218,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
@@ -4506,14 +4506,16 @@
           },
           "yaxes": [
             {
-              "format": "none",
-              "label": null,
+              "$$hashKey": "object:643",
+              "format": "short",
+              "label": "",
               "logBase": 1,
               "max": null,
               "min": null,
               "show": true
             },
             {
+              "$$hashKey": "object:644",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -4551,13 +4553,15 @@
           "hiddenSeries": false,
           "id": 229,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
             "min": false,
             "rightSide": false,
             "show": true,
+            "sort": "max",
+            "sortDesc": true,
             "total": false,
             "values": true
           },
@@ -4609,6 +4613,7 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:915",
               "format": "none",
               "label": null,
               "logBase": 1,
@@ -4617,6 +4622,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:916",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -4654,7 +4660,7 @@
           "hiddenSeries": false,
           "id": 228,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
@@ -4712,7 +4718,8 @@
           },
           "yaxes": [
             {
-              "format": "none",
+              "$$hashKey": "object:1089",
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -4720,6 +4727,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:1090",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -4757,7 +4765,7 @@
           "hiddenSeries": false,
           "id": 220,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
@@ -4815,6 +4823,7 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:1403",
               "format": "none",
               "label": null,
               "logBase": 1,
@@ -4823,6 +4832,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:1404",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -4860,7 +4870,7 @@
           "hiddenSeries": false,
           "id": 219,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
@@ -4918,7 +4928,8 @@
           },
           "yaxes": [
             {
-              "format": "none",
+              "$$hashKey": "object:1121",
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -4926,6 +4937,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:1122",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -4963,7 +4975,7 @@
           "hiddenSeries": false,
           "id": 224,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
@@ -5021,6 +5033,7 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:1568",
               "format": "none",
               "label": null,
               "logBase": 1,
@@ -5029,6 +5042,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:1569",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -5066,7 +5080,7 @@
           "hiddenSeries": false,
           "id": 223,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
@@ -5124,7 +5138,8 @@
           },
           "yaxes": [
             {
-              "format": "none",
+              "$$hashKey": "object:1273",
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -5132,6 +5147,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:1274",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -5169,7 +5185,7 @@
           "hiddenSeries": false,
           "id": 221,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
@@ -5272,7 +5288,7 @@
           "hiddenSeries": false,
           "id": 664,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
@@ -5331,7 +5347,8 @@
           },
           "yaxes": [
             {
-              "format": "none",
+              "$$hashKey": "object:1318",
+              "format": "short",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -5339,6 +5356,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:1319",
               "format": "none",
               "label": null,
               "logBase": 1,
@@ -5376,7 +5394,7 @@
           "hiddenSeries": false,
           "id": 665,
           "legend": {
-            "alignAsTable": false,
+            "alignAsTable": true,
             "avg": false,
             "current": true,
             "max": true,
@@ -6221,7 +6239,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 6
+            "y": 26
           },
           "hiddenSeries": false,
           "id": 618,
@@ -6343,7 +6361,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 6
+            "y": 26
           },
           "hiddenSeries": false,
           "id": 620,
@@ -6449,7 +6467,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 14
+            "y": 34
           },
           "hiddenSeries": false,
           "id": 619,
@@ -6547,7 +6565,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 14
+            "y": 34
           },
           "hiddenSeries": false,
           "id": 634,
@@ -6644,7 +6662,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 22
+            "y": 42
           },
           "hiddenSeries": false,
           "id": 635,
@@ -12874,6 +12892,7 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:359",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -12882,6 +12901,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:360",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -12950,10 +12970,12 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(ticdc_kvclient_pull_event_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",namespace=~\"$namespace\", changefeed=~\"$changefeed\"}[1m])) by (instance, type)",
+              "exemplar": true,
+              "expr": "sum(rate(ticdc_kvclient_pull_event_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\",namespace=~\"$namespace\", changefeed=~\"$changefeed\"}[1m])) by (instance, type, changefeed)",
               "format": "time_series",
+              "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{instance}}-{{type}}",
+              "legendFormat": "{{changefeed}}-{{instance}}-{{type}}",
               "refId": "A"
             }
           ],
@@ -12977,6 +12999,7 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:242",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -12985,6 +13008,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:243",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -13214,6 +13238,7 @@
           },
           "yaxes": [
             {
+              "$$hashKey": "object:542",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -13222,6 +13247,7 @@
               "show": true
             },
             {
+              "$$hashKey": "object:543",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -18858,7 +18884,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 1
+            "y": 16
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -18932,7 +18958,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 1
+            "y": 16
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -19006,7 +19032,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 9
+            "y": 24
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -19080,7 +19106,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 9
+            "y": 24
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -19147,7 +19173,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 32
           },
           "hiddenSeries": false,
           "id": 10031,
@@ -19257,7 +19283,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 32
           },
           "hiddenSeries": false,
           "id": 10033,
@@ -19353,7 +19379,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 25
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 10035,
@@ -20022,7 +20048,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 18
       },
       "id": 10000,
       "panels": [
@@ -20042,7 +20068,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1
+            "y": 50
           },
           "hiddenSeries": false,
           "id": 10001,
@@ -20147,7 +20173,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1
+            "y": 50
           },
           "hiddenSeries": false,
           "id": 10002,
@@ -20252,7 +20278,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 10
+            "y": 59
           },
           "hiddenSeries": false,
           "id": 10003,
@@ -20357,7 +20383,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 10
+            "y": 59
           },
           "hiddenSeries": false,
           "id": 10004,
@@ -20453,7 +20479,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 68
           },
           "hiddenSeries": false,
           "id": 10005,
@@ -20549,7 +20575,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 19
+            "y": 68
           },
           "hiddenSeries": false,
           "id": 10006,
@@ -20645,7 +20671,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 77
           },
           "hiddenSeries": false,
           "id": 10007,
@@ -20742,7 +20768,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 28
+            "y": 77
           },
           "hiddenSeries": false,
           "id": 10008,
@@ -20841,7 +20867,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 37
+            "y": 86
           },
           "hiddenSeries": false,
           "id": 10009,
@@ -20974,7 +21000,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 37
+            "y": 86
           },
           "id": 10010,
           "options": {
@@ -21033,7 +21059,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 46
+            "y": 95
           },
           "hiddenSeries": false,
           "id": 10011,
@@ -21134,7 +21160,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 46
+            "y": 95
           },
           "hiddenSeries": false,
           "id": 10012,
@@ -21235,7 +21261,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 46
+            "y": 104
           },
           "hiddenSeries": false,
           "id": 10013,
@@ -21451,7 +21477,7 @@
         "options": [],
         "query": {
           "query": "label_values(process_start_time_seconds{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", job=\"ticdc\"}, instance)",
-          "refId": "local-ticdc_instance-Variable-Query"
+          "refId": "StandardVariableQuery"
         },
         "refresh": 2,
         "regex": "",
@@ -21542,6 +21568,7 @@
           }
         ],
         "query": "1, 3, 5, 10, 60, 300",
+        "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
       },
@@ -21633,5 +21660,5 @@
   "timezone": "browser",
   "title": "${DS_TEST-CLUSTER}-TiCDC",
   "uid": "YiGL8hBZ1",
-  "version": 56
+  "version": 57
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10449, close #10447, close #10438

### What is changed and how it works?
1. For #10449, always cleanup metrics [whether the changefeed has been cleaned or not](https://github.com/pingcap/tiflow/pull/10459/files#diff-953746562776cf8aa41cd4a971df8c546649d2721ae787607aed2069f3b44eb0R732-L759).
![image](https://github.com/pingcap/tiflow/assets/61726649/379e24dc-13ab-4a7e-90be-891b75686865)

2. For #10447, use the type of ticdc_kvclient_pull_event_count to distinguish incresmental scan and real-time raft log.
![image](https://github.com/pingcap/tiflow/assets/61726649/e05f6e05-f178-425b-9c39-da448dc1e471)


3. For #10438, add changefeedStartTimeGauge metric, which record the changefeed create time and restart time. **Note that** changefeedStartTimeGauge records the physical time with ***millisecond precision.***
![image](https://github.com/pingcap/tiflow/assets/61726649/dff7d48a-829a-47c2-936c-7d748f84e14f)

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
