### PR TITLE
ticdc: Fix unstable test TestRetry

### DIFF
--- a/pkg/etcd/client_test.go
+++ b/pkg/etcd/client_test.go
@@ -71,7 +71,8 @@ func (m mockWatcher) RequestProgress(ctx context.Context) error {
 }
 
 func TestRetry(t *testing.T) {
-	t.Parallel()
+	// here we need to change maxTries, which is not thread safe
+	// so we don't use t.Parallel() for this test
 
 	originValue := maxTries
 	// to speedup the test


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10771

### What is changed and how it works?
In test TestRetry, we try to change `maxTries` to reduce test time, which makes this test is not thread safe.
So it can't run parallel with other tests like `TestDeleteCaptureInfo`, which will also use maxTries.
Thus we delete `t.Parallel()` here to make the test run successfully with an acceptable test time.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 
#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
