### PR TITLE
redo(ticdc): return ErrStorageInitialize if the external storage initialization fails

### DIFF
--- a/pkg/redo/config.go
+++ b/pkg/redo/config.go
@@ -36,7 +36,7 @@ var (
 
 const (
 	// DefaultTimeout is the default timeout for writing external storage.
-	DefaultTimeout = 15 * time.Minute
+	DefaultTimeout = 5 * time.Minute
 	// CloseTimeout is the default timeout for close redo writer.
 	CloseTimeout = 15 * time.Second
 
@@ -192,7 +192,8 @@ func IsBlackholeStorage(scheme string) bool {
 var InitExternalStorage = func(ctx context.Context, uri url.URL) (storage.ExternalStorage, error) {
 	s, err := util.GetExternalStorageWithTimeout(ctx, uri.String(), DefaultTimeout)
 	if err != nil {
-		return nil, errors.WrapChangefeedUnretryableErr(errors.ErrStorageInitialize, err)
+		return nil, errors.WrapError(errors.ErrStorageInitialize, err,
+			fmt.Sprintf("can't init external storage for %s", uri.String()))
 	}
 	return s, nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10710

### What is changed and how it works?
- return ErrStorageInitialize if the external storage initialization fails
- Use a smaller DefaultTimeout, since changefeed will be restart when meet error.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
