### PR TITLE
csv(ticdc): Add a new config "output_handle_key" in csv protocol to support output handle key info in csv protocol

### DIFF
--- a/cdc/api/v2/model.go
+++ b/cdc/api/v2/model.go
@@ -293,6 +293,7 @@ func (c *ReplicaConfig) toInternalReplicaConfigWithOriginConfig(
 				IncludeCommitTs:      c.Sink.CSVConfig.IncludeCommitTs,
 				BinaryEncodingMethod: c.Sink.CSVConfig.BinaryEncodingMethod,
 				OutputOldValue:       c.Sink.CSVConfig.OutputOldValue,
+				OutputHandleKey:      c.Sink.CSVConfig.OutputHandleKey,
 			}
 		}
 		var pulsarConfig *config.PulsarConfig
@@ -575,6 +576,7 @@ func ToAPIReplicaConfig(c *config.ReplicaConfig) *ReplicaConfig {
 				IncludeCommitTs:      cloned.Sink.CSVConfig.IncludeCommitTs,
 				BinaryEncodingMethod: cloned.Sink.CSVConfig.BinaryEncodingMethod,
 				OutputOldValue:       cloned.Sink.CSVConfig.OutputOldValue,
+				OutputHandleKey:      cloned.Sink.CSVConfig.OutputHandleKey,
 			}
 		}
 		var kafkaConfig *KafkaConfig
@@ -934,6 +936,7 @@ type CSVConfig struct {
 	IncludeCommitTs      bool   `json:"include_commit_ts"`
 	BinaryEncodingMethod string `json:"binary_encoding_method"`
 	OutputOldValue       bool   `json:"output_old_value"`
+	OutputHandleKey      bool   `json:"output_handle_key"`
 }
 
 // LargeMessageHandleConfig denotes the large message handling config

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -231,6 +231,7 @@ func (m *mounter) unmarshalRowKVEntry(
 		return nil, errors.Trace(err)
 	}
 	base.RecordID = recordID
