### PR TITLE
ticdc: fix update calls to runtime.fastrand to use cheaprand for compatibility with Go 1.22

### DIFF
--- a/cdc/puller/frontier/list.go
+++ b/cdc/puller/frontier/list.go
@@ -93,9 +93,6 @@ func (l *skipList) randomHeight() int {
 	return h
 }
 
-//go:linkname fastrand runtime.fastrand
-func fastrand() uint32
-
 // Seek returns the seek seekTempResult
 // the seek seekTempResult is a slice of nodes,
 // Each element in the slice represents the nearest(left) node to the target value at each level of the skip list.

--- a/cdc/puller/frontier/runtime.go
+++ b/cdc/puller/frontier/runtime.go
@@ -1,0 +1,23 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !go1.22
+
+package frontier
+
+import (
+	_ "unsafe" // required by go:linkname
+)
+
+//go:linkname fastrand runtime.fastrand
+func fastrand() uint32

--- a/cdc/puller/frontier/runtime_1.22.go
+++ b/cdc/puller/frontier/runtime_1.22.go
@@ -1,0 +1,23 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.22
+
+package frontier
+
+import (
+	_ "unsafe" // required by go:linkname
+)
+
+//go:linkname fastrand runtime.cheaprand
+func fastrand() uint32


### PR DESCRIPTION
fix update calls to runtime.fastrand to use cheaprand for compatibility with Go 1.22

In Golang 1.22, the `runtime.fastrand` method was renamed to `cheaprand`. This commit updates all occurrences of `runtime.fastrand` in the project to use the new `cheaprand` method to maintain compatibility with the latest Golang version and address performance concerns.

Refer: https://gist.github.com/Aoang/3dc06f127f3f54507b7e06b7b6550c28

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - [x] Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->
None
##### Will it cause performance regression or break compatibility?
None
##### Do you need to update user documentation, design documentation or monitoring documentation?
None
### Release note <!-- bugfixes or new features need a release note -->
None
```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
