### PR TITLE
mysql(ticdc): Add a tableInfo cache to reduce the memory and cpu overhead of BuildTiDBTableInfo

### DIFF
--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -530,8 +530,10 @@ type RedoColumn struct {
 }
 
 // BuildTiDBTableInfo builds a TiDB TableInfo from given information.
-func BuildTiDBTableInfo(columns []*Column, indexColumns [][]int) *model.TableInfo {
-	ret := &model.TableInfo{}
+func BuildTiDBTableInfo(version uint64, columns []*Column, indexColumns [][]int) *model.TableInfo {
+	ret := &model.TableInfo{
+		UpdateTS: version,
+	}
 	// nowhere will use this field, so we set a debug message
 	ret.Name = model.NewCIStr("BuildTiDBTableInfo")
 

--- a/cdc/sink/dmlsink/txn/mysql/mysql.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql.go
@@ -197,6 +197,7 @@ func NewMySQLBackends(
 			stmtCache:                       stmtCache,
 			cachePrepStmts:                  cachePrepStmts,
 			maxAllowedPacket:                maxAllowedPacket,
+			tableInfoCache:                  make(map[model.TableID]*timodel.TableInfo),
 		})
 	}
 

--- a/cdc/sink/dmlsink/txn/mysql/mysql_test.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql_test.go
@@ -1869,7 +1869,7 @@ func TestGroupRowsByType(t *testing.T) {
 			if len(colums) == 0 {
 				colums = tc.input[0].PreColumns
 			}
-			tableInfo := model.BuildTiDBTableInfo(colums, tc.input[0].IndexColumns)
+			tableInfo := model.BuildTiDBTableInfo(0, colums, tc.input[0].IndexColumns)
 			ms.cfg.MaxTxnRow = tc.maxTxnRow
 			inserts, updates, deletes := ms.groupRowsByType(event, tableInfo, false)
 			for _, rows := range inserts {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
