### PR TITLE
upstream, api(ticdc): support topology and config 

### DIFF
--- a/cdc/api/v2/unsafe_test.go
+++ b/cdc/api/v2/unsafe_test.go
@@ -82,7 +82,7 @@ func TestCDCMetaData(t *testing.T) {
 func TestWithUpstreamConfig(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	upManager := upstream.NewManager(ctx, "abc")
+	upManager := upstream.NewManager(ctx, upstream.CaptureTopologyCfg{GCServiceID: "abc"})
 	upManager.AddUpstream(&model.UpstreamInfo{
 		ID:          uint64(1),
 		PDEndpoints: "http://127.0.0.1:22379",

--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -242,8 +242,12 @@ func (c *captureImpl) reset(ctx context.Context) error {
 	if c.upstreamManager != nil {
 		c.upstreamManager.Close()
 	}
-	c.upstreamManager = upstream.NewManager(ctx, c.EtcdClient.GetGCServiceID())
-	_, err = c.upstreamManager.AddDefaultUpstream(c.pdEndpoints, c.config.Security, c.pdClient)
+	c.upstreamManager = upstream.NewManager(ctx, upstream.CaptureTopologyCfg{
+		CaptureInfo: c.info,
+		GCServiceID: c.EtcdClient.GetGCServiceID(),
+		SessionTTL:  int64(c.config.CaptureSessionTTL),
+	})
+	_, err = c.upstreamManager.AddDefaultUpstream(c.pdEndpoints, c.config.Security, c.pdClient, c.EtcdClient.GetEtcdClient())
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cdc/http.go
+++ b/cdc/http.go
@@ -25,6 +25,7 @@ import (
 	v2 "github.com/pingcap/tiflow/cdc/api/v2"
 	"github.com/pingcap/tiflow/cdc/capture"
 	_ "github.com/pingcap/tiflow/docs/swagger" // use for OpenAPI online docs
+	"github.com/pingcap/tiflow/pkg/config"
 	"github.com/pingcap/tiflow/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -54,6 +55,9 @@ func RegisterRoutes(
 
 	// Log API
 	router.POST("/admin/log", gin.WrapF(owner.HandleAdminLogLevel))
+	router.GET("/config", func(c *gin.Context) {
+		c.JSON(http.StatusOK, config.GetDefaultServerConfig())
+	})
 
 	// pprof debug API
 	pprofGroup := router.Group("/debug/pprof/")

--- a/cdc/server/server.go
+++ b/cdc/server/server.go
@@ -130,11 +130,6 @@ func New(pdEndpoints []string) (*server, error) {
 
 func (s *server) prepare(ctx context.Context) error {
 	conf := config.GetGlobalServerConfig()
-
-	tlsConfig, err := conf.Security.ToTLSConfig()
-	if err != nil {
-		return errors.Trace(err)
-	}
 	grpcTLSOption, err := conf.Security.ToGRPCDialOption()
 	if err != nil {
 		return errors.Trace(err)
@@ -174,7 +169,7 @@ func (s *server) prepare(ctx context.Context) error {
 	// the key will be kept for the lease TTL, which is 10 seconds,
 	// then cause the new owner cannot be elected immediately after the old owner offline.
 	// see https://github.com/etcd-io/etcd/blob/525d53bd41/client/v3/concurrency/election.go#L98
-	etcdCli, err := etcd.CreateRawEtcdClient(tlsConfig, grpcTLSOption, s.pdEndpoints...)
+	etcdCli, err := etcd.CreateRawEtcdClient(conf.Security, grpcTLSOption, s.pdEndpoints...)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cdcv2/capture/capture.go
+++ b/cdcv2/capture/capture.go
@@ -204,8 +204,12 @@ func (c *captureImpl) reset(ctx context.Context) error {
 	if c.upstreamManager != nil {
 		c.upstreamManager.Close()
 	}
-	c.upstreamManager = upstream.NewManager(ctx, c.EtcdClient.GetGCServiceID())
-	_, err := c.upstreamManager.AddDefaultUpstream(c.pdEndpoints, c.config.Security, c.pdClient)
+	c.upstreamManager = upstream.NewManager(ctx, upstream.CaptureTopologyCfg{
+		CaptureInfo: c.info,
+		GCServiceID: c.EtcdClient.GetGCServiceID(),
+		SessionTTL:  int64(c.config.CaptureSessionTTL),
+	})
+	_, err := c.upstreamManager.AddDefaultUpstream(c.pdEndpoints, c.config.Security, c.pdClient, c.EtcdClient.GetEtcdClient())
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -26,6 +26,7 @@ import (
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/errorutil"
 	"github.com/pingcap/tiflow/pkg/retry"
+	"github.com/pingcap/tiflow/pkg/security"
 	"github.com/pingcap/tiflow/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tikv/pd/pkg/errs"
@@ -386,7 +387,14 @@ func newClient(tlsConfig *tls.Config, grpcDialOption grpc.DialOption, endpoints 
 
 // CreateRawEtcdClient creates etcd v3 client with detecting endpoints.
 // It will check the health of endpoints periodically, and update endpoints if needed.
-func CreateRawEtcdClient(tlsConfig *tls.Config, grpcDialOption grpc.DialOption, endpoints ...string) (*clientv3.Client, error) {
+func CreateRawEtcdClient(securityConf *security.Credential, grpcDialOption grpc.DialOption, endpoints ...string) (*clientv3.Client, error) {
+	log.Info("create etcdCli", zap.Strings("endpoints", endpoints))
+
+	tlsConfig, err := securityConf.ToTLSConfig()
+	if err != nil {
+		return nil, err
+	}
+
 	client, err := newClient(tlsConfig, grpcDialOption, endpoints...)
 	if err != nil {
 		return nil, err

--- a/pkg/security/credential.go
+++ b/pkg/security/credential.go
@@ -41,7 +41,7 @@ type Credential struct {
 	// 2) connections between TiCDC and PD
 	// 3) http server of TiCDC which is used for open API
 	// 4) p2p server of TiCDC which is used sending messages between TiCDC nodes
-	// Todo: just enable mTLS for 4) and 5) by default
+	// Todo: just enable mTLS for 3) and 4) by default
 	MTLS bool `toml:"mtls" json:"mtls"`
 }
 

--- a/pkg/upstream/main_test.go
+++ b/pkg/upstream/main_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upstream
+
+import (
+	"testing"
+
+	"github.com/pingcap/tiflow/pkg/leakutil"
+)
+
+func TestMain(m *testing.M) {
+	leakutil.SetUpLeakTest(m)
+}

--- a/pkg/upstream/manager_test.go
+++ b/pkg/upstream/manager_test.go
@@ -107,25 +107,23 @@ func TestRemoveErrorUpstream(t *testing.T) {
 }
 
 func TestAddDefaultUpstream(t *testing.T) {
-	m := NewManager(context.Background(), "id")
-	m.initUpstreamFunc = func(ctx context.Context,
-		up *Upstream, gcID string,
-	) error {
+	m := NewManager(context.Background(), CaptureTopologyCfg{GCServiceID: "id"})
+	m.initUpstreamFunc = func(context.Context, *Upstream, CaptureTopologyCfg) error {
 		return errors.New("test")
 	}
+
 	pdClient := &gc.MockPDClient{}
-	_, err := m.AddDefaultUpstream([]string{}, &security.Credential{}, pdClient)
+
+	_, err := m.AddDefaultUpstream([]string{}, &security.Credential{}, pdClient, nil)
 	require.NotNil(t, err)
 	up, err := m.GetDefaultUpstream()
 	require.Nil(t, up)
 	require.NotNil(t, err)
-	m.initUpstreamFunc = func(ctx context.Context,
-		up *Upstream, gcID string,
-	) error {
+	m.initUpstreamFunc = func(_ context.Context, up *Upstream, _ CaptureTopologyCfg) error {
 		up.ID = uint64(2)
 		return nil
 	}
-	_, err = m.AddDefaultUpstream([]string{}, &security.Credential{}, pdClient)
+	_, err = m.AddDefaultUpstream([]string{}, &security.Credential{}, pdClient, nil)
 	require.Nil(t, err)
 	up, err = m.GetDefaultUpstream()
 	require.NotNil(t, up)
@@ -136,10 +134,8 @@ func TestAddDefaultUpstream(t *testing.T) {
 }
 
 func TestAddUpstream(t *testing.T) {
-	m := NewManager(context.Background(), "id")
-	m.initUpstreamFunc = func(ctx context.Context,
-		up *Upstream, gcID string,
-	) error {
+	m := NewManager(context.Background(), CaptureTopologyCfg{GCServiceID: "id"})
+	m.initUpstreamFunc = func(context.Context, *Upstream, CaptureTopologyCfg) error {
 		return errors.New("test")
 	}
 	up := m.AddUpstream(&model.UpstreamInfo{ID: uint64(3)})
@@ -174,10 +170,8 @@ func TestCloseManager(t *testing.T) {
 }
 
 func TestRemoveThenAddAgain(t *testing.T) {
-	m := NewManager(context.Background(), "id")
-	m.initUpstreamFunc = func(ctx context.Context,
-		up *Upstream, gcID string,
-	) error {
+	m := NewManager(context.Background(), CaptureTopologyCfg{GCServiceID: "id"})
+	m.initUpstreamFunc = func(context.Context, *Upstream, CaptureTopologyCfg) error {
 		return nil
 	}
 	up := m.AddUpstream(&model.UpstreamInfo{ID: uint64(3)})

--- a/pkg/upstream/upstream.go
+++ b/pkg/upstream/upstream.go
@@ -22,19 +22,22 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	tidbkv "github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tiflow/cdc/kv"
+	"github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/etcd"
 	"github.com/pingcap/tiflow/pkg/pdutil"
 	"github.com/pingcap/tiflow/pkg/security"
 	"github.com/pingcap/tiflow/pkg/txnutil/gc"
 	"github.com/pingcap/tiflow/pkg/version"
+	"github.com/prometheus/client_golang/prometheus"
 	tikvconfig "github.com/tikv/client-go/v2/config"
 	"github.com/tikv/client-go/v2/tikv"
 	pd "github.com/tikv/pd/client"
 	uatomic "github.com/uber-go/atomic"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/concurrency"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
@@ -51,17 +54,22 @@ const (
 	closed
 
 	maxIdleDuration = time.Minute * 30
+	// topologyKey is /topology/ticdc/{clusterID}/{ip:port}
+	topologyTiCDC = "/topology/ticdc/%s/%s"
 )
 
 // Upstream holds resources of a TiDB cluster, it can be shared by many changefeeds
 // and processors. All public fields and method of an upstream should be thread-safe.
 // Please be careful that never change any exported field of an Upstream.
 type Upstream struct {
-	ID             uint64
+	ID uint64
+
 	PdEndpoints    []string
 	SecurityConfig *security.Credential
+	PDClient       pd.Client
+	etcdCli        *etcd.Client
+	session        *concurrency.Session
 
-	PDClient    pd.Client
 	KVStorage   tidbkv.Storage
 	GrpcPool    kv.GrpcPool
 	RegionCache *tikv.RegionCache
@@ -85,8 +93,11 @@ func newUpstream(pdEndpoints []string,
 	securityConfig *security.Credential,
 ) *Upstream {
 	return &Upstream{
-		PdEndpoints: pdEndpoints, status: uninit,
-		SecurityConfig: securityConfig, wg: new(sync.WaitGroup), clock: clock.New(),
+		PdEndpoints:    pdEndpoints,
+		SecurityConfig: securityConfig,
+		status:         uninit,
+		wg:             new(sync.WaitGroup),
+		clock:          clock.New(),
 	}
 }
 
@@ -112,9 +123,8 @@ func NewUpstream4Test(pdClient pd.Client) *Upstream {
 }
 
 // init initializes the upstream
-func initUpstream(ctx context.Context, up *Upstream, gcServiceID string) error {
-	ctx, cancel := context.WithCancel(ctx)
-	up.cancel = cancel
+func initUpstream(ctx context.Context, up *Upstream, cfg CaptureTopologyCfg) error {
+	ctx, up.cancel = context.WithCancel(ctx)
 	grpcTLSOption, err := up.SecurityConfig.ToGRPCDialOption()
 	if err != nil {
 		up.err.Store(err)
@@ -146,6 +156,12 @@ func initUpstream(ctx context.Context, up *Upstream, gcServiceID string) error {
 			up.err.Store(err)
 			return errors.Trace(err)
 		}
+
+		etcdCli, err := etcd.CreateRawEtcdClient(up.SecurityConfig, grpcTLSOption, up.PdEndpoints...)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		up.etcdCli = etcd.Wrap(etcdCli, make(map[string]prometheus.Counter))
 	}
 	clusterID := up.PDClient.GetClusterID(ctx)
 	if up.ID != 0 && up.ID != clusterID {
@@ -183,7 +199,7 @@ func initUpstream(ctx context.Context, up *Upstream, gcServiceID string) error {
 		return errors.Trace(err)
 	}
 
-	up.GCManager = gc.NewManager(gcServiceID, up.PDClient, up.PDClock)
+	up.GCManager = gc.NewManager(cfg.GCServiceID, up.PDClient, up.PDClock)
 
 	// Update meta-region label to ensure that meta region isolated from data regions.
 	pc, err := pdutil.NewPDAPIClient(up.PDClient, up.SecurityConfig)
@@ -199,6 +215,10 @@ func initUpstream(ctx context.Context, up *Upstream, gcServiceID string) error {
 			zap.Error(err),
 			zap.Uint64("upstreamID", up.ID),
 			zap.Strings("upstreamEndpoints", up.PdEndpoints))
+	}
+	err = up.registerTopologyInfo(ctx, cfg)
+	if err != nil {
+		return errors.Trace(err)
 	}
 
 	up.wg.Add(1)
@@ -242,10 +262,18 @@ func (up *Upstream) Close() {
 	}
 	atomic.StoreInt32(&up.status, closing)
 
-	// should never close default upstream's pdClient here
-	// because it's shared by the cdc server
-	if up.PDClient != nil && !up.isDefaultUpstream {
-		up.PDClient.Close()
+	// should never close default upstream's pdClient and etcdClient here
+	// because it's shared in the cdc server
+	if !up.isDefaultUpstream {
+		if up.PDClient != nil {
+			up.PDClient.Close()
+		}
+		if up.etcdCli != nil {
+			err := up.etcdCli.Unwrap().Close()
+			if err != nil {
+				log.Warn("etcd client close failed", zap.Error(err))
+			}
+		}
 	}
 
 	if up.KVStorage != nil {
@@ -263,6 +291,12 @@ func (up *Upstream) Close() {
 	}
 	if up.PDClock != nil {
 		up.PDClock.Stop()
+	}
+	if up.session != nil {
+		err := up.session.Close()
+		if err != nil {
+			log.Warn("etcd session close failed", zap.Error(err))
+		}
 	}
 
 	up.wg.Wait()
@@ -307,6 +341,25 @@ func (up *Upstream) trySetIdleTime() {
 			zap.Uint64("id", up.ID))
 		up.idleTime = up.clock.Now()
 	}
+}
+
+func (up *Upstream) registerTopologyInfo(ctx context.Context, cfg CaptureTopologyCfg) error {
+	lease, err := up.etcdCli.Grant(ctx, cfg.SessionTTL)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	up.session, err = concurrency.NewSession(up.etcdCli.Unwrap(), concurrency.WithLease(lease.ID))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// register capture info to upstream pd
+	key := fmt.Sprintf(topologyTiCDC, cfg.GCServiceID, cfg.AdvertiseAddr)
+	value, err := cfg.CaptureInfo.Marshal()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	_, err = up.etcdCli.Put(ctx, key, string(value), clientv3.WithLease(up.session.Lease()))
+	return errors.WrapError(errors.ErrPDEtcdAPIError, err)
 }
 
 // shouldClose returns true if

--- a/pkg/upstream/upstream_test.go
+++ b/pkg/upstream/upstream_test.go
@@ -14,14 +14,26 @@
 package upstream
 
 import (
+	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/benbjohnson/clock"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tiflow/cdc/model"
+	"github.com/pingcap/tiflow/pkg/etcd"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/client/pkg/v3/logutil"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestUpstreamShouldClose(t *testing.T) {
+	t.Parallel()
+
 	up := &Upstream{}
 	up.isDefaultUpstream = false
 	mockClock := clock.NewMock()
@@ -34,6 +46,8 @@ func TestUpstreamShouldClose(t *testing.T) {
 }
 
 func TestUpstreamError(t *testing.T) {
+	t.Parallel()
+
 	up := &Upstream{}
 	err := errors.New("test")
 	up.err.Store(err)
@@ -43,6 +57,8 @@ func TestUpstreamError(t *testing.T) {
 }
 
 func TestUpstreamIsNormal(t *testing.T) {
+	t.Parallel()
+
 	up := &Upstream{}
 	up.status = uninit
 	require.False(t, up.IsNormal())
@@ -53,6 +69,8 @@ func TestUpstreamIsNormal(t *testing.T) {
 }
 
 func TestTrySetIdleTime(t *testing.T) {
+	t.Parallel()
+
 	up := newUpstream(nil, nil)
 	require.Equal(t, uninit, up.status)
 	up.clock = clock.New()
@@ -65,4 +83,58 @@ func TestTrySetIdleTime(t *testing.T) {
 	require.True(t, up.idleTime.IsZero())
 	up.resetIdleTime()
 	require.True(t, up.idleTime.IsZero())
+}
+
+func TestRegisterTopo(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	clientURL, etcdServer, err := etcd.SetupEmbedEtcd(t.TempDir())
+	defer etcdServer.Close()
+
+	require.NoError(t, err)
+	logConfig := logutil.DefaultZapLoggerConfig
+	logConfig.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
+
+	rawEtcdCli, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{clientURL.String()},
+		Context:     ctx,
+		LogConfig:   &logConfig,
+		DialTimeout: 3 * time.Second,
+	})
+	require.NoError(t, err)
+	defer rawEtcdCli.Close()
+	etcdCli := etcd.Wrap(rawEtcdCli, make(map[string]prometheus.Counter))
+	up := &Upstream{
+		cancel:  func() {},
+		etcdCli: etcdCli,
+		wg:      &sync.WaitGroup{},
+	}
+
+	info := &model.CaptureInfo{
+		AdvertiseAddr: "localhost:8300",
+		Version:       "test.1.0",
+	}
+	err = up.registerTopologyInfo(ctx, CaptureTopologyCfg{
+		CaptureInfo: info,
+		GCServiceID: "clusterID",
+		SessionTTL:  2,
+	})
+	require.NoError(t, err)
+
+	resp, err := etcdCli.Get(ctx, "/topology/ticdc/clusterID/localhost:8300")
+	require.NoError(t, err)
+
+	infoData, err := info.Marshal()
+	require.NoError(t, err)
+	require.Equal(t, infoData, resp.Kvs[0].Value)
+
+	up.etcdCli = nil
+	up.Close()
+	require.Eventually(t, func() bool {
+		resp, err := etcdCli.Get(ctx, "/topology/ticdc/clusterID/localhost:8300")
+		require.NoError(t, err)
+		return len(resp.Kvs) == 0
+	}, time.Second*5, time.Millisecond*100)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #10375, ref https://github.com/pingcap/tidb/issues/50723

### What is changed and how it works?
1. Use `/topology/ticdc/{clusterID}/{ip:port}` to store topology info.
![image](https://github.com/pingcap/tiflow/assets/61726649/a43eaa7b-e06a-40e4-b1ca-98697494a48a)

2. Support querying server config via `/config` api.
![image](https://github.com/pingcap/tiflow/assets/61726649/7c2e872c-2ed3-4f6c-9dfc-62ff128730cd)

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
 `None`.
```
