### PR TITLE
chore: make the codecov status informational to not affect the PR commit status

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -46,6 +46,7 @@ component_management:
     statuses:
       - type: project # in this case every component that doens't have a status defined will have a project type one
         target: auto
+        informational: true # resulting status will pass no matter what the coverage is or what other settings are specified.
   individual_components:
     - component_id: component_cdc # this is an identifier that should not be changed
       name: cdc # this is a display name, and can be changed freely

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -69,8 +69,10 @@ flag_management:
     statuses:
       - type: project
         target: 60%
+        informational: true # resulting status will pass no matter what the coverage is or what other settings are specified. 
       - type: patch
         target: 60%
+        informational: true # resulting status will pass no matter what the coverage is or what other settings are specified. 
 
   individual_flags: # exceptions to the default rules above, stated flag by flag
     - name: cdc  #fill in your own flag name


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/10473

### What is changed and how it works?
To make the codecov status just informational in github commit statuses on components and flags level, not fail the 
 commit statuses.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - [x] No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
