### PR TITLE
ticdc: Add metrics to observe slow initialize region count

### DIFF
--- a/cdc/kv/metrics.go
+++ b/cdc/kv/metrics.go
@@ -158,6 +158,13 @@ var (
 			Name:      "region_worker_channel_size",
 			Help:      "size of each channel in region worker",
 		}, []string{"namespace", "changefeed", "table", "store", "type"})
+	slowInitializeRegion = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "ticdc",
+			Subsystem: "kvclient",
+			Name:      "slow_initialize_region_count",
+			Help:      "the number of slow initialize region",
+		}, []string{"namespace", "changefeed"})
 )
 
 // GetGlobalGrpcMetrics gets the global grpc metrics.
@@ -184,6 +191,7 @@ func InitMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(regionWorkerQueueDuration)
 	registry.MustRegister(workerBusyRatio)
 	registry.MustRegister(workerChannelSize)
+	registry.MustRegister(slowInitializeRegion)
 
 	// Register client metrics to registry.
 	registry.MustRegister(grpcMetrics)

--- a/metrics/grafana/ticdc.json
+++ b/metrics/grafana/ticdc.json
@@ -15197,6 +15197,106 @@
             "align": false,
             "alignLevel": null
           }
+        },
+        {
+          "aliasColors": {},
+          "dashLength": 10,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 122
+          },
+          "id": 10039,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "pluginVersion": "7.5.17",
+          "pointradius": 2,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "targets": [
+            {
+              "expr": "ticdc_kvclient_slow_initialize_region_count{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$ticdc_instance\"}",
+              "legendFormat": "{{instance}}-{{changefeed}}-{{namespace}}",
+              "interval": "",
+              "exemplar": true,
+              "hide": false,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "KV client slow initalize region count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true,
+              "$$hashKey": "object:432"
+            },
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false,
+              "$$hashKey": "object:433"
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          },
+          "description": "The count of regions that initialize slow",
+          "bars": false,
+          "dashes": false,
+          "fillGradient": 0,
+          "hiddenSeries": false,
+          "percentage": false,
+          "points": false,
+          "stack": false,
+          "steppedLine": false,
+          "timeFrom": null,
+          "timeShift": null
         }
       ],
       "title": "KVClient",

--- a/metrics/grafana/ticdc.json
+++ b/metrics/grafana/ticdc.json
@@ -15286,7 +15286,7 @@
             "align": false,
             "alignLevel": null
           },
-          "description": "The count of regions that initialize slow",
+          "description": "The count of regions that initialize slow. You can search the log [event feed initializes a region too slow] to get slow region id",
           "bars": false,
           "dashes": false,
           "fillGradient": 0,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #10862

### What is changed and how it works?
Add metrics to observe slow initialize region count
![image](https://github.com/pingcap/tiflow/assets/26538495/4ebce3ee-06ef-4e62-9b4b-d08dd57ef171)


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
