### PR TITLE
kv (ticdc): fix kvClient reconnection downhill loop

### DIFF
--- a/cdc/entry/schema_test_helper.go
+++ b/cdc/entry/schema_test_helper.go
@@ -15,13 +15,11 @@ package entry
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/pingcap/log"
 	ticonfig "github.com/pingcap/tidb/pkg/config"
 	tiddl "github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/domain"
@@ -39,7 +37,6 @@ import (
 	"github.com/pingcap/tiflow/pkg/util"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/oracle"
-	"go.uber.org/zap"
 )
 
 // SchemaTestHelper is a test helper for schema which creates an internal tidb instance to generate DDL jobs with meta information
@@ -197,7 +194,6 @@ func (s *SchemaTestHelper) DML2Event(dml string, schema, table string) *model.Ro
 	polymorphicEvent := model.NewPolymorphicEvent(rawKV)
 	err := s.mounter.DecodeEvent(context.Background(), polymorphicEvent)
 	require.NoError(s.t, err)
-	log.Info("fizz dml event", zap.String("key", hex.EncodeToString(polymorphicEvent.RawKV.Key)))
 	return polymorphicEvent.Row
 }
 

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -1438,6 +1438,7 @@ func (s *eventFeedSession) addStream(stream *eventFeedStream) {
 		}
 	}
 	s.storeStreamsCache.m[stream.addr] = stream
+	s.storeStreamsCache.lastAlterTime[stream.addr] = time.Now()
 }
 
 // deleteStream deletes a stream from the session.streams.

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -77,12 +77,14 @@ const (
 	scanRegionsConcurrency = 1024
 
 	tableMonitorInterval = 2 * time.Second
-
-	streamAlterInterval = 1 * time.Second
 )
 
 // time interval to force kv client to terminate gRPC stream and reconnect
 var reconnectInterval = 60 * time.Minute
+
+// streamAlterInterval is the interval to limit the frequency of creating/deleting streams.
+// Make it a variable so that we can change it in unit test.
+var streamAlterInterval = 1 * time.Second
 
 type regionStatefulEvent struct {
 	changeEvent     *cdcpb.Event

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -769,8 +769,6 @@ func (s *eventFeedSession) requestRegionToStore(
 					zap.String("store", storeAddr),
 					zap.Error(err))
 			}
