### PR TITLE
Add new column "is-updated" for output-old-value in csv protocol

### DIFF
--- a/cdc/api/v2/model.go
+++ b/cdc/api/v2/model.go
@@ -292,6 +292,7 @@ func (c *ReplicaConfig) toInternalReplicaConfigWithOriginConfig(
 				NullString:           c.Sink.CSVConfig.NullString,
 				IncludeCommitTs:      c.Sink.CSVConfig.IncludeCommitTs,
 				BinaryEncodingMethod: c.Sink.CSVConfig.BinaryEncodingMethod,
+				OutputOldValue:       c.Sink.CSVConfig.OutputOldValue,
 			}
 		}
 		var pulsarConfig *config.PulsarConfig
@@ -573,6 +574,7 @@ func ToAPIReplicaConfig(c *config.ReplicaConfig) *ReplicaConfig {
 				NullString:           cloned.Sink.CSVConfig.NullString,
 				IncludeCommitTs:      cloned.Sink.CSVConfig.IncludeCommitTs,
 				BinaryEncodingMethod: cloned.Sink.CSVConfig.BinaryEncodingMethod,
+				OutputOldValue:       cloned.Sink.CSVConfig.OutputOldValue,
 			}
 		}
 		var kafkaConfig *KafkaConfig

--- a/pkg/sink/codec/csv/csv_message.go
+++ b/pkg/sink/codec/csv/csv_message.go
@@ -125,6 +125,15 @@ func (c *csvMessage) encodeMeta(opType string, b *strings.Builder) {
 	if c.config.IncludeCommitTs {
 		c.formatValue(c.commitTs, b)
 	}
+	if c.config.OutputOldValue {
+		// When c.config.OutputOldValue, we need an extra column "is-updated"
+		// to indicate whether the row is updated or just original insert/delete
+		if c.opType == operationUpdate {
+			c.formatValue(true, b)
+		} else {
+			c.formatValue(false, b)
+		}
+	}
 }
 
 func (c *csvMessage) encodeColumns(columns []any, b *strings.Builder) {

--- a/pkg/sink/codec/csv/csv_message_test.go
+++ b/pkg/sink/codec/csv/csv_message_test.go
@@ -804,8 +804,27 @@ func TestCSVMessageEncode(t *testing.T) {
 				preColumns: []any{"a!b!c", "abc"},
 				columns:    []any{"a!b!c", "def"},
 			},
-			want: []byte(`D!table2!test!435661838416609281!a\!b\!c!abc` + "\n" +
-				`I!table2!test!435661838416609281!a\!b\!c!def` + "\n"),
+			want: []byte(`D!table2!test!435661838416609281!true!a\!b\!c!abc` + "\n" +
+				`I!table2!test!435661838416609281!true!a\!b\!c!def` + "\n"),
+		},
+		{
+			name: "csv encode values containing single-character delimter string, without quote mark, update with old value",
+			fields: fields{
+				config: &common.Config{
+					Delimiter:       "!",
+					Quote:           "",
+					Terminator:      "\n",
+					NullString:      "\\N",
+					IncludeCommitTs: true,
+					OutputOldValue:  true,
+				},
+				opType:     operationInsert,
+				tableName:  "table2",
+				schemaName: "test",
+				commitTs:   435661838416609281,
+				columns:    []any{"a!b!c", "def"},
+			},
+			want: []byte(`I!table2!test!435661838416609281!false!a\!b\!c!def` + "\n"),
 		},
 		{
 			name: "csv encode values containing single-character delimter string, with quote mark",


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/10167

### What is changed and how it works?
1. Add new column "is-updated" when enable output-old-value to indicate whether the row is updated or just original insert/delete.
2. Make output-old-value config take effects. 

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

set changefeed configuration add do some insert/update/delete events:
[sink.csv]
include-commit-ts = true
output-old-value = true

the output csv looks like 

"I","t1","test",447240134323863555,false,1,2
"I","t1","test",447240134323863555,false,3,4
"I","t1","test",447240134323863555,false,5,6
"I","t1","test",447240134323863555,false,7,8
"D","t1","test",447240137390686212,true,1,2
"I","t1","test",447240137390686212,true,1,10


 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
