### PR TITLE
tests (ticdc): make bdr_mode integration test more stable

### DIFF
--- a/tests/integration_tests/bdr_mode/data/up.sql
+++ b/tests/integration_tests/bdr_mode/data/up.sql
@@ -151,6 +151,7 @@ INSERT INTO t4 (id, name) VALUES (29, 'Michael 7');
 INSERT INTO t4 (id, name) VALUES (30, 'Sophia 7');
 
 
+SLEEP(30) -- waiting for `add index` finish in downstream TiDB
 -- drop not unique index
 ALTER TABLE t3 DROP INDEX idx_name_age;
 

--- a/tests/integration_tests/bdr_mode/data/up.sql
+++ b/tests/integration_tests/bdr_mode/data/up.sql
@@ -151,7 +151,7 @@ INSERT INTO t4 (id, name) VALUES (29, 'Michael 7');
 INSERT INTO t4 (id, name) VALUES (30, 'Sophia 7');
 
 
-SLEEP(30) -- waiting for `add index` finish in downstream TiDB
+DO SLEEP(30); -- waiting for `add index` finish in downstream TiDB
 -- drop not unique index
 ALTER TABLE t3 DROP INDEX idx_name_age;
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10619 

### What is changed and how it works?

This issue occurs because the "add index" operation may take some time to complete downstream. If we add and drop the same index sequentially, the "drop index" operation may fail because the index doesn't exist yet, as the "add index" operation has not finished.

To ensure the success of the "add index" operation, a `SLEEP(30)` command is added before the "drop index" operation.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
