### PR TITLE
test(ticdc): pulsar consumer support oauth and mtls auth

### DIFF
--- a/cmd/pulsar-consumer/main.go
+++ b/cmd/pulsar-consumer/main.go
@@ -68,9 +68,9 @@ type ConsumerOption struct {
 	ca, cert, key string
 
 	oauth2PrivateKey string
-	oauth2IssuerUrl  string
+	oauth2IssuerURL  string
 	privateKey       string
-	oauth2ClientId   string
+	oauth2ClientID   string
 	oauth2Audience   string
 
 	mtlsAuthTLSCertificatePath string
@@ -154,8 +154,8 @@ func main() {
 	cmd.Flags().StringVar(&consumerOption.logPath, "log-file", "cdc_pulsar_consumer.log", "log file path")
 	cmd.Flags().StringVar(&consumerOption.logLevel, "log-level", "info", "log file path")
 	cmd.Flags().StringVar(&consumerOption.oauth2PrivateKey, "oauth2-private-key", "", "oauth2 private key path")
-	cmd.Flags().StringVar(&consumerOption.oauth2IssuerUrl, "oauth2-issuer-url", "", "oauth2 issuer url")
-	cmd.Flags().StringVar(&consumerOption.oauth2ClientId, "oauth2-client-id", "", "oauth2 client id")
+	cmd.Flags().StringVar(&consumerOption.oauth2IssuerURL, "oauth2-issuer-url", "", "oauth2 issuer url")
+	cmd.Flags().StringVar(&consumerOption.oauth2ClientID, "oauth2-client-id", "", "oauth2 client id")
 	cmd.Flags().StringVar(&consumerOption.oauth2Audience, "oauth2-audience", "", "oauth2 audience")
 	cmd.Flags().StringVar(&consumerOption.mtlsAuthTLSCertificatePath, "auth-tls-certificate-path", "", "mtls certificate path")
 	cmd.Flags().StringVar(&consumerOption.mtlsAuthTLSCertificatePath, "auth-tls-private-key-path", "", "mtls private key path")
@@ -275,10 +275,10 @@ func NewPulsarConsumer(option *ConsumerOption) (pulsar.Consumer, pulsar.Client) 
 	var authentication pulsar.Authentication
 	if len(option.oauth2PrivateKey) != 0 {
 		authentication = pulsar.NewAuthenticationOAuth2(map[string]string{
-			auth.ConfigParamIssuerURL: option.oauth2IssuerUrl,
+			auth.ConfigParamIssuerURL: option.oauth2IssuerURL,
 			auth.ConfigParamAudience:  option.oauth2Audience,
 			auth.ConfigParamKeyFile:   option.oauth2PrivateKey,
-			auth.ConfigParamClientID:  option.oauth2ClientId,
+			auth.ConfigParamClientID:  option.oauth2ClientID,
 			auth.ConfigParamType:      auth.ConfigParamTypeClientCredentials,
 		})
 		clientOption.Authentication = authentication

--- a/cmd/pulsar-consumer/main.go
+++ b/cmd/pulsar-consumer/main.go
@@ -69,8 +69,8 @@ type ConsumerOption struct {
 
 	oauth2PrivateKey string
 	oauth2IssuerURL  string
-	privateKey       string
 	oauth2ClientID   string
+	oauth2Scope      string
 	oauth2Audience   string
 
 	mtlsAuthTLSCertificatePath string
@@ -156,6 +156,7 @@ func main() {
 	cmd.Flags().StringVar(&consumerOption.oauth2PrivateKey, "oauth2-private-key", "", "oauth2 private key path")
 	cmd.Flags().StringVar(&consumerOption.oauth2IssuerURL, "oauth2-issuer-url", "", "oauth2 issuer url")
 	cmd.Flags().StringVar(&consumerOption.oauth2ClientID, "oauth2-client-id", "", "oauth2 client id")
+	cmd.Flags().StringVar(&consumerOption.oauth2Audience, "oauth2-scope", "", "oauth2 scope")
 	cmd.Flags().StringVar(&consumerOption.oauth2Audience, "oauth2-audience", "", "oauth2 audience")
 	cmd.Flags().StringVar(&consumerOption.mtlsAuthTLSCertificatePath, "auth-tls-certificate-path", "", "mtls certificate path")
 	cmd.Flags().StringVar(&consumerOption.mtlsAuthTLSPrivateKeyPath, "auth-tls-private-key-path", "", "mtls private key path")
@@ -279,6 +280,7 @@ func NewPulsarConsumer(option *ConsumerOption) (pulsar.Consumer, pulsar.Client) 
 			auth.ConfigParamAudience:  option.oauth2Audience,
 			auth.ConfigParamKeyFile:   option.oauth2PrivateKey,
 			auth.ConfigParamClientID:  option.oauth2ClientID,
+			auth.ConfigParamScope:     option.oauth2Scope,
 			auth.ConfigParamType:      auth.ConfigParamTypeClientCredentials,
 		})
 		log.Info("oauth2 authentication is enabled", zap.String("issuer url", option.oauth2IssuerURL))


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10653

### What is changed and how it works?
add some command line options to support oauth2 and mtls auth,  so we can test pulsar sink with oauth2 or mtls enabled in integrations tests.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
 `None`.
```
