### PR TITLE
go.mod: replace seahash with a valid github repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -411,3 +411,5 @@ replace gorm.io/driver/mysql v1.4.5 => gorm.io/driver/mysql v1.3.3
 replace sourcegraph.com/sourcegraph/appdash => github.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0
 
 replace sourcegraph.com/sourcegraph/appdash-data => github.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
+
+replace blainsmith.com/go/seahash => github.com/YangKeao/seahash v0.0.0-20240229041150-e7bf269c3140

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-blainsmith.com/go/seahash v1.2.1 h1:6tEG97FuuhU06FdFD4tXZlyw7saa9CoXBorsc+rnuZA=
-blainsmith.com/go/seahash v1.2.1/go.mod h1:pnKU6FdQMfYOGoDBo5FPdlZG7kmOJ/nuNyfu0czty8k=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -86,6 +84,8 @@ github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1o
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/VividCortex/mysqlerr v1.0.0 h1:5pZ2TZA+YnzPgzBfiUWGqWmKDVNBdrkf9g+DNe1Tiq8=
 github.com/VividCortex/mysqlerr v1.0.0/go.mod h1:xERx8E4tBhLvpjzdUyQiSfUxeMcATEQrflDAfXsqcAE=
+github.com/YangKeao/seahash v0.0.0-20240229041150-e7bf269c3140 h1:t7DNyDoEPlT5YYkkTBHEH90VZ3GSZXCPD4d2zLnqhds=
+github.com/YangKeao/seahash v0.0.0-20240229041150-e7bf269c3140/go.mod h1:pnKU6FdQMfYOGoDBo5FPdlZG7kmOJ/nuNyfu0czty8k=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10673

### What is changed and how it works?

Use a cloned repo to replace the official seahash, because the original seahash repo has been removed.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - [x] No code

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
