### PR TITLE
kv (ticdc): fix kv client data race panic

### DIFF
--- a/cdc/kv/client.go
+++ b/cdc/kv/client.go
@@ -478,6 +478,7 @@ func (s *eventFeedSession) eventFeed(ctx context.Context) error {
 	}()
 
 	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(scanRegionsConcurrency)
 
 	g.Go(func() error { return s.dispatchRequest(ctx) })
 
@@ -486,8 +487,6 @@ func (s *eventFeedSession) eventFeed(ctx context.Context) error {
 	g.Go(func() error { return s.logSlowRegions(ctx) })
 
 	g.Go(func() error {
-		g, ctx := errgroup.WithContext(ctx)
-		g.SetLimit(scanRegionsConcurrency)
 		for {
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10718

### What is changed and how it works?

As described in the issue comment https://github.com/pingcap/tiflow/issues/10718#issuecomment-1980122405, the problem is caused by the goroutine that writes the channel not being uniformly managed by the wait method of the parent goroutine group that created it. 

Therefore, this PR uses the same goroutine group to manage the child goroutines to avoid the occurrence of the problem.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a bug that may cause cdc panic.
```