-			// TODO(dongmen): remove this line after testing.
-			time.Sleep(time.Second * 5)
 			// Delete the stream from the cache so that when next time the store is accessed,
 			// the stream can be re-established.
 			s.deleteStream(stream)

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -280,7 +280,9 @@ func (c *CDCClient) newStream(
 			zap.String("changefeed", c.changefeed.ID),
 			zap.Int64("tableID", c.tableID),
 			zap.String("tableName", c.tableName),
-			zap.String("store", addr))
+			zap.String("store", addr),
+			zap.Uint64("storeID", storeID),
+			zap.Uint64("streamID", stream.id))
 		return nil
 	}
 	if c.config.Debug.EnableKVConnectBackOff {
@@ -762,6 +764,7 @@ func (s *eventFeedSession) requestRegionToStore(
 				zap.String("tableName", s.tableName),
 				zap.Uint64("storeID", storeID),
 				zap.String("store", storeAddr),
+				zap.Uint64("streamID", stream.id),
 				zap.Uint64("regionID", regionID),
 				zap.Uint64("requestID", requestID),
 				zap.Error(err))
@@ -771,6 +774,7 @@ func (s *eventFeedSession) requestRegionToStore(
 					zap.String("changefeed", s.changefeed.ID),
 					zap.Int64("tableID", s.tableID),
 					zap.String("tableName", s.tableName),
+					zap.Uint64("streamID", stream.id),
 					zap.Uint64("storeID", storeID),
 					zap.String("store", storeAddr),
 					zap.Error(err))
@@ -1098,10 +1102,8 @@ func (s *eventFeedSession) receiveFromStream(
 	// to call exactly once from outer code logic
 	worker := newRegionWorker(
 		parentCtx,
-		stream.cancel,
-		s.changefeed,
+		stream,
 		s,
-		stream.addr,
 		pendingRegions)
 	defer worker.evictAllRegions()
 
@@ -1179,6 +1181,7 @@ func (s *eventFeedSession) receiveFromStream(
 						zap.String("namespace", s.changefeed.Namespace),
 						zap.String("changefeed", s.changefeed.ID),
 						zap.Int64("tableID", s.tableID),
+						zap.String("tableName", s.tableName),
 						zap.String("store", stream.addr),
 						zap.Uint64("storeID", stream.storeID),
 						zap.Uint64("streamID", stream.id))

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -673,7 +673,6 @@ func (s *eventFeedSession) requestRegionToStore(
 			pendingRegions := newSyncRegionFeedStateMap()
 			streamCtx, streamCancel := context.WithCancel(ctx)
 			stream, err = s.client.newStream(streamCtx, streamCancel, storeAddr, storeID)
-			storePendingRegions[stream.id] = pendingRegions
 			if err != nil {
 				// get stream failed, maybe the store is down permanently, we should try to relocate the active store
 				log.Warn("get grpc stream client failed",
@@ -698,6 +697,8 @@ func (s *eventFeedSession) requestRegionToStore(
 				s.onRegionFail(ctx, errInfo)
 				continue
 			}
+
+			storePendingRegions[stream.id] = pendingRegions
 			s.addStream(stream)
 			log.Info("creating new stream to store to send request",
 				zap.String("namespace", s.changefeed.Namespace),

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -768,7 +768,8 @@ func (s *eventFeedSession) requestRegionToStore(
 					zap.String("store", storeAddr),
 					zap.Error(err))
 			}
-
+			// TODO(dongmen): remove this line after testing.
+			time.Sleep(time.Second * 5)
 			// Delete the stream from the cache so that when next time the store is accessed,
 			// the stream can be re-established.
 			s.deleteStream(stream)
@@ -1420,7 +1421,7 @@ func (s *eventFeedSession) deleteStream(streamToDelete *eventFeedStream) {
 
 	if streamInMap, ok := s.storeStreamsCache[streamToDelete.addr]; ok {
 		if streamInMap.id != streamToDelete.id {
-			log.Info("delete stream failed, stream id mismatch, ignore it",
+			log.Warn("delete stream failed, stream id mismatch, ignore it",
 				zap.String("namespace", s.changefeed.Namespace),
 				zap.String("changefeed", s.changefeed.ID),
 				zap.Int64("tableID", s.tableID),

--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -671,9 +671,9 @@ func (s *eventFeedSession) requestRegionToStore(
 			// regions map, the old map will be used in old `receiveFromStream`
 			// and won't be deleted until that goroutine exits.
 			pendingRegions := newSyncRegionFeedStateMap()
-			storePendingRegions[stream.id] = pendingRegions
 			streamCtx, streamCancel := context.WithCancel(ctx)
 			stream, err = s.client.newStream(streamCtx, streamCancel, storeAddr, storeID)
+			storePendingRegions[stream.id] = pendingRegions
 			if err != nil {
 				// get stream failed, maybe the store is down permanently, we should try to relocate the active store
 				log.Warn("get grpc stream client failed",

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -286,7 +286,7 @@ func waitRequestID(t *testing.T, allocatedID uint64) {
 			return nil
 		}
 		return errors.Errorf("request id %d is not larger than %d", getCurrentRequestID(), allocatedID)
-	}, retry.WithBackoffBaseDelay(10), retry.WithMaxTries(20))
+	}, retry.WithBackoffBaseDelay(20), retry.WithMaxTries(100))
 
 	require.Nil(t, err)
 }
@@ -1502,6 +1502,7 @@ func TestStreamRecvWithErrorAndResolvedGoBack(t *testing.T) {
 	server1, addr1 := newMockService(ctx, t, srv1, wg)
 
 	defer func() {
+		cancel()
 		close(ch1)
 		server1.Stop()
 		wg.Wait()
@@ -1547,7 +1548,7 @@ func TestStreamRecvWithErrorAndResolvedGoBack(t *testing.T) {
 		}
 		return errors.Errorf("request is not received, requestID: %d, expected: %d",
 			atomic.LoadUint64(&requestID), getCurrentRequestID())
-	}, retry.WithBackoffBaseDelay(50), retry.WithMaxTries(10))
+	}, retry.WithBackoffBaseDelay(50), retry.WithMaxTries(30))
 
 	require.Nil(t, err)
 	initialized1 := mockInitializedEvent(regionID, getCurrentRequestID())
@@ -1601,7 +1602,7 @@ func TestStreamRecvWithErrorAndResolvedGoBack(t *testing.T) {
 		}
 		return errors.Errorf("request is not received, requestID: %d, expected: %d",
 			atomic.LoadUint64(&requestID), getCurrentRequestID())
-	}, retry.WithBackoffBaseDelay(50), retry.WithMaxTries(10))
+	}, retry.WithBackoffBaseDelay(50), retry.WithMaxTries(30))
 
 	require.Nil(t, err)
 	initialized2 := mockInitializedEvent(regionID, getCurrentRequestID())

--- a/cdc/kv/client_test.go
+++ b/cdc/kv/client_test.go
@@ -57,6 +57,7 @@ func Test(t *testing.T) {
 	conf := config.GetDefaultServerConfig()
 	config.StoreGlobalServerConfig(conf)
 	InitWorkerPool()
+	streamAlterInterval = 1 * time.Microsecond
 	go func() {
 		RunWorkerPool(context.Background()) //nolint:errcheck
 	}()
@@ -1364,6 +1365,7 @@ func testStreamRecvWithError(t *testing.T, failpointStr string) {
 	server1, addr1 := newMockService(ctx, t, srv1, wg)
 
 	defer func() {
+		cancel()
 		close(ch1)
 		server1.Stop()
 		wg.Wait()
@@ -1414,7 +1416,7 @@ func testStreamRecvWithError(t *testing.T, failpointStr string) {
 			return nil
 		}
 		return errors.New("message is not sent")
-	}, retry.WithBackoffBaseDelay(200), retry.WithBackoffMaxDelay(60*1000), retry.WithMaxTries(10))
+	}, retry.WithBackoffBaseDelay(200), retry.WithBackoffMaxDelay(60*1000), retry.WithMaxTries(30))
 
 	require.Nil(t, err)
 
@@ -2076,6 +2078,7 @@ func testEventCommitTsFallback(t *testing.T, events []*cdcpb.ChangeDataEvent) {
 	server1, addr1 := newMockService(ctx, t, srv1, wg)
 
 	defer func() {
+		cancel()
 		close(ch1)
 		server1.Stop()
 		wg.Wait()

--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -165,6 +165,7 @@ func newRegionWorker(
 		session:        s,
 		inputCh:        make(chan []*regionStatefulEvent, regionWorkerInputChanSize),
 		outputCh:       s.eventCh,
+		stream:         stream,
 		errorCh:        make(chan error, 1),
 		statesManager:  newRegionStateManager(-1),
 		rtsManager:     newRegionTsManager(),

--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -114,7 +114,8 @@ type regionWorker struct {
 
 	metrics *regionWorkerMetrics
 
-	storeAddr    string
+	storeAddr string
+	// streamCancel is used to cancel the gRPC stream of this region worker's stream.
 	streamCancel func()
 	// how many pending input events
 	inputPending int32
@@ -603,6 +604,9 @@ func (w *regionWorker) cancelStream(delay time.Duration) {
 	// This will make the receiveFromStream goroutine exit and the stream can
 	// be re-established by the caller.
 	// Note: use context cancel is the only way to terminate a gRPC stream.
+
+	// TODO(dongmen): remove this line after testing.
+	time.Sleep(time.Second * 5)
 	w.streamCancel()
 	// Failover in stream.Recv has 0-100ms delay, the onRegionFail
 	// should be called after stream has been deleted. Add a delay here

--- a/cdc/kv/region_worker.go
+++ b/cdc/kv/region_worker.go
@@ -605,8 +605,6 @@ func (w *regionWorker) cancelStream(delay time.Duration) {
 	// be re-established by the caller.
 	// Note: use context cancel is the only way to terminate a gRPC stream.
 
-	// TODO(dongmen): remove this line after testing.
-	time.Sleep(time.Second * 5)
 	w.streamCancel()
 	// Failover in stream.Recv has 0-100ms delay, the onRegionFail
 	// should be called after stream has been deleted. Add a delay here

--- a/cdc/kv/region_worker_test.go
+++ b/cdc/kv/region_worker_test.go
@@ -159,7 +159,7 @@ func TestRegionWokerHandleEventEntryEventOutOfOrder(t *testing.T) {
 		&tikv.RPCContext{}), 0)
 	state.sri.lockedRange = &regionlock.LockedRange{}
 	state.start()
-	worker := newRegionWorker(ctx, model.ChangeFeedID{}, s, "", newSyncRegionFeedStateMap())
+	worker := newRegionWorker(ctx, cancel, model.ChangeFeedID{}, s, "", newSyncRegionFeedStateMap())
 	require.Equal(t, 2, cap(worker.outputCh))
 
 	// Receive prewrite2 with empty value.
@@ -311,7 +311,7 @@ func TestRegionWorkerHandleResolvedTs(t *testing.T) {
 }
 
 func TestRegionWorkerHandleEventsBeforeStartTs(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 	s := createFakeEventFeedSession()
 	s.eventCh = make(chan model.RegionFeedEvent, 2)
 	s1 := newRegionFeedState(newSingleRegionInfo(
@@ -322,7 +322,7 @@ func TestRegionWorkerHandleEventsBeforeStartTs(t *testing.T) {
 	s1.sri.lockedRange = &regionlock.LockedRange{}
 	s1.sri.lockedRange.CheckpointTs.Store(9)
 	s1.start()
-	w := newRegionWorker(ctx, model.ChangeFeedID{}, s, "", newSyncRegionFeedStateMap())
+	w := newRegionWorker(ctx, cancel, model.ChangeFeedID{}, s, "", newSyncRegionFeedStateMap())
 
 	err := w.handleResolvedTs(ctx, &resolvedTsEvent{
 		resolvedTs: 5,

--- a/cdc/kv/region_worker_test.go
+++ b/cdc/kv/region_worker_test.go
@@ -159,7 +159,11 @@ func TestRegionWokerHandleEventEntryEventOutOfOrder(t *testing.T) {
 		&tikv.RPCContext{}), 0)
 	state.sri.lockedRange = &regionlock.LockedRange{}
 	state.start()
-	worker := newRegionWorker(ctx, cancel, model.ChangeFeedID{}, s, "", newSyncRegionFeedStateMap())
+	stream := &eventFeedStream{
+		storeID: 1,
+		id:      2,
+	}
+	worker := newRegionWorker(ctx, stream, s, newSyncRegionFeedStateMap())
 	require.Equal(t, 2, cap(worker.outputCh))
 
 	// Receive prewrite2 with empty value.
@@ -311,7 +315,7 @@ func TestRegionWorkerHandleResolvedTs(t *testing.T) {
 }
 
 func TestRegionWorkerHandleEventsBeforeStartTs(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := context.Background()
 	s := createFakeEventFeedSession()
 	s.eventCh = make(chan model.RegionFeedEvent, 2)
 	s1 := newRegionFeedState(newSingleRegionInfo(
@@ -322,7 +326,11 @@ func TestRegionWorkerHandleEventsBeforeStartTs(t *testing.T) {
 	s1.sri.lockedRange = &regionlock.LockedRange{}
 	s1.sri.lockedRange.CheckpointTs.Store(9)
 	s1.start()
-	w := newRegionWorker(ctx, cancel, model.ChangeFeedID{}, s, "", newSyncRegionFeedStateMap())
+	stream := &eventFeedStream{
+		storeID: 1,
+		id:      2,
+	}
+	w := newRegionWorker(ctx, stream, s, newSyncRegionFeedStateMap())
 
 	err := w.handleResolvedTs(ctx, &resolvedTsEvent{
 		resolvedTs: 5,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10239 

### What is changed and how it works?

1. Add an ID to the `eventFeedStream` struct to identify a stream and prevent it from being deleted unexpectedly.
2. Bind the cancel function of a gRPC stream to its `eventFeedStream` to prevent the stream from being canceled unexpectedly.
3. Reduce the number of calls to `s.deleteStream` to only once to prevent the stream from being deleted unexpectedly.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)

1. Add hard code `time.sleep(5 * time.second)` before calling `s.deleteStream` in both unfixed and fixed version of code. 
2. Deploy a TiDB cluster with 3 TiKV nodes and 1 TiCDC server, create a changefeed. 
3. Patch the changed cdc binary, and restart a TiKV node randomly and observe the changefeed's lag. 

unfixed cdc:
![img_v3_027f_9b5e20b7-2aab-44b7-8884-fc29d2797beg](https://github.com/pingcap/tiflow/assets/20351731/013bfffe-6593-4260-8167-7b80ef009fe5)


fixed cdc:
![image](https://github.com/pingcap/tiflow/assets/20351731/363f2cae-1aef-43ac-8022-37e92c4e82d1)
 
From the above graphs, it is evident that in the unfixed CDC, the lag of resolvedTs can exceed 12 minutes when a TiKV node is restarted. However, in the fixed CDC, the increase in resolvedTs is limited to a maximum of 35 seconds. This demonstrates the effectiveness of the fix.

Moreover, when the hard-coded `time.sleep(5 * time.second)` is removed and the fixed version of CDC is tested again, the lag becomes even smaller:
![image](https://github.com/pingcap/tiflow/assets/20351731/e753d9a9-77ef-4f4a-9239-60f8e3c6e799)



#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a bug in kv client that could cause an increase in changefeed lag when TiKV is restarted.
```
