### PR TITLE
sorter(cdc): correct stale table range cleaning and metric it

### DIFF
--- a/cdc/processor/sourcemanager/sorter/metrics.go
+++ b/cdc/processor/sourcemanager/sorter/metrics.go
@@ -101,6 +101,13 @@ var (
 		Name:      "block_cache_access_total",
 		Help:      "The total number of db block cache access",
 	}, []string{"id", "type"})
+
+	dbRangeCleanCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "ticdc",
+		Subsystem: "db",
+		Name:      "range_clean_count",
+		Help:      "The total number of db range clean",
+	})
 )
 
 /* Some metrics are shared in pipeline sorter and pull-based-sink sort engine */
@@ -155,6 +162,11 @@ func BlockCacheAccess() *prometheus.GaugeVec {
 	return dbBlockCacheAccess
 }
 
+// RangeCleanCount returns dbRangeCleanCount.
+func RangeCleanCount() prometheus.Counter {
+	return dbRangeCleanCount
+}
+
 // InitMetrics registers all metrics in this file
 func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(mountWaitDuration)
@@ -170,4 +182,5 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(dbLevelCount)
 	registry.MustRegister(dbWriteDelayCount)
 	registry.MustRegister(dbBlockCacheAccess)
+	registry.MustRegister(dbRangeCleanCount)
 }

--- a/cdc/processor/sourcemanager/sorter/pebble/event_sorter.go
+++ b/cdc/processor/sourcemanager/sorter/pebble/event_sorter.go
@@ -520,6 +520,11 @@ func (s *EventSorter) cleanTable(
 	db := s.dbs[getDB(span, len(s.dbs))]
 	err := db.DeleteRange(start, end, &pebble.WriteOptions{Sync: false})
 	if err != nil {
+		log.Info("clean stale table range fails",
+			zap.String("namespace", s.changefeedID.Namespace),
+			zap.String("changefeed", s.changefeedID.ID),
+			zap.Stringer("span", &span),
+			zap.Error(err))
 		return err
 	}
 

--- a/cdc/processor/sourcemanager/sorter/pebble/event_sorter.go
+++ b/cdc/processor/sourcemanager/sorter/pebble/event_sorter.go
@@ -515,8 +515,7 @@ func (s *EventSorter) cleanTable(
 
 	start = encoding.EncodeTsKey(state.uniqueID, uint64(span.TableID), 0)
 	toCleanNext := toClean.Next()
-	end = encoding.EncodeTsKey(
-		state.uniqueID, uint64(span.TableID), toCleanNext.CommitTs, toCleanNext.StartTs)
+	end = encoding.EncodeTsKey(state.uniqueID, uint64(span.TableID), toCleanNext.CommitTs, toCleanNext.StartTs)
 
 	db := s.dbs[getDB(span, len(s.dbs))]
 	err := db.DeleteRange(start, end, &pebble.WriteOptions{Sync: false})
@@ -524,6 +523,7 @@ func (s *EventSorter) cleanTable(
 		return err
 	}
 
+	sorter.RangeCleanCount().Inc()
 	state.cleaned = toClean
 	return nil
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10641 

### What is changed and how it works?

#10467 introduces a bug that `SortEngine` disk space can't be recycled if redo isn't enabled. This PR corrects it.

And, add a metric to count stale table range cleaning.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
   here is a test for **WITHOUT the patch** and **WITH the patch**:
   ![图片](https://github.com/pingcap/tiflow/assets/8407317/a296d3d4-4294-476b-9a86-e8eaf5d36fa7)


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
