### PR TITLE
sinkManger(ticdc): update barrierTs when starting table

### DIFF
--- a/cdc/kv/shared_client.go
+++ b/cdc/kv/shared_client.go
@@ -793,15 +793,7 @@ func (r *requestedTable) associateSubscriptionID(event model.RegionFeedEvent) Mu
 }
 
 func (r *requestedTable) updateStaleLocks(s *SharedClient, maxVersion uint64) {
-	for {
-		old := r.staleLocksVersion.Load()
-		if old >= maxVersion {
-			return
-		}
-		if r.staleLocksVersion.CompareAndSwap(old, maxVersion) {
-			break
-		}
-	}
+	util.MustCompareAndIncrease(&r.lastAdvanceTime, int64(maxVersion))
 
 	res := r.rangeLock.CollectLockedRangeAttrs(r.postUpdateRegionResolvedTs)
 	log.Warn("event feed finds slow locked ranges",

--- a/cdc/kv/shared_client.go
+++ b/cdc/kv/shared_client.go
@@ -793,7 +793,7 @@ func (r *requestedTable) associateSubscriptionID(event model.RegionFeedEvent) Mu
 }
 
 func (r *requestedTable) updateStaleLocks(s *SharedClient, maxVersion uint64) {
-	util.MustCompareAndIncrease(&r.lastAdvanceTime, int64(maxVersion))
+	util.MustCompareAndMonotonicIncrease(&r.staleLocksVersion, maxVersion)
 
 	res := r.rangeLock.CollectLockedRangeAttrs(r.postUpdateRegionResolvedTs)
 	log.Warn("event feed finds slow locked ranges",

--- a/cdc/processor/sinkmanager/table_sink_wrapper.go
+++ b/cdc/processor/sinkmanager/table_sink_wrapper.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tiflow/cdc/sink/tablesink"
 	cerrors "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/retry"
+	"github.com/pingcap/tiflow/pkg/util"
 	"github.com/tikv/client-go/v2/oracle"
 	pd "github.com/tikv/pd/client"
 	"go.uber.org/zap"
@@ -161,12 +162,10 @@ func (t *tableSinkWrapper) start(ctx context.Context, startTs model.Ts) (err err
 	// This start ts maybe greater than the initial start ts of the table sink.
 	// Because in two phase scheduling, the table sink may be advanced to a later ts.
 	// And we can just continue to replicate the table sink from the new start ts.
-	for {
-		old := t.receivedSorterResolvedTs.Load()
-		if startTs <= old || t.receivedSorterResolvedTs.CompareAndSwap(old, startTs) {
-			break
-		}
-	}
+	util.MustCompareAndIncrease(&t.barrierTs, startTs)
+	// the barrierTs should always larger than or equal to the checkpointTs, so we need to update
+	// barrierTs before the checkpointTs is updated.
+	t.updateBarrierTs(startTs)
 	if model.NewResolvedTs(startTs).Greater(t.tableSink.checkpointTs) {
 		t.tableSink.checkpointTs = model.NewResolvedTs(startTs)
 		t.tableSink.resolvedTs = model.NewResolvedTs(startTs)
@@ -188,26 +187,14 @@ func (t *tableSinkWrapper) appendRowChangedEvents(events ...*model.RowChangedEve
 }
 
 func (t *tableSinkWrapper) updateBarrierTs(ts model.Ts) {
-	for {
-		old := t.barrierTs.Load()
-		if ts <= old || t.barrierTs.CompareAndSwap(old, ts) {
-			break
-		}
-	}
+	util.MustCompareAndIncrease(&t.barrierTs, ts)
 }
 
 func (t *tableSinkWrapper) updateReceivedSorterResolvedTs(ts model.Ts) {
-	for {
-		old := t.receivedSorterResolvedTs.Load()
-		if ts <= old {
-			return
-		}
-		if t.receivedSorterResolvedTs.CompareAndSwap(old, ts) {
-			if t.state.Load() == tablepb.TableStatePreparing {
-				t.state.Store(tablepb.TableStatePrepared)
-			}
-			return
-		}
+	increased := util.CompareAndIncrease(&t.receivedSorterResolvedTs, ts)
+	if increased && t.state.Load() == tablepb.TableStatePreparing {
+		// Update the state to `Prepared` when the receivedSorterResolvedTs is updated for the first time.
+		t.state.Store(tablepb.TableStatePrepared)
 	}
 }
 

--- a/cdc/processor/sinkmanager/table_sink_wrapper.go
+++ b/cdc/processor/sinkmanager/table_sink_wrapper.go
@@ -162,7 +162,7 @@ func (t *tableSinkWrapper) start(ctx context.Context, startTs model.Ts) (err err
 	// This start ts maybe greater than the initial start ts of the table sink.
 	// Because in two phase scheduling, the table sink may be advanced to a later ts.
 	// And we can just continue to replicate the table sink from the new start ts.
-	util.MustCompareAndIncrease(&t.barrierTs, startTs)
+	util.MustCompareAndMonotonicIncrease(&t.receivedSorterResolvedTs, startTs)
 	// the barrierTs should always larger than or equal to the checkpointTs, so we need to update
 	// barrierTs before the checkpointTs is updated.
 	t.updateBarrierTs(startTs)
@@ -187,7 +187,7 @@ func (t *tableSinkWrapper) appendRowChangedEvents(events ...*model.RowChangedEve
 }
 
 func (t *tableSinkWrapper) updateBarrierTs(ts model.Ts) {
-	util.MustCompareAndIncrease(&t.barrierTs, ts)
+	util.MustCompareAndMonotonicIncrease(&t.barrierTs, ts)
 }
 
 func (t *tableSinkWrapper) updateReceivedSorterResolvedTs(ts model.Ts) {

--- a/cdc/processor/sinkmanager/table_sink_wrapper.go
+++ b/cdc/processor/sinkmanager/table_sink_wrapper.go
@@ -191,7 +191,7 @@ func (t *tableSinkWrapper) updateBarrierTs(ts model.Ts) {
 }
 
 func (t *tableSinkWrapper) updateReceivedSorterResolvedTs(ts model.Ts) {
-	increased := util.CompareAndIncrease(&t.receivedSorterResolvedTs, ts)
+	increased := util.CompareAndMonotonicIncrease(&t.receivedSorterResolvedTs, ts)
 	if increased && t.state.Load() == tablepb.TableStatePreparing {
 		// Update the state to `Prepared` when the receivedSorterResolvedTs is updated for the first time.
 		t.state.Store(tablepb.TableStatePrepared)

--- a/cdc/redo/manager.go
+++ b/cdc/redo/manager.go
@@ -161,8 +161,8 @@ type statefulRts struct {
 }
 
 func newStatefulRts(ts model.Ts) (ret statefulRts) {
-	ret.unflushed.Store(uint64(ts))
-	ret.flushed.Store(uint64(ts))
+	ret.unflushed.Store(ts)
+	ret.flushed.Store(ts)
 	return
 }
 
@@ -175,11 +175,11 @@ func (s *statefulRts) getUnflushed() model.Ts {
 }
 
 func (s *statefulRts) checkAndSetUnflushed(unflushed model.Ts) (ok bool) {
-	return util.CompareAndIncrease(&s.unflushed, uint64(unflushed))
+	return util.CompareAndIncrease(&s.unflushed, unflushed)
 }
 
 func (s *statefulRts) checkAndSetFlushed(flushed model.Ts) (ok bool) {
-	return util.CompareAndIncrease(&s.flushed, uint64(flushed))
+	return util.CompareAndIncrease(&s.flushed, flushed)
 }
 
 // logManager manages redo log writer, buffers un-persistent redo logs, calculates

--- a/cdc/redo/manager.go
+++ b/cdc/redo/manager.go
@@ -174,11 +174,11 @@ func (s *statefulRts) getUnflushed() model.Ts {
 	return s.unflushed.Load()
 }
 
-func (s *statefulRts) checkAndSetUnflushed(unflushed model.Ts) (changed bool) {
+func (s *statefulRts) checkAndSetUnflushed(unflushed model.Ts) (ok bool) {
 	return util.CompareAndIncrease(&s.unflushed, uint64(unflushed))
 }
 
-func (s *statefulRts) checkAndSetFlushed(flushed model.Ts) (changed bool) {
+func (s *statefulRts) checkAndSetFlushed(flushed model.Ts) (ok bool) {
 	return util.CompareAndIncrease(&s.flushed, uint64(flushed))
 }
 

--- a/cdc/redo/meta_manager.go
+++ b/cdc/redo/meta_manager.go
@@ -271,8 +271,8 @@ func (m *metaManager) initMeta(ctx context.Context) error {
 			zap.Uint64("checkpointTs", checkpointTs),
 			zap.Uint64("resolvedTs", resolvedTs))
 	}
-	m.metaResolvedTs.unflushed = resolvedTs
-	m.metaCheckpointTs.unflushed = checkpointTs
+	m.metaResolvedTs.unflushed.Store(resolvedTs)
+	m.metaCheckpointTs.unflushed.Store(checkpointTs)
 	if err := m.maybeFlushMeta(ctx); err != nil {
 		return errors.WrapError(errors.ErrRedoMetaInitialize, err)
 	}

--- a/pkg/util/atomic.go
+++ b/pkg/util/atomic.go
@@ -23,12 +23,6 @@ type genericAtomic[T numbers] interface {
 	CompareAndSwap(old, new T) bool
 }
 
-// MustCompareAndIncrease updates the target if the new value is larger than the old value. It do nothing
-// if the new value is smaller than or equal to the old value.
-func MustCompareAndIncrease[T numbers](target genericAtomic[T], new T) {
-	_ = CompareAndMonotonicIncrease(target, new)
-}
-
 // CompareAndIncrease updates the target if the new value is larger than or equal to the old value.
 // It returns false if the new value is smaller than the old value.
 func CompareAndIncrease[T numbers](target genericAtomic[T], new T) bool {
@@ -55,4 +49,10 @@ func CompareAndMonotonicIncrease[T numbers](target genericAtomic[T], new T) bool
 			return true
 		}
 	}
+}
+
+// MustCompareAndMonotonicIncrease updates the target if the new value is larger than the old value. It do nothing
+// if the new value is smaller than or equal to the old value.
+func MustCompareAndMonotonicIncrease[T numbers](target genericAtomic[T], new T) {
+	_ = CompareAndMonotonicIncrease(target, new)
 }

--- a/pkg/util/atomic.go
+++ b/pkg/util/atomic.go
@@ -1,0 +1,47 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+type numbers interface {
+	int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64 | uintptr | float32 | float64
+}
+
+type genericAtomic[T numbers] interface {
+	Load() T
+	Store(T)
+	CompareAndSwap(old, new T) bool
+}
+
+// MustCompareAndIncrease only updates the target if the new value is larger than the old value.
+func MustCompareAndIncrease[T numbers](target genericAtomic[T], val T) {
+	for {
+		old := target.Load()
+		if val <= old || target.CompareAndSwap(old, val) {
+			return
+		}
+	}
+}
+
+// CompareAndIncrease only updates the target if the new value is larger than or equal to the old value.
+func CompareAndIncrease[T numbers](target genericAtomic[T], val T) bool {
+	for {
+		old := target.Load()
+		if old > val {
+			return false
+		}
+		if val <= old || target.CompareAndSwap(old, val) {
+			return true
+		}
+	}
+}

--- a/pkg/util/atomic_test.go
+++ b/pkg/util/atomic_test.go
@@ -40,7 +40,7 @@ func TestMustCompareAndIncrease(t *testing.T) {
 			default:
 				delta := rand.Int63n(100)
 				v := target.Load() + delta
-				MustCompareAndIncrease(&target, v)
+				MustCompareAndMonotonicIncrease(&target, v)
 				require.GreaterOrEqual(t, target.Load(), v)
 			}
 		}
@@ -67,7 +67,7 @@ func TestMustCompareAndIncrease(t *testing.T) {
 				return
 			default:
 				v := target.Load() - 1
-				MustCompareAndIncrease(&target, v)
+				MustCompareAndMonotonicIncrease(&target, v)
 				require.Greater(t, target.Load(), v)
 			}
 		}

--- a/pkg/util/atomic_test.go
+++ b/pkg/util/atomic_test.go
@@ -1,0 +1,106 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMustCompareAndIncrease(t *testing.T) {
+	t.Parallel()
+
+	var target atomic.Int64
+	target.Store(10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := sync.WaitGroup{}
+
+	doIncrease := func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				delta := rand.Int63n(100)
+				v := target.Load() + delta
+				MustCompareAndIncrease(&target, v)
+				require.GreaterOrEqual(t, target.Load(), v)
+			}
+		}
+	}
+
+	// Test target increase.
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		doIncrease()
+	}()
+	go func() {
+		defer wg.Done()
+		doIncrease()
+	}()
+
+	wg.Add(1)
+	// Test target never decrease.
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				v := target.Load() - 1
+				MustCompareAndIncrease(&target, v)
+				require.Greater(t, target.Load(), v)
+			}
+		}
+	}()
+
+	cancel()
+	wg.Wait()
+}
+
+func TestCompareAndIncrease(t *testing.T) {
+	t.Parallel()
+
+	var target atomic.Int64
+	target.Store(10)
+	require.True(t, CompareAndIncrease(&target, 10))
+	require.Equal(t, int64(10), target.Load())
+
+	require.True(t, CompareAndIncrease(&target, 20))
+	require.Equal(t, int64(20), target.Load())
+	require.False(t, CompareAndIncrease(&target, 19))
+	require.Equal(t, int64(20), target.Load())
+}
+
+func TestCompareAndMonotonicIncrease(t *testing.T) {
+	t.Parallel()
+
+	var target atomic.Int64
+	target.Store(10)
+	require.False(t, CompareAndMonotonicIncrease(&target, 10))
+	require.Equal(t, int64(10), target.Load())
+
+	require.True(t, CompareAndMonotonicIncrease(&target, 11))
+	require.Equal(t, int64(11), target.Load())
+	require.False(t, CompareAndMonotonicIncrease(&target, 10))
+	require.Equal(t, int64(11), target.Load())
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10613

### What is changed and how it works?
1. [update barrierTs when starting table](https://github.com/pingcap/tiflow/pull/10740/files#diff-f1a821fc6bccdd087045289477de1ba938f0174afc2fed865a66d5264548abd7R168). Ref [the resaon](https://github.com/pingcap/tiflow/issues/10613#issuecomment-1983173348)
2. Extract a [new util](https://github.com/pingcap/tiflow/pull/10740/files#diff-ba333197f13ad9389bf03b0261938edd52c195094307c506a071bbbac99cc330R27) to simplify code base.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a bug that may cause TiCDC panic when scheduling tables.
```
