### PR TITLE
codec(ticdc): simple protocol decoder support cache message and return table info delayed events

### DIFF
--- a/cmd/kafka-consumer/main.go
+++ b/cmd/kafka-consumer/main.go
@@ -592,7 +592,7 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 
 	eventGroups := make(map[int64]*eventsGroup)
 	for message := range claim.Messages() {
-		if err := decoder.AddKeyValue(message.Key, message.Value); err != nil {
+		if err = decoder.AddKeyValue(message.Key, message.Value); err != nil {
 			log.Error("add key value to the decoder failed", zap.Error(err))
 			return cerror.Trace(err)
 		}
@@ -629,7 +629,8 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 						zap.ByteString("value", message.Value),
 						zap.Error(err))
 				}
-				if partition == 0 {
+				// the Query maybe empty if using simple protocol, it's comes from `bootstrap` event.
+				if partition == 0 && ddl.Query != "" {
 					c.appendDDL(ddl)
 				}
 				// todo: mark the offset after the DDL is fully synced to the downstream mysql.
@@ -755,7 +756,7 @@ func (c *Consumer) appendDDL(ddl *model.DDLEvent) {
 		log.Warn("DDL CommitTs < maxCommitTsDDL.CommitTs",
 			zap.Uint64("commitTs", ddl.CommitTs),
 			zap.Uint64("maxCommitTs", c.ddlWithMaxCommitTs.CommitTs),
-			zap.Any("DDL", ddl))
+			zap.String("DDL", ddl.Query))
 		return
 	}
 
@@ -764,12 +765,12 @@ func (c *Consumer) appendDDL(ddl *model.DDLEvent) {
 	// the current DDL and the DDL with max CommitTs.
 	if ddl == c.ddlWithMaxCommitTs {
 		log.Info("ignore redundant DDL, the DDL is equal to ddlWithMaxCommitTs",
-			zap.Any("DDL", ddl))
+			zap.Uint64("commitTs", ddl.CommitTs), zap.String("DDL", ddl.Query))
 		return
 	}
 
 	c.ddlList = append(c.ddlList, ddl)
-	log.Info("DDL event received", zap.Any("DDL", ddl))
+	log.Info("DDL event received", zap.Uint64("commitTs", ddl.CommitTs), zap.String("DDL", ddl.Query))
 	c.ddlWithMaxCommitTs = ddl
 }
 

