### PR TITLE
kvClient (ticdc): resolve stale lock more aggressively to reduce resolvedTs lag

### DIFF
--- a/cdc/kv/shared_client.go
+++ b/cdc/kv/shared_client.go
@@ -680,7 +680,9 @@ func (s *SharedClient) resolveLock(ctx context.Context) error {
 			}
 		}
 		start := time.Now()
-		defer s.metrics.lockResolveRunDuration.Observe(float64(time.Since(start).Milliseconds()))
+		defer func() {
+			s.metrics.lockResolveRunDuration.Observe(float64(time.Since(start).Milliseconds()))
+		}()
 
 		if err := s.lockResolver.Resolve(ctx, regionID, maxVersion); err != nil {
 			log.Warn("event feed resolve lock fail",

--- a/cdc/puller/multiplexing_puller.go
+++ b/cdc/puller/multiplexing_puller.go
@@ -33,8 +33,8 @@ import (
 )
 
 const (
-	resolveLockFence        time.Duration = 20 * time.Second
-	resolveLockTickInterval time.Duration = 10 * time.Second
+	resolveLockFence        time.Duration = 4 * time.Second
+	resolveLockTickInterval time.Duration = 2 * time.Second
 
 	// Suppose there are 50K tables, total size of `resolvedEventsCache`s will be
 	// unsafe.SizeOf(kv.MultiplexingEvent) * 50K * 256 = 800M.

--- a/scripts/generate-mock.sh
+++ b/scripts/generate-mock.sh
@@ -43,24 +43,24 @@ fi
 "$MOCKGEN" -source pkg/sink/kafka/v2/gssapi.go -destination pkg/sink/kafka/v2/mock/gssapi_mock.go
 "$MOCKGEN" -source pkg/sink/kafka/v2/writer.go -destination pkg/sink/kafka/v2/mock/writer_mock.go
 
-# DM mock
-"$MOCKGEN" -package pbmock -destination dm/pbmock/dmmaster.go github.com/pingcap/tiflow/dm/pb MasterClient,MasterServer
-"$MOCKGEN" -package pbmock -destination dm/pbmock/dmworker.go github.com/pingcap/tiflow/dm/pb WorkerClient,WorkerServer
+# # DM mock
+# "$MOCKGEN" -package pbmock -destination dm/pbmock/dmmaster.go github.com/pingcap/tiflow/dm/pb MasterClient,MasterServer
+# "$MOCKGEN" -package pbmock -destination dm/pbmock/dmworker.go github.com/pingcap/tiflow/dm/pb WorkerClient,WorkerServer
 
-# Engine mock
-"$MOCKGEN" -package mock -destination engine/pkg/meta/mock/client_mock.go github.com/pingcap/tiflow/engine/pkg/meta/model KVClient
-"$MOCKGEN" -package mock -destination engine/executor/server/mock/metastore_mock.go github.com/pingcap/tiflow/engine/executor/server MetastoreCreator
-"$MOCKGEN" -package mock -destination engine/enginepb/mock/executor_mock.go github.com/pingcap/tiflow/engine/enginepb ExecutorServiceClient
-"$MOCKGEN" -package mock -destination engine/enginepb/mock/broker_mock.go github.com/pingcap/tiflow/engine/enginepb BrokerServiceClient
-"$MOCKGEN" -package mock -destination engine/enginepb/mock/resource_mock.go github.com/pingcap/tiflow/engine/enginepb ResourceManagerClient
-"$MOCKGEN" -package mock -destination engine/pkg/httputil/mock/jobhttpclient_mock.go github.com/pingcap/tiflow/engine/pkg/httputil JobHTTPClient
-"$MOCKGEN" -package mock -destination engine/servermaster/jobop/mock/joboperator_mock.go github.com/pingcap/tiflow/engine/servermaster/jobop JobOperator
-"$MOCKGEN" -package mock -destination engine/pkg/orm/mock/client_mock.go github.com/pingcap/tiflow/engine/pkg/orm Client
-"$MOCKGEN" -package mock -destination engine/servermaster/jobop/mock/backoffmanager_mock.go github.com/pingcap/tiflow/engine/servermaster/jobop BackoffManager
-"$MOCKGEN" -package mock -source engine/pkg/rpcutil/checker.go -destination engine/pkg/rpcutil/mock/checker_mock.go
-"$MOCKGEN" -package client -self_package github.com/pingcap/tiflow/engine/pkg/client \
-	-destination engine/pkg/client/client_mock.go github.com/pingcap/tiflow/engine/pkg/client ExecutorClient,ServerMasterClient
+# # Engine mock
+# "$MOCKGEN" -package mock -destination engine/pkg/meta/mock/client_mock.go github.com/pingcap/tiflow/engine/pkg/meta/model KVClient
+# "$MOCKGEN" -package mock -destination engine/executor/server/mock/metastore_mock.go github.com/pingcap/tiflow/engine/executor/server MetastoreCreator
+# "$MOCKGEN" -package mock -destination engine/enginepb/mock/executor_mock.go github.com/pingcap/tiflow/engine/enginepb ExecutorServiceClient
+# "$MOCKGEN" -package mock -destination engine/enginepb/mock/broker_mock.go github.com/pingcap/tiflow/engine/enginepb BrokerServiceClient
+# "$MOCKGEN" -package mock -destination engine/enginepb/mock/resource_mock.go github.com/pingcap/tiflow/engine/enginepb ResourceManagerClient
+# "$MOCKGEN" -package mock -destination engine/pkg/httputil/mock/jobhttpclient_mock.go github.com/pingcap/tiflow/engine/pkg/httputil JobHTTPClient
+# "$MOCKGEN" -package mock -destination engine/servermaster/jobop/mock/joboperator_mock.go github.com/pingcap/tiflow/engine/servermaster/jobop JobOperator
+# "$MOCKGEN" -package mock -destination engine/pkg/orm/mock/client_mock.go github.com/pingcap/tiflow/engine/pkg/orm Client
+# "$MOCKGEN" -package mock -destination engine/servermaster/jobop/mock/backoffmanager_mock.go github.com/pingcap/tiflow/engine/servermaster/jobop BackoffManager
+# "$MOCKGEN" -package mock -source engine/pkg/rpcutil/checker.go -destination engine/pkg/rpcutil/mock/checker_mock.go
+# "$MOCKGEN" -package client -self_package github.com/pingcap/tiflow/engine/pkg/client \
+# 	-destination engine/pkg/client/client_mock.go github.com/pingcap/tiflow/engine/pkg/client ExecutorClient,ServerMasterClient
 
-# PKG mock
-"$MOCKGEN" -package mock -destination pkg/election/mock/storage_mock.go github.com/pingcap/tiflow/pkg/election Storage
-"$MOCKGEN" -package mock -destination pkg/election/mock/elector_mock.go github.com/pingcap/tiflow/pkg/election Elector
+# # PKG mock
+# "$MOCKGEN" -package mock -destination pkg/election/mock/storage_mock.go github.com/pingcap/tiflow/pkg/election Storage
+# "$MOCKGEN" -package mock -destination pkg/election/mock/elector_mock.go github.com/pingcap/tiflow/pkg/election Elector

--- a/scripts/generate-mock.sh
+++ b/scripts/generate-mock.sh
@@ -43,24 +43,24 @@ fi
 "$MOCKGEN" -source pkg/sink/kafka/v2/gssapi.go -destination pkg/sink/kafka/v2/mock/gssapi_mock.go
 "$MOCKGEN" -source pkg/sink/kafka/v2/writer.go -destination pkg/sink/kafka/v2/mock/writer_mock.go
 
-# # DM mock
-# "$MOCKGEN" -package pbmock -destination dm/pbmock/dmmaster.go github.com/pingcap/tiflow/dm/pb MasterClient,MasterServer
-# "$MOCKGEN" -package pbmock -destination dm/pbmock/dmworker.go github.com/pingcap/tiflow/dm/pb WorkerClient,WorkerServer
+# DM mock
+"$MOCKGEN" -package pbmock -destination dm/pbmock/dmmaster.go github.com/pingcap/tiflow/dm/pb MasterClient,MasterServer
+"$MOCKGEN" -package pbmock -destination dm/pbmock/dmworker.go github.com/pingcap/tiflow/dm/pb WorkerClient,WorkerServer
 
-# # Engine mock
-# "$MOCKGEN" -package mock -destination engine/pkg/meta/mock/client_mock.go github.com/pingcap/tiflow/engine/pkg/meta/model KVClient
-# "$MOCKGEN" -package mock -destination engine/executor/server/mock/metastore_mock.go github.com/pingcap/tiflow/engine/executor/server MetastoreCreator
-# "$MOCKGEN" -package mock -destination engine/enginepb/mock/executor_mock.go github.com/pingcap/tiflow/engine/enginepb ExecutorServiceClient
-# "$MOCKGEN" -package mock -destination engine/enginepb/mock/broker_mock.go github.com/pingcap/tiflow/engine/enginepb BrokerServiceClient
-# "$MOCKGEN" -package mock -destination engine/enginepb/mock/resource_mock.go github.com/pingcap/tiflow/engine/enginepb ResourceManagerClient
-# "$MOCKGEN" -package mock -destination engine/pkg/httputil/mock/jobhttpclient_mock.go github.com/pingcap/tiflow/engine/pkg/httputil JobHTTPClient
-# "$MOCKGEN" -package mock -destination engine/servermaster/jobop/mock/joboperator_mock.go github.com/pingcap/tiflow/engine/servermaster/jobop JobOperator
-# "$MOCKGEN" -package mock -destination engine/pkg/orm/mock/client_mock.go github.com/pingcap/tiflow/engine/pkg/orm Client
-# "$MOCKGEN" -package mock -destination engine/servermaster/jobop/mock/backoffmanager_mock.go github.com/pingcap/tiflow/engine/servermaster/jobop BackoffManager
-# "$MOCKGEN" -package mock -source engine/pkg/rpcutil/checker.go -destination engine/pkg/rpcutil/mock/checker_mock.go
-# "$MOCKGEN" -package client -self_package github.com/pingcap/tiflow/engine/pkg/client \
-# 	-destination engine/pkg/client/client_mock.go github.com/pingcap/tiflow/engine/pkg/client ExecutorClient,ServerMasterClient
+# Engine mock
+"$MOCKGEN" -package mock -destination engine/pkg/meta/mock/client_mock.go github.com/pingcap/tiflow/engine/pkg/meta/model KVClient
+"$MOCKGEN" -package mock -destination engine/executor/server/mock/metastore_mock.go github.com/pingcap/tiflow/engine/executor/server MetastoreCreator
+"$MOCKGEN" -package mock -destination engine/enginepb/mock/executor_mock.go github.com/pingcap/tiflow/engine/enginepb ExecutorServiceClient
+"$MOCKGEN" -package mock -destination engine/enginepb/mock/broker_mock.go github.com/pingcap/tiflow/engine/enginepb BrokerServiceClient
+"$MOCKGEN" -package mock -destination engine/enginepb/mock/resource_mock.go github.com/pingcap/tiflow/engine/enginepb ResourceManagerClient
+"$MOCKGEN" -package mock -destination engine/pkg/httputil/mock/jobhttpclient_mock.go github.com/pingcap/tiflow/engine/pkg/httputil JobHTTPClient
+"$MOCKGEN" -package mock -destination engine/servermaster/jobop/mock/joboperator_mock.go github.com/pingcap/tiflow/engine/servermaster/jobop JobOperator
+"$MOCKGEN" -package mock -destination engine/pkg/orm/mock/client_mock.go github.com/pingcap/tiflow/engine/pkg/orm Client
+"$MOCKGEN" -package mock -destination engine/servermaster/jobop/mock/backoffmanager_mock.go github.com/pingcap/tiflow/engine/servermaster/jobop BackoffManager
+"$MOCKGEN" -package mock -source engine/pkg/rpcutil/checker.go -destination engine/pkg/rpcutil/mock/checker_mock.go
+"$MOCKGEN" -package client -self_package github.com/pingcap/tiflow/engine/pkg/client \
+	-destination engine/pkg/client/client_mock.go github.com/pingcap/tiflow/engine/pkg/client ExecutorClient,ServerMasterClient
 
-# # PKG mock
-# "$MOCKGEN" -package mock -destination pkg/election/mock/storage_mock.go github.com/pingcap/tiflow/pkg/election Storage
-# "$MOCKGEN" -package mock -destination pkg/election/mock/elector_mock.go github.com/pingcap/tiflow/pkg/election Elector
+# PKG mock
+"$MOCKGEN" -package mock -destination pkg/election/mock/storage_mock.go github.com/pingcap/tiflow/pkg/election Storage
+"$MOCKGEN" -package mock -destination pkg/election/mock/elector_mock.go github.com/pingcap/tiflow/pkg/election Elector


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #10880 

### What is changed and how it works?

Reduce the delay of the resolvedTs required to trigger the sending of resolve stale lock requests, adjusting from 20s to 4s. This can more actively request the upstream TiKV to advance the resolvedTs as soon as possible.

In the test environment, after using this PR, the changefeed CheckpointTs lag caused by the rolling restart of TiKV and TiDB is stable between 6-15s.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
