### PR TITLE
codec(ticdc): simple protocol add table id as message field

### DIFF
--- a/pkg/sink/codec/simple/avro.go
+++ b/pkg/sink/codec/simple/avro.go
@@ -185,6 +185,7 @@ func newDMLMessageMap(
 		"version":            defaultVersion,
 		"schema":             event.Table.Schema,
 		"table":              event.Table.Table,
+		"tableID":            event.Table.TableID,
 		"commitTs":           int64(event.CommitTs),
 		"buildTs":            time.Now().UnixMilli(),
 		"schemaVersion":      int64(event.TableInfo.UpdateTS),
@@ -427,6 +428,7 @@ func newMessageFromAvroNative(native interface{}, m *message) error {
 	m.BuildTs = rawValues["buildTs"].(int64)
 	m.Schema = rawValues["schema"].(string)
 	m.Table = rawValues["table"].(string)
+	m.TableID = rawValues["tableID"].(int64)
 	m.SchemaVersion = uint64(rawValues["schemaVersion"].(int64))
 	m.HandleKeyOnly = rawValues["handleKeyOnly"].(bool)
 	m.ClaimCheckLocation = rawValues["claimCheckLocation"].(string)

--- a/pkg/sink/codec/simple/avro.go
+++ b/pkg/sink/codec/simple/avro.go
@@ -113,7 +113,7 @@ func newTableSchemaMap(tableInfo *model.TableInfo) interface{} {
 	result := map[string]interface{}{
 		"schema":  tableInfo.TableName.Schema,
 		"table":   tableInfo.TableName.Table,
-		"tableID": tableInfo.TableName.TableID,
+		"tableID": tableInfo.ID,
 		"version": int64(tableInfo.UpdateTS),
 		"columns": columnsSchema,
 		"indexes": indexesSchema,
@@ -186,7 +186,7 @@ func newDMLMessageMap(
 		"version":            defaultVersion,
 		"schema":             event.Table.Schema,
 		"table":              event.Table.Table,
-		"tableID":            event.Table.TableID,
+		"tableID":            event.TableInfo.ID,
 		"commitTs":           int64(event.CommitTs),
 		"buildTs":            time.Now().UnixMilli(),
 		"schemaVersion":      int64(event.TableInfo.UpdateTS),

--- a/pkg/sink/codec/simple/avro.go
+++ b/pkg/sink/codec/simple/avro.go
@@ -113,6 +113,7 @@ func newTableSchemaMap(tableInfo *model.TableInfo) interface{} {
 	result := map[string]interface{}{
 		"schema":  tableInfo.TableName.Schema,
 		"table":   tableInfo.TableName.Table,
+		"tableID": tableInfo.TableName.TableID,
 		"version": int64(tableInfo.UpdateTS),
 		"columns": columnsSchema,
 		"indexes": indexesSchema,
@@ -364,6 +365,7 @@ func newTableSchemaFromAvroNative(native map[string]interface{}) *TableSchema {
 	return &TableSchema{
 		Schema:  native["schema"].(string),
 		Table:   native["table"].(string),
+		TableID: native["tableID"].(int64),
 		Version: uint64(native["version"].(int64)),
 		Columns: columns,
 		Indexes: indexes,

--- a/pkg/sink/codec/simple/decoder.go
+++ b/pkg/sink/codec/simple/decoder.go
@@ -62,14 +62,14 @@ func NewDecoder(ctx context.Context, config *common.Config, db *sql.DB) (*decode
 			GenWithStack("handle-key-only is enabled, but upstream TiDB is not provided")
 	}
 
-	marshaller, err := newMarshaller(config.EncodingFormat)
+	m, err := newMarshaller(config.EncodingFormat)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	return &decoder{
 		config:     config,
-		marshaller: marshaller,
+		marshaller: m,
 
 		storage:      externalStorage,
 		upstreamTiDB: db,

--- a/pkg/sink/codec/simple/encoder.go
+++ b/pkg/sink/codec/simple/encoder.go
@@ -180,7 +180,7 @@ func NewBuilder(ctx context.Context, config *common.Config) (*builder, error) {
 		}
 	}
 
-	marshaller, err := newMarshaller(config.EncodingFormat)
+	m, err := newMarshaller(config.EncodingFormat)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -188,7 +188,7 @@ func NewBuilder(ctx context.Context, config *common.Config) (*builder, error) {
 	return &builder{
 		config:     config,
 		claimCheck: claimCheck,
-		marshaller: marshaller,
+		marshaller: m,
 	}, nil
 }
 

--- a/pkg/sink/codec/simple/encoder_test.go
+++ b/pkg/sink/codec/simple/encoder_test.go
@@ -211,6 +211,7 @@ func TestEncodeDDLEvent(t *testing.T) {
 
 			event, err := dec.NextDDLEvent()
 			require.NoError(t, err)
+			require.Equal(t, createTableDDLEvent.TableInfo.TableName.TableID, event.TableInfo.TableName.TableID)
 			require.Equal(t, createTableDDLEvent.CommitTs, event.CommitTs)
 			// because we don't we don't set startTs in the encoded message,
 			// so the startTs is equal to commitTs
@@ -260,6 +261,7 @@ func TestEncodeDDLEvent(t *testing.T) {
 
 			event, err = dec.NextDDLEvent()
 			require.NoError(t, err)
+			require.Equal(t, renameTableDDLEvent.TableInfo.TableName.TableID, event.TableInfo.TableName.TableID)
 			require.Equal(t, renameTableDDLEvent.CommitTs, event.CommitTs)
 			// because we don't we don't set startTs in the encoded message,
 			// so the startTs is equal to commitTs
@@ -505,6 +507,7 @@ func TestEncodeBootstrapEvent(t *testing.T) {
 
 			event, err := dec.NextDDLEvent()
 			require.NoError(t, err)
+			require.Equal(t, ddlEvent.TableInfo.TableName.TableID, event.TableInfo.TableName.TableID)
 			// Bootstrap event doesn't have query
 			require.Equal(t, "", event.Query)
 			require.Equal(t, len(ddlEvent.TableInfo.Columns), len(event.TableInfo.Columns))

--- a/pkg/sink/codec/simple/encoder_test.go
+++ b/pkg/sink/codec/simple/encoder_test.go
@@ -614,6 +614,7 @@ func TestEncodeLargeEventsNormal(t *testing.T) {
 				require.Equal(t, decodedRow.CommitTs, event.CommitTs)
 				require.Equal(t, decodedRow.Table.Schema, event.Table.Schema)
 				require.Equal(t, decodedRow.Table.Table, event.Table.Table)
+				require.Equal(t, decodedRow.Table.TableID, event.Table.TableID)
 
 				decodedColumns := make(map[string]*model.Column, len(decodedRow.Columns))
 				for _, column := range decodedRow.Columns {

--- a/pkg/sink/codec/simple/marshaller.go
+++ b/pkg/sink/codec/simple/marshaller.go
@@ -100,14 +100,12 @@ func (m *jsonMarshaller) MarshalDDLEvent(event *model.DDLEvent) ([]byte, error) 
 // MarshalRowChangedEvent implement the marshaller interface
 func (m *jsonMarshaller) MarshalRowChangedEvent(
 	event *model.RowChangedEvent, config *common.Config,
-	handleKeyOnly bool,
-	claimCheckFileName string,
+	handleKeyOnly bool, claimCheckFileName string,
 ) ([]byte, error) {
-	msg, err := newDMLMessage(event, config, handleKeyOnly)
+	msg, err := newDMLMessage(event, config, handleKeyOnly, claimCheckFileName)
 	if err != nil {
 		return nil, err
 	}
-	msg.ClaimCheckLocation = claimCheckFileName
 
 	value, err := json.Marshal(msg)
 	if err != nil {

--- a/pkg/sink/codec/simple/message.go
+++ b/pkg/sink/codec/simple/message.go
@@ -276,7 +276,7 @@ func newTableSchema(tableInfo *model.TableInfo) (*TableSchema, error) {
 	return &TableSchema{
 		Schema:  tableInfo.TableName.Schema,
 		Table:   tableInfo.TableName.Table,
-		TableID: tableInfo.TableName.TableID,
+		TableID: tableInfo.ID,
 		Version: tableInfo.UpdateTS,
 		Columns: columns,
 		Indexes: indexes,
@@ -557,7 +557,7 @@ func newDMLMessage(
 		Version:            defaultVersion,
 		Schema:             event.Table.Schema,
 		Table:              event.Table.Table,
-		TableID:            event.Table.TableID,
+		TableID:            event.TableInfo.ID,
 		CommitTs:           event.CommitTs,
 		BuildTs:            time.Now().UnixMilli(),
 		SchemaVersion:      event.TableInfo.UpdateTS,

--- a/pkg/sink/codec/simple/message.go
+++ b/pkg/sink/codec/simple/message.go
@@ -228,6 +228,7 @@ func newTiIndexInfo(indexSchema *IndexSchema) *timodel.IndexInfo {
 type TableSchema struct {
 	Schema  string          `json:"schema"`
 	Table   string          `json:"table"`
+	TableID int64           `json:"tableID"`
 	Version uint64          `json:"version"`
 	Columns []*columnSchema `json:"columns"`
 	Indexes []*IndexSchema  `json:"indexes"`
@@ -275,6 +276,7 @@ func newTableSchema(tableInfo *model.TableInfo) (*TableSchema, error) {
 	return &TableSchema{
 		Schema:  tableInfo.TableName.Schema,
 		Table:   tableInfo.TableName.Table,
+		TableID: tableInfo.TableName.TableID,
 		Version: tableInfo.UpdateTS,
 		Columns: columns,
 		Indexes: indexes,
@@ -286,17 +288,20 @@ func newTableInfo(m *TableSchema) (*model.TableInfo, error) {
 	var (
 		database      string
 		table         string
+		tableID       int64
 		schemaVersion uint64
 	)
 	if m != nil {
 		database = m.Schema
 		table = m.Table
+		tableID = m.TableID
 		schemaVersion = m.Version
 	}
 	info := &model.TableInfo{
 		TableName: model.TableName{
-			Schema: database,
-			Table:  table,
+			Schema:  database,
+			Table:   table,
+			TableID: tableID,
 		},
 		TableInfo: &timodel.TableInfo{
 			Name:     timodel.NewCIStr(table),

--- a/pkg/sink/codec/simple/message.json
+++ b/pkg/sink/codec/simple/message.json
@@ -116,6 +116,10 @@
         "type": "string"
       },
       {
+        "name": "tableID",
+        "type": "long"
+      },
+      {
         "name": "version",
         "type": "long"
       },

--- a/pkg/sink/codec/simple/message.json
+++ b/pkg/sink/codec/simple/message.json
@@ -265,6 +265,10 @@
         "type": "string"
       },
       {
+        "name": "tableID",
+        "type": "long"
+      },
+      {
         "name": "type",
         "type": {
           "type": "enum",

--- a/pkg/sink/codec/simple/message_test.go
+++ b/pkg/sink/codec/simple/message_test.go
@@ -37,6 +37,7 @@ func TestNewTableSchema(t *testing.T) {
 	want := &TableSchema{
 		Schema:  tableInfo.TableName.Schema,
 		Table:   tableInfo.TableName.Table,
+		TableID: tableInfo.TableName.TableID,
 		Version: tableInfo.UpdateTS,
 		Columns: []*columnSchema{
 			{
@@ -122,6 +123,7 @@ func TestNewTableSchema(t *testing.T) {
 	want = &TableSchema{
 		Schema:  tableInfo.TableName.Schema,
 		Table:   tableInfo.TableName.Table,
+		TableID: tableInfo.TableName.TableID,
 		Version: tableInfo.UpdateTS,
 		Columns: []*columnSchema{
 			{
@@ -237,6 +239,7 @@ func TestNewTableSchema(t *testing.T) {
 	want = &TableSchema{
 		Schema:  tableInfo.TableName.Schema,
 		Table:   tableInfo.TableName.Table,
+		TableID: tableInfo.TableName.TableID,
 		Version: tableInfo.UpdateTS,
 		Columns: []*columnSchema{
 			{


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10474 

### What is changed and how it works?

* Encode `TableID` into simple protocol DML and DDL message content

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
