### PR TITLE
cdc: fix build table info

### DIFF
--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -569,6 +569,10 @@ func (m *mounter) mountRowKVEntry(tableInfo *model.TableInfo, row *rowKVEntry, d
 			Version:   checksumVersion,
 		}
 	}
+	log.Info("decode table info",
+		zap.String("table info ", tableInfo.String()),
+		zap.String("columns", fmt.Sprintf("%v", cols)),
+		zap.String("pre columns", fmt.Sprintf("%v", preCols)))
 
 	return &model.RowChangedEvent{
 		StartTs:  row.StartTs,

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -569,10 +569,6 @@ func (m *mounter) mountRowKVEntry(tableInfo *model.TableInfo, row *rowKVEntry, d
 			Version:   checksumVersion,
 		}
 	}
-	log.Info("decode table info",
-		zap.String("table info ", tableInfo.String()),
-		zap.String("columns", fmt.Sprintf("%v", cols)),
-		zap.String("pre columns", fmt.Sprintf("%v", preCols)))
 
 	return &model.RowChangedEvent{
 		StartTs:  row.StartTs,

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -1522,85 +1522,85 @@ func TestBuildTableInfo(t *testing.T) {
 		recovered           string
 		recoveredWithNilCol string
 	}{
-		{
-			"CREATE TABLE t1 (c INT PRIMARY KEY)",
-			"CREATE TABLE `BuildTiDBTableInfo` (\n" +
-				"  `c` int(0) NOT NULL,\n" +
-				"  PRIMARY KEY (`c`(0)) /*T![clustered_index] CLUSTERED */\n" +
-				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-			"CREATE TABLE `BuildTiDBTableInfo` (\n" +
-				"  `c` int(0) NOT NULL,\n" +
-				"  PRIMARY KEY (`c`(0)) /*T![clustered_index] CLUSTERED */\n" +
-				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-		},
-		{
-			"CREATE TABLE t1 (" +
-				" c INT UNSIGNED," +
-				" c2 VARCHAR(10) NOT NULL," +
-				" c3 BIT(10) NOT NULL," +
-				" UNIQUE KEY (c2, c3)" +
-				")",
-			// CDC discards field length.
-			"CREATE TABLE `BuildTiDBTableInfo` (\n" +
-				"  `c` int(0) unsigned DEFAULT NULL,\n" +
-				"  `c2` varchar(0) NOT NULL,\n" +
-				"  `c3` bit(0) NOT NULL,\n" +
-				"  UNIQUE KEY `idx_0` (`c2`(0),`c3`(0))\n" +
-				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-			"CREATE TABLE `BuildTiDBTableInfo` (\n" +
-				"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
-				"  `c2` varchar(0) NOT NULL,\n" +
-				"  `c3` bit(0) NOT NULL,\n" +
-				"  UNIQUE KEY `idx_0` (`c2`(0),`c3`(0))\n" +
-				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-		},
-		{
-			"CREATE TABLE t1 (" +
-				" c INT UNSIGNED," +
-				" gen INT AS (c+1) VIRTUAL," +
-				" c2 VARCHAR(10) NOT NULL," +
-				" gen2 INT AS (c+2) STORED," +
-				" c3 BIT(10) NOT NULL," +
-				" PRIMARY KEY (c, c2)" +
-				")",
-			// CDC discards virtual generated column, and generating expression of stored generated column.
-			"CREATE TABLE `BuildTiDBTableInfo` (\n" +
-				"  `c` int(0) unsigned NOT NULL,\n" +
-				"  `c2` varchar(0) NOT NULL,\n" +
-				"  `gen2` int(0) GENERATED ALWAYS AS (pass_generated_check) STORED,\n" +
-				"  `c3` bit(0) NOT NULL,\n" +
-				"  PRIMARY KEY (`c`(0),`c2`(0)) /*T![clustered_index] CLUSTERED */\n" +
-				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-			"CREATE TABLE `BuildTiDBTableInfo` (\n" +
-				"  `c` int(0) unsigned NOT NULL,\n" +
-				"  `c2` varchar(0) NOT NULL,\n" +
-				"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
-				"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
-				"  PRIMARY KEY (`c`(0),`c2`(0)) /*T![clustered_index] CLUSTERED */\n" +
-				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-		},
-		{
-			"CREATE TABLE `t1` (" +
-				"  `a` int(11) NOT NULL," +
-				"  `b` int(11) DEFAULT NULL," +
-				"  `c` int(11) DEFAULT NULL," +
-				"  PRIMARY KEY (`a`) /*T![clustered_index] CLUSTERED */," +
-				"  UNIQUE KEY `b` (`b`)" +
-				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-			"CREATE TABLE `BuildTiDBTableInfo` (\n" +
-				"  `a` int(0) NOT NULL,\n" +
-				"  `b` int(0) DEFAULT NULL,\n" +
-				"  `c` int(0) DEFAULT NULL,\n" +
-				"  PRIMARY KEY (`a`(0)) /*T![clustered_index] CLUSTERED */,\n" +
-				"  UNIQUE KEY `idx_1` (`b`(0))\n" +
-				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-			"CREATE TABLE `BuildTiDBTableInfo` (\n" +
-				"  `a` int(0) NOT NULL,\n" +
-				"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
-				"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
-				"  PRIMARY KEY (`a`(0)) /*T![clustered_index] CLUSTERED */\n" +
-				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-		},
+		// {
+		// 	"CREATE TABLE t1 (c INT PRIMARY KEY)",
+		// 	"CREATE TABLE `t1` (\n" +
+		// 		"  `c` int(0) NOT NULL,\n" +
+		// 		"  PRIMARY KEY (`c`(0)) /*T![clustered_index] CLUSTERED */\n" +
+		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+		// 	"CREATE TABLE `t1` (\n" +
+		// 		"  `c` int(0) NOT NULL,\n" +
+		// 		"  PRIMARY KEY (`c`(0)) /*T![clustered_index] CLUSTERED */\n" +
+		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+		// },
+		// {
+		// 	"CREATE TABLE t1 (" +
+		// 		" c INT UNSIGNED," +
+		// 		" c2 VARCHAR(10) NOT NULL," +
+		// 		" c3 BIT(10) NOT NULL," +
+		// 		" UNIQUE KEY (c2, c3)" +
+		// 		")",
+		// 	// CDC discards field length.
+		// 	"CREATE TABLE `t1` (\n" +
+		// 		"  `c` int(0) unsigned DEFAULT NULL,\n" +
+		// 		"  `c2` varchar(0) NOT NULL,\n" +
+		// 		"  `c3` bit(0) NOT NULL,\n" +
+		// 		"  UNIQUE KEY `idx_0` (`c2`(0),`c3`(0))\n" +
+		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+		// 	"CREATE TABLE `t1` (\n" +
+		// 		"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
+		// 		"  `c2` varchar(0) NOT NULL,\n" +
+		// 		"  `c3` bit(0) NOT NULL,\n" +
+		// 		"  UNIQUE KEY `idx_0` (`c2`(0),`c3`(0))\n" +
+		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+		// },
+		// {
+		// 	"CREATE TABLE t1 (" +
+		// 		" c INT UNSIGNED," +
+		// 		" gen INT AS (c+1) VIRTUAL," +
+		// 		" c2 VARCHAR(10) NOT NULL," +
+		// 		" gen2 INT AS (c+2) STORED," +
+		// 		" c3 BIT(10) NOT NULL," +
+		// 		" PRIMARY KEY (c, c2)" +
+		// 		")",
+		// 	// CDC discards virtual generated column, and generating expression of stored generated column.
+		// 	"CREATE TABLE `t1` (\n" +
+		// 		"  `c` int(0) unsigned NOT NULL,\n" +
+		// 		"  `c2` varchar(0) NOT NULL,\n" +
+		// 		"  `gen2` int(0) GENERATED ALWAYS AS (pass_generated_check) STORED,\n" +
+		// 		"  `c3` bit(0) NOT NULL,\n" +
+		// 		"  PRIMARY KEY (`c`(0),`c2`(0)) /*T![clustered_index] CLUSTERED */\n" +
+		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+		// 	"CREATE TABLE `t1` (\n" +
+		// 		"  `c` int(0) unsigned NOT NULL,\n" +
+		// 		"  `c2` varchar(0) NOT NULL,\n" +
+		// 		"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
+		// 		"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
+		// 		"  PRIMARY KEY (`c`(0),`c2`(0)) /*T![clustered_index] CLUSTERED */\n" +
+		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+		// },
+		// {
+		// 	"CREATE TABLE `t1` (" +
+		// 		"  `a` int(11) NOT NULL," +
+		// 		"  `b` int(11) DEFAULT NULL," +
+		// 		"  `c` int(11) DEFAULT NULL," +
+		// 		"  PRIMARY KEY (`a`) /*T![clustered_index] CLUSTERED */," +
+		// 		"  UNIQUE KEY `b` (`b`)" +
+		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+		// 	"CREATE TABLE `t1` (\n" +
+		// 		"  `a` int(0) NOT NULL,\n" +
+		// 		"  `b` int(0) DEFAULT NULL,\n" +
+		// 		"  `c` int(0) DEFAULT NULL,\n" +
+		// 		"  PRIMARY KEY (`a`(0)) /*T![clustered_index] CLUSTERED */,\n" +
+		// 		"  UNIQUE KEY `idx_1` (`b`(0))\n" +
+		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+		// 	"CREATE TABLE `t1` (\n" +
+		// 		"  `a` int(0) NOT NULL,\n" +
+		// 		"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
+		// 		"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
+		// 		"  PRIMARY KEY (`a`(0)) /*T![clustered_index] CLUSTERED */\n" +
+		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+		// },
 		{ // This case is to check the primary key is correctly identified by BuildTiDBTableInfo
 			"CREATE TABLE your_table (" +
 				" id INT NOT NULL," +
@@ -1612,7 +1612,7 @@ func TestBuildTableInfo(t *testing.T) {
 				" UNIQUE INDEX idx_unique_1 (id, email, age)," +
 				" UNIQUE INDEX idx_unique_2 (name, email, address)" +
 				" );",
-			"CREATE TABLE `BuildTiDBTableInfo` (\n" +
+			"CREATE TABLE `your_table` (\n" +
 				"  `id` int(0) NOT NULL,\n" +
 				"  `name` varchar(0) NOT NULL,\n" +
 				"  `email` varchar(0) NOT NULL,\n" +
@@ -1622,7 +1622,7 @@ func TestBuildTableInfo(t *testing.T) {
 				"  UNIQUE KEY `idx_1` (`id`(0),`email`(0),`age`(0)),\n" +
 				"  UNIQUE KEY `idx_2` (`name`(0),`email`(0),`address`(0))\n" +
 				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-			"CREATE TABLE `BuildTiDBTableInfo` (\n" +
+			"CREATE TABLE `your_table` (\n" +
 				"  `id` int(0) NOT NULL,\n" +
 				"  `name` varchar(0) NOT NULL,\n" +
 				"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
@@ -1643,7 +1643,7 @@ func TestBuildTableInfo(t *testing.T) {
 		cdcTableInfo := model.WrapTableInfo(0, "test", 0, originTI)
 		cols, _, _, _, err := datum2Column(cdcTableInfo, map[int64]types.Datum{})
 		require.NoError(t, err)
-		recoveredTI := model.BuildTiDBTableInfo(cols, cdcTableInfo.IndexColumnsOffset)
+		recoveredTI := model.BuildTiDBTableInfo(cdcTableInfo.TableName.Table, cols, cdcTableInfo.IndexColumnsOffset)
 		handle := sqlmodel.GetWhereHandle(recoveredTI, recoveredTI)
 		require.NotNil(t, handle.UniqueNotNullIdx)
 		require.Equal(t, c.recovered, showCreateTable(t, recoveredTI))
@@ -1665,7 +1665,7 @@ func TestBuildTableInfo(t *testing.T) {
 				cols[i] = nil
 			}
 		}
-		recoveredTI = model.BuildTiDBTableInfo(cols, cdcTableInfo.IndexColumnsOffset)
+		recoveredTI = model.BuildTiDBTableInfo(cdcTableInfo.TableName.Table, cols, cdcTableInfo.IndexColumnsOffset)
 		handle = sqlmodel.GetWhereHandle(recoveredTI, recoveredTI)
 		require.NotNil(t, handle.UniqueNotNullIdx)
 		require.Equal(t, c.recoveredWithNilCol, showCreateTable(t, recoveredTI))
@@ -1717,7 +1717,7 @@ func TestNewDMRowChange(t *testing.T) {
 				Name: "a3", Type: 3, Charset: "binary", Flag: 51, Value: 2, Default: nil,
 			},
 		}
-		recoveredTI := model.BuildTiDBTableInfo(cols, cdcTableInfo.IndexColumnsOffset)
+		recoveredTI := model.BuildTiDBTableInfo(cdcTableInfo.TableName.Table, cols, cdcTableInfo.IndexColumnsOffset)
 		require.Equal(t, c.recovered, showCreateTable(t, recoveredTI))
 		tableName := &model.TableName{Schema: "db", Table: "t1"}
 		rowChange := sqlmodel.NewRowChange(tableName, nil, []interface{}{1, 1, 2}, nil, recoveredTI, nil, nil)

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -1691,7 +1691,7 @@ func TestNewDMRowChange(t *testing.T) {
 				" a1 INT NOT NULL," +
 				" a3 INT NOT NULL," +
 				" UNIQUE KEY dex1(a1, a3));",
-			"CREATE TABLE `BuildTiDBTableInfo` (\n" +
+			"CREATE TABLE `t1` (\n" +
 				"  `id` int(0) DEFAULT NULL,\n" +
 				"  `a1` int(0) NOT NULL,\n" +
 				"  `a3` int(0) NOT NULL,\n" +

--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -1522,85 +1522,85 @@ func TestBuildTableInfo(t *testing.T) {
 		recovered           string
 		recoveredWithNilCol string
 	}{
-		// {
-		// 	"CREATE TABLE t1 (c INT PRIMARY KEY)",
-		// 	"CREATE TABLE `t1` (\n" +
-		// 		"  `c` int(0) NOT NULL,\n" +
-		// 		"  PRIMARY KEY (`c`(0)) /*T![clustered_index] CLUSTERED */\n" +
-		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-		// 	"CREATE TABLE `t1` (\n" +
-		// 		"  `c` int(0) NOT NULL,\n" +
-		// 		"  PRIMARY KEY (`c`(0)) /*T![clustered_index] CLUSTERED */\n" +
-		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-		// },
-		// {
-		// 	"CREATE TABLE t1 (" +
-		// 		" c INT UNSIGNED," +
-		// 		" c2 VARCHAR(10) NOT NULL," +
-		// 		" c3 BIT(10) NOT NULL," +
-		// 		" UNIQUE KEY (c2, c3)" +
-		// 		")",
-		// 	// CDC discards field length.
-		// 	"CREATE TABLE `t1` (\n" +
-		// 		"  `c` int(0) unsigned DEFAULT NULL,\n" +
-		// 		"  `c2` varchar(0) NOT NULL,\n" +
-		// 		"  `c3` bit(0) NOT NULL,\n" +
-		// 		"  UNIQUE KEY `idx_0` (`c2`(0),`c3`(0))\n" +
-		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-		// 	"CREATE TABLE `t1` (\n" +
-		// 		"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
-		// 		"  `c2` varchar(0) NOT NULL,\n" +
-		// 		"  `c3` bit(0) NOT NULL,\n" +
-		// 		"  UNIQUE KEY `idx_0` (`c2`(0),`c3`(0))\n" +
-		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-		// },
-		// {
-		// 	"CREATE TABLE t1 (" +
-		// 		" c INT UNSIGNED," +
-		// 		" gen INT AS (c+1) VIRTUAL," +
-		// 		" c2 VARCHAR(10) NOT NULL," +
-		// 		" gen2 INT AS (c+2) STORED," +
-		// 		" c3 BIT(10) NOT NULL," +
-		// 		" PRIMARY KEY (c, c2)" +
-		// 		")",
-		// 	// CDC discards virtual generated column, and generating expression of stored generated column.
-		// 	"CREATE TABLE `t1` (\n" +
-		// 		"  `c` int(0) unsigned NOT NULL,\n" +
-		// 		"  `c2` varchar(0) NOT NULL,\n" +
-		// 		"  `gen2` int(0) GENERATED ALWAYS AS (pass_generated_check) STORED,\n" +
-		// 		"  `c3` bit(0) NOT NULL,\n" +
-		// 		"  PRIMARY KEY (`c`(0),`c2`(0)) /*T![clustered_index] CLUSTERED */\n" +
-		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-		// 	"CREATE TABLE `t1` (\n" +
-		// 		"  `c` int(0) unsigned NOT NULL,\n" +
-		// 		"  `c2` varchar(0) NOT NULL,\n" +
-		// 		"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
-		// 		"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
-		// 		"  PRIMARY KEY (`c`(0),`c2`(0)) /*T![clustered_index] CLUSTERED */\n" +
-		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-		// },
-		// {
-		// 	"CREATE TABLE `t1` (" +
-		// 		"  `a` int(11) NOT NULL," +
-		// 		"  `b` int(11) DEFAULT NULL," +
-		// 		"  `c` int(11) DEFAULT NULL," +
-		// 		"  PRIMARY KEY (`a`) /*T![clustered_index] CLUSTERED */," +
-		// 		"  UNIQUE KEY `b` (`b`)" +
-		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-		// 	"CREATE TABLE `t1` (\n" +
-		// 		"  `a` int(0) NOT NULL,\n" +
-		// 		"  `b` int(0) DEFAULT NULL,\n" +
-		// 		"  `c` int(0) DEFAULT NULL,\n" +
-		// 		"  PRIMARY KEY (`a`(0)) /*T![clustered_index] CLUSTERED */,\n" +
-		// 		"  UNIQUE KEY `idx_1` (`b`(0))\n" +
-		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-		// 	"CREATE TABLE `t1` (\n" +
-		// 		"  `a` int(0) NOT NULL,\n" +
-		// 		"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
-		// 		"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
-		// 		"  PRIMARY KEY (`a`(0)) /*T![clustered_index] CLUSTERED */\n" +
-		// 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
-		// },
+		{
+			"CREATE TABLE t1 (c INT PRIMARY KEY)",
+			"CREATE TABLE `t1` (\n" +
+				"  `c` int(0) NOT NULL,\n" +
+				"  PRIMARY KEY (`c`(0)) /*T![clustered_index] CLUSTERED */\n" +
+				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+			"CREATE TABLE `t1` (\n" +
+				"  `c` int(0) NOT NULL,\n" +
+				"  PRIMARY KEY (`c`(0)) /*T![clustered_index] CLUSTERED */\n" +
+				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+		},
+		{
+			"CREATE TABLE t1 (" +
+				" c INT UNSIGNED," +
+				" c2 VARCHAR(10) NOT NULL," +
+				" c3 BIT(10) NOT NULL," +
+				" UNIQUE KEY (c2, c3)" +
+				")",
+			// CDC discards field length.
+			"CREATE TABLE `t1` (\n" +
+				"  `c` int(0) unsigned DEFAULT NULL,\n" +
+				"  `c2` varchar(0) NOT NULL,\n" +
+				"  `c3` bit(0) NOT NULL,\n" +
+				"  UNIQUE KEY `idx_0` (`c2`(0),`c3`(0))\n" +
+				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+			"CREATE TABLE `t1` (\n" +
+				"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
+				"  `c2` varchar(0) NOT NULL,\n" +
+				"  `c3` bit(0) NOT NULL,\n" +
+				"  UNIQUE KEY `idx_0` (`c2`(0),`c3`(0))\n" +
+				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+		},
+		{
+			"CREATE TABLE t1 (" +
+				" c INT UNSIGNED," +
+				" gen INT AS (c+1) VIRTUAL," +
+				" c2 VARCHAR(10) NOT NULL," +
+				" gen2 INT AS (c+2) STORED," +
+				" c3 BIT(10) NOT NULL," +
+				" PRIMARY KEY (c, c2)" +
+				")",
+			// CDC discards virtual generated column, and generating expression of stored generated column.
+			"CREATE TABLE `t1` (\n" +
+				"  `c` int(0) unsigned NOT NULL,\n" +
+				"  `c2` varchar(0) NOT NULL,\n" +
+				"  `gen2` int(0) GENERATED ALWAYS AS (pass_generated_check) STORED,\n" +
+				"  `c3` bit(0) NOT NULL,\n" +
+				"  PRIMARY KEY (`c`(0),`c2`(0)) /*T![clustered_index] CLUSTERED */\n" +
+				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+			"CREATE TABLE `t1` (\n" +
+				"  `c` int(0) unsigned NOT NULL,\n" +
+				"  `c2` varchar(0) NOT NULL,\n" +
+				"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
+				"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
+				"  PRIMARY KEY (`c`(0),`c2`(0)) /*T![clustered_index] CLUSTERED */\n" +
+				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+		},
+		{
+			"CREATE TABLE `t1` (" +
+				"  `a` int(11) NOT NULL," +
+				"  `b` int(11) DEFAULT NULL," +
+				"  `c` int(11) DEFAULT NULL," +
+				"  PRIMARY KEY (`a`) /*T![clustered_index] CLUSTERED */," +
+				"  UNIQUE KEY `b` (`b`)" +
+				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+			"CREATE TABLE `t1` (\n" +
+				"  `a` int(0) NOT NULL,\n" +
+				"  `b` int(0) DEFAULT NULL,\n" +
+				"  `c` int(0) DEFAULT NULL,\n" +
+				"  PRIMARY KEY (`a`(0)) /*T![clustered_index] CLUSTERED */,\n" +
+				"  UNIQUE KEY `idx_1` (`b`(0))\n" +
+				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+			"CREATE TABLE `t1` (\n" +
+				"  `a` int(0) NOT NULL,\n" +
+				"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
+				"  `omitted` unspecified GENERATED ALWAYS AS (pass_generated_check) VIRTUAL,\n" +
+				"  PRIMARY KEY (`a`(0)) /*T![clustered_index] CLUSTERED */\n" +
+				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+		},
 		{ // This case is to check the primary key is correctly identified by BuildTiDBTableInfo
 			"CREATE TABLE your_table (" +
 				" id INT NOT NULL," +

--- a/cdc/model/schema_storage_test.go
+++ b/cdc/model/schema_storage_test.go
@@ -409,18 +409,18 @@ func TestBuildTiDBTableInfoWithCommonPrimaryKey(t *testing.T) {
 	}, {
 		Name: "a4",
 		Type: mysql.TypeVarchar,
-		Flag: PrimaryKeyFlag | HandleKeyFlag | MultipleKeyFlag,
+		Flag: PrimaryKeyFlag | UniqueKeyFlag | HandleKeyFlag | MultipleKeyFlag,
 	}, {
 		Name: "a9",
 		Type: mysql.TypeLong,
 		Flag: NullableFlag | UnsignedFlag,
 	}}
-	tidbTableInfo := BuildTiDBTableInfo("t", columns, [][]int{{0, 2}, {0, 1}})
+	tidbTableInfo := BuildTiDBTableInfo("t", columns, [][]int{{0, 2}, {0, 1}, {2}})
 	tableInfo := WrapTableInfo(100, "test", 1000, tidbTableInfo)
 	require.Equal(t, "test", tableInfo.TableName.Schema)
 	require.Equal(t, "t", tableInfo.TableName.Table)
 	require.Equal(t, 4, len(tableInfo.columnsOffset))
-	require.Equal(t, 2, len(tableInfo.indicesOffset))
+	require.Equal(t, 3, len(tableInfo.indicesOffset))
 	require.Equal(t, 4, len(tableInfo.Columns))
 
 	require.Equal(t, tableInfo.Columns[0].ID, tableInfo.ForceGetColumnIDByName("a1"))

--- a/cdc/model/schema_storage_test.go
+++ b/cdc/model/schema_storage_test.go
@@ -353,3 +353,151 @@ func TestColumnsByNames(t *testing.T) {
 	require.False(t, ok)
 	require.Nil(t, offsets)
 }
+
+func TestBuildTiDBTableInfoWithIntPrimaryKey(t *testing.T) {
+	columns := []*Column{{
+		Name: "a1",
+		Type: mysql.TypeLong,
+		Flag: BinaryFlag | PrimaryKeyFlag | HandleKeyFlag,
+	}, {
+		Name:      "a2",
+		Type:      mysql.TypeVarchar,
+		Collation: mysql.UTF8DefaultCollation,
+	}, {
+		Name:    "a4",
+		Type:    mysql.TypeTinyBlob,
+		Charset: mysql.Latin1Charset,
+	}}
+	tidbTableInfo := BuildTiDBTableInfo("t", columns, [][]int{{0}})
+	tableInfo := WrapTableInfo(100, "test", 1000, tidbTableInfo)
+	require.Equal(t, "test", tableInfo.TableName.Schema)
+	require.Equal(t, "t", tableInfo.TableName.Table)
+	require.Equal(t, 3, len(tableInfo.columnsOffset))
+	require.Equal(t, 1, len(tableInfo.indicesOffset))
+	require.Equal(t, 3, len(tableInfo.Columns))
+
+	require.Equal(t, tableInfo.Columns[0].ID, tableInfo.ForceGetColumnIDByName("a1"))
+	require.Equal(t, columns[0].Name, tableInfo.ForceGetColumnName(tableInfo.Columns[0].ID))
+	require.Equal(t, columns[0].Type, tableInfo.ForceGetColumnInfo(tableInfo.Columns[0].ID).GetType())
+	require.Equal(t, "binary", tableInfo.ForceGetColumnInfo(tableInfo.Columns[0].ID).GetCharset())
+	require.Equal(t, mysql.UTF8MB4DefaultCollation, tableInfo.ForceGetColumnInfo(tableInfo.Columns[0].ID).GetCollate())
+	require.Equal(t, columns[0].Flag, *tableInfo.ForceGetColumnFlagType(tableInfo.Columns[0].ID))
+
+	require.Equal(t, columns[1].Name, tableInfo.ForceGetColumnName(tableInfo.Columns[1].ID))
+	require.Equal(t, columns[1].Type, tableInfo.ForceGetColumnInfo(tableInfo.Columns[1].ID).GetType())
+	require.Equal(t, mysql.UTF8MB4Charset, tableInfo.ForceGetColumnInfo(tableInfo.Columns[1].ID).GetCharset())
+	require.Equal(t, mysql.UTF8DefaultCollation, tableInfo.ForceGetColumnInfo(tableInfo.Columns[1].ID).GetCollate())
+	require.Equal(t, columns[1].Flag, *tableInfo.ForceGetColumnFlagType(tableInfo.Columns[1].ID))
+
+	require.Equal(t, columns[2].Name, tableInfo.ForceGetColumnName(tableInfo.Columns[2].ID))
+	require.Equal(t, columns[2].Type, tableInfo.ForceGetColumnInfo(tableInfo.Columns[2].ID).GetType())
+	require.Equal(t, mysql.Latin1Charset, tableInfo.ForceGetColumnInfo(tableInfo.Columns[2].ID).GetCharset())
+	require.Equal(t, mysql.UTF8MB4DefaultCollation, tableInfo.ForceGetColumnInfo(tableInfo.Columns[2].ID).GetCollate())
+	require.Equal(t, columns[2].Flag, *tableInfo.ForceGetColumnFlagType(tableInfo.Columns[2].ID))
+}
+
+func TestBuildTiDBTableInfoWithCommonPrimaryKey(t *testing.T) {
+	columns := []*Column{{
+		Name: "a1",
+		Type: mysql.TypeLong,
+		Flag: BinaryFlag | PrimaryKeyFlag | UniqueKeyFlag | HandleKeyFlag | MultipleKeyFlag,
+	}, {
+		Name:    "a2",
+		Type:    mysql.TypeTinyBlob,
+		Charset: mysql.Latin1Charset,
+		Flag:    UniqueKeyFlag | UnsignedFlag | MultipleKeyFlag,
+	}, {
+		Name: "a4",
+		Type: mysql.TypeVarchar,
+		Flag: PrimaryKeyFlag | HandleKeyFlag | MultipleKeyFlag,
+	}, {
+		Name: "a9",
+		Type: mysql.TypeLong,
+		Flag: NullableFlag | UnsignedFlag,
+	}}
+	tidbTableInfo := BuildTiDBTableInfo("t", columns, [][]int{{0, 2}, {0, 1}})
+	tableInfo := WrapTableInfo(100, "test", 1000, tidbTableInfo)
+	require.Equal(t, "test", tableInfo.TableName.Schema)
+	require.Equal(t, "t", tableInfo.TableName.Table)
+	require.Equal(t, 4, len(tableInfo.columnsOffset))
+	require.Equal(t, 2, len(tableInfo.indicesOffset))
+	require.Equal(t, 4, len(tableInfo.Columns))
+
+	require.Equal(t, tableInfo.Columns[0].ID, tableInfo.ForceGetColumnIDByName("a1"))
+	require.Equal(t, columns[0].Name, tableInfo.ForceGetColumnName(tableInfo.Columns[0].ID))
+	require.Equal(t, columns[0].Type, tableInfo.ForceGetColumnInfo(tableInfo.Columns[0].ID).GetType())
+	require.Equal(t, "binary", tableInfo.ForceGetColumnInfo(tableInfo.Columns[0].ID).GetCharset())
+	require.Equal(t, mysql.UTF8MB4DefaultCollation, tableInfo.ForceGetColumnInfo(tableInfo.Columns[0].ID).GetCollate())
+	require.Equal(t, columns[0].Flag, *tableInfo.ForceGetColumnFlagType(tableInfo.Columns[0].ID))
+
+	require.Equal(t, columns[1].Name, tableInfo.ForceGetColumnName(tableInfo.Columns[1].ID))
+	require.Equal(t, columns[1].Type, tableInfo.ForceGetColumnInfo(tableInfo.Columns[1].ID).GetType())
+	require.Equal(t, mysql.Latin1Charset, tableInfo.ForceGetColumnInfo(tableInfo.Columns[1].ID).GetCharset())
+	require.Equal(t, mysql.UTF8MB4DefaultCollation, tableInfo.ForceGetColumnInfo(tableInfo.Columns[1].ID).GetCollate())
+	require.Equal(t, columns[1].Flag, *tableInfo.ForceGetColumnFlagType(tableInfo.Columns[1].ID))
+
+	require.Equal(t, columns[2].Name, tableInfo.ForceGetColumnName(tableInfo.Columns[2].ID))
+	require.Equal(t, columns[2].Type, tableInfo.ForceGetColumnInfo(tableInfo.Columns[2].ID).GetType())
+	require.Equal(t, mysql.UTF8MB4Charset, tableInfo.ForceGetColumnInfo(tableInfo.Columns[2].ID).GetCharset())
+	require.Equal(t, mysql.UTF8MB4DefaultCollation, tableInfo.ForceGetColumnInfo(tableInfo.Columns[2].ID).GetCollate())
+	require.Equal(t, columns[2].Flag, *tableInfo.ForceGetColumnFlagType(tableInfo.Columns[2].ID))
+
+	require.Equal(t, columns[3].Name, tableInfo.ForceGetColumnName(tableInfo.Columns[3].ID))
+	require.Equal(t, columns[3].Type, tableInfo.ForceGetColumnInfo(tableInfo.Columns[3].ID).GetType())
+	require.Equal(t, mysql.UTF8MB4Charset, tableInfo.ForceGetColumnInfo(tableInfo.Columns[3].ID).GetCharset())
+	require.Equal(t, mysql.UTF8MB4DefaultCollation, tableInfo.ForceGetColumnInfo(tableInfo.Columns[3].ID).GetCollate())
+	require.Equal(t, columns[3].Flag, *tableInfo.ForceGetColumnFlagType(tableInfo.Columns[3].ID))
+}
+
+func TestBuildTiDBTableInfoWithUniqueKey(t *testing.T) {
+	columns := []*Column{{
+		Name: "a1",
+		Type: mysql.TypeLong,
+		Flag: BinaryFlag | UniqueKeyFlag | HandleKeyFlag | MultipleKeyFlag,
+	}, {
+		Name:    "a2",
+		Type:    mysql.TypeTinyBlob,
+		Charset: mysql.Latin1Charset,
+		Flag:    UniqueKeyFlag | MultipleKeyFlag,
+	}, {
+		Name: "a4",
+		Type: mysql.TypeVarchar,
+		Flag: UniqueKeyFlag | HandleKeyFlag | MultipleKeyFlag,
+	}, {
+		Name: "a9",
+		Type: mysql.TypeLong,
+		Flag: UnsignedFlag | UniqueKeyFlag | MultipleKeyFlag,
+	}}
+	tidbTableInfo := BuildTiDBTableInfo("t", columns, [][]int{{0, 2}, {1, 3}})
+	tableInfo := WrapTableInfo(100, "test", 1000, tidbTableInfo)
+	require.Equal(t, "test", tableInfo.TableName.Schema)
+	require.Equal(t, "t", tableInfo.TableName.Table)
+	require.Equal(t, 4, len(tableInfo.columnsOffset))
+	require.Equal(t, 2, len(tableInfo.indicesOffset))
+	require.Equal(t, 4, len(tableInfo.Columns))
+
+	require.Equal(t, tableInfo.Columns[0].ID, tableInfo.ForceGetColumnIDByName("a1"))
+	require.Equal(t, columns[0].Name, tableInfo.ForceGetColumnName(tableInfo.Columns[0].ID))
+	require.Equal(t, columns[0].Type, tableInfo.ForceGetColumnInfo(tableInfo.Columns[0].ID).GetType())
+	require.Equal(t, "binary", tableInfo.ForceGetColumnInfo(tableInfo.Columns[0].ID).GetCharset())
+	require.Equal(t, mysql.UTF8MB4DefaultCollation, tableInfo.ForceGetColumnInfo(tableInfo.Columns[0].ID).GetCollate())
+	require.Equal(t, columns[0].Flag, *tableInfo.ForceGetColumnFlagType(tableInfo.Columns[0].ID))
+
+	require.Equal(t, columns[1].Name, tableInfo.ForceGetColumnName(tableInfo.Columns[1].ID))
+	require.Equal(t, columns[1].Type, tableInfo.ForceGetColumnInfo(tableInfo.Columns[1].ID).GetType())
+	require.Equal(t, mysql.Latin1Charset, tableInfo.ForceGetColumnInfo(tableInfo.Columns[1].ID).GetCharset())
+	require.Equal(t, mysql.UTF8MB4DefaultCollation, tableInfo.ForceGetColumnInfo(tableInfo.Columns[1].ID).GetCollate())
+	require.Equal(t, columns[1].Flag, *tableInfo.ForceGetColumnFlagType(tableInfo.Columns[1].ID))
+
+	require.Equal(t, columns[2].Name, tableInfo.ForceGetColumnName(tableInfo.Columns[2].ID))
+	require.Equal(t, columns[2].Type, tableInfo.ForceGetColumnInfo(tableInfo.Columns[2].ID).GetType())
+	require.Equal(t, mysql.UTF8MB4Charset, tableInfo.ForceGetColumnInfo(tableInfo.Columns[2].ID).GetCharset())
+	require.Equal(t, mysql.UTF8MB4DefaultCollation, tableInfo.ForceGetColumnInfo(tableInfo.Columns[2].ID).GetCollate())
+	require.Equal(t, columns[2].Flag, *tableInfo.ForceGetColumnFlagType(tableInfo.Columns[2].ID))
+
+	require.Equal(t, columns[3].Name, tableInfo.ForceGetColumnName(tableInfo.Columns[3].ID))
+	require.Equal(t, columns[3].Type, tableInfo.ForceGetColumnInfo(tableInfo.Columns[3].ID).GetType())
+	require.Equal(t, mysql.UTF8MB4Charset, tableInfo.ForceGetColumnInfo(tableInfo.Columns[3].ID).GetCharset())
+	require.Equal(t, mysql.UTF8MB4DefaultCollation, tableInfo.ForceGetColumnInfo(tableInfo.Columns[3].ID).GetCollate())
+	require.Equal(t, columns[3].Flag, *tableInfo.ForceGetColumnFlagType(tableInfo.Columns[3].ID))
+}

--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -638,7 +638,6 @@ func BuildTiDBTableInfo(tableName string, columns []*Column, indexColumns [][]in
 	// TiCDC handles columns according to the following rules:
 	// 1. If a primary key (PK) exists, it is chosen.
 	// 2. If there is no PK, TiCDC looks for a not null unique key (UK) with the least number of columns and the smallest index ID.
-	// And when the columns num is the same, it will choose the one with smallest index id.
 	// So we assign the smallest index id to the index which is selected as handle to mock this behavior.
 	minIndexID := int64(1)
 	nextMockIndexID := minIndexID + 1

--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -663,7 +663,7 @@ func BuildTiDBTableInfo(tableName string, columns []*Column, indexColumns [][]in
 				log.Panic("Invalid state: multiple handle index found",
 					zap.Int("index", i),
 					zap.Any("colOffsets", colOffsets),
-					zap.String("index name", indexInfo.Name.O))
+					zap.String("indexName", indexInfo.Name.O))
 			}
 			hasHandleIndex = true
 		} else {

--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -635,7 +635,9 @@ func BuildTiDBTableInfo(tableName string, columns []*Column, indexColumns [][]in
 
 	hasPrimaryKeyIndex := false
 	hasHandleIndex := false
-	// When there is no primary key, cdc will select the not null unique index with least columns.
+	// TiCDC handles columns according to the following rules:
+	// 1. If a primary key (PK) exists, it is chosen.
+	// 2. If there is no PK, TiCDC looks for a not null unique key (UK) with the least number of columns and the smallest index ID.
 	// And when the columns num is the same, it will choose the one with smallest index id.
 	// So we assign the smallest index id to the index which is selected as handle to mock this behavior.
 	minIndexID := int64(1)

--- a/cdc/sink/dmlsink/txn/mysql/mysql.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql.go
@@ -571,7 +571,7 @@ func (s *mysqlBackend) prepareDMLs() *preparedDMLs {
 			// only use batch dml when the table has a handle key
 			if hasHandleKey(tableColumns) {
 				// TODO(dongmen): find a better way to get table info.
-				tableInfo := model.BuildTiDBTableInfo(tableColumns, firstRow.IndexColumns)
+				tableInfo := model.BuildTiDBTableInfo(firstRow.Table.Table, tableColumns, firstRow.IndexColumns)
 				sql, value := s.batchSingleTxnDmls(event, tableInfo, translateToInsert)
 				sqls = append(sqls, sql...)
 				values = append(values, value...)

--- a/cdc/sink/dmlsink/txn/mysql/mysql_test.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql_test.go
@@ -345,6 +345,7 @@ func TestNewMySQLBackendExecDML(t *testing.T) {
 					Value: "test",
 				},
 			},
+			IndexColumns: [][]int{{0}},
 		},
 		{
 			StartTs:  5,
@@ -364,6 +365,7 @@ func TestNewMySQLBackendExecDML(t *testing.T) {
 					Value: "test",
 				},
 			},
+			IndexColumns: [][]int{{0}},
 		},
 	}
 
@@ -398,6 +400,7 @@ func TestExecDMLRollbackErrDatabaseNotExists(t *testing.T) {
 					Value: 1,
 				},
 			},
+			IndexColumns: [][]int{{0}},
 		},
 		{
 			Table: &model.TableName{Schema: "s1", Table: "t1", TableID: 1},
@@ -409,6 +412,7 @@ func TestExecDMLRollbackErrDatabaseNotExists(t *testing.T) {
 					Value: 2,
 				},
 			},
+			IndexColumns: [][]int{{0}},
 		},
 	}
 
@@ -469,6 +473,7 @@ func TestExecDMLRollbackErrTableNotExists(t *testing.T) {
 					Value: 1,
 				},
 			},
