### PR TITLE
filter (ticdc): fix synpoint table is replicated in BDR mode

### DIFF
--- a/cdc/syncpointstore/mysql_syncpoint_store.go
+++ b/cdc/syncpointstore/mysql_syncpoint_store.go
@@ -26,15 +26,9 @@ import (
 	"github.com/pingcap/tiflow/pkg/config"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/errorutil"
+	"github.com/pingcap/tiflow/pkg/filter"
 	"github.com/pingcap/tiflow/pkg/sink/mysql"
 	"go.uber.org/zap"
-)
-
-const (
-	// syncPointTableName is the name of table where all syncpoint maps sit
-	syncPointTableName string = "syncpoint_v1"
-	// schemaName is the name of database where syncPoint maps sit
-	schemaName = "tidb_cdc"
 )
 
 type mysqlSyncPointStore struct {
@@ -88,7 +82,7 @@ func newMySQLSyncPointStore(
 }
 
 func (s *mysqlSyncPointStore) CreateSyncTable(ctx context.Context) error {
-	database := schemaName
+	database := filter.TiCDCSystemSchema
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		log.Error("create sync table: begin Tx fail", zap.Error(err))
@@ -120,7 +114,7 @@ func (s *mysqlSyncPointStore) CreateSyncTable(ctx context.Context) error {
 		INDEX (created_at),
 		PRIMARY KEY (changefeed, primary_ts)
 	);`
-	query = fmt.Sprintf(query, syncPointTableName)
+	query = fmt.Sprintf(query, filter.SyncPointTable)
 	_, err = tx.Exec(query)
 	if err != nil {
 		err2 := tx.Rollback()
@@ -154,7 +148,7 @@ func (s *mysqlSyncPointStore) SinkSyncPoint(ctx context.Context,
 		return cerror.WrapError(cerror.ErrMySQLTxnError, err)
 	}
 	// insert ts map
-	query := "insert ignore into " + schemaName + "." + syncPointTableName +
+	query := "insert ignore into " + filter.TiCDCSystemSchema + "." + filter.SyncPointTable +
 		"(ticdc_cluster_id, changefeed, primary_ts, secondary_ts) VALUES (?,?,?,?)"
 	_, err = tx.Exec(query, s.clusterID, id.ID, checkpointTs, secondaryTs)
 	if err != nil {
@@ -186,8 +180,8 @@ func (s *mysqlSyncPointStore) SinkSyncPoint(ctx context.Context,
 	if time.Since(s.lastCleanSyncPointTime) >= s.syncPointRetention {
 		query = fmt.Sprintf(
 			"DELETE IGNORE FROM "+
-				schemaName+"."+
-				syncPointTableName+
+				filter.TiCDCSystemSchema+"."+
+				filter.SyncPointTable+
 				" WHERE ticdc_cluster_id = '%s' and changefeed = '%s' and created_at < (NOW() - INTERVAL %.2f SECOND)",
 			s.clusterID,
 			id.ID,

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -20,6 +20,13 @@ import (
 	"github.com/pingcap/tiflow/pkg/config"
 )
 
+const (
+	// SyncPointTable is the tale name use to write ts-map when sync-point is enable.
+	SyncPointTable = "syncpoint_v1"
+	// TiCDCSystemSchema is the schema only use by TiCDC.
+	TiCDCSystemSchema = "tidb_cdc"
+)
+
 // allowDDLList is a list of DDL types that can be applied to cdc's schema storage.
 // It's a white list.
 var allowDDLList = []timodel.ActionType{

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -33,7 +33,7 @@ func TestShouldUseDefaultRules(t *testing.T) {
 	require.True(t, filter.ShouldIgnoreTable("performance_schema", ""))
 	require.False(t, filter.ShouldIgnoreTable("metric_schema", "query_duration"))
 	require.False(t, filter.ShouldIgnoreTable("sns", "user"))
-	require.False(t, filter.ShouldIgnoreTable("tidb_cdc", "repl_mark_a_a"))
+	require.True(t, filter.ShouldIgnoreTable("tidb_cdc", "repl_mark_a_a"))
 }
 
 func TestShouldUseCustomRules(t *testing.T) {

--- a/pkg/filter/utils.go
+++ b/pkg/filter/utils.go
@@ -27,7 +27,14 @@ import (
 
 // isSysSchema returns true if the given schema is a system schema
 func isSysSchema(db string) bool {
-	return tifilter.IsSystemSchema(db)
+	switch db {
+	// schema `tidb_cdc` is used in syncpoint function.
+	// Tables in `tidb_cdc` should not be replicated by cdc.
+	case "tidb_cdc":
+		return true
+	default:
+		return tifilter.IsSystemSchema(db)
+	}
 }
 
 // VerifyTableRules checks the table filter rules in the configuration

--- a/pkg/filter/utils.go
+++ b/pkg/filter/utils.go
@@ -28,9 +28,9 @@ import (
 // isSysSchema returns true if the given schema is a system schema
 func isSysSchema(db string) bool {
 	switch db {
-	// schema `tidb_cdc` is used in syncpoint function.
-	// Tables in `tidb_cdc` should not be replicated by cdc.
-	case "tidb_cdc":
+	// TiCDCSystemSchema is used by TiCDC only.
+	// Tables in TiCDCSystemSchema should not be replicated by cdc.
+	case TiCDCSystemSchema:
 		return true
 	default:
 		return tifilter.IsSystemSchema(db)

--- a/pkg/filter/utils_test.go
+++ b/pkg/filter/utils_test.go
@@ -42,6 +42,7 @@ func TestIsSchema(t *testing.T) {
 		{tifilter.InspectionSchemaName, true},
 		{tifilter.PerformanceSchemaName, true},
 		{tifilter.MetricSchemaName, true},
+		{"tidb_cdc", true},
 	}
 	for _, c := range cases {
 		require.Equal(t, c.result, isSysSchema(c.schema))

--- a/pkg/filter/utils_test.go
+++ b/pkg/filter/utils_test.go
@@ -42,7 +42,7 @@ func TestIsSchema(t *testing.T) {
 		{tifilter.InspectionSchemaName, true},
 		{tifilter.PerformanceSchemaName, true},
 		{tifilter.MetricSchemaName, true},
-		{"tidb_cdc", true},
+		{TiCDCSystemSchema, true},
 	}
 	for _, c := range cases {
 		require.Equal(t, c.result, isSysSchema(c.schema))

--- a/tests/integration_tests/bdr_mode/conf/cf.toml
+++ b/tests/integration_tests/bdr_mode/conf/cf.toml
@@ -1,1 +1,0 @@
-bdr-mode = true

--- a/tests/integration_tests/bdr_mode/conf/down.toml
+++ b/tests/integration_tests/bdr_mode/conf/down.toml
@@ -1,0 +1,1 @@
+bdr-mode = true

--- a/tests/integration_tests/bdr_mode/conf/up.toml
+++ b/tests/integration_tests/bdr_mode/conf/up.toml
@@ -1,0 +1,3 @@
+bdr-mode = true
+enable-sync-point = true
+sync-point-interval = "30s"

--- a/tests/integration_tests/bdr_mode/run.sh
+++ b/tests/integration_tests/bdr_mode/run.sh
@@ -30,14 +30,18 @@ function run() {
 	SINK_URI_2="mysql://root@127.0.0.1:4000"
 
 	# up -> down
-	run_cdc_cli changefeed create --sink-uri="$SINK_URI_1" -c "test-1" --config="$CUR/conf/cf.toml"
+	run_cdc_cli changefeed create --sink-uri="$SINK_URI_1" -c "test-1" --config="$CUR/conf/up.toml"
 	# down -> up
-	run_cdc_cli changefeed create --sink-uri="$SINK_URI_2" -c "test-2" --server "http://127.0.0.1:8400" --config="$CUR/conf/cf.toml"
+	run_cdc_cli changefeed create --sink-uri="$SINK_URI_2" -c "test-2" --server "http://127.0.0.1:8400" --config="$CUR/conf/down.toml"
 
 	run_sql_file $CUR/data/up.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql_file $CUR/data/down.sql ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 
 	run_sql_file $CUR/data/finished.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+	# syncpoint table should exists in secondary tidb, but does not exists in primary cluster
+	check_table_exists "tidb_cdc.syncpoint_v1" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 60
+	check_table_not_exists "tidb_cdc.syncpoint_v1" ${UP_TIDB_HOST} ${UP_TIDB_PORT} 60
 
 	check_table_exists "bdr_mode.finish_mark" ${UP_TIDB_HOST} ${UP_TIDB_PORT} 60
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10576 

### What is changed and how it works?
Make isSysSchema() also treat `tidb_cdc` as a system schema. 
This also helps the case of non-BDR "A→B→C" scenario, where the syncpoint table of A→B polluted B→C.
When the schema `tidb_cdc` is considered as a system schema, it will not be listened to by CDC at all.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a bug that causes syncpoint table being replicated by cdc.
```
