### PR TITLE
kafka(ticdc): use table dispatcher as the default dispatcher

### DIFF
--- a/cdc/sink/dmlsink/mq/dispatcher/event_router.go
+++ b/cdc/sink/dmlsink/mq/dispatcher/event_router.go
@@ -243,7 +243,7 @@ func getPartitionDispatcher(
 	case partitionDispatchRuleTable:
 		d = partition.NewTableDispatcher()
 	case partitionDispatchRuleDefault:
-		d = partition.NewDefaultDispatcher(enableOldValue)
+		d = partition.NewDefaultDispatcher()
 	}
 
 	return d

--- a/cdc/sink/dmlsink/mq/dispatcher/event_router_test.go
+++ b/cdc/sink/dmlsink/mq/dispatcher/event_router_test.go
@@ -293,7 +293,7 @@ func TestGetPartitionForRowChange(t *testing.T) {
 		},
 		IndexColumns: [][]int{{0}},
 	}, 16)
-	require.Equal(t, int32(10), p)
+	require.Equal(t, int32(14), p)
 	p = d.GetPartitionForRowChange(&model.RowChangedEvent{
 		Table: &model.TableName{Schema: "test_default2", Table: "table"},
 		Columns: []*model.Column{
@@ -305,7 +305,7 @@ func TestGetPartitionForRowChange(t *testing.T) {
 		},
 		IndexColumns: [][]int{{0}},
 	}, 16)
-	require.Equal(t, int32(4), p)
+	require.Equal(t, int32(0), p)
 
 	p = d.GetPartitionForRowChange(&model.RowChangedEvent{
 		Table:    &model.TableName{Schema: "test_table", Table: "table"},

--- a/cdc/sink/dmlsink/mq/dispatcher/partition/default.go
+++ b/cdc/sink/dmlsink/mq/dispatcher/partition/default.go
@@ -19,28 +19,18 @@ import (
 
 // DefaultDispatcher is the default partition dispatcher.
 type DefaultDispatcher struct {
-	tbd            *TableDispatcher
-	ivd            *IndexValueDispatcher
-	enableOldValue bool
+	tbd *TableDispatcher
 }
 
 // NewDefaultDispatcher creates a DefaultDispatcher.
-func NewDefaultDispatcher(enableOldValue bool) *DefaultDispatcher {
+func NewDefaultDispatcher() *DefaultDispatcher {
 	return &DefaultDispatcher{
-		tbd:            NewTableDispatcher(),
-		ivd:            NewIndexValueDispatcher(),
-		enableOldValue: enableOldValue,
+		tbd: NewTableDispatcher(),
 	}
 }
 
 // DispatchRowChangedEvent returns the target partition to which
 // a row changed event should be dispatched.
 func (d *DefaultDispatcher) DispatchRowChangedEvent(row *model.RowChangedEvent, partitionNum int32) int32 {
-	if d.enableOldValue {
-		return d.tbd.DispatchRowChangedEvent(row, partitionNum)
-	}
-	if len(row.IndexColumns) != 1 {
-		return d.tbd.DispatchRowChangedEvent(row, partitionNum)
-	}
-	return d.ivd.DispatchRowChangedEvent(row, partitionNum)
+	return d.tbd.DispatchRowChangedEvent(row, partitionNum)
 }

--- a/cdc/sink/dmlsink/mq/dispatcher/partition/default_test.go
+++ b/cdc/sink/dmlsink/mq/dispatcher/partition/default_test.go
@@ -40,7 +40,7 @@ func TestDefaultDispatcher(t *testing.T) {
 				},
 			},
 			IndexColumns: [][]int{{0}},
-		}, expectPartition: 11},
+		}, expectPartition: 15},
 		{row: &model.RowChangedEvent{
 			Table: &model.TableName{
 				Schema: "test",
@@ -54,7 +54,7 @@ func TestDefaultDispatcher(t *testing.T) {
 				},
 			},
 			IndexColumns: [][]int{{0}},
-		}, expectPartition: 1},
+		}, expectPartition: 15},
 		{row: &model.RowChangedEvent{
 			Table: &model.TableName{
 				Schema: "test",
@@ -68,7 +68,7 @@ func TestDefaultDispatcher(t *testing.T) {
 				},
 			},
 			IndexColumns: [][]int{{0}},
-		}, expectPartition: 7},
+		}, expectPartition: 15},
 		{row: &model.RowChangedEvent{
 			Table: &model.TableName{
 				Schema: "test",
@@ -85,7 +85,7 @@ func TestDefaultDispatcher(t *testing.T) {
 				},
 			},
 			IndexColumns: [][]int{{0}},
-		}, expectPartition: 1},
+		}, expectPartition: 5},
 		{row: &model.RowChangedEvent{
 			Table: &model.TableName{
 				Schema: "test",
@@ -102,7 +102,7 @@ func TestDefaultDispatcher(t *testing.T) {
 				},
 			},
 			IndexColumns: [][]int{{0}},
-		}, expectPartition: 11},
+		}, expectPartition: 5},
 		{row: &model.RowChangedEvent{
 			Table: &model.TableName{
 				Schema: "test",
@@ -119,7 +119,7 @@ func TestDefaultDispatcher(t *testing.T) {
 				},
 			},
 			IndexColumns: [][]int{{0}},
-		}, expectPartition: 13},
+		}, expectPartition: 5},
 		{row: &model.RowChangedEvent{
 			Table: &model.TableName{
 				Schema: "test",
@@ -136,7 +136,7 @@ func TestDefaultDispatcher(t *testing.T) {
 				},
 			},
 			IndexColumns: [][]int{{0}},
-		}, expectPartition: 13},
+		}, expectPartition: 5},
 		{row: &model.RowChangedEvent{
 			Table: &model.TableName{
 				Schema: "test",

--- a/cdc/sink/dmlsink/mq/dispatcher/partition/default_test.go
+++ b/cdc/sink/dmlsink/mq/dispatcher/partition/default_test.go
@@ -193,34 +193,8 @@ func TestDefaultDispatcher(t *testing.T) {
 			IndexColumns: [][]int{{0}, {1}},
 		}, expectPartition: 3},
 	}
-	p := NewDefaultDispatcher(false)
+	p := NewDefaultDispatcher()
 	for _, tc := range testCases {
 		require.Equal(t, tc.expectPartition, p.DispatchRowChangedEvent(tc.row, 16))
 	}
-}
-
-func TestDefaultDispatcherWithOldValue(t *testing.T) {
-	t.Parallel()
-
-	row := &model.RowChangedEvent{
-		Table: &model.TableName{
-			Schema: "test",
-			Table:  "t3",
-		},
-		Columns: []*model.Column{
-			{
-				Name:  "id",
-				Value: 2,
-				Flag:  model.HandleKeyFlag | model.PrimaryKeyFlag,
-			}, {
-				Name:  "a",
-				Value: 3,
-				Flag:  model.UniqueKeyFlag,
-			},
-		},
-		IndexColumns: [][]int{{0}, {1}},
-	}
-
-	p := NewDefaultDispatcher(true)
-	require.Equal(t, int32(3), p.DispatchRowChangedEvent(row, 16))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10712

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
use table dispatcher as the default dispatcher to guarantee the avro protocol dispatch behavior backward compatibility
```
