### PR TITLE
ticdc: make UT TestRemoveChangefeed more stable

### DIFF
--- a/cdc/owner/changefeed_test.go
+++ b/cdc/owner/changefeed_test.go
@@ -596,6 +596,13 @@ func testChangefeedReleaseResource(
 	tester.MustApplyPatches()
 	require.Equal(t, cf.initialized, expectedInitialized)
 
+	// redo's metaManager:Run() will call preStart, which will clean up the redo log dir.
+	// Run() is another background goroutine called in tick()
+	// so it's not guaranteed to be started before the next tick()
+	// Thus, we need to wait for a while to make sure the redo log dir is cleaned up before remove changefeed
+	// Otherwise, it will delete the delete mark file after we remove changefeed, which will cause the test to fail
+	time.Sleep(5 * time.Second)
+
 	// remove changefeed from state manager by admin job
 	cf.feedStateManager.PushAdminJob(&model.AdminJob{
 		CfID: cf.id,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/10785

### What is changed and how it works?
This ut want to exam that in a changefeed with redo, when we remove changefeed, there will only left one delete mark file in redo dir.

Here are two places will influence the delete mark file. One is after removing changefeed. We will do cleanup, and delete all logs and create delete mark file. The other is in `preCleanupExtStorage()`, which is called in `Run()`. 
`Run()` is called in `tick()`, but is a background goroutine. Therefore, sometimes, `preCleanupExtStorage()` is actually called after  we create delete mark file, make the test failed.

Thus, we add sleep, try to make `preCleanupExtStorage()` called before we remove the changefeed.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
