### PR TITLE
ticdc: Fix CPU surge problem in sorter

### DIFF
--- a/cdc/processor/sourcemanager/sorter/pebble/event_sorter.go
+++ b/cdc/processor/sourcemanager/sorter/pebble/event_sorter.go
@@ -443,7 +443,7 @@ func (s *EventSorter) handleEvents(
 	batch := db.NewBatch()
 	newResolved := spanz.NewHashMap[model.Ts]()
 
-	handleItem := func(item eventWithTableID) {
+	encodeItemAndBatch := func(item eventWithTableID) {
 		if item.event.IsResolved() {
 			newResolved.ReplaceOrInsert(item.span, item.event.CRTs)
 			return
@@ -470,7 +470,7 @@ func (s *EventSorter) handleEvents(
 		for {
 			select {
 			case item := <-inputCh:
-				handleItem(item)
+				encodeItemAndBatch(item)
 				if len(batch.Repr()) >= batchCommitSize {
 					return
 				}

--- a/cdc/processor/sourcemanager/sorter/pebble/event_sorter.go
+++ b/cdc/processor/sourcemanager/sorter/pebble/event_sorter.go
@@ -14,7 +14,6 @@
 package pebble
 
 import (
-	"fmt"
 	"math"
 	"strconv"
 	"sync"
@@ -458,7 +457,6 @@ func (s *EventSorter) handleEvents(
 				zap.String("namespace", s.changefeedID.Namespace),
 				zap.String("changefeed", s.changefeedID.ID))
 		}
-		fmt.Println("set batch here")
 		if err = batch.Set(key, value, &pebbleWriteOptions); err != nil {
 			log.Panic("failed to update pebble batch", zap.Error(err),
 				zap.String("namespace", s.changefeedID.Namespace),
@@ -466,9 +464,9 @@ func (s *EventSorter) handleEvents(
 		}
 	}
 
-	// we batch item and commit until batch size is larger than batchCommitSize,
+	// Batch item and commit until batch size is larger than batchCommitSize,
 	// or the time since the last commit is larger than batchCommitInterval.
-	// we only return false when the sorter is closed.
+	// Only return false when the sorter is closed.
 	doBatching := func() (*DBBatchEvent, bool) {
 		batch := db.NewBatch()
 		newResolved := spanz.NewHashMap[model.Ts]()


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10738

### What is changed and how it works?

The problematic code snippet here:https://github.com/pingcap/tiflow/blob/e5edb1906cc6c1c3addf9e82120ebefd96b13e81/cdc/processor/sourcemanager/sorter/pebble/event_sorter.go#L466-L482
is a busy loop that continuously polls an input channel and does some work when an item is available. 
The issue here is with the 'default' clause in the select statement. If there's no item available in the 'inputCh' channel, it will immediately continue to the next iteration instead of blocking until an item is available or the 's.closed' channel is closed. This could lead to high CPU usage as the loop is continuously running.

This PR replace the 'default' clause with a ticker. This will cause the goroutine to block when there's no work to do, reducing CPU usage. 

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
