### PR TITLE
ticdc: fix unstable test TestRemoveExpiredFilesWithoutPartition

### DIFF
--- a/cdc/sink/ddlsink/cloudstorage/cloud_storage_ddl_sink.go
+++ b/cdc/sink/ddlsink/cloudstorage/cloud_storage_ddl_sink.go
@@ -250,7 +250,9 @@ func (d *DDLSink) genCleanupJob(ctx context.Context, uri *url.URL) []func() {
 		defer isCleanupRunning.Store(false)
 		start := time.Now()
 		checkpointTs := d.lastCheckpointTs.Load()
-		cnt, err := cloudstorage.RemoveExpiredFiles(ctx, d.id, d.storage, d.cfg, checkpointTs)
+		// FIXME: currently the date part in file paths is formatted using local TZ,
+		// this may cause problem if the tz info is different between different cdc servers.
+		cnt, err := cloudstorage.RemoveExpiredFiles(ctx, d.id, d.storage, d.cfg, checkpointTs, time.Local)
 		if err != nil {
 			log.Error("failed to remove expired files",
 				zap.String("namespace", d.id.Namespace),

--- a/cdc/sink/ddlsink/cloudstorage/cloud_storage_ddl_sink.go
+++ b/cdc/sink/ddlsink/cloudstorage/cloud_storage_ddl_sink.go
@@ -250,9 +250,7 @@ func (d *DDLSink) genCleanupJob(ctx context.Context, uri *url.URL) []func() {
 		defer isCleanupRunning.Store(false)
 		start := time.Now()
 		checkpointTs := d.lastCheckpointTs.Load()
-		// TODO: currently the date part in file paths is formatted using local TZ,
-		// this may cause problem if the tz info is different between different cdc servers.
-		cnt, err := cloudstorage.RemoveExpiredFiles(ctx, d.id, d.storage, d.cfg, checkpointTs, time.Local)
+		cnt, err := cloudstorage.RemoveExpiredFiles(ctx, d.id, d.storage, d.cfg, checkpointTs)
 		if err != nil {
 			log.Error("failed to remove expired files",
 				zap.String("namespace", d.id.Namespace),

--- a/cdc/sink/ddlsink/cloudstorage/cloud_storage_ddl_sink.go
+++ b/cdc/sink/ddlsink/cloudstorage/cloud_storage_ddl_sink.go
@@ -250,7 +250,7 @@ func (d *DDLSink) genCleanupJob(ctx context.Context, uri *url.URL) []func() {
 		defer isCleanupRunning.Store(false)
 		start := time.Now()
 		checkpointTs := d.lastCheckpointTs.Load()
-		// FIXME: currently the date part in file paths is formatted using local TZ,
+		// TODO: currently the date part in file paths is formatted using local TZ,
 		// this may cause problem if the tz info is different between different cdc servers.
 		cnt, err := cloudstorage.RemoveExpiredFiles(ctx, d.id, d.storage, d.cfg, checkpointTs, time.Local)
 		if err != nil {

--- a/pkg/sink/cloudstorage/path.go
+++ b/pkg/sink/cloudstorage/path.go
@@ -440,7 +440,6 @@ func RemoveExpiredFiles(
 	storage storage.ExternalStorage,
 	cfg *Config,
 	checkpointTs model.Ts,
-	loc *time.Location,
 ) (uint64, error) {
 	if cfg.DateSeparator != config.DateSeparatorDay.String() {
 		return 0, nil
@@ -451,7 +450,9 @@ func RemoveExpiredFiles(
 
 	ttl := time.Duration(cfg.FileExpirationDays) * time.Hour * 24
 	currTime := oracle.GetTimeFromTS(checkpointTs).Add(-ttl)
-	expiredDate := currTime.In(loc).Format("2006-01-02")
+	// TODO: currently the date part in file paths is formatted using local TZ,
+	// this may cause problem if the tz info is different between different cdc servers.
+	expiredDate := currTime.Format("2006-01-02")
 
 	cnt := uint64(0)
 	err := util.RemoveFilesIf(ctx, storage, func(path string) bool {

--- a/pkg/sink/cloudstorage/path.go
+++ b/pkg/sink/cloudstorage/path.go
@@ -276,8 +276,7 @@ func (f *FilePathGenerator) GenerateDateStr() string {
 	var dateStr string
 
 	currTime := f.pdClock.CurrentTime()
-	// TODO: currently `dateStr` is formatted using local TZ,
-	// this may cause problem if the tz info is different between different cdc servers.
+	// Note: `dateStr` is formatted using local TZ.
 	switch f.config.DateSeparator {
 	case config.DateSeparatorYear.String():
 		dateStr = currTime.Format("2006")
@@ -450,8 +449,7 @@ func RemoveExpiredFiles(
 
 	ttl := time.Duration(cfg.FileExpirationDays) * time.Hour * 24
 	currTime := oracle.GetTimeFromTS(checkpointTs).Add(-ttl)
-	// TODO: currently the date part in file paths is formatted using local TZ,
-	// this may cause problem if the tz info is different between different cdc servers.
+	// Note: `dateStr` is formatted using local TZ.
 	expiredDate := currTime.Format("2006-01-02")
 
 	cnt := uint64(0)

--- a/pkg/sink/cloudstorage/path.go
+++ b/pkg/sink/cloudstorage/path.go
@@ -276,7 +276,7 @@ func (f *FilePathGenerator) GenerateDateStr() string {
 	var dateStr string
 
 	currTime := f.pdClock.CurrentTime()
-	// FIXME: currently `dateStr` is formatted using local TZ,
+	// TODO: currently `dateStr` is formatted using local TZ,
 	// this may cause problem if the tz info is different between different cdc servers.
 	switch f.config.DateSeparator {
 	case config.DateSeparatorYear.String():

--- a/pkg/sink/cloudstorage/path.go
+++ b/pkg/sink/cloudstorage/path.go
@@ -449,7 +449,7 @@ func RemoveExpiredFiles(
 
 	ttl := time.Duration(cfg.FileExpirationDays) * time.Hour * 24
 	currTime := oracle.GetTimeFromTS(checkpointTs).Add(-ttl)
-	// Note: `dateStr` is formatted using local TZ.
+	// Note: `expiredDate` is formatted using local TZ.
 	expiredDate := currTime.Format("2006-01-02")
 
 	cnt := uint64(0)

--- a/pkg/sink/cloudstorage/path_test.go
+++ b/pkg/sink/cloudstorage/path_test.go
@@ -430,9 +430,9 @@ func TestRemoveExpiredFilesWithoutPartition(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	currTime := time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC)
+	currTime := time.Date(2021, 1, 3, 0, 0, 0, 0, time.Local)
 	checkpointTs := oracle.GoTimeToTS(currTime)
-	cnt, err := RemoveExpiredFiles(ctx, model.ChangeFeedID{}, storage, cfg, checkpointTs, time.UTC)
+	cnt, err := RemoveExpiredFiles(ctx, model.ChangeFeedID{}, storage, cfg, checkpointTs)
 	require.NoError(t, err)
 	require.Equal(t, uint64(16), cnt)
 }

--- a/pkg/sink/cloudstorage/path_test.go
+++ b/pkg/sink/cloudstorage/path_test.go
@@ -432,7 +432,7 @@ func TestRemoveExpiredFilesWithoutPartition(t *testing.T) {
 
 	currTime := time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC)
 	checkpointTs := oracle.GoTimeToTS(currTime)
-	cnt, err := RemoveExpiredFiles(ctx, model.ChangeFeedID{}, storage, cfg, checkpointTs)
+	cnt, err := RemoveExpiredFiles(ctx, model.ChangeFeedID{}, storage, cfg, checkpointTs, time.UTC)
 	require.NoError(t, err)
 	require.Equal(t, uint64(16), cnt)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10815 

### What is changed and how it works?
Currently, the **date part** in storage file path is formatted using local timezone. 
And in the test `TestRemoveExpiredFilesWithoutPartition`, the `checkpointTS` is generated using UTC timezone. But when removing expired files in `RemoveExpiredFiles`, the **date str** is formatted using local timezone. This will make the test fail in some specific timezone.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None.
```
