### PR TITLE
test(ticdc):  fix http_api integration test

### DIFF
--- a/cdc/api/middleware/middleware.go
+++ b/cdc/api/middleware/middleware.go
@@ -46,7 +46,7 @@ func LogMiddleware() gin.HandlerFunc {
 			stdErr = err.Err
 		}
 		version := c.Request.Header.Get(ClientVersionHeader)
-		log.Info(path,
+		log.Info("cdc open api request",
 			zap.Int("status", c.Writer.Status()),
 			zap.String("method", c.Request.Method),
 			zap.String("path", path),

--- a/cdc/api/v1/api.go
+++ b/cdc/api/v1/api.go
@@ -745,7 +745,8 @@ func (h *OpenAPI) ListProcessor(c *gin.Context) {
 	for i, info := range infos {
 		resp := &model.ProcessorCommonInfo{
 			Namespace: info.CfID.Namespace,
-			CfID:      info.CfID.ID, CaptureID: info.CaptureID,
+			CfID:      info.CfID.ID,
+			CaptureID: info.CaptureID,
 		}
 		resps[i] = resp
 	}

--- a/tests/integration_tests/http_api/run.sh
+++ b/tests/integration_tests/http_api/run.sh
@@ -76,8 +76,8 @@ function run() {
 	sequential_cases2=(
 		"list_changefeed"
 		"get_changefeed"
-		"resume_changefeed"
 		"pause_changefeed"
+		"resume_changefeed"
 		"rebalance_table"
 		"move_table"
 		"get_processor"

--- a/tests/integration_tests/http_api/util/test_case.py
+++ b/tests/integration_tests/http_api/util/test_case.py
@@ -287,7 +287,7 @@ def get_processor():
     assert resp.status_code == rq.codes.ok
     data = resp.json()[0]
     time.sleep(2)
-    url = base_url + "/" + data["changefeed_id"] + "/" + data["capture_id"]
+    url = base_url + "/changefeed-test1/" + data["capture_id"]
     resp = requests_get_with_retry(url)
     # print error message for debug 
     if (resp.status_code != rq.codes.ok):

--- a/tests/integration_tests/http_api_tls/util/test_case.py
+++ b/tests/integration_tests/http_api_tls/util/test_case.py
@@ -255,7 +255,7 @@ def get_processor():
     assert resp.status_code == rq.codes.ok
     data = resp.json()[0]
     time.sleep(2)
-    url = base_url + "/" + data["changefeed_id"] + "/" + data["capture_id"]
+    url = base_url + "/changefeed-test1/" + data["capture_id"]
     resp = rq.get(url, cert=CERT, verify=VERIFY)
     # print error message for debug 
     if (resp.status_code != rq.codes.ok):
@@ -269,7 +269,7 @@ def get_processor():
     resp = rq.get(url, cert=CERT, verify=VERIFY)
     assert resp.status_code == rq.codes.bad_request
 
-    print("pass test: get processors")
+    print("pass test: get processor")
 
 
 def check_health():


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10470

### What is changed and how it works?
http_api is not robust, the get_processor case will fail if the first changefeed  returned by getProcessors API is paused. `api/v1/processors/{changefeed_id}/{capture_id}` API always return status code `400`.   because paused changefeed will not be scheduled to capture.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
 `None`.
```
