### PR TITLE
ticdc: Fix generate-protobuf.sh to make it works in various basic os envs

### DIFF
--- a/scripts/generate-protobuf.sh
+++ b/scripts/generate-protobuf.sh
@@ -61,8 +61,8 @@ generate ./dm/pb ./dm/proto/dmworker.proto plugins=grpc,protoc-gen-grpc-gateway=
 generate ./dm/pb ./dm/proto/dmmaster.proto plugins=grpc,protoc-gen-grpc-gateway="$GRPC_GATEWAY"
 
 for pb in $(find cdc -name '*.proto'); do
-    # Output generated go files next to protobuf files.
-    generate ./cdc $pb paths="source_relative"
+	# Output generated go files next to protobuf files.
+	generate ./cdc $pb paths="source_relative"
 done
 
 echo "generate enginepb..."

--- a/scripts/generate-protobuf.sh
+++ b/scripts/generate-protobuf.sh
@@ -59,10 +59,14 @@ generate ./proto/benchmark ./proto/CraftBenchmark.proto
 generate ./proto/p2p ./proto/CDCPeerToPeer.proto plugins=grpc
 generate ./dm/pb ./dm/proto/dmworker.proto plugins=grpc,protoc-gen-grpc-gateway="$GRPC_GATEWAY"
 generate ./dm/pb ./dm/proto/dmmaster.proto plugins=grpc,protoc-gen-grpc-gateway="$GRPC_GATEWAY"
-shopt -s globstar
-for pb in cdc/**/*.proto; do
-	# Output generated go files next to protobuf files.
-	generate ./cdc $pb paths="source_relative"
+# shopt -s globstar
+# for pb in cdc/**/*.proto; do
+# 	# Output generated go files next to protobuf files.
+# 	generate ./cdc $pb paths="source_relative"
+# done
+for pb in $(find cdc -name '*.proto'); do
+    # Output generated go files next to protobuf files.
+    generate ./cdc $pb paths="source_relative"
 done
 
 echo "generate enginepb..."

--- a/scripts/generate-protobuf.sh
+++ b/scripts/generate-protobuf.sh
@@ -59,11 +59,7 @@ generate ./proto/benchmark ./proto/CraftBenchmark.proto
 generate ./proto/p2p ./proto/CDCPeerToPeer.proto plugins=grpc
 generate ./dm/pb ./dm/proto/dmworker.proto plugins=grpc,protoc-gen-grpc-gateway="$GRPC_GATEWAY"
 generate ./dm/pb ./dm/proto/dmmaster.proto plugins=grpc,protoc-gen-grpc-gateway="$GRPC_GATEWAY"
-# shopt -s globstar
-# for pb in cdc/**/*.proto; do
-# 	# Output generated go files next to protobuf files.
-# 	generate ./cdc $pb paths="source_relative"
-# done
+
 for pb in $(find cdc -name '*.proto'); do
     # Output generated go files next to protobuf files.
     generate ./cdc $pb paths="source_relative"


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10756

### What is changed and how it works?
use `find` instead of  `shopt -s globstar` to make it works in various basic os envs

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
test generate protobuf in both linux and macos

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
