### PR TITLE
kvclient(ticdc): close the grpc client after all goroutine exited to prevent data race and panic

### DIFF
--- a/cdc/kv/shared_stream.go
+++ b/cdc/kv/shared_stream.go
@@ -169,7 +169,8 @@ func (s *requestedStream) run(ctx context.Context, c *SharedClient, rs *requeste
 		}
 	}()
 
-	cc, err := c.grpcPool.Connect(ctx, rs.storeAddr)
+	g, gctx := errgroup.WithContext(ctx)
+	cc, err := c.grpcPool.Connect(gctx, rs.storeAddr)
 	if err != nil {
 		log.Warn("event feed create grpc stream failed",
 			zap.String("namespace", c.changefeed.Namespace),
@@ -181,7 +182,6 @@ func (s *requestedStream) run(ctx context.Context, c *SharedClient, rs *requeste
 		return isCanceled()
 	}
 
-	g, gctx := errgroup.WithContext(ctx)
 	if cc.Multiplexing() {
 		s.multiplexing = cc
 		g.Go(func() error { return s.receive(gctx, c, rs, s.multiplexing, invalidSubscriptionID) })

--- a/cdc/kv/shared_stream.go
+++ b/cdc/kv/shared_stream.go
@@ -169,6 +169,8 @@ func (s *requestedStream) run(ctx context.Context, c *SharedClient, rs *requeste
 		}
 	}()
 
+	// grpc stream can be canceled by this context when any goroutine meet error,
+	// the underline established grpc connections is unaffected.
 	g, gctx := errgroup.WithContext(ctx)
 	cc, err := c.grpcPool.Connect(gctx, rs.storeAddr)
 	if err != nil {

--- a/cdc/kv/sharedconn/conn_and_client.go
+++ b/cdc/kv/sharedconn/conn_and_client.go
@@ -163,7 +163,6 @@ func (c *ConnAndClient) Multiplexing() bool {
 func (c *ConnAndClient) Release() {
 	if c.client != nil {
 		_ = c.client.CloseSend()
-		c.client = nil
 	}
 	if c.conn != nil && c.array != nil {
 		c.array.release(c.conn, false)

--- a/cdc/kv/sharedconn/conn_and_client.go
+++ b/cdc/kv/sharedconn/conn_and_client.go
@@ -56,6 +56,7 @@ type ConnAndClient struct {
 	conn   *Conn
 	array  *connArray
 	client cdcpb.ChangeData_EventFeedV2Client
+	closed atomic.Bool
 }
 
 // Conn is a connection.
@@ -161,8 +162,9 @@ func (c *ConnAndClient) Multiplexing() bool {
 
 // Release releases a ConnAndClient object.
 func (c *ConnAndClient) Release() {
-	if c.client != nil {
+	if c.client != nil && !c.closed.Load() {
 		_ = c.client.CloseSend()
+		c.closed.Store(true)
 	}
 	if c.conn != nil && c.array != nil {
 		c.array.release(c.conn, false)

--- a/tests/integration_tests/kafka_big_txn_v2/run.sh
+++ b/tests/integration_tests/kafka_big_txn_v2/run.sh
@@ -45,12 +45,9 @@ function run() {
 	check_table_exists "big_txn.usertable" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
 	run_sql "CREATE TABLE big_txn.usertable1 LIKE big_txn.usertable" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "INSERT INTO big_txn.usertable1 SELECT * FROM big_txn.usertable" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-	sleep 60
-	check_table_exists "big_txn.usertable1" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT}
-
-	run_sql "CREATE TABLE big_txn.finish_mark_1 (a int primary key);"
+	run_sql "CREATE TABLE big_txn.finish_mark (a int primary key);"
 	sleep 120
-	check_table_exists "big_txn.finish_mark_1" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 60
+	check_table_exists "big_txn.finish_mark" ${DOWN_TIDB_HOST} ${DOWN_TIDB_PORT} 120
 
 	check_sync_diff $WORK_DIR $CUR/conf/diff_config.toml
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10799

### What is changed and how it works?

* use errgroup context to control grpc stream, to make it can be canceld.
* do not set the grpc stream to nil after `CloseSend`

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
