### PR TITLE
dm: fix update dml loss if binary column is primary key (#10685)

### DIFF
--- a/dm/tests/many_tables/run.sh
+++ b/dm/tests/many_tables/run.sh
@@ -100,8 +100,7 @@ function run() {
 	check_sync_diff $WORK_DIR $cur/conf/diff_config.toml
 	check_metric $WORKER1_PORT 'lightning_tables{result="success",source_id="mysql-replica-01",state="completed",task="test"}' 1 $(($TABLE_NUM - 1)) $(($TABLE_NUM + 1))
 
-	run_sql_tidb "select count(*) from dm_meta.test_syncer_checkpoint"
-	check_contains "count(*): $(($TABLE_NUM + 1))"
+	run_sql_tidb_with_retry "select count(*) from dm_meta.test_syncer_checkpoint" "count(*): $(($TABLE_NUM + 1))"
 
 	check_log_contains $WORK_DIR/worker1/log/dm-worker.log 'Error 8004: Transaction is too large'
 

--- a/dm/tests/shardddl1_1/conf/single-source-no-sharding.yaml
+++ b/dm/tests/shardddl1_1/conf/single-source-no-sharding.yaml
@@ -48,3 +48,4 @@ syncers:
   global:
     worker-count: 16
     batch: 100
+    safe-mode-duration: 0


### PR DESCRIPTION
close pingcap/tiflow#10672

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10672 

### What is changed and how it works?
ref: https://dev.mysql.com/doc/refman/8.0/en/binary-varbinary.html
if column is binary type, we should padding it with \0, otherwise the where condition will also be false

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fixed the issue where data loss could occur when the upstream primary key is of binary type.
```