+	log.Info("hyy RecordID is ", zap.String("recordID", recordID.String()))
 
 	var (
 		row, preRow           map[int64]types.Datum
@@ -581,6 +582,7 @@ func (m *mounter) mountRowKVEntry(tableInfo *model.TableInfo, row *rowKVEntry, d
 		StartTs:         row.StartTs,
 		CommitTs:        row.CRTs,
 		RowID:           intRowID,
+		HandleKey:       row.RecordID,
 		PhysicalTableID: row.PhysicalTableID,
 		ColInfos:        extendColumnInfos,
 		TableInfo:       tableInfo,

--- a/cdc/entry/mounter.go
+++ b/cdc/entry/mounter.go
@@ -231,7 +231,6 @@ func (m *mounter) unmarshalRowKVEntry(
 		return nil, errors.Trace(err)
 	}
 	base.RecordID = recordID
-	log.Info("hyy RecordID is ", zap.String("recordID", recordID.String()))
 
 	var (
 		row, preRow           map[int64]types.Datum

--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -357,7 +357,9 @@ type RowChangedEvent struct {
 	SplitTxn bool `json:"-" msg:"-"`
 	// ReplicatingTs is ts when a table starts replicating events to downstream.
 	ReplicatingTs Ts `json:"-" msg:"-"`
-
+	// HandleKey is the handle key of each row changed event.
+	// It is used to identify the row changed event.
+	// It can be common_handle, int_handle or _tidb_rowid
 	HandleKey kv.Handle `json:"handle-key" msg:"handle-key"`
 }
 

--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -22,6 +22,7 @@ import (
 	"unsafe"
 
 	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/util/rowcodec"
@@ -356,6 +357,8 @@ type RowChangedEvent struct {
 	SplitTxn bool `json:"-" msg:"-"`
 	// ReplicatingTs is ts when a table starts replicating events to downstream.
 	ReplicatingTs Ts `json:"-" msg:"-"`
+
+	HandleKey kv.Handle `json:"handle-key" msg:"handle-key"`
 }
 
 // RowChangedEventInRedoLog is used to store RowChangedEvent in redo log v2 format

--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -365,7 +365,7 @@ type RowChangedEvent struct {
 	// 3. when the table doesn't have the primary key and clustered index,
 	//    tidb will make a hidden column called "_tidb_rowid" as the handle.
 	//    due to the type of "_tidb_rowid" is int, so we also use IntHandle to represent.
-	HandleKey kv.Handle `json:"handle-key" msg:"handle-key"`
+	HandleKey kv.Handle `json:"handle-key" msg:"-"`
 }
 
 // RowChangedEventInRedoLog is used to store RowChangedEvent in redo log v2 format

--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -357,9 +357,14 @@ type RowChangedEvent struct {
 	SplitTxn bool `json:"-" msg:"-"`
 	// ReplicatingTs is ts when a table starts replicating events to downstream.
 	ReplicatingTs Ts `json:"-" msg:"-"`
-	// HandleKey is the handle key of each row changed event.
-	// It is used to identify the row changed event.
-	// It can be common_handle, int_handle or _tidb_rowid
+	// HandleKey is the key of the row changed event.
+	// It can be used to identify the row changed event.
+	// It can be one of three : common_handle, int_handle or _tidb_rowid based on the table definitions
+	// 1. primary key is the clustered index, and key is not int type, then we use `CommonHandle`
+	// 2. primary key is int type(including different types of int, such as bigint, TINYINT), then we use IntHandle
+	// 3. when the table doesn't have the primary key and clustered index,
+	//    tidb will make a hidden column called "_tidb_rowid" as the handle.
+	//    due to the type of "_tidb_rowid" is int, so we also use IntHandle to represent.
 	HandleKey kv.Handle `json:"handle-key" msg:"handle-key"`
 }
 

--- a/cdc/model/sink_gen.go
+++ b/cdc/model/sink_gen.go
@@ -1661,12 +1661,6 @@ func (z *RowChangedEvent) DecodeMsg(dc *msgp.Reader) (err error) {
 					}
 				}
 			}
-		case "handle-key":
-			err = z.HandleKey.DecodeMsg(dc)
-			if err != nil {
-				err = msgp.WrapError(err, "HandleKey")
-				return
-			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -1680,9 +1674,9 @@ func (z *RowChangedEvent) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *RowChangedEvent) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 6
+	// map header, size 5
 	// write "start-ts"
-	err = en.Append(0x86, 0xa8, 0x73, 0x74, 0x61, 0x72, 0x74, 0x2d, 0x74, 0x73)
+	err = en.Append(0x85, 0xa8, 0x73, 0x74, 0x61, 0x72, 0x74, 0x2d, 0x74, 0x73)
 	if err != nil {
 		return
 	}
@@ -1759,25 +1753,15 @@ func (z *RowChangedEvent) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 	}
-	// write "handle-key"
-	err = en.Append(0xaa, 0x68, 0x61, 0x6e, 0x64, 0x6c, 0x65, 0x2d, 0x6b, 0x65, 0x79)
-	if err != nil {
-		return
-	}
-	err = z.HandleKey.EncodeMsg(en)
-	if err != nil {
-		err = msgp.WrapError(err, "HandleKey")
-		return
-	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z *RowChangedEvent) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 6
+	// map header, size 5
 	// string "start-ts"
-	o = append(o, 0x86, 0xa8, 0x73, 0x74, 0x61, 0x72, 0x74, 0x2d, 0x74, 0x73)
+	o = append(o, 0x85, 0xa8, 0x73, 0x74, 0x61, 0x72, 0x74, 0x2d, 0x74, 0x73)
 	o = msgp.AppendUint64(o, z.StartTs)
 	// string "commit-ts"
 	o = append(o, 0xa9, 0x63, 0x6f, 0x6d, 0x6d, 0x69, 0x74, 0x2d, 0x74, 0x73)
@@ -1812,13 +1796,6 @@ func (z *RowChangedEvent) MarshalMsg(b []byte) (o []byte, err error) {
 				return
 			}
 		}
-	}
-	// string "handle-key"
-	o = append(o, 0xaa, 0x68, 0x61, 0x6e, 0x64, 0x6c, 0x65, 0x2d, 0x6b, 0x65, 0x79)
-	o, err = z.HandleKey.MarshalMsg(o)
-	if err != nil {
-		err = msgp.WrapError(err, "HandleKey")
-		return
 	}
 	return
 }
@@ -1919,12 +1896,6 @@ func (z *RowChangedEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 				}
 			}
-		case "handle-key":
-			bts, err = z.HandleKey.UnmarshalMsg(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "HandleKey")
-				return
-			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -1955,7 +1926,6 @@ func (z *RowChangedEvent) Msgsize() (s int) {
 			s += z.PreColumns[za0002].Msgsize()
 		}
 	}
-	s += 11 + z.HandleKey.Msgsize()
 	return
 }
 