+			IndexColumns: [][]int{{0}},
 		},
 		{
 			Table: &model.TableName{Schema: "s1", Table: "t1", TableID: 1},
@@ -480,6 +485,7 @@ func TestExecDMLRollbackErrTableNotExists(t *testing.T) {
 					Value: 2,
 				},
 			},
+			IndexColumns: [][]int{{0}},
 		},
 	}
 
@@ -540,6 +546,7 @@ func TestExecDMLRollbackErrRetryable(t *testing.T) {
 					Value: 1,
 				},
 			},
+			IndexColumns: [][]int{{0}},
 		},
 		{
 			Table: &model.TableName{Schema: "s1", Table: "t1", TableID: 1},
@@ -551,6 +558,7 @@ func TestExecDMLRollbackErrRetryable(t *testing.T) {
 					Value: 2,
 				},
 			},
+			IndexColumns: [][]int{{0}},
 		},
 	}
 
@@ -618,6 +626,7 @@ func TestMysqlSinkNotRetryErrDupEntry(t *testing.T) {
 					Value: 1,
 				},
 			},
+			IndexColumns: [][]int{{0}},
 		},
 	}
 
@@ -848,6 +857,7 @@ func TestMySQLSinkExecDMLError(t *testing.T) {
 					Value: "test",
 				},
 			},
