### PR TITLE
ticdc: Fix data race problem in Node

### DIFF
--- a/.github/workflows/check_and_build.yaml
+++ b/.github/workflows/check_and_build.yaml
@@ -43,43 +43,5 @@ jobs:
       - name: Build-engine
         run: docker build -f ./deployments/engine/docker/Dockerfile .
 
-  mac_build:
-    name: Mac OS Build
-    runs-on: macos-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Setup Go environment
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.21'
-
-      - name: Cache Tools
-        id: cache-tools
-        uses: actions/cache@v2
-        with:
-          path: tools/bin
-          key: macos-latest-ticdc-tools-${{ hashFiles('tools/check/go.sum') }}
-
-      - name: Build
-        run: make build
-
-  arm_build:
-    runs-on: [ARM64]
-    name: Arm Build
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [ARM64]
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Setup Go environment
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.21'
-
-      - name: Build
-        run: make build
+      - name: make unit_test
+        run : make unit_test_in_verify_ci

--- a/.github/workflows/check_and_build.yaml
+++ b/.github/workflows/check_and_build.yaml
@@ -34,14 +34,5 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Build-cdc
-        run: docker build -f ./deployments/ticdc/docker/Dockerfile .
-
-      - name: Build-dm
-        run: docker build -f ./dm/Dockerfile .
-
-      - name: Build-engine
-        run: docker build -f ./deployments/engine/docker/Dockerfile .
-
       - name: make unit_test
         run : make unit_test_in_verify_ci

--- a/.github/workflows/check_and_build.yaml
+++ b/.github/workflows/check_and_build.yaml
@@ -27,158 +27,59 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ut_run1:
-    name: ut_run1
+  docker_build:
+    name: Docker Build
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: make unit_test
-        run : make unit_test_in_verify_ci
-  ut_run2:
-    name: ut_run2
-    runs-on: ubuntu-latest
+      - name: Build-cdc
+        run: docker build -f ./deployments/ticdc/docker/Dockerfile .
+
+      - name: Build-dm
+        run: docker build -f ./dm/Dockerfile .
+
+      - name: Build-engine
+        run: docker build -f ./deployments/engine/docker/Dockerfile .
+
+  mac_build:
+    name: Mac OS Build
+    runs-on: macos-latest
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: make unit_test
-        run : make unit_test_in_verify_ci
+      - name: Setup Go environment
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.21'
 
-  ut_run3:
-    name: ut_run3
-    runs-on: ubuntu-latest
+      - name: Cache Tools
+        id: cache-tools
+        uses: actions/cache@v2
+        with:
+          path: tools/bin
+          key: macos-latest-ticdc-tools-${{ hashFiles('tools/check/go.sum') }}
+
+      - name: Build
+        run: make build
+
+  arm_build:
+    runs-on: [ARM64]
+    name: Arm Build
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ARM64]
     steps:
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v2
 
-      - name: make unit_test
-        run : make unit_test_in_verify_ci
+      - name: Setup Go environment
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.21'
 
-  ut_run4:
-    name: ut_run4
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: make unit_test
-        run : make unit_test_in_verify_ci
-  
-  ut_run5:
-    name: ut_run5
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: make unit_test
-        run : make unit_test_in_verify_ci
-  ut_run6:
-    name: ut_run6
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: make unit_test
-        run : make unit_test_in_verify_ci
-
-  ut_run7:
-    name: ut_run7
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: make unit_test
-        run : make unit_test_in_verify_ci
-
-  ut_run8:
-    name: ut_run8
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: make unit_test
-        run : make unit_test_in_verify_ci
-
-  ut_run11:
-    name: ut_run11
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: make unit_test
-        run : make unit_test_in_verify_ci
-  ut_run12:
-    name: ut_run12
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: make unit_test
-        run : make unit_test_in_verify_ci
-
-  ut_run13:
-    name: ut_run13
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: make unit_test
-        run : make unit_test_in_verify_ci
-
-  ut_run14:
-    name: ut_run14
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: make unit_test
-        run : make unit_test_in_verify_ci
-  
-  ut_run15:
-    name: ut_run15
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: make unit_test
-        run : make unit_test_in_verify_ci
-  ut_run16:
-    name: ut_run16
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: make unit_test
-        run : make unit_test_in_verify_ci
-
-  ut_run17:
-    name: ut_run17
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: make unit_test
-        run : make unit_test_in_verify_ci
-
-  ut_run18:
-    name: ut_run18
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: make unit_test
-        run : make unit_test_in_verify_ci
+      - name: Build
+        run: make build

--- a/.github/workflows/check_and_build.yaml
+++ b/.github/workflows/check_and_build.yaml
@@ -104,3 +104,81 @@ jobs:
 
       - name: make unit_test
         run : make unit_test_in_verify_ci
+
+  ut_run11:
+    name: ut_run11
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: make unit_test
+        run : make unit_test_in_verify_ci
+  ut_run12:
+    name: ut_run12
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: make unit_test
+        run : make unit_test_in_verify_ci
+
+  ut_run13:
+    name: ut_run13
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: make unit_test
+        run : make unit_test_in_verify_ci
+
+  ut_run14:
+    name: ut_run14
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: make unit_test
+        run : make unit_test_in_verify_ci
+  
+  ut_run15:
+    name: ut_run15
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: make unit_test
+        run : make unit_test_in_verify_ci
+  ut_run16:
+    name: ut_run16
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: make unit_test
+        run : make unit_test_in_verify_ci
+
+  ut_run17:
+    name: ut_run17
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: make unit_test
+        run : make unit_test_in_verify_ci
+
+  ut_run18:
+    name: ut_run18
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: make unit_test
+        run : make unit_test_in_verify_ci

