### PR TITLE
simple (ticdc): fix simple rename table ddl handle error

### DIFF
--- a/pkg/sink/codec/bootstraper.go
+++ b/pkg/sink/codec/bootstraper.go
@@ -109,7 +109,7 @@ func (b *bootstrapWorker) addEvent(
 ) error {
 	table, ok := b.activeTables.Load(row.PhysicalTableID)
 	if !ok {
-		tb := newTableStatus(key, row)
+		tb := newTableStatistic(key, row)
 		b.activeTables.Store(tb.id, tb)
 		// Send bootstrap message immediately when a new table is added
 		err := b.sendBootstrapMsg(ctx, tb)
@@ -218,7 +218,7 @@ type tableStatistic struct {
 	tableInfo atomic.Value
 }
 
-func newTableStatus(key model.TopicPartitionKey, row *model.RowChangedEvent) *tableStatistic {
+func newTableStatistic(key model.TopicPartitionKey, row *model.RowChangedEvent) *tableStatistic {
 	res := &tableStatistic{
 		id:    row.PhysicalTableID,
 		topic: key.Topic,
@@ -245,11 +245,13 @@ func (t *tableStatistic) update(row *model.RowChangedEvent, totalPartition int32
 	t.counter.Add(1)
 	t.lastMsgReceivedTime.Store(time.Now())
 
-	if t.version.Load() != row.TableInfo.UpdateTS {
+	// Note(dongmen): Rename Table DDL is a special case,
+	// the TableInfo.Name is changed but the TableInfo.UpdateTs is not changed.
+	if t.version.Load() != row.TableInfo.UpdateTS ||
+		t.tableInfo.Load().(*model.TableInfo).Name != row.TableInfo.Name {
 		t.version.Store(row.TableInfo.UpdateTS)
 		t.tableInfo.Store(row.TableInfo)
 	}
-
 	if t.totalPartition.Load() != totalPartition {
 		t.totalPartition.Store(totalPartition)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #9898 

### What is changed and how it works?

After a rename table ddl happens, the `tableStatistic` of the table in `bootstraper` should be updated.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
