### PR TITLE
reduce table level logs for module kv-client

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -1485,7 +1485,7 @@ func (s *eventFeedSession) logSlowRegions(ctx context.Context) error {
 		attr := s.rangeLock.CollectLockedRangeAttrs(nil)
 		ckptTime := oracle.GetTimeFromTS(attr.SlowestRegion.ResolvedTs)
 		currTime := s.client.pdClock.CurrentTime()
-		log.Info("event feed starts to check locked regions",
+		s.client.logRegionDetails("event feed starts to check locked regions",
 			zap.String("namespace", s.changefeed.Namespace),
 			zap.String("changefeed", s.changefeed.ID),
 			zap.Int64("tableID", s.tableID),


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #10486 

### What is changed and how it works?

There is still a table level log `starts to check locked regions`. If there are lots of tables, the log will be print too frequently.

This PR disables the log by default. However, it's still enabled for `SharedClient`, because it's a changefeed level log in `SharedClient`.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
