### PR TITLE
codec(ticdc): simple protocol fix primary key not found and adjust schema

### DIFF
--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -1192,51 +1192,6 @@ func TestE2ERowLevelChecksum(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestRowLevelChecksum(t *testing.T) {
-	replicaConfig := config.GetDefaultReplicaConfig()
-	replicaConfig.Integrity.IntegrityCheckLevel = integrity.CheckLevelCorrectness
-	helper := NewSchemaTestHelperWithReplicaConfig(t, replicaConfig)
-	defer helper.Close()
-
-	helper.tk.MustExec("set global tidb_enable_row_level_checksum = 1")
-	helper.Tk().MustExec("use test")
-
-	_ = helper.DDL2Event(`CREATE TABLE TBL1 (id int PRIMARY KEY)`)
-	_ = helper.DML2Event(`INSERT INTO TBL1 (id) VALUES(1)`, "test", "TBL1")
-
-	_ = helper.DDL2Event(`ALTER TABLE TBL1 ADD COLUMN v1 INTEGER DEFAULT 0`)
-	_ = helper.DML2Event(`INSERT INTO TBL1 (id) VALUES(2)`, "test", "TBL1")
-
-	_ = helper.DML2Event(`UPDATE TBL1 SET id = 3, v1 = 10 WHERE id = 1`, "test", "TBL1")
-	_ = helper.DML2Event(`UPDATE TBL1 SET v1 = 11 WHERE id = 2`, "test", "TBL1")
-	_ = helper.DML2Event(`INSERT INTO TBL1 (id, v1) VALUES(1000, 1000)`, "test", "TBL1")
-	_ = helper.DML2Event(`UPDATE TBL1 SET v1 = 1001 WHERE id = 1000`, "test", "TBL1")
-}
-
-func TestVerifyChecksumTime(t *testing.T) {
-	replicaConfig := config.GetDefaultReplicaConfig()
-	replicaConfig.Integrity.IntegrityCheckLevel = integrity.CheckLevelCorrectness
-	replicaConfig.Integrity.CorruptionHandleLevel = integrity.CorruptionHandleLevelError
-
-	helper := NewSchemaTestHelperWithReplicaConfig(t, replicaConfig)
-	defer helper.Close()
-
-	helper.Tk().MustExec("set global tidb_enable_row_level_checksum = 1")
-	helper.Tk().MustExec("use test")
-
-	helper.Tk().MustExec("set global time_zone = '+00:00'")
-	helper.Tk().MustExec("set @@global.time_zone = 'system'")
-
-	_ = helper.DDL2Event(`CREATE table TBL1 (datetime_column DATETIME, timestamp_column TIMESTAMP, PRIMARY KEY (datetime_column))`)
-	event := helper.DML2Event(`INSERT INTO TBL1 VALUES ('2023-02-09 13:00:00', '2023-02-09 13:00:00')`, "test", "TBL1")
-	require.NotNil(t, event)
-
-	helper.Tk().MustExec("set global time_zone = '-5:00'")
-	_ = helper.DDL2Event(`CREATE table TBL2 (datetime_column DATETIME, timestamp_column TIMESTAMP, PRIMARY KEY (datetime_column))`)
-	event = helper.DML2Event(`INSERT INTO TBL2 VALUES ('2023-02-09 13:00:00', '2023-02-09 13:00:00')`, "test", "TBL2")
-	require.NotNil(t, event)
-}
-
 func TestDecodeRowEnableChecksum(t *testing.T) {
 	helper := NewSchemaTestHelper(t)
 	defer helper.Close()

--- a/pkg/sink/codec/simple/avro.go
+++ b/pkg/sink/codec/simple/avro.go
@@ -135,7 +135,7 @@ func newTableSchemaMap(tableInfo *model.TableInfo) interface{} {
 func newResolvedMessageMap(ts uint64) map[string]interface{} {
 	watermark := map[string]interface{}{
 		"version":  defaultVersion,
-		"type":     string(WatermarkType),
+		"type":     string(MessageTypeWatermark),
 		"commitTs": int64(ts),
 		"buildTs":  time.Now().UnixMilli(),
 	}
@@ -144,6 +144,7 @@ func newResolvedMessageMap(ts uint64) map[string]interface{} {
 	}
 
 	payload := map[string]interface{}{
+		"type":    string(MessageTypeWatermark),
 		"payload": watermark,
 	}
 
@@ -155,7 +156,7 @@ func newResolvedMessageMap(ts uint64) map[string]interface{} {
 func newBootstrapMessageMap(tableInfo *model.TableInfo) map[string]interface{} {
 	m := map[string]interface{}{
 		"version":     defaultVersion,
-		"type":        string(BootstrapType),
+		"type":        string(MessageTypeBootstrap),
 		"tableSchema": newTableSchemaMap(tableInfo),
 		"buildTs":     time.Now().UnixMilli(),
 	}
@@ -165,6 +166,7 @@ func newBootstrapMessageMap(tableInfo *model.TableInfo) map[string]interface{} {
 	}
 
 	payload := map[string]interface{}{
+		"type":    string(MessageTypeBootstrap),
 		"payload": m,
 	}
 
@@ -199,6 +201,7 @@ func newDDLMessageMap(ddl *model.DDLEvent) map[string]interface{} {
 		"com.pingcap.simple.avro.DDL": result,
 	}
 	payload := map[string]interface{}{
+		"type":    string(MessageTypeDDL),
 		"payload": result,
 	}
 	return map[string]interface{}{
@@ -214,8 +217,8 @@ var (
 		},
 	}
 
-	// payloadHolderPool return holder for the payload
-	payloadHolderPool = sync.Pool{
+	// dmlPayloadHolderPool return holder for the payload
+	dmlPayloadHolderPool = sync.Pool{
 		New: func() any {
 			return make(map[string]interface{})
 		},
@@ -274,14 +277,14 @@ func newDMLMessageMap(
 			return nil, err
 		}
 		m["data"] = data
-		m["type"] = string(InsertType)
+		m["type"] = string(DMLTypeInsert)
 	} else if event.IsDelete() {
 		old, err := collectColumns(event.PreColumns, event.ColInfos, onlyHandleKey)
 		if err != nil {
 			return nil, err
 		}
 		m["old"] = old
-		m["type"] = string(DeleteType)
+		m["type"] = string(DMLTypeDelete)
 	} else if event.IsUpdate() {
 		data, err := collectColumns(event.Columns, event.ColInfos, onlyHandleKey)
 		if err != nil {
@@ -293,7 +296,7 @@ func newDMLMessageMap(
 			return nil, err
 		}
 		m["old"] = old
-		m["type"] = string(UpdateType)
+		m["type"] = string(DMLTypeUpdate)
 	} else {
 		log.Panic("invalid event type, this should not hit", zap.Any("event", event))
 	}
@@ -302,7 +305,8 @@ func newDMLMessageMap(
 		"com.pingcap.simple.avro.DML": m,
 	}
 
-	holder := payloadHolderPool.Get().(map[string]interface{})
+	holder := dmlPayloadHolderPool.Get().(map[string]interface{})
+	holder["type"] = string(MessageTypeDML)
 	holder["payload"] = m
 
 	messageHolder := messageHolderPool.Get().(map[string]interface{})
@@ -343,7 +347,7 @@ func recycleMap(m map[string]interface{}) {
 		}
 	}
 	holder["payload"] = nil
-	payloadHolderPool.Put(holder)
+	dmlPayloadHolderPool.Put(holder)
 	m["com.pingcap.simple.avro.Message"] = nil
 	messageHolderPool.Put(m)
 }
@@ -475,7 +479,7 @@ func newMessageFromAvroNative(native interface{}, m *message) error {
 	if rawMessage != nil {
 		rawValues = rawMessage.(map[string]interface{})
 		m.Version = int(rawValues["version"].(int32))
-		m.Type = WatermarkType
+		m.Type = MessageTypeWatermark
 		m.CommitTs = uint64(rawValues["commitTs"].(int64))
 		m.BuildTs = rawValues["buildTs"].(int64)
 		return nil
@@ -485,7 +489,7 @@ func newMessageFromAvroNative(native interface{}, m *message) error {
 	if rawMessage != nil {
 		rawValues = rawMessage.(map[string]interface{})
 		m.Version = int(rawValues["version"].(int32))
-		m.Type = BootstrapType
+		m.Type = MessageTypeBootstrap
 		m.BuildTs = rawValues["buildTs"].(int64)
 		m.TableSchema = newTableSchemaFromAvroNative(rawValues["tableSchema"].(map[string]interface{}))
 		return nil
@@ -495,7 +499,7 @@ func newMessageFromAvroNative(native interface{}, m *message) error {
 	if rawMessage != nil {
 		rawValues = rawMessage.(map[string]interface{})
 		m.Version = int(rawValues["version"].(int32))
-		m.Type = EventType(rawValues["type"].(string))
+		m.Type = MessageType(rawValues["type"].(string))
 		m.SQL = rawValues["sql"].(string)
 		m.CommitTs = uint64(rawValues["commitTs"].(int64))
 		m.BuildTs = rawValues["buildTs"].(int64)
@@ -517,7 +521,7 @@ func newMessageFromAvroNative(native interface{}, m *message) error {
 	}
 
 	rawValues = rawPayload["com.pingcap.simple.avro.DML"].(map[string]interface{})
-	m.Type = EventType(rawValues["type"].(string))
+	m.Type = MessageType(rawValues["type"].(string))
 	m.Version = int(rawValues["version"].(int32))
 	m.CommitTs = uint64(rawValues["commitTs"].(int64))
 	m.BuildTs = rawValues["buildTs"].(int64)

--- a/pkg/sink/codec/simple/decoder.go
+++ b/pkg/sink/codec/simple/decoder.go
@@ -110,7 +110,7 @@ func (d *decoder) HasNext() (model.MessageType, bool, error) {
 		return model.MessageTypeRow, true, nil
 	}
 
-	if m.Type == WatermarkType {
+	if m.Type == MessageTypeWatermark {
 		return model.MessageTypeResolved, true, nil
 	}
 
@@ -119,7 +119,7 @@ func (d *decoder) HasNext() (model.MessageType, bool, error) {
 
 // NextResolvedEvent returns the next resolved event if exists
 func (d *decoder) NextResolvedEvent() (uint64, error) {
-	if d.msg.Type != WatermarkType {
+	if d.msg.Type != MessageTypeWatermark {
 		return 0, cerror.ErrCodecDecode.GenWithStack(
 			"not found resolved event message")
 	}
@@ -210,7 +210,7 @@ func (d *decoder) assembleHandleKeyOnlyRowChangedEvent(m *message) (*model.RowCh
 
 	ctx := context.Background()
 	switch m.Type {
-	case InsertType:
+	case DMLTypeInsert:
 		holder, err := common.SnapshotQuery(ctx, d.upstreamTiDB, m.CommitTs, m.Schema, m.Table, m.Data)
 		if err != nil {
 			return nil, err
@@ -220,7 +220,7 @@ func (d *decoder) assembleHandleKeyOnlyRowChangedEvent(m *message) (*model.RowCh
 			return nil, err
 		}
 		result.Data = data
-	case UpdateType:
+	case DMLTypeUpdate:
 		holder, err := common.SnapshotQuery(ctx, d.upstreamTiDB, m.CommitTs, m.Schema, m.Table, m.Data)
 		if err != nil {
 			return nil, err
@@ -240,7 +240,7 @@ func (d *decoder) assembleHandleKeyOnlyRowChangedEvent(m *message) (*model.RowCh
 			return nil, err
 		}
 		result.Old = old
-	case DeleteType:
+	case DMLTypeDelete:
 		holder, err := common.SnapshotQuery(ctx, d.upstreamTiDB, m.CommitTs-1, m.Schema, m.Table, m.Old)
 		if err != nil {
 			return nil, err

--- a/pkg/sink/codec/simple/encoder_test.go
+++ b/pkg/sink/codec/simple/encoder_test.go
@@ -146,6 +146,55 @@ func TestEncodeDMLEnableChecksum(t *testing.T) {
 	}
 }
 
+func TestEncodeDDLSequence(t *testing.T) {
+	helper := entry.NewSchemaTestHelper(t)
+	defer helper.Close()
+
+	helper.Tk().MustExec("use test")
+
+	createTableDDL := "CREATE TABLE `TBL1` (`id` INT PRIMARY KEY AUTO_INCREMENT,`value` VARCHAR(255),`payload` VARCHAR(2000),`a` INT)"
+	createTableDDLEvent := helper.DDL2Event(createTableDDL)
+	//addColumnDDLEvent := helper.DDL2Event("ALTER TABLE `TBL1` ADD COLUMN `nn` INT")
+	//dropColumnDDLEvent := helper.DDL2Event("ALTER TABLE `TBL1` DROP COLUMN `nn`")
+	//changeColumnDDLEvent := helper.DDL2Event("ALTER TABLE `TBL1` CHANGE COLUMN `value` `value2` VARCHAR(512)")
+	//modifyColumnDDLEvent := helper.DDL2Event("ALTER TABLE `TBL1` MODIFY COLUMN `value2` VARCHAR(512) FIRST")
+
+	ctx := context.Background()
+	codecConfig := common.NewConfig(config.ProtocolSimple)
+	b, err := NewBuilder(ctx, codecConfig)
+	require.NoError(t, err)
+
+	enc := b.Build()
+	dec, err := NewDecoder(ctx, codecConfig, nil)
+	require.NoError(t, err)
+
+	m, err := enc.EncodeDDLEvent(createTableDDLEvent)
+	require.NoError(t, err)
+
+	err = dec.AddKeyValue(m.Key, m.Value)
+	require.NoError(t, err)
+
+	messageType, hasNext, err := dec.HasNext()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+	require.Equal(t, model.MessageTypeDDL, messageType)
+
+	event, err := dec.NextDDLEvent()
+	require.NoError(t, err)
+
+	require.Len(t, event.TableInfo.Indices, 1)
+	require.Len(t, event.TableInfo.Columns, 4)
+
+	//setDefaultDDLEvent := helper.DDL2Event("ALTER TABLE `TBL1` ALTER COLUMN `payload` SET DEFAULT _UTF8MB4'a'")
+	//dropDefaultDDLEvent := helper.DDL2Event("ALTER TABLE `TBL1` ALTER COLUMN `payload` DROP DEFAULT")
+	//
+	//autoIncrementDDLEvent := helper.DDL2Event("ALTER TABLE `TBL1` AUTO_INCREMENT = 5")
+	//
+	//modifyColumnDDLEvent2 := helper.DDL2Event("ALTER TABLE `TBL1` MODIFY COLUMN `a` INT NULL")
+	//modifyColumnDDLEvent3 := helper.DDL2Event("ALTER TABLE `TBL1` MODIFY COLUMN `a` INT NOT NULL")
+
+}
+
 func TestEncodeDDLEvent(t *testing.T) {
 	replicaConfig := config.GetDefaultReplicaConfig()
 	replicaConfig.Integrity.IntegrityCheckLevel = integrity.CheckLevelCorrectness

--- a/pkg/sink/codec/simple/encoder_test.go
+++ b/pkg/sink/codec/simple/encoder_test.go
@@ -273,16 +273,20 @@ func TestEncodeDDLEvent(t *testing.T) {
 			sort.Slice(sortedColumns, func(i, j int) bool {
 				return sortedColumns[i].ID < sortedColumns[j].ID
 			})
+
 			for idx, column := range sortedColumns {
 				require.Equal(t, column.Name.O, columnSchemas[idx].Name)
 			}
 
 			event, err := dec.NextDDLEvent()
+
 			require.NoError(t, err)
 			require.Equal(t, createTableDDLEvent.TableInfo.TableName.TableID, event.TableInfo.TableName.TableID)
 			require.Equal(t, createTableDDLEvent.CommitTs, event.CommitTs)
+
 			// because we don't we don't set startTs in the encoded message,
 			// so the startTs is equal to commitTs
+			
 			require.Equal(t, createTableDDLEvent.CommitTs, event.StartTs)
 			require.Equal(t, createTableDDLEvent.Query, event.Query)
 			require.Equal(t, len(createTableDDLEvent.TableInfo.Columns), len(event.TableInfo.Columns))

--- a/pkg/sink/codec/simple/encoder_test.go
+++ b/pkg/sink/codec/simple/encoder_test.go
@@ -286,7 +286,7 @@ func TestEncodeDDLEvent(t *testing.T) {
 
 			// because we don't we don't set startTs in the encoded message,
 			// so the startTs is equal to commitTs
-			
+
 			require.Equal(t, createTableDDLEvent.CommitTs, event.StartTs)
 			require.Equal(t, createTableDDLEvent.Query, event.Query)
 			require.Equal(t, len(createTableDDLEvent.TableInfo.Columns), len(event.TableInfo.Columns))

--- a/pkg/sink/codec/simple/marshaller.go
+++ b/pkg/sink/codec/simple/marshaller.go
@@ -83,7 +83,7 @@ func (m *jsonMarshaller) MarshalDDLEvent(event *model.DDLEvent) ([]byte, error) 
 		err error
 	)
 	if event.IsBootstrap {
-		msg, err = newBootstrapMessage(event)
+		msg, err = newBootstrapMessage(event.TableInfo)
 	} else {
 		msg, err = newDDLMessage(event)
 	}

--- a/pkg/sink/codec/simple/message.go
+++ b/pkg/sink/codec/simple/message.go
@@ -41,45 +41,63 @@ const (
 	defaultVersion = 1
 )
 
-// EventType describes the type of the event.
-type EventType string
+type MessageType string
 
-// The list of event types.
 const (
-	// WatermarkType is the type of the watermark event.
-	WatermarkType EventType = "WATERMARK"
-	// BootstrapType is the type of the bootstrap event.
-	BootstrapType EventType = "BOOTSTRAP"
-	// InsertType is the type of the insert event.
-	InsertType EventType = "INSERT"
-	// UpdateType is the type of the update event.
-	UpdateType EventType = "UPDATE"
-	// DeleteType is the type of the delete event.
-	DeleteType EventType = "DELETE"
+	// MessageTypeWatermark is the type of the watermark event.
+	MessageTypeWatermark MessageType = "WATERMARK"
+	// MessageTypeBootstrap is the type of the bootstrap event.
+	MessageTypeBootstrap MessageType = "BOOTSTRAP"
+	// MessageTypeDDL is the type of the ddl event.
+	MessageTypeDDL MessageType = "DDL"
+	// MessageTypeDML is the type of the row event.
+	MessageTypeDML MessageType = "DML"
 )
 
-func getDDLType(t timodel.ActionType) EventType {
+// DML Message types
+const (
+	// DMLTypeInsert is the type of the insert event.
+	DMLTypeInsert MessageType = "INSERT"
+	// DMLTypeUpdate is the type of the update event.
+	DMLTypeUpdate MessageType = "UPDATE"
+	// DMLTypeDelete is the type of the delete event.
+	DMLTypeDelete MessageType = "DELETE"
+)
+
+// DDL message types
+const (
+	DDLTypeCreate   MessageType = "CREATE"
+	DDLTypeRename   MessageType = "RENAME"
+	DDLTypeCIndex   MessageType = "CINDEX"
+	DDLTypeDIndex   MessageType = "DINDEX"
+	DDLTypeErase    MessageType = "ERASE"
+	DDLTypeTruncate MessageType = "TRUNCATE"
+	DDLTypeAlter    MessageType = "ALTER"
+	DDLTypeQuery    MessageType = "QUERY"
+)
+
+func getDDLType(t timodel.ActionType) MessageType {
 	switch t {
 	case timodel.ActionCreateTable:
-		return "CREATE"
+		return DDLTypeCreate
 	case timodel.ActionRenameTable, timodel.ActionRenameTables:
-		return "RENAME"
+		return DDLTypeRename
 	case timodel.ActionAddIndex, timodel.ActionAddForeignKey, timodel.ActionAddPrimaryKey:
-		return "CINDEX"
+		return DDLTypeCIndex
 	case timodel.ActionDropIndex, timodel.ActionDropForeignKey, timodel.ActionDropPrimaryKey:
-		return "DINDEX"
+		return DDLTypeDIndex
 	case timodel.ActionDropTable:
-		return "ERASE"
+		return DDLTypeErase
 	case timodel.ActionTruncateTable:
-		return "TRUNCATE"
+		return DDLTypeTruncate
 	case timodel.ActionAddColumn, timodel.ActionDropColumn, timodel.ActionModifyColumn, timodel.ActionRebaseAutoID,
 		timodel.ActionSetDefaultValue, timodel.ActionModifyTableComment, timodel.ActionRenameIndex, timodel.ActionAddTablePartition,
 		timodel.ActionDropTablePartition, timodel.ActionModifyTableCharsetAndCollate, timodel.ActionTruncateTablePartition,
 		timodel.ActionAlterIndexVisibility, timodel.ActionMultiSchemaChange, timodel.ActionReorganizePartition,
 		timodel.ActionAlterTablePartitioning, timodel.ActionRemovePartitioning:
-		return "ALTER"
+		return DDLTypeAlter
 	default:
-		return "QUERY"
+		return DDLTypeQuery
 	}
 }
 
@@ -484,10 +502,10 @@ type checksum struct {
 type message struct {
 	Version int `json:"version"`
 	// Schema and Table is empty for the resolved ts event.
-	Schema  string    `json:"database,omitempty"`
-	Table   string    `json:"table,omitempty"`
-	TableID int64     `json:"tableID,omitempty"`
-	Type    EventType `json:"type"`
+	Schema  string      `json:"database,omitempty"`
+	Table   string      `json:"table,omitempty"`
+	TableID int64       `json:"tableID,omitempty"`
+	Type    MessageType `json:"type"`
 	// SQL is only for the DDL event.
 	SQL      string `json:"sql,omitempty"`
 	CommitTs uint64 `json:"commitTs"`
@@ -516,7 +534,7 @@ type message struct {
 func newResolvedMessage(ts uint64) *message {
 	return &message{
 		Version:  defaultVersion,
-		Type:     WatermarkType,
+		Type:     MessageTypeWatermark,
 		CommitTs: ts,
 		BuildTs:  time.Now().UnixMilli(),
 	}
@@ -529,7 +547,7 @@ func newBootstrapMessage(event *model.DDLEvent) (*message, error) {
 	}
 	msg := &message{
 		Version:     defaultVersion,
-		Type:        BootstrapType,
+		Type:        MessageTypeBootstrap,
 		BuildTs:     time.Now().UnixMilli(),
 		TableSchema: schema,
 	}
@@ -585,19 +603,19 @@ func newDMLMessage(
 	}
 	var err error
 	if event.IsInsert() {
-		m.Type = InsertType
+		m.Type = DMLTypeInsert
 		m.Data, err = formatColumns(event.Columns, event.ColInfos, onlyHandleKey)
 		if err != nil {
 			return nil, err
 		}
 	} else if event.IsDelete() {
-		m.Type = DeleteType
+		m.Type = DMLTypeDelete
 		m.Old, err = formatColumns(event.PreColumns, event.ColInfos, onlyHandleKey)
 		if err != nil {
 			return nil, err
 		}
 	} else if event.IsUpdate() {
-		m.Type = UpdateType
+		m.Type = DMLTypeUpdate
 		m.Data, err = formatColumns(event.Columns, event.ColInfos, onlyHandleKey)
 		if err != nil {
 			return nil, err

--- a/pkg/sink/codec/simple/message.go
+++ b/pkg/sink/codec/simple/message.go
@@ -276,19 +276,6 @@ type TableSchema struct {
 }
 
 func newTableSchema(tableInfo *model.TableInfo) (*TableSchema, error) {
-	sort.SliceStable(tableInfo.Columns, func(i, j int) bool {
-		return tableInfo.Columns[i].ID < tableInfo.Columns[j].ID
-	})
-
-	columns := make([]*columnSchema, 0, len(tableInfo.Columns))
-	for _, col := range tableInfo.Columns {
-		colSchema, err := newColumnSchema(col)
-		if err != nil {
-			return nil, err
-		}
-		columns = append(columns, colSchema)
-	}
-
 	pkInIndexes := false
 	indexes := make([]*IndexSchema, 0, len(tableInfo.Indices))
 	for _, idx := range tableInfo.Indices {
@@ -312,6 +299,19 @@ func newTableSchema(tableInfo *model.TableInfo) (*TableSchema, error) {
 			}
 			indexes = append(indexes, index)
 		}
+	}
+
+	sort.SliceStable(tableInfo.Columns, func(i, j int) bool {
+		return tableInfo.Columns[i].ID < tableInfo.Columns[j].ID
+	})
+
+	columns := make([]*columnSchema, 0, len(tableInfo.Columns))
+	for _, col := range tableInfo.Columns {
+		colSchema, err := newColumnSchema(col)
+		if err != nil {
+			return nil, err
+		}
+		columns = append(columns, colSchema)
 	}
 
 	return &TableSchema{

--- a/pkg/sink/codec/simple/message.go
+++ b/pkg/sink/codec/simple/message.go
@@ -41,6 +41,7 @@ const (
 	defaultVersion = 1
 )
 
+// MessageType is the type of the message.
 type MessageType string
 
 const (

--- a/pkg/sink/codec/simple/message.go
+++ b/pkg/sink/codec/simple/message.go
@@ -541,8 +541,8 @@ func newResolvedMessage(ts uint64) *message {
 	}
 }
 
-func newBootstrapMessage(event *model.DDLEvent) (*message, error) {
-	schema, err := newTableSchema(event.TableInfo)
+func newBootstrapMessage(tableInfo *model.TableInfo) (*message, error) {
+	schema, err := newTableSchema(tableInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sink/codec/simple/message.json
+++ b/pkg/sink/codec/simple/message.json
@@ -189,10 +189,6 @@
         "type": "int"
       },
       {
-        "name": "type",
-        "type": "string"
-      },
-      {
         "name": "commitTs",
         "type": "long"
       },
@@ -211,10 +207,6 @@
       {
         "name": "version",
         "type": "int"
-      },
-      {
-        "name": "type",
-        "type": "string"
       },
       {
         "name": "buildTs",
@@ -399,6 +391,19 @@
     "docs": "the wrapper for all kind of messages",
     "type": "record",
     "fields": [
+      {
+        "name": "type",
+        "type": {
+          "type": "enum",
+          "name": "MessageType",
+          "symbols": [
+            "WATERMARK",
+            "BOOTSTRAP",
+            "DDL",
+            "DML"
+          ]
+        }
+      },
       {
         "name": "payload",
         "type": [

--- a/pkg/sink/codec/simple/message.json
+++ b/pkg/sink/codec/simple/message.json
@@ -361,12 +361,10 @@
             "type": "map",
             "values": [
               "null",
-              "int",
               "long",
               "float",
               "double",
               "string",
-              "boolean",
               "bytes"
             ],
             "default": null


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10563

### What is changed and how it works?

* fix the primary key that cannot be found, by sort columns after all indexes were found.
* adjust simple avro schema, remove useless field
* add more unit test to the simple protocol encoding.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
