### PR TITLE
ticdc: fix metrics `ownership histroy` to be more stable

### DIFF
--- a/metrics/alertmanager/ticdc.rules.yml
+++ b/metrics/alertmanager/ticdc.rules.yml
@@ -3,24 +3,24 @@ groups:
   rules:
   # server related alter rules
   - alert: cdc_multiple_owners
-    expr: sum(rate(ticdc_owner_ownership_counter[30s])) >= 2
+    expr: sum(rate(ticdc_owner_ownership_counter[240s])) >= 0.125
     for: 1m
     labels:
       env: ENV_LABELS_ENV
       level: warning
-      expr: sum(rate(ticdc_owner_ownership_counter[30s])) >= 2
+      expr: sum(rate(ticdc_owner_ownership_counter[240s])) >= 0.125
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values: {{ $value }}'
       value: '{{ $value }}'
       summary: cdc cluster has multiple owners
 
   - alert: cdc_no_owner
-    expr: sum(rate(ticdc_owner_ownership_counter[30s])) < 0.5
+    expr: sum(rate(ticdc_owner_ownership_counter[240s])) < 0.0625
     for: 10m
     labels:
       env: ENV_LABELS_ENV
       level: warning
-      expr: sum(rate(ticdc_owner_ownership_counter[30s])) < 0.5
+      expr: sum(rate(ticdc_owner_ownership_counter[240s])) < 0.0625
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values: {{ $value }}'
       value: '{{ $value }}'

--- a/metrics/grafana/ticdc.json
+++ b/metrics/grafana/ticdc.json
@@ -2675,7 +2675,7 @@
           "pluginVersion": "7.5.11",
           "targets": [
             {
-              "expr": "rate(ticdc_owner_ownership_counter{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[30s])",
+              "expr": "rate(ticdc_owner_ownership_counter{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[240s])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
@@ -2972,7 +2972,7 @@
           "steppedLine": true,
           "targets": [
             {
-              "expr": "sum(rate(ticdc_owner_ownership_counter{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[30s])) by (instance) > BOOL 0.5",
+              "expr": "sum(rate(ticdc_owner_ownership_counter{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}[240s])) by (instance) > BOOL 0.0625",
               "format": "time_series",
               "interval": "30s",
               "intervalFactor": 1,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/10796

### What is changed and how it works?
In the issue, because the duration of owner's tick is larger than 30s, makes the rate calculation to be 0 instead of 1.

To avoid this situation, I enlarge the duration in metrics to 240s, which we can regard it's must be longer than owner's tick. Otherwise, ticdc must be under a terrible performance. Thus, in this way, we can make the metrics more stable.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 test in the issue case
![image](https://github.com/pingcap/tiflow/assets/26538495/a9351557-2d5f-4945-b1d9-7f6e0a42e721)


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