+			IndexColumns: [][]int{{0}},
 		},
 		{
 			StartTs:  2,
@@ -867,6 +877,7 @@ func TestMySQLSinkExecDMLError(t *testing.T) {
 					Value: "test",
 				},
 			},
+			IndexColumns: [][]int{{0}},
 		},
 	}
 
@@ -1202,9 +1213,10 @@ func TestPrepareBatchDMLs(t *testing.T) {
 					CommitTs: 418658114257813515,
 					Table:    &model.TableName{Schema: "common_1", Table: "uk_without_pk"},
 					PreColumns: []*model.Column{nil, {
-						Name:  "a1",
-						Type:  mysql.TypeLong,
-						Flag:  model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag | model.UniqueKeyFlag,
+						Name: "a1",
+						Type: mysql.TypeLong,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 1,
 					}, {
 						Name:    "a3",
@@ -1222,9 +1234,10 @@ func TestPrepareBatchDMLs(t *testing.T) {
 					CommitTs: 418658114257813515,
 					Table:    &model.TableName{Schema: "common_1", Table: "uk_without_pk"},
 					PreColumns: []*model.Column{nil, {
-						Name:  "a1",
-						Type:  mysql.TypeLong,
-						Flag:  model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag | model.UniqueKeyFlag,
+						Name: "a1",
+						Type: mysql.TypeLong,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 2,
 					}, {
 						Name:    "a3",
@@ -1254,16 +1267,18 @@ func TestPrepareBatchDMLs(t *testing.T) {
 					CommitTs: 418658114257813517,
 					Table:    &model.TableName{Schema: "common_1", Table: "uk_without_pk"},
 					Columns: []*model.Column{nil, {
-						Name:  "a1",
-						Type:  mysql.TypeLong,
-						Flag:  model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag,
+						Name: "a1",
+						Type: mysql.TypeLong,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 1,
 					}, {
 						Name:    "a3",
 						Type:    mysql.TypeVarchar,
 						Charset: charset.CharsetGBK,
-						Flag:    model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag,
-						Value:   "你好",
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
+						Value: "你好",
 					}},
 					IndexColumns:        [][]int{{1, 1}},
 					ApproximateDataSize: 10,
@@ -1273,9 +1288,10 @@ func TestPrepareBatchDMLs(t *testing.T) {
 					CommitTs: 418658114257813517,
 					Table:    &model.TableName{Schema: "common_1", Table: "uk_without_pk"},
 					Columns: []*model.Column{nil, {
-						Name:  "a1",
-						Type:  mysql.TypeLong,
-						Flag:  model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag | model.HandleKeyFlag,
+						Name: "a1",
+						Type: mysql.TypeLong,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 2,
 					}, {
 						Name:    "a3",
@@ -1306,9 +1322,10 @@ func TestPrepareBatchDMLs(t *testing.T) {
 					CommitTs: 418658114257813517,
 					Table:    &model.TableName{Schema: "common_1", Table: "uk_without_pk"},
 					PreColumns: []*model.Column{nil, {
-						Name:  "a1",
-						Type:  mysql.TypeLong,
-						Flag:  model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag | model.UniqueKeyFlag,
+						Name: "a1",
+						Type: mysql.TypeLong,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 1,
 					}, {
 						Name:    "a3",
@@ -1319,9 +1336,10 @@ func TestPrepareBatchDMLs(t *testing.T) {
 						Value: []byte("开发"),
 					}},
 					Columns: []*model.Column{nil, {
-						Name:  "a1",
-						Type:  mysql.TypeLong,
-						Flag:  model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag | model.UniqueKeyFlag,
+						Name: "a1",
+						Type: mysql.TypeLong,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 2,
 					}, {
 						Name:    "a3",
@@ -1339,9 +1357,10 @@ func TestPrepareBatchDMLs(t *testing.T) {
 					CommitTs: 418658114257813517,
 					Table:    &model.TableName{Schema: "common_1", Table: "uk_without_pk"},
 					PreColumns: []*model.Column{nil, {
-						Name:  "a1",
-						Type:  mysql.TypeLong,
-						Flag:  model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag | model.UniqueKeyFlag,
+						Name: "a1",
+						Type: mysql.TypeLong,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 3,
 					}, {
 						Name:    "a3",
@@ -1352,9 +1371,10 @@ func TestPrepareBatchDMLs(t *testing.T) {
 						Value: []byte("纽约"),
 					}},
 					Columns: []*model.Column{nil, {
-						Name:  "a1",
-						Type:  mysql.TypeLong,
-						Flag:  model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag | model.UniqueKeyFlag,
+						Name: "a1",
+						Type: mysql.TypeLong,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 4,
 					}, {
 						Name:    "a3",
@@ -1391,9 +1411,10 @@ func TestPrepareBatchDMLs(t *testing.T) {
 					CommitTs: 418658114257813515,
 					Table:    &model.TableName{Schema: "common_1", Table: "uk_without_pk"},
 					Columns: []*model.Column{nil, {
-						Name:  "a1",
-						Type:  mysql.TypeLong,
-						Flag:  model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag | model.UniqueKeyFlag,
+						Name: "a1",
+						Type: mysql.TypeLong,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 2,
 					}, {
 						Name:    "a3",
@@ -1411,9 +1432,10 @@ func TestPrepareBatchDMLs(t *testing.T) {
 					CommitTs: 418658114257813515,
 					Table:    &model.TableName{Schema: "common_1", Table: "uk_without_pk"},
 					PreColumns: []*model.Column{nil, {
-						Name:  "a1",
-						Type:  mysql.TypeLong,
-						Flag:  model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag | model.UniqueKeyFlag,
+						Name: "a1",
+						Type: mysql.TypeLong,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 1,
 					}, {
 						Name:    "a3",
@@ -1431,9 +1453,10 @@ func TestPrepareBatchDMLs(t *testing.T) {
 					CommitTs: 418658114257813515,
 					Table:    &model.TableName{Schema: "common_1", Table: "uk_without_pk"},
 					PreColumns: []*model.Column{nil, {
-						Name:  "a1",
-						Type:  mysql.TypeLong,
-						Flag:  model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag | model.UniqueKeyFlag,
+						Name: "a1",
+						Type: mysql.TypeLong,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 2,
 					}, {
 						Name:    "a3",
@@ -1451,9 +1474,10 @@ func TestPrepareBatchDMLs(t *testing.T) {
 					CommitTs: 418658114257813517,
 					Table:    &model.TableName{Schema: "common_1", Table: "uk_without_pk"},
 					PreColumns: []*model.Column{nil, {
-						Name:  "a1",
-						Type:  mysql.TypeLong,
-						Flag:  model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag | model.UniqueKeyFlag,
+						Name: "a1",
+						Type: mysql.TypeLong,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 1,
 					}, {
 						Name:    "a3",
@@ -1464,9 +1488,10 @@ func TestPrepareBatchDMLs(t *testing.T) {
 						Value: []byte("开发"),
 					}},
 					Columns: []*model.Column{nil, {
-						Name:  "a1",
-						Type:  mysql.TypeLong,
-						Flag:  model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag | model.UniqueKeyFlag,
+						Name: "a1",
+						Type: mysql.TypeLong,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 2,
 					}, {
 						Name:    "a3",
@@ -1484,9 +1509,10 @@ func TestPrepareBatchDMLs(t *testing.T) {
 					CommitTs: 418658114257813517,
 					Table:    &model.TableName{Schema: "common_1", Table: "uk_without_pk"},
 					PreColumns: []*model.Column{nil, {
-						Name:  "a1",
-						Type:  mysql.TypeLong,
-						Flag:  model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag | model.UniqueKeyFlag,
+						Name: "a1",
+						Type: mysql.TypeLong,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 3,
 					}, {
 						Name:    "a3",
@@ -1497,9 +1523,10 @@ func TestPrepareBatchDMLs(t *testing.T) {
 						Value: []byte("纽约"),
 					}},
 					Columns: []*model.Column{nil, {
-						Name:  "a1",
-						Type:  mysql.TypeLong,
-						Flag:  model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag | model.UniqueKeyFlag,
+						Name: "a1",
+						Type: mysql.TypeLong,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 4,
 					}, {
 						Name:    "a3",
@@ -1546,10 +1573,8 @@ func TestPrepareBatchDMLs(t *testing.T) {
 					PreColumns: []*model.Column{nil, {
 						Name: "a1",
 						Type: mysql.TypeLong,
-						Flag: model.BinaryFlag |
-							model.MultipleKeyFlag |
-							model.HandleKeyFlag |
-							model.UniqueKeyFlag,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 1,
 					}, {
 						Name:    "a3",
@@ -1601,8 +1626,7 @@ func TestPrepareBatchDMLs(t *testing.T) {
 					Columns: []*model.Column{nil, {
 						Name: "a1",
 						Type: mysql.TypeLong,
-						Flag: model.BinaryFlag |
-							model.MultipleKeyFlag |
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
 							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 4,
 					}, {
@@ -1747,17 +1771,19 @@ func TestGroupRowsByType(t *testing.T) {
 					CommitTs: 418658114257813517,
 					Table:    &model.TableName{Schema: "common_1", Table: "uk_without_pk"},
 					Columns: []*model.Column{nil, {
-						Name:  "a1",
-						Type:  mysql.TypeLong,
-						Flag:  model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag,
+						Name: "a1",
+						Type: mysql.TypeLong,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 1,
 					}, {
-						Name:  "a3",
-						Type:  mysql.TypeLong,
-						Flag:  model.BinaryFlag | model.MultipleKeyFlag | model.HandleKeyFlag,
+						Name: "a3",
+						Type: mysql.TypeLong,
+						Flag: model.BinaryFlag | model.MultipleKeyFlag |
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 1,
 					}},
-					IndexColumns: [][]int{{1, 1}},
+					IndexColumns: [][]int{{1, 2}},
 				},
 				{
 					StartTs:  418658114257813516,
@@ -1767,16 +1793,16 @@ func TestGroupRowsByType(t *testing.T) {
 						Name: "a1",
 						Type: mysql.TypeLong,
 						Flag: model.BinaryFlag | model.MultipleKeyFlag |
-							model.HandleKeyFlag | model.HandleKeyFlag,
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 2,
 					}, {
 						Name: "a3",
 						Type: mysql.TypeLong,
 						Flag: model.BinaryFlag | model.MultipleKeyFlag |
-							model.HandleKeyFlag | model.HandleKeyFlag,
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 2,
 					}},
-					IndexColumns: [][]int{{2, 2}},
+					IndexColumns: [][]int{{1, 2}},
 				},
 				{
 					StartTs:  418658114257813516,
@@ -1786,16 +1812,16 @@ func TestGroupRowsByType(t *testing.T) {
 						Name: "a1",
 						Type: mysql.TypeLong,
 						Flag: model.BinaryFlag | model.MultipleKeyFlag |
-							model.HandleKeyFlag | model.HandleKeyFlag,
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 2,
 					}, {
 						Name: "a3",
 						Type: mysql.TypeLong,
 						Flag: model.BinaryFlag | model.MultipleKeyFlag |
-							model.HandleKeyFlag | model.HandleKeyFlag,
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 2,
 					}},
-					IndexColumns: [][]int{{2, 2}},
+					IndexColumns: [][]int{{1, 2}},
 				},
 				{
 					StartTs:  418658114257813516,
@@ -1805,16 +1831,16 @@ func TestGroupRowsByType(t *testing.T) {
 						Name: "a1",
 						Type: mysql.TypeLong,
 						Flag: model.BinaryFlag | model.MultipleKeyFlag |
-							model.HandleKeyFlag | model.HandleKeyFlag,
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 2,
 					}, {
 						Name: "a3",
 						Type: mysql.TypeLong,
 						Flag: model.BinaryFlag | model.MultipleKeyFlag |
-							model.HandleKeyFlag | model.HandleKeyFlag,
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 2,
 					}},
-					IndexColumns: [][]int{{2, 2}},
+					IndexColumns: [][]int{{1, 2}},
 				},
 
 				{
@@ -1825,16 +1851,16 @@ func TestGroupRowsByType(t *testing.T) {
 						Name: "a1",
 						Type: mysql.TypeLong,
 						Flag: model.BinaryFlag | model.MultipleKeyFlag |
-							model.HandleKeyFlag | model.HandleKeyFlag,
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 2,
 					}, {
 						Name: "a3",
 						Type: mysql.TypeLong,
 						Flag: model.BinaryFlag | model.MultipleKeyFlag |
-							model.HandleKeyFlag | model.HandleKeyFlag,
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 2,
 					}},
-					IndexColumns: [][]int{{2, 2}},
+					IndexColumns: [][]int{{1, 2}},
 				},
 
 				{
@@ -1845,16 +1871,16 @@ func TestGroupRowsByType(t *testing.T) {
 						Name: "a1",
 						Type: mysql.TypeLong,
 						Flag: model.BinaryFlag | model.MultipleKeyFlag |
-							model.HandleKeyFlag | model.HandleKeyFlag,
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 2,
 					}, {
 						Name: "a3",
 						Type: mysql.TypeLong,
 						Flag: model.BinaryFlag | model.MultipleKeyFlag |
-							model.HandleKeyFlag | model.HandleKeyFlag,
+							model.HandleKeyFlag | model.UniqueKeyFlag,
 						Value: 2,
 					}},
-					IndexColumns: [][]int{{2, 2}},
+					IndexColumns: [][]int{{1, 2}},
 				},
 			},
 			maxTxnRow: 4,

--- a/cdc/sink/dmlsink/txn/mysql/mysql_test.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql_test.go
@@ -1869,7 +1869,7 @@ func TestGroupRowsByType(t *testing.T) {
 			if len(colums) == 0 {
 				colums = tc.input[0].PreColumns
 			}
-			tableInfo := model.BuildTiDBTableInfo(colums, tc.input[0].IndexColumns)
+			tableInfo := model.BuildTiDBTableInfo("t", colums, tc.input[0].IndexColumns)
 			ms.cfg.MaxTxnRow = tc.maxTxnRow
 			inserts, updates, deletes := ms.groupRowsByType(event, tableInfo, false)
 			for _, rows := range inserts {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #10386 

### What is changed and how it works?
Fix and improve `BuildTiDBTableInfo`;
1. Add mock column id and mock index id for the generated TableInfo;
2. Add checks to verify the legality of the arguments;
3. Fix some small incorrect behaviour of the previous implementation including set charset and collation correctly;

Fix the wrong behavior that a primary column is always set an extra unique key flag in `WrapTableInfo`;

Add some helper method on `TableInfo` to query related information for columns;

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
