### PR TITLE
ticdc: correctly initialize replicationSet to make puller resolved ts calculation correctly

### DIFF
--- a/cdc/scheduler/internal/v3/replication/replication_set.go
+++ b/cdc/scheduler/internal/v3/replication/replication_set.go
@@ -153,6 +153,36 @@ func NewReplicationSet(
 			CheckpointTs: checkpoint,
 			ResolvedTs:   checkpoint,
 		},
+		// We need to initialize the stats with the checkpoint ts.
+		// Only when the table into ReplicationSetStateReplicating state, we can update the stats
+		// In advanceCheckpoint, it will first check table.Stats.StageCheckpoints["puller-egress"] whether it is nil,
+		// Only when it's not nil, then consider it join to calculate the slowest puller resolved ts.
+		// If we don't initialize the stats here, when the new table is stuck in incremental scan
+		// the min puller resolved ts calulcated in advanceCheckpoint will increase continuely
+		Stats: tablepb.Stats{
+			StageCheckpoints: map[string]tablepb.Checkpoint{
+				"puller-egress": {
+					CheckpointTs: checkpoint,
+					ResolvedTs:   checkpoint,
+				},
+				"puller-ingress": {
+					CheckpointTs: checkpoint,
+					ResolvedTs:   checkpoint,
+				},
+				"sink": {
+					CheckpointTs: checkpoint,
+					ResolvedTs:   checkpoint,
+				},
+				"sorter-ingress": {
+					CheckpointTs: checkpoint,
+					ResolvedTs:   checkpoint,
+				},
+				"sorter-egress": {
+					CheckpointTs: checkpoint,
+					ResolvedTs:   checkpoint,
+				},
+			},
+		},
 	}
 	// Count of captures that is in Stopping states.
 	stoppingCount := 0

--- a/cdc/scheduler/internal/v3/replication/replication_set.go
+++ b/cdc/scheduler/internal/v3/replication/replication_set.go
@@ -154,7 +154,7 @@ func NewReplicationSet(
 			ResolvedTs:   checkpoint,
 		},
 		// We need to initialize the stats with the checkpoint ts.
-		// Only when the table into ReplicationSetStateReplicating state, we can update the stats
+		// Only when the table into ReplicationSetStateReplicating state, owner will update the table's stats
 		// In advanceCheckpoint, it will first check table.Stats.StageCheckpoints["puller-egress"] whether it is nil,
 		// Only when it's not nil, then consider it join to calculate the slowest puller resolved ts.
 		// If we don't initialize the stats here, when the new table is stuck in incremental scan

