### PR TITLE
cli(ticdc): fix create changefeed failure when `enable-old-value` is set to true

### DIFF
--- a/cdc/api/v2/model.go
+++ b/cdc/api/v2/model.go
@@ -184,14 +184,16 @@ func (d *JSONDuration) UnmarshalJSON(b []byte) error {
 
 // ReplicaConfig is a duplicate of  config.ReplicaConfig
 type ReplicaConfig struct {
-	MemoryQuota           uint64 `json:"memory_quota"`
-	CaseSensitive         bool   `json:"case_sensitive"`
-	ForceReplicate        bool   `json:"force_replicate"`
-	IgnoreIneligibleTable bool   `json:"ignore_ineligible_table"`
-	CheckGCSafePoint      bool   `json:"check_gc_safe_point"`
-	EnableSyncPoint       *bool  `json:"enable_sync_point,omitempty"`
-	EnableTableMonitor    *bool  `json:"enable_table_monitor,omitempty"`
-	BDRMode               *bool  `json:"bdr_mode,omitempty"`
+	MemoryQuota   uint64 `json:"memory_quota"`
+	CaseSensitive bool   `json:"case_sensitive"`
+	// Deprecated: we don't use this field since v7.5.0.
+	EnableOldValue        bool  `json:"-"`
+	ForceReplicate        bool  `json:"force_replicate"`
+	IgnoreIneligibleTable bool  `json:"ignore_ineligible_table"`
+	CheckGCSafePoint      bool  `json:"check_gc_safe_point"`
+	EnableSyncPoint       *bool `json:"enable_sync_point,omitempty"`
+	EnableTableMonitor    *bool `json:"enable_table_monitor,omitempty"`
+	BDRMode               *bool `json:"bdr_mode,omitempty"`
 
 	SyncPointInterval  *JSONDuration `json:"sync_point_interval,omitempty" swaggertype:"string"`
 	SyncPointRetention *JSONDuration `json:"sync_point_retention,omitempty" swaggertype:"string"`

--- a/cdc/api/v2/model.go
+++ b/cdc/api/v2/model.go
@@ -520,6 +520,7 @@ func ToAPIReplicaConfig(c *config.ReplicaConfig) *ReplicaConfig {
 	res := &ReplicaConfig{
 		MemoryQuota:           cloned.MemoryQuota,
 		CaseSensitive:         cloned.CaseSensitive,
+		EnableOldValue:        cloned.EnableOldValue,
 		ForceReplicate:        cloned.ForceReplicate,
 		IgnoreIneligibleTable: cloned.IgnoreIneligibleTable,
 		CheckGCSafePoint:      cloned.CheckGCSafePoint,

--- a/pkg/cmd/cli/cli_changefeed_create.go
+++ b/pkg/cmd/cli/cli_changefeed_create.go
@@ -147,10 +147,12 @@ func (o *createChangefeedOptions) complete(f factory.Factory) error {
 func (o *createChangefeedOptions) completeReplicaCfg() error {
 	cfg := config.GetDefaultReplicaConfig()
 	if len(o.commonChangefeedOptions.configFile) > 0 {
+		log.Warn("completeReplicaCfg decode file")
 		if err := o.commonChangefeedOptions.strictDecodeConfig("TiCDC changefeed", cfg); err != nil {
 			return err
 		}
 	}
+	log.Warn("completeReplicaCfg", zap.Bool("enableOldValue", cfg.EnableOldValue))
 
 	uri, err := url.Parse(o.commonChangefeedOptions.sinkURI)
 	if err != nil {

--- a/pkg/cmd/cli/cli_changefeed_create.go
+++ b/pkg/cmd/cli/cli_changefeed_create.go
@@ -165,6 +165,10 @@ func (o *createChangefeedOptions) completeReplicaCfg() error {
 		cfg.Sink.SchemaRegistry = putil.AddressOf(o.commonChangefeedOptions.schemaRegistry)
 	}
 
+	if cfg.EnableOldValue {
+		log.Warn("Config option enable-old-value is deprecated")
+	}
+
 	switch o.commonChangefeedOptions.sortEngine {
 	case model.SortInMemory:
 	case model.SortInFile:

--- a/pkg/cmd/cli/cli_changefeed_create.go
+++ b/pkg/cmd/cli/cli_changefeed_create.go
@@ -88,7 +88,6 @@ func (o *changefeedCommonOptions) addFlags(cmd *cobra.Command) {
 
 // strictDecodeConfig do strictDecodeFile check and only verify the rules for now.
 func (o *changefeedCommonOptions) strictDecodeConfig(component string, cfg *config.ReplicaConfig) error {
-	log.Info("changefeedCommonOptions.strictDecodeConfig")
 	err := util.StrictDecodeFile(o.configFile, component, cfg)
 	if err != nil {
 		return err
@@ -192,6 +191,9 @@ func (o *createChangefeedOptions) validate(cmd *cobra.Command) error {
 	if o.timezone != "SYSTEM" {
 		cmd.Printf(color.HiYellowString("[WARN] --tz is deprecated in changefeed settings.\n"))
 	}
+	if o.cfg.EnableOldValue {
+		cmd.Printf("[WARN] enable-old-value is deprecated in changefeed config files.\n")
+	}
 
 	// user is not allowed to set sort-dir at changefeed level
 	if o.commonChangefeedOptions.sortDir != "" {
@@ -284,9 +286,6 @@ func (o *createChangefeedOptions) run(ctx context.Context, cmd *cobra.Command) e
 		SinkURI:       createChangefeedCfg.SinkURI,
 	}
 
-	if verifyTableConfig.ReplicaConfig.EnableOldValue {
-		cmd.Printf("[WARN] Config option enable-old-value is deprecated.\n")
-	}
 	if !verifyTableConfig.ReplicaConfig.EnableOldValue {
 		cmd.Printf("[WARN] Config not set.\n")
 	}

--- a/pkg/cmd/cli/cli_changefeed_create.go
+++ b/pkg/cmd/cli/cli_changefeed_create.go
@@ -166,10 +166,6 @@ func (o *createChangefeedOptions) completeReplicaCfg() error {
 		cfg.Sink.SchemaRegistry = putil.AddressOf(o.commonChangefeedOptions.schemaRegistry)
 	}
 
-	if cfg.EnableOldValue {
-		log.Warn("Config option enable-old-value is deprecated")
-	}
-
 	switch o.commonChangefeedOptions.sortEngine {
 	case model.SortInMemory:
 	case model.SortInFile:
@@ -284,6 +280,10 @@ func (o *createChangefeedOptions) run(ctx context.Context, cmd *cobra.Command) e
 		ReplicaConfig: createChangefeedCfg.ReplicaConfig,
 		StartTs:       createChangefeedCfg.StartTs,
 		SinkURI:       createChangefeedCfg.SinkURI,
+	}
+
+	if verifyTableConfig.ReplicaConfig.EnableOldValue {
+		cmd.Printf("[WARN] Config option enable-old-value is deprecated.")
 	}
 
 	tables, err := o.apiClient.Changefeeds().VerifyTable(ctx, verifyTableConfig)

--- a/pkg/cmd/cli/cli_changefeed_create.go
+++ b/pkg/cmd/cli/cli_changefeed_create.go
@@ -285,6 +285,7 @@ func (o *createChangefeedOptions) run(ctx context.Context, cmd *cobra.Command) e
 	if verifyTableConfig.ReplicaConfig.EnableOldValue {
 		cmd.Printf("[WARN] Config option enable-old-value is deprecated.")
 	}
+	cmd.Printf("[WARN] Config option enable-old-value is not deprecated.")
 
 	tables, err := o.apiClient.Changefeeds().VerifyTable(ctx, verifyTableConfig)
 	if err != nil {

--- a/pkg/cmd/cli/cli_changefeed_create.go
+++ b/pkg/cmd/cli/cli_changefeed_create.go
@@ -88,6 +88,7 @@ func (o *changefeedCommonOptions) addFlags(cmd *cobra.Command) {
 
 // strictDecodeConfig do strictDecodeFile check and only verify the rules for now.
 func (o *changefeedCommonOptions) strictDecodeConfig(component string, cfg *config.ReplicaConfig) error {
+	log.Info("changefeedCommonOptions.strictDecodeConfig")
 	err := util.StrictDecodeFile(o.configFile, component, cfg)
 	if err != nil {
 		return err

--- a/pkg/cmd/cli/cli_changefeed_create.go
+++ b/pkg/cmd/cli/cli_changefeed_create.go
@@ -146,12 +146,10 @@ func (o *createChangefeedOptions) complete(f factory.Factory) error {
 func (o *createChangefeedOptions) completeReplicaCfg() error {
 	cfg := config.GetDefaultReplicaConfig()
 	if len(o.commonChangefeedOptions.configFile) > 0 {
-		log.Warn("completeReplicaCfg decode file")
 		if err := o.commonChangefeedOptions.strictDecodeConfig("TiCDC changefeed", cfg); err != nil {
 			return err
 		}
 	}
-	log.Warn("completeReplicaCfg", zap.Bool("enableOldValue", cfg.EnableOldValue))
 
 	uri, err := url.Parse(o.commonChangefeedOptions.sinkURI)
 	if err != nil {
@@ -192,7 +190,8 @@ func (o *createChangefeedOptions) validate(cmd *cobra.Command) error {
 		cmd.Printf(color.HiYellowString("[WARN] --tz is deprecated in changefeed settings.\n"))
 	}
 	if o.cfg.EnableOldValue {
-		cmd.Printf("[WARN] enable-old-value is deprecated in changefeed config files.\n")
+		cmd.Printf("[WARN] `enable-old-value` is deprecated in changefeed config files. " +
+			"And it is the default behaviour of cdc now.\n")
 	}
 
 	// user is not allowed to set sort-dir at changefeed level
@@ -284,10 +283,6 @@ func (o *createChangefeedOptions) run(ctx context.Context, cmd *cobra.Command) e
 		ReplicaConfig: createChangefeedCfg.ReplicaConfig,
 		StartTs:       createChangefeedCfg.StartTs,
 		SinkURI:       createChangefeedCfg.SinkURI,
-	}
-
-	if !verifyTableConfig.ReplicaConfig.EnableOldValue {
-		cmd.Printf("[WARN] Config not set.\n")
 	}
 
 	tables, err := o.apiClient.Changefeeds().VerifyTable(ctx, verifyTableConfig)

--- a/pkg/cmd/cli/cli_changefeed_create.go
+++ b/pkg/cmd/cli/cli_changefeed_create.go
@@ -283,9 +283,11 @@ func (o *createChangefeedOptions) run(ctx context.Context, cmd *cobra.Command) e
 	}
 
 	if verifyTableConfig.ReplicaConfig.EnableOldValue {
-		cmd.Printf("[WARN] Config option enable-old-value is deprecated.")
+		cmd.Printf("[WARN] Config option enable-old-value is deprecated.\n")
 	}
-	cmd.Printf("[WARN] Config option enable-old-value is not deprecated.")
+	if !verifyTableConfig.ReplicaConfig.EnableOldValue {
+		cmd.Printf("[WARN] Config not set.\n")
+	}
 
 	tables, err := o.apiClient.Changefeeds().VerifyTable(ctx, verifyTableConfig)
 	if err != nil {

--- a/pkg/cmd/cli/cli_changefeed_helper.go
+++ b/pkg/cmd/cli/cli_changefeed_helper.go
@@ -93,7 +93,7 @@ func confirmOverwriteCheckpointTs(
 // If ignore it will return true.
 func confirmIgnoreIneligibleTables(cmd *cobra.Command) (bool, error) {
 	cmd.Printf("Could you agree to ignore those tables, and continue to replicate [Y/N]\n" +
-		"Note: If you don't want to ignore those tables, please set `force-replicate to` true " +
+		"Note: If you don't want to ignore those tables, please set `force-replicate` to true " +
 		"in the changefeed config file.\n")
 	confirmed := readYOrN(cmd)
 	if !confirmed {

--- a/pkg/config/replica_config.go
+++ b/pkg/config/replica_config.go
@@ -125,10 +125,12 @@ func (d *Duration) UnmarshalText(text []byte) error {
 type ReplicaConfig replicaConfig
 
 type replicaConfig struct {
-	MemoryQuota      uint64 `toml:"memory-quota" json:"memory-quota"`
-	CaseSensitive    bool   `toml:"case-sensitive" json:"case-sensitive"`
-	ForceReplicate   bool   `toml:"force-replicate" json:"force-replicate"`
-	CheckGCSafePoint bool   `toml:"check-gc-safe-point" json:"check-gc-safe-point"`
+	MemoryQuota   uint64 `toml:"memory-quota" json:"memory-quota"`
+	CaseSensitive bool   `toml:"case-sensitive" json:"case-sensitive"`
+	// Deprecated: we don't use this field since v7.5.0.
+	EnableOldValue   bool `toml:"enable-old-value" json:"-"`
+	ForceReplicate   bool `toml:"force-replicate" json:"force-replicate"`
+	CheckGCSafePoint bool `toml:"check-gc-safe-point" json:"check-gc-safe-point"`
 	// EnableSyncPoint is only available when the downstream is a Database.
 	EnableSyncPoint    *bool `toml:"enable-sync-point" json:"enable-sync-point,omitempty"`
 	EnableTableMonitor *bool `toml:"enable-table-monitor" json:"enable-table-monitor"`


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
