### PR TITLE
metrics(ticdc): fix slowest table metrics in scheduler

### DIFF
--- a/cdc/scheduler/internal/v3/replication/replication_manager.go
+++ b/cdc/scheduler/internal/v3/replication/replication_manager.go
@@ -591,6 +591,7 @@ func (r *Manager) AdvanceCheckpoint(
 
 	r.slowestPuller = tablepb.Span{}
 	r.slowestSink = tablepb.Span{}
+	resolvedTsOfSlowestSink := model.Ts(math.MaxUint64)
 
 	watermark = schedulepb.Watermark{
 		CheckpointTs:     math.MaxUint64,
@@ -625,9 +626,12 @@ func (r *Manager) AdvanceCheckpoint(
 				}
 
 				// Find the minimum checkpoint ts and resolved ts.
-				if watermark.CheckpointTs > table.Checkpoint.CheckpointTs {
+				if watermark.CheckpointTs > table.Checkpoint.CheckpointTs ||
+					(watermark.CheckpointTs == table.Checkpoint.CheckpointTs &&
+						resolvedTsOfSlowestSink > table.Checkpoint.ResolvedTs) {
 					watermark.CheckpointTs = table.Checkpoint.CheckpointTs
 					r.slowestSink = span
+					resolvedTsOfSlowestSink = table.Checkpoint.ResolvedTs
 				}
 				if watermark.ResolvedTs > table.Checkpoint.ResolvedTs {
 					watermark.ResolvedTs = table.Checkpoint.ResolvedTs
@@ -854,7 +858,7 @@ func (r *Manager) CollectMetrics() {
 			Set(float64(counter))
 	}
 
-	if table, ok := r.spans.Get(r.slowestSink); ok {
+	if table, ok := r.spans.Get(r.slowestPuller); ok {
 		if pullerCkpt, ok := table.Stats.StageCheckpoints["puller-egress"]; ok {
 			phyCkptTs := oracle.ExtractPhysical(pullerCkpt.ResolvedTs)
 			slowestTablePullerResolvedTs.WithLabelValues(cf.Namespace, cf.ID).Set(float64(phyCkptTs))


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10482

### What is changed and how it works?
1. [Record the correct progress in slowestTablePullerResolvedTs](https://github.com/pingcap/tiflow/pull/10484/files#diff-ec8c2629076697b5b91801313d52d043e53e4418f0317c4b944d380cdaca1466R861-R864)
2. [For tables with equal checkpoints, set the table with the smallest resovedTs to the slowest table](https://github.com/pingcap/tiflow/pull/10484/files#diff-ec8c2629076697b5b91801313d52d043e53e4418f0317c4b944d380cdaca1466R630-R631)


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