--- a/cdc/model/sink_gen.go
+++ b/cdc/model/sink_gen.go
@@ -1661,6 +1661,12 @@ func (z *RowChangedEvent) DecodeMsg(dc *msgp.Reader) (err error) {
 					}
 				}
 			}
+		case "handle-key":
+			err = z.HandleKey.DecodeMsg(dc)
+			if err != nil {
+				err = msgp.WrapError(err, "HandleKey")
+				return
+			}
 		default:
 			err = dc.Skip()
 			if err != nil {
@@ -1674,9 +1680,9 @@ func (z *RowChangedEvent) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *RowChangedEvent) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 5
+	// map header, size 6
 	// write "start-ts"
-	err = en.Append(0x85, 0xa8, 0x73, 0x74, 0x61, 0x72, 0x74, 0x2d, 0x74, 0x73)
+	err = en.Append(0x86, 0xa8, 0x73, 0x74, 0x61, 0x72, 0x74, 0x2d, 0x74, 0x73)
 	if err != nil {
 		return
 	}
@@ -1753,15 +1759,25 @@ func (z *RowChangedEvent) EncodeMsg(en *msgp.Writer) (err error) {
 			}
 		}
 	}
+	// write "handle-key"
+	err = en.Append(0xaa, 0x68, 0x61, 0x6e, 0x64, 0x6c, 0x65, 0x2d, 0x6b, 0x65, 0x79)
+	if err != nil {
+		return
+	}
+	err = z.HandleKey.EncodeMsg(en)
+	if err != nil {
+		err = msgp.WrapError(err, "HandleKey")
+		return
+	}
 	return
 }
 
 // MarshalMsg implements msgp.Marshaler
 func (z *RowChangedEvent) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 5
+	// map header, size 6
 	// string "start-ts"
-	o = append(o, 0x85, 0xa8, 0x73, 0x74, 0x61, 0x72, 0x74, 0x2d, 0x74, 0x73)
+	o = append(o, 0x86, 0xa8, 0x73, 0x74, 0x61, 0x72, 0x74, 0x2d, 0x74, 0x73)
 	o = msgp.AppendUint64(o, z.StartTs)
 	// string "commit-ts"
 	o = append(o, 0xa9, 0x63, 0x6f, 0x6d, 0x6d, 0x69, 0x74, 0x2d, 0x74, 0x73)
@@ -1796,6 +1812,13 @@ func (z *RowChangedEvent) MarshalMsg(b []byte) (o []byte, err error) {
 				return
 			}
 		}
+	}
+	// string "handle-key"
+	o = append(o, 0xaa, 0x68, 0x61, 0x6e, 0x64, 0x6c, 0x65, 0x2d, 0x6b, 0x65, 0x79)
+	o, err = z.HandleKey.MarshalMsg(o)
+	if err != nil {
+		err = msgp.WrapError(err, "HandleKey")
+		return
 	}
 	return
 }
@@ -1896,6 +1919,12 @@ func (z *RowChangedEvent) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					}
 				}
 			}
+		case "handle-key":
+			bts, err = z.HandleKey.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "HandleKey")
+				return
+			}
 		default:
 			bts, err = msgp.Skip(bts)
 			if err != nil {
@@ -1926,6 +1955,7 @@ func (z *RowChangedEvent) Msgsize() (s int) {
 			s += z.PreColumns[za0002].Msgsize()
 		}
 	}
+	s += 11 + z.HandleKey.Msgsize()
 	return
 }
 

--- a/pkg/config/config_test_data.go
+++ b/pkg/config/config_test_data.go
@@ -238,7 +238,8 @@ const (
       "null": "\\N",
       "include-commit-ts": true,
       "binary-encoding-method":"base64",
-      "output-old-value": false
+      "output-old-value": false,
+      "output-handle-key": false
     },
     "date-separator": "month",
     "enable-partition-separator": true,