--- a/cdc/scheduler/internal/v3/replication/replication_set_test.go
+++ b/cdc/scheduler/internal/v3/replication/replication_set_test.go
@@ -62,6 +62,35 @@ func TestNewReplicationSet(t *testing.T) {
 			set: &ReplicationSet{
 				State:    ReplicationSetStateAbsent,
 				Captures: map[string]Role{},
+				Stats: tablepb.Stats{
+					StageCheckpoints: map[string]tablepb.Checkpoint{
+						"puller-egress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"puller-ingress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sink": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sorter-ingress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sorter-egress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+					},
+				},
 			},
 			tableStatus: map[model.CaptureID]*tablepb.TableStatus{},
 		},
@@ -72,6 +101,35 @@ func TestNewReplicationSet(t *testing.T) {
 				Captures: map[string]Role{"1": RolePrimary},
 				Checkpoint: tablepb.Checkpoint{
 					CheckpointTs: 2, ResolvedTs: 2,
+				},
+				Stats: tablepb.Stats{
+					StageCheckpoints: map[string]tablepb.Checkpoint{
+						"puller-egress": {
+							CheckpointTs: 2,
+							ResolvedTs:   2,
+							LastSyncedTs: 0,
+						},
+						"puller-ingress": {
+							CheckpointTs: 2,
+							ResolvedTs:   2,
+							LastSyncedTs: 0,
+						},
+						"sink": {
+							CheckpointTs: 2,
+							ResolvedTs:   2,
+							LastSyncedTs: 0,
+						},
+						"sorter-ingress": {
+							CheckpointTs: 2,
+							ResolvedTs:   2,
+							LastSyncedTs: 0,
+						},
+						"sorter-egress": {
+							CheckpointTs: 2,
+							ResolvedTs:   2,
+							LastSyncedTs: 0,
+						},
+					},
 				},
 			},
 			checkpoint: 2,
@@ -89,6 +147,35 @@ func TestNewReplicationSet(t *testing.T) {
 			set: &ReplicationSet{
 				State:    ReplicationSetStatePrepare,
 				Captures: map[string]Role{"1": RoleSecondary},
+				Stats: tablepb.Stats{
+					StageCheckpoints: map[string]tablepb.Checkpoint{
+						"puller-egress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"puller-ingress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sink": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sorter-ingress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sorter-egress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+					},
+				},
 			},
 			tableStatus: map[model.CaptureID]*tablepb.TableStatus{
 				"1": {
@@ -108,6 +195,35 @@ func TestNewReplicationSet(t *testing.T) {
 				Checkpoint: tablepb.Checkpoint{
 					CheckpointTs: 2,
 					ResolvedTs:   2,
+				},
+				Stats: tablepb.Stats{
+					StageCheckpoints: map[string]tablepb.Checkpoint{
+						"puller-egress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"puller-ingress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sink": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sorter-ingress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sorter-egress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+					},
 				},
 			},
 			tableStatus: map[model.CaptureID]*tablepb.TableStatus{
@@ -135,6 +251,35 @@ func TestNewReplicationSet(t *testing.T) {
 				Captures: map[string]Role{
 					"1": RoleSecondary, "2": RolePrimary,
 				},
+				Stats: tablepb.Stats{
+					StageCheckpoints: map[string]tablepb.Checkpoint{
+						"puller-egress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"puller-ingress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sink": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sorter-ingress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sorter-egress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+					},
+				},
 			},
 			tableStatus: map[model.CaptureID]*tablepb.TableStatus{
 				"1": {
@@ -154,6 +299,35 @@ func TestNewReplicationSet(t *testing.T) {
 				Captures: map[string]Role{
 					"1": RoleSecondary, "2": RoleUndetermined,
 				},
+				Stats: tablepb.Stats{
+					StageCheckpoints: map[string]tablepb.Checkpoint{
+						"puller-egress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"puller-ingress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sink": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sorter-ingress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sorter-egress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+					},
+				},
 			},
 			tableStatus: map[model.CaptureID]*tablepb.TableStatus{
 				"1": {
@@ -171,6 +345,35 @@ func TestNewReplicationSet(t *testing.T) {
 			set: &ReplicationSet{
 				State:    ReplicationSetStateCommit,
 				Captures: map[string]Role{"1": RoleSecondary},
+				Stats: tablepb.Stats{
+					StageCheckpoints: map[string]tablepb.Checkpoint{
+						"puller-egress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"puller-ingress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sink": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sorter-ingress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sorter-egress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+					},
+				},
 			},
 			tableStatus: map[model.CaptureID]*tablepb.TableStatus{
 				"1": {
@@ -189,6 +392,35 @@ func TestNewReplicationSet(t *testing.T) {
 				State: ReplicationSetStateRemoving,
 				Captures: map[string]Role{
 					"1": RoleUndetermined, "2": RoleUndetermined,
+				},
+				Stats: tablepb.Stats{
+					StageCheckpoints: map[string]tablepb.Checkpoint{
+						"puller-egress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"puller-ingress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sink": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sorter-ingress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+						"sorter-egress": {
+							CheckpointTs: 0,
+							ResolvedTs:   0,
+							LastSyncedTs: 0,
+						},
+					},
 				},
 			},
 			tableStatus: map[model.CaptureID]*tablepb.TableStatus{


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/10856

### What is changed and how it works?
Initialize ReplicationSet stats with checkpointTs. Only when a table into ReplicationSetStateReplicating state, then owner will update stats based on handleMessage. 

Thus, if we don't initialize stats at the beginning, before the table into ReplicationSetStateReplicating state, it can't join to calculation the minimal puller resolve ts.  It will lead some misleading when some table is stuck in incremental scan.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
I add sleep for a while in incremental scan logic. Then I exam the minimal puller resolved ts before the table created and after the table created. We can see before the table created, the minimal puller resolved ts will stuck, and back to increase continuely after the table is created.
![image](https://github.com/pingcap/tiflow/assets/26538495/46866b8d-00e9-445c-81d3-d8388cd8456f)

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
