### PR TITLE
api(ticdc):  fix resign owner cause capture restart bug

### DIFF
--- a/cdc/capture/capture.go
+++ b/cdc/capture/capture.go
@@ -526,7 +526,6 @@ func (c *captureImpl) campaignOwner(ctx cdcContext.Context) error {
 		})
 
 		g, ctx := errgroup.WithContext(ctx)
-		ctx, cancelOwner := context.WithCancel(ctx)
 		ownerCtx := cdcContext.NewContext(ctx, newGlobalVars)
 		g.Go(func() error {
 			return c.runEtcdWorker(ownerCtx, owner.(orchestrator.Reactor),
@@ -538,8 +537,8 @@ func (c *captureImpl) campaignOwner(ctx cdcContext.Context) error {
 				globalState,
 				// todo: do not use owner flush interval
 				ownerFlushInterval, util.RoleController.String())
-			// controller is exited, cancel owner to exit the loop.
-			cancelOwner()
+			// controller is exited, tell owner to exit the loop.
+			c.owner.AsyncStop()
 			return er
 		})
 		err = g.Wait()


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10781

### What is changed and how it works?
call owner.AsyncClose function to tell the owner to exit etcd worker loop, which will make the owner exit normally.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
 Fix a bug that resign owner API will cause capture restart
```
