### PR TITLE
puller(ticdc):  fix resolvedTs get stuck when region split and merge

### DIFF
--- a/cdc/puller/frontier/frontier_test.go
+++ b/cdc/puller/frontier/frontier_test.go
@@ -216,7 +216,7 @@ func TestSpanString(t *testing.T) {
 
 	spAH := tablepb.Span{StartKey: []byte("a"), EndKey: []byte("h")}
 	f := NewFrontier(1, spAH).(*spanFrontier)
-	require.Equal(t, `[0:a @ 1] [0:h @ Max] `, f.SpanString(spAH))
+	require.Equal(t, `[0:61 @ 1] [0:68 @ Max] `, f.SpanString(spAH))
 
 	f.Forward(1, spAB, 2)
 	f.Forward(2, spBC, 5)
@@ -226,14 +226,14 @@ func TestSpanString(t *testing.T) {
 	f.Forward(6, spFG, 25)
 	f.Forward(7, spGH, 35)
 	require.Equal(t, uint64(2), f.Frontier())
-	require.Equal(t, `[1:a @ 2] [2:b @ 5] [3:c @ 10] [4:d @ 20] [5:e @ 30] [6:f @ 25] [7:g @ 35] [0:h @ Max] `, f.stringWtihRegionID())
+	require.Equal(t, `[1:61 @ 2] [2:62 @ 5] [3:63 @ 10] [4:64 @ 20] [5:65 @ 30] [6:66 @ 25] [7:67 @ 35] [0:68 @ Max] `, f.stringWtihRegionID())
 	// Print 5 span: start, before, target span, next, end
-	require.Equal(t, `[1:a @ 2] [3:c @ 10] [4:d @ 20] [5:e @ 30] [0:h @ Max] `, f.SpanString(spDE))
+	require.Equal(t, `[1:61 @ 2] [3:63 @ 10] [4:64 @ 20] [5:65 @ 30] [0:68 @ Max] `, f.SpanString(spDE))
 
 	spBH := tablepb.Span{StartKey: []byte("b"), EndKey: []byte("h")}
 	f.Forward(8, spBH, 18)
 	require.Equal(t, uint64(2), f.Frontier())
-	require.Equal(t, `[1:a @ 2] [8:b @ 18] [0:h @ Max] `, f.stringWtihRegionID())
+	require.Equal(t, `[1:61 @ 2] [8:62 @ 18] [0:68 @ Max] `, f.stringWtihRegionID())
 }
 
 func TestMinMax(t *testing.T) {

--- a/cdc/puller/puller.go
+++ b/cdc/puller/puller.go
@@ -237,6 +237,7 @@ func (p *pullerImpl) Run(ctx context.Context) error {
 									zap.Stringer("resolvedSpan", &resolvedSpan.Span),
 									zap.Stringer("slowestRange", lastSlowestRange),
 									zap.Uint64("resolvedTs", lastResolvedTs),
+									zap.Uint64("regionID", resolvedSpan.Region),
 									zap.String("tsTracker", p.tsTracker.SpanString(*lastSlowestRange)),
 								)
 								lastCheckSlowestRangeTime = time.Now()


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #10157

### What is changed and how it works?

Always delete the the mapping in `cachedRegions` when a span's regionID changes. 

This can prevent an old span node in the frontier from becoming an orphan node, which would cause the resolvedTs of the corresponding span to not be updated.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a bug where region split and merge cause the changefeed resolvedTs to get stuck.
```