@@ -404,7 +405,9 @@ const (
       "quote": "\"",
       "null": "\\N",
       "include-commit-ts": true,
-      "binary-encoding-method":"base64"
+      "binary-encoding-method":"base64",
+      "output-old-value": false,
+      "output-handle-key": false
     },
     "terminator": "\r\n",
 	"transaction-atomicity": "",

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -233,6 +233,8 @@ type CSVConfig struct {
 	BinaryEncodingMethod string `toml:"binary-encoding-method" json:"binary-encoding-method"`
 	// output old value
 	OutputOldValue bool `toml:"output-old-value" json:"output-old-value"`
+	// output handle key
+	OutputHandleKey bool `toml:"output-handle-key" json:"output-handle-key"`
 }
 
 func (c *CSVConfig) validateAndAdjust() error {

--- a/pkg/sink/codec/common/config.go
+++ b/pkg/sink/codec/common/config.go
@@ -72,6 +72,7 @@ type Config struct {
 	Terminator           string
 	BinaryEncodingMethod string
 	OutputOldValue       bool
+	OutputHandleKey      bool
 
 	// for open protocol
 	OnlyOutputUpdatedColumns bool
@@ -222,6 +223,7 @@ func (c *Config) Apply(sinkURI *url.URL, replicaConfig *config.ReplicaConfig) er
 			c.IncludeCommitTs = replicaConfig.Sink.CSVConfig.IncludeCommitTs
 			c.BinaryEncodingMethod = replicaConfig.Sink.CSVConfig.BinaryEncodingMethod
 			c.OutputOldValue = replicaConfig.Sink.CSVConfig.OutputOldValue
+			c.OutputHandleKey = replicaConfig.Sink.CSVConfig.OutputHandleKey
 		}
 		if replicaConfig.Sink.KafkaConfig != nil && replicaConfig.Sink.KafkaConfig.LargeMessageHandle != nil {
 			c.LargeMessageHandle = replicaConfig.Sink.KafkaConfig.LargeMessageHandle

--- a/pkg/sink/codec/csv/csv_message_test.go
+++ b/pkg/sink/codec/csv/csv_message_test.go
@@ -798,6 +798,7 @@ func TestCSVMessageEncode(t *testing.T) {
 					NullString:      "\\N",
 					IncludeCommitTs: true,
 					OutputOldValue:  true,
+					OutputHandleKey: true,
 				},
 				opType:     operationUpdate,
 				tableName:  "table2",
@@ -807,8 +808,8 @@ func TestCSVMessageEncode(t *testing.T) {
 				columns:    []any{"a!b!c", "def"},
 				HandleKey:  kv.IntHandle(1),
 			},
-			want: []byte(`D!table2!test!435661838416609281!true!"1"!a\!b\!c!abc` + "\n" +
-				`I!table2!test!435661838416609281!true!"1"!a\!b\!c!def` + "\n"),
+			want: []byte(`D!table2!test!435661838416609281!true!1!a\!b\!c!abc` + "\n" +
+				`I!table2!test!435661838416609281!true!1!a\!b\!c!def` + "\n"),
 		},
 		{
 			name: "csv encode values containing single-character delimter string, without quote mark, update with old value",
@@ -949,6 +950,7 @@ func TestCSVMessageEncode(t *testing.T) {
 				columns:    tc.fields.columns,
 				preColumns: tc.fields.preColumns,
 				newRecord:  true,
+				HandleKey:  tc.fields.HandleKey,
 			}
 
 			require.Equal(t, tc.want, c.encode())

--- a/pkg/sink/codec/csv/csv_message_test.go
+++ b/pkg/sink/codec/csv/csv_message_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tidb/pkg/parser/charset"
 	timodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
@@ -744,6 +745,7 @@ func TestCSVMessageEncode(t *testing.T) {
 		commitTs   uint64
 		preColumns []any
 		columns    []any
+		HandleKey  kv.Handle
 	}
 	testCases := []struct {
 		name   string
@@ -803,9 +805,10 @@ func TestCSVMessageEncode(t *testing.T) {
 				commitTs:   435661838416609281,
 				preColumns: []any{"a!b!c", "abc"},
 				columns:    []any{"a!b!c", "def"},
+				HandleKey:  kv.IntHandle(1),
 			},
-			want: []byte(`D!table2!test!435661838416609281!true!a\!b\!c!abc` + "\n" +
-				`I!table2!test!435661838416609281!true!a\!b\!c!def` + "\n"),
+			want: []byte(`D!table2!test!435661838416609281!true!"1"!a\!b\!c!abc` + "\n" +
+				`I!table2!test!435661838416609281!true!"1"!a\!b\!c!def` + "\n"),
 		},
 		{
 			name: "csv encode values containing single-character delimter string, without quote mark, update with old value",


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #10167

### What is changed and how it works?

Add a new config called "output_handle_key" enable to output handle key info in csv protocol

set changefeed configuration add do some insert/update/delete events:
[sink.csv]
include-commit-ts = true
output-old-value = true
output-handle-key = true

the output csv looks like

"I","t3","test",447353152622297101,false,"{5, 2}",5,2,3 

I","t6","test",447353152596082707,false,"1",10,22,3

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