--- a/pkg/sink/codec/simple/decoder.go
+++ b/pkg/sink/codec/simple/decoder.go
@@ -14,10 +14,10 @@
 package simple
 
 import (
+	"container/list"
 	"context"
 	"database/sql"
 	"path/filepath"
-	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
@@ -30,7 +30,7 @@ import (
 	"go.uber.org/zap"
 )
 
-type decoder struct {
+type Decoder struct {
 	config *common.Config
 
 	marshaller marshaller
@@ -41,10 +41,15 @@ type decoder struct {
 	value []byte
 	msg   *message
 	memo  TableInfoProvider
+
+	// cachedMessages is used to store the messages which does not have received corresponding table info yet.
+	cachedMessages *list.List
+	// CachedRowChangedEvents are events just decoded from the cachedMessages
+	CachedRowChangedEvents []*model.RowChangedEvent
 }
 
-// NewDecoder returns a new decoder
-func NewDecoder(ctx context.Context, config *common.Config, db *sql.DB) (*decoder, error) {
+// NewDecoder returns a new Decoder
+func NewDecoder(ctx context.Context, config *common.Config, db *sql.DB) (*Decoder, error) {
 	var (
 		externalStorage storage.ExternalStorage
 		err             error
@@ -67,22 +72,23 @@ func NewDecoder(ctx context.Context, config *common.Config, db *sql.DB) (*decode
 		return nil, errors.Trace(err)
 	}
 
-	return &decoder{
+	return &Decoder{
 		config:     config,
 		marshaller: m,
 
 		storage:      externalStorage,
 		upstreamTiDB: db,
 
-		memo: newMemoryTableInfoProvider(),
+		memo:           newMemoryTableInfoProvider(),
+		cachedMessages: list.New(),
 	}, nil
 }
 
-// AddKeyValue add the received key and values to the decoder,
-func (d *decoder) AddKeyValue(_, value []byte) error {
+// AddKeyValue add the received key and values to the Decoder,
+func (d *Decoder) AddKeyValue(_, value []byte) error {
 	if d.value != nil {
 		return cerror.ErrDecodeFailed.GenWithStack(
-			"decoder value already exists, not consumed yet")
+			"Decoder value already exists, not consumed yet")
 	}
 	value, err := common.Decompress(d.config.LargeMessageHandle.LargeMessageHandleCompression, value)
 	if err != nil {
@@ -93,7 +99,7 @@ func (d *decoder) AddKeyValue(_, value []byte) error {
 }
 
 // HasNext returns whether there is any event need to be consumed
-func (d *decoder) HasNext() (model.MessageType, bool, error) {
+func (d *Decoder) HasNext() (model.MessageType, bool, error) {
 	if d.value == nil {
 		return model.MessageTypeUnknown, false, nil
 	}
@@ -118,7 +124,7 @@ func (d *decoder) HasNext() (model.MessageType, bool, error) {
 }
 
 // NextResolvedEvent returns the next resolved event if exists
-func (d *decoder) NextResolvedEvent() (uint64, error) {
+func (d *Decoder) NextResolvedEvent() (uint64, error) {
 	if d.msg.Type != MessageTypeWatermark {
 		return 0, cerror.ErrCodecDecode.GenWithStack(
 			"not found resolved event message")
@@ -131,7 +137,7 @@ func (d *decoder) NextResolvedEvent() (uint64, error) {
 }
 
 // NextRowChangedEvent returns the next row changed event if exists
-func (d *decoder) NextRowChangedEvent() (*model.RowChangedEvent, error) {
+func (d *Decoder) NextRowChangedEvent() (*model.RowChangedEvent, error) {
 	if d.msg == nil || (d.msg.Data == nil && d.msg.Old == nil) {
 		return nil, cerror.ErrCodecDecode.GenWithStack(
 			"invalid row changed event message")
@@ -147,9 +153,14 @@ func (d *decoder) NextRowChangedEvent() (*model.RowChangedEvent, error) {
 
 	tableInfo := d.memo.Read(d.msg.Schema, d.msg.Table, d.msg.SchemaVersion)
 	if tableInfo == nil {
-		return nil, cerror.ErrCodecDecode.GenWithStack(
-			"cannot found the table info, schema: %s, table: %s, version: %d",
-			d.msg.Schema, d.msg.Table, d.msg.SchemaVersion)
+		log.Warn("table info not found for the event, "+
+			"the consumer should cache this event temporarily, and update the tableInfo after it's received",
+			zap.String("schema", d.msg.Schema),
+			zap.String("table", d.msg.Table),
+			zap.Uint64("version", d.msg.SchemaVersion))
+		d.cachedMessages.PushBack(d.msg)
+		d.msg = nil
+		return nil, nil
 	}
 
 	event, err := buildRowChangedEvent(d.msg, tableInfo, d.config.EnableRowChecksum)
@@ -161,7 +172,7 @@ func (d *decoder) NextRowChangedEvent() (*model.RowChangedEvent, error) {
 	return event, nil
 }
 
-func (d *decoder) assembleClaimCheckRowChangedEvent(claimCheckLocation string) (*model.RowChangedEvent, error) {
+func (d *Decoder) assembleClaimCheckRowChangedEvent(claimCheckLocation string) (*model.RowChangedEvent, error) {
 	_, claimCheckFileName := filepath.Split(claimCheckLocation)
 	data, err := d.storage.ReadFile(context.Background(), claimCheckFileName)
 	if err != nil {
@@ -186,7 +197,7 @@ func (d *decoder) assembleClaimCheckRowChangedEvent(claimCheckLocation string) (
 	return d.NextRowChangedEvent()
 }
 
-func (d *decoder) assembleHandleKeyOnlyRowChangedEvent(m *message) (*model.RowChangedEvent, error) {
+func (d *Decoder) assembleHandleKeyOnlyRowChangedEvent(m *message) (*model.RowChangedEvent, error) {
 	tableInfo := d.memo.Read(m.Schema, m.Table, m.SchemaVersion)
 	if tableInfo == nil {
 		return nil, cerror.ErrCodecDecode.GenWithStack(
@@ -256,7 +267,7 @@ func (d *decoder) assembleHandleKeyOnlyRowChangedEvent(m *message) (*model.RowCh
 	return d.NextRowChangedEvent()
 }
 
-func (d *decoder) buildData(
+func (d *Decoder) buildData(
 	holder *common.ColumnsHolder, fieldTypeMap map[string]*types.FieldType,
 ) (map[string]interface{}, error) {
 	columnsCount := holder.Length()
@@ -278,7 +289,7 @@ func (d *decoder) buildData(
 }
 
 // NextDDLEvent returns the next DDL event if exists
-func (d *decoder) NextDDLEvent() (*model.DDLEvent, error) {
+func (d *Decoder) NextDDLEvent() (*model.DDLEvent, error) {
 	if d.msg == nil {
 		return nil, cerror.ErrCodecDecode.GenWithStack(
 			"no message found when decode DDL event")
@@ -292,7 +303,30 @@ func (d *decoder) NextDDLEvent() (*model.DDLEvent, error) {
 	d.memo.Write(ddl.TableInfo)
 	d.memo.Write(ddl.PreTableInfo)
 
+	for ele := d.cachedMessages.Front(); ele != nil; {
+		d.msg = ele.Value.(*message)
+		event, err := d.NextRowChangedEvent()
+		if err != nil {
+			return nil, err
+		}
+		if event == nil {
+			ele = ele.Next()
+			continue
+		}
+		d.CachedRowChangedEvents = append(d.CachedRowChangedEvents, event)
+
+		next := ele.Next()
+		d.cachedMessages.Remove(ele)
+		ele = next
+	}
 	return ddl, nil
+}
+
+// GetCachedEvents returns the cached events
+func (d *Decoder) GetCachedEvents() []*model.RowChangedEvent {
+	result := d.CachedRowChangedEvents
+	d.cachedMessages = nil
+	return result
 }
 
 // TableInfoProvider is used to store and read table info
@@ -349,33 +383,11 @@ func (m *memoryTableInfoProvider) Read(schema, table string, version uint64) *mo
 		version: version,
 	}
 
-	// Note(dongmen): Since the decoder is only use in unit test for now,
-	// we don't need to consider the performance
-	// Just use a ticker to check if the table info is stored every second.
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
-
-	for {
-		entry, ok := m.memo[key]
-		if ok {
-			return entry
-		}
-		select {
-		case <-ticker.C:
-			entry, ok = m.memo[key]
-			if ok {
-				return entry
-			}
-		case <-ctx.Done():
-			log.Panic("table info read timeout",
-				zap.String("schema", schema),
-				zap.String("table", table),
-				zap.Uint64("version", version))
-			return nil
-		}
+	entry, ok := m.memo[key]
+	if ok {
+		return entry
 	}
+	return nil
 }
 
 type tableSchemaKey struct {

--- a/pkg/sink/codec/simple/decoder.go
+++ b/pkg/sink/codec/simple/decoder.go
@@ -326,7 +326,7 @@ func (d *Decoder) NextDDLEvent() (*model.DDLEvent, error) {
 // GetCachedEvents returns the cached events
 func (d *Decoder) GetCachedEvents() []*model.RowChangedEvent {
 	result := d.CachedRowChangedEvents
-	d.cachedMessages = nil
+	d.CachedRowChangedEvents = nil
 	return result
 }
 

--- a/pkg/sink/codec/simple/decoder.go
+++ b/pkg/sink/codec/simple/decoder.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/zap"
 )
 
+// Decoder implement the RowEventDecoder interface
 type Decoder struct {
 	config *common.Config
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10678

### What is changed and how it works?

* if the table info not found, cache the message into a list
* after the table info received, decode the message into event if possible
* kafka consumer check cached event and consume it

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
