### PR TITLE
apiv2(ticdc): update changefeed config keep old config to prevent loss configuration

### DIFF
--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -441,7 +441,9 @@ func (h *OpenAPIV2) updateChangefeed(c *gin.Context) {
 		return
 	}
 
-	updateCfConfig := &ChangefeedConfig{}
+	updateCfConfig := &ChangefeedConfig{
+		ReplicaConfig: ToAPIReplicaConfig(oldCfInfo.Config),
+	}
 	if err = c.BindJSON(updateCfConfig); err != nil {
 		_ = c.Error(cerror.WrapError(cerror.ErrAPIInvalidParam, err))
 		return

--- a/pkg/api/v2/changefeed.go
+++ b/pkg/api/v2/changefeed.go
@@ -128,7 +128,7 @@ func (c *changefeeds) Pause(ctx context.Context,
 		Do(ctx).Error()
 }
 
-// Get gets a changefeed detaail info
+// Get gets a changefeed detail info
 func (c *changefeeds) Get(ctx context.Context,
 	namespace string, name string,
 ) (*v2.ChangeFeedInfo, error) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10830

### What is changed and how it works?

* when bind the new changefeed config, also keep the old configuration

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
fix the open API v2 update changefeed config may loss previous configurations
```
