### PR TITLE
cli(ticdc): verify start-ts to make sure it's not in the future

### DIFF
--- a/cdc/api/v1/validator.go
+++ b/cdc/api/v1/validator.go
@@ -63,13 +63,17 @@ func verifyCreateChangefeedConfig(
 		return nil, cerror.ErrChangeFeedAlreadyExists.GenWithStackByArgs(changefeedConfig.ID)
 	}
 
+	ts, logical, err := up.PDClient.GetTS(ctx)
+	if err != nil {
+		return nil, cerror.ErrPDEtcdAPIError.GenWithStackByArgs("fail to get ts from pd client")
+	}
+	currentTSO := oracle.ComposeTS(ts, logical)
 	// verify start-ts
 	if changefeedConfig.StartTS == 0 {
-		ts, logical, err := up.PDClient.GetTS(ctx)
-		if err != nil {
-			return nil, cerror.ErrPDEtcdAPIError.GenWithStackByArgs("fail to get ts from pd client")
-		}
-		changefeedConfig.StartTS = oracle.ComposeTS(ts, logical)
+		changefeedConfig.StartTS = currentTSO
+	} else if changefeedConfig.StartTS > currentTSO {
+		return nil, cerror.ErrAPIInvalidParam.GenWithStack(
+			"invalid start-ts %v, larger than current tso %v", changefeedConfig.StartTS, currentTSO)
 	}
 
 	// Ensure the start ts is valid in the next 1 hour.

--- a/cdc/api/v2/api_helpers.go
+++ b/cdc/api/v2/api_helpers.go
@@ -408,7 +408,7 @@ func (APIV2HelpersImpl) verifyResumeChangefeedConfig(ctx context.Context,
 	changefeedID model.ChangeFeedID,
 	overrideCheckpointTs uint64,
 ) error {
-	if checkpointTs == 0 {
+	if overrideCheckpointTs == 0 {
 		return nil
 	}
 
@@ -417,9 +417,9 @@ func (APIV2HelpersImpl) verifyResumeChangefeedConfig(ctx context.Context,
 		return cerror.ErrPDEtcdAPIError.GenWithStackByArgs("fail to get ts from pd client")
 	}
 	currentTSO := oracle.ComposeTS(ts, logical)
-	if checkpointTs > currentTSO {
+	if overrideCheckpointTs > currentTSO {
 		return cerror.ErrAPIInvalidParam.GenWithStack(
-			"invalid checkpoint-ts %v, larger than current tso %v", checkpointTs, currentTSO)
+			"invalid checkpoint-ts %v, larger than current tso %v", overrideCheckpointTs, currentTSO)
 	}
 
 	// 1h is enough for resuming a changefeed.

--- a/cdc/api/v2/api_helpers.go
+++ b/cdc/api/v2/api_helpers.go
@@ -184,7 +184,7 @@ func (APIV2HelpersImpl) verifyCreateChangefeedConfig(
 	}
 	// Ensure the start ts is valid in the next 3600 seconds, aka 1 hour
 	const ensureTTL = 60 * 60
-	if err := gc.EnsureChangefeedStartTsSafety(
+	if err = gc.EnsureChangefeedStartTsSafety(
 		ctx,
 		pdClient,
 		ensureGCServiceID,

--- a/cdc/api/v2/api_helpers_test.go
+++ b/cdc/api/v2/api_helpers_test.go
@@ -106,7 +106,7 @@ func TestVerifyCreateChangefeedConfig(t *testing.T) {
 	require.Error(t, cerror.ErrOldValueNotEnabled, err)
 
 	// invalid start-ts, in the future
-	cfg.StartTs = 100000000000000000
+	cfg.StartTs = 1000000000000000000
 	ctrl.EXPECT().IsChangefeedExists(gomock.Any(), gomock.Any()).Return(false, nil)
 	_, err = h.verifyCreateChangefeedConfig(ctx, cfg, pdClient, ctrl, "en", storage)
 	require.Error(t, cerror.ErrAPIInvalidParam, err)

--- a/cdc/api/v2/api_helpers_test.go
+++ b/cdc/api/v2/api_helpers_test.go
@@ -104,6 +104,12 @@ func TestVerifyCreateChangefeedConfig(t *testing.T) {
 	ctrl.EXPECT().IsChangefeedExists(gomock.Any(), gomock.Any()).Return(false, nil)
 	_, err = h.verifyCreateChangefeedConfig(ctx, cfg, pdClient, ctrl, "en", storage)
 	require.Error(t, cerror.ErrOldValueNotEnabled, err)
+
+	// invalid start-ts, in the future
+	cfg.StartTs = 100000000000000000
+	ctrl.EXPECT().IsChangefeedExists(gomock.Any(), gomock.Any()).Return(false, nil)
+	_, err = h.verifyCreateChangefeedConfig(ctx, cfg, pdClient, ctrl, "en", storage)
+	require.Error(t, cerror.ErrAPIInvalidParam, err)
 }
 
 func TestVerifyUpdateChangefeedConfig(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10499

### What is changed and how it works?

When creating and resuming the changefeed, make sure the `start-ts` is not in the future, this should be helpful to prevent the changefeed not make progressing after initialized, since the `start-ts` is not coming yet.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
validate the start-ts when creating and resuming changefeed
```