--- a/.github/workflows/check_and_build.yaml
+++ b/.github/workflows/check_and_build.yaml
@@ -27,8 +27,76 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docker_build:
-    name: Docker Build
+  ut_run1:
+    name: ut_run1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: make unit_test
+        run : make unit_test_in_verify_ci
+  ut_run2:
+    name: ut_run2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: make unit_test
+        run : make unit_test_in_verify_ci
+
+  ut_run3:
+    name: ut_run3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: make unit_test
+        run : make unit_test_in_verify_ci
+
+  ut_run4:
+    name: ut_run4
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: make unit_test
+        run : make unit_test_in_verify_ci
+  
+  ut_run5:
+    name: ut_run5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: make unit_test
+        run : make unit_test_in_verify_ci
+  ut_run6:
+    name: ut_run6
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: make unit_test
+        run : make unit_test_in_verify_ci
+
+  ut_run7:
+    name: ut_run7
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: make unit_test
+        run : make unit_test_in_verify_ci
+
+  ut_run8:
+    name: ut_run8
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory

--- a/pkg/causality/internal/node_test.go
+++ b/pkg/causality/internal/node_test.go
@@ -65,9 +65,10 @@ func TestNodeSingleDependency(t *testing.T) {
 	// Node B depends on A, without any other removed dependencies.
 	nodeA := NewNode()
 	nodeB := NewNode()
+	nodeA.RandWorkerID = func() workerID { return 1 }
 	nodeB.RandWorkerID = func() workerID { return 100 }
 	nodeB.DependOn(map[int64]*Node{nodeA.NodeID(): nodeA}, 0)
-	require.True(t, nodeA.assignTo(1))
+	require.True(t, nodeA.assign())
 	require.Equal(t, workerID(1), nodeA.assignedWorkerID())
 	// Node B should be unassigned before Node A is removed.
 	require.Equal(t, unassigned, nodeB.assignedWorkerID())
@@ -78,9 +79,10 @@ func TestNodeSingleDependency(t *testing.T) {
 	// Node D depends on C, with some other resolved dependencies.
 	nodeC := NewNode()
 	nodeD := NewNode()
+	nodeC.RandWorkerID = func() workerID { return 2 }
 	nodeD.RandWorkerID = func() workerID { return 100 }
 	nodeD.DependOn(map[int64]*Node{nodeA.NodeID(): nodeC}, 999)
-	require.True(t, nodeC.assignTo(2))
+	require.True(t, nodeC.assign())
 	require.Equal(t, workerID(2), nodeC.assignedWorkerID())
 	nodeC.Remove()
 	require.Equal(t, workerID(100), nodeD.assignedWorkerID())
@@ -99,10 +101,12 @@ func TestNodeMultipleDependencies(t *testing.T) {
 	nodeC := NewNode()
 
 	nodeC.DependOn(map[int64]*Node{nodeA.NodeID(): nodeA, nodeB.NodeID(): nodeB}, 999)
+	nodeA.RandWorkerID = func() workerID { return 1 }
+	nodeB.RandWorkerID = func() workerID { return 2 }
 	nodeC.RandWorkerID = func() workerID { return 100 }
 
-	require.True(t, nodeA.assignTo(1))
-	require.True(t, nodeB.assignTo(2))
+	require.True(t, nodeA.assign())
+	require.True(t, nodeB.assign())
 
 	require.Equal(t, unassigned, nodeC.assignedWorkerID())
 
@@ -122,9 +126,11 @@ func TestNodeResolveImmediately(t *testing.T) {
 
 	// Node D depends on B and C, all of them are assigned to 1.
 	nodeB := NewNode()
-	require.True(t, nodeB.assignTo(1))
+	nodeB.RandWorkerID = func() workerID { return 1 }
+	require.True(t, nodeB.assign())
 	nodeC := NewNode()
-	require.True(t, nodeC.assignTo(1))
+	nodeC.RandWorkerID = func() workerID { return 1 }
+	require.True(t, nodeC.assign())
 	nodeD := NewNode()
 	nodeD.RandWorkerID = func() workerID { return workerID(100) }
 	nodeD.DependOn(map[int64]*Node{nodeB.NodeID(): nodeB, nodeC.NodeID(): nodeC}, 0)
@@ -155,6 +161,6 @@ func TestNodeDoubleAssigning(t *testing.T) {
 	t.Parallel()
 
 	nodeA := NewNode()
-	require.True(t, nodeA.assignTo(1))
-	require.False(t, nodeA.assignTo(2))
+	nodeA.RandWorkerID = func() workerID { return 1 }
+	require.True(t, nodeA.assign())
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/10762

### What is changed and how it works?
The data race problem is because `maybeReadyToRun` and `Free` maybe called simultaneously.

Consider the following scenario:
A only depends B, and B call B's remove first, and reduce A's removedDependencies to 0
Then A just call A's `maybeReadyToRun`, and assign to a worker and remove and free itself
Simultaneously, B call A's maybeReadyToRun.

Besides to avoid use too much mutex.lock, we don't choose to add lock in `maybeReadyToRun`, but let `RandWorkerID` do in `assign`. It protected by mutex, and will first check whether the node is assigned before, which can avoid to call `RandWorkerID` when it is nil.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
