### PR TITLE
codecov: make project coverage status informational

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,9 +10,11 @@ coverage:
     project:
       default:
         threshold: 3 #Allow the coverage to drop by threshold%, and posting a success status.
+        informational: true
     patch:
       default:
         target: 0%
+        informational: true
     changes: no
 
 parsers:


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref https://github.com/pingcap/tiflow/issues/10473

### What is changed and how it works?
To make the codecov status of project just informational in github commit statuses on components and flags level, not fail the commit statuses.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - [x] No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
