### PR TITLE
redo(ticdc): enable pprof and set memory limit for redo applier

### DIFF
--- a/cdc/redo/reader/reader.go
+++ b/cdc/redo/reader/reader.go
@@ -37,7 +37,7 @@ import (
 const (
 	emitBatch             = mysql.DefaultMaxTxnRow
 	defaultReaderChanSize = mysql.DefaultWorkerCount * emitBatch
-	maxTotalMemoryUsage   = 90.0
+	maxTotalMemoryUsage   = 80.0
 	maxWaitDuration       = time.Minute * 2
 )
 
@@ -205,7 +205,7 @@ func (l *LogReader) runReader(egCtx context.Context, cfg *readerConfig) error {
 				case l.rowCh <- row:
 				}
 			}
-			err := util.WaitMemoryAvailable(maxTotalMemoryUsage, maxWaitDuration)
+			err := util.WaitMemoryAvailable(egCtx, maxTotalMemoryUsage, maxWaitDuration)
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/cdc/redo/reader/reader.go
+++ b/cdc/redo/reader/reader.go
@@ -205,11 +205,6 @@ func (l *LogReader) runReader(egCtx context.Context, cfg *readerConfig) error {
 				case l.rowCh <- row:
 				}
 			}
-			err := util.WaitMemoryAvailable(egCtx, maxTotalMemoryUsage, maxWaitDuration)
-			if err != nil {
-				return errors.Trace(err)
-			}
-
 		case redo.RedoDDLLogFileType:
 			ddl := item.data.RedoDDL.DDL
 			if ddl != nil && ddl.CommitTs > cfg.startTs && ddl.CommitTs <= cfg.endTs {

--- a/pkg/cmd/redo/apply.go
+++ b/pkg/cmd/redo/apply.go
@@ -75,7 +75,7 @@ func (o *applyRedoOptions) complete(cmd *cobra.Command) error {
 			memoryLimitInBytes = totalMemoryInBytes
 		}
 		debug.SetMemoryLimit(memoryLimitInBytes)
-		log.Info("set memory limit", zap.Int64("memory-limit", memoryLimitInBytes))
+		log.Info("set memory limit", zap.Int64("memoryLimit", memoryLimitInBytes))
 	}
 
 	return nil

--- a/pkg/cmd/redo/apply.go
+++ b/pkg/cmd/redo/apply.go
@@ -15,7 +15,7 @@ package redo
 
 import (
 	"net/http"
-	_ "net/http/pprof"
+	_ "net/http/pprof" // init pprof
 	"net/url"
 	"runtime/debug"
 	"time"

--- a/pkg/util/memory.go
+++ b/pkg/util/memory.go
@@ -14,6 +14,7 @@
 package util
 
 import (
+	"context"
 	"math"
 	"time"
 
@@ -48,21 +49,28 @@ func CheckMemoryUsage(limit float64) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+
+	log.Info("check memory usage", zap.Any("memory", stat))
 	return stat.UsedPercent < limit, nil
 }
 
 // WaitMemoryAvailable waits until the memory usage is less than the limit.
-func WaitMemoryAvailable(limit float64, timeout time.Duration) error {
-	start := time.Now()
+func WaitMemoryAvailable(ctx context.Context, limit float64, timeout time.Duration) error {
+	ticker := time.NewTicker(time.Second * 5)
+	timeoutTimer := time.NewTimer(timeout)
 	for {
-		hasFreeMemory, err := CheckMemoryUsage(limit)
-		if err != nil {
-			return err
-		}
-		if hasFreeMemory {
-			return nil
-		}
-		if time.Since(start) > timeout {
+		select {
+		case <-ctx.Done():
+			return errors.WrapError(errors.ErrWaitFreeMemoryTimeout, ctx.Err())
+		case <-ticker.C:
+			hasFreeMemory, err := CheckMemoryUsage(limit)
+			if err != nil {
+				return err
+			}
+			if hasFreeMemory {
+				return nil
+			}
+		case <-timeoutTimer.C:
 			return errors.ErrWaitFreeMemoryTimeout.GenWithStackByArgs()
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10900

### What is changed and how it works?
1. Set memory limit for redo applier.
2. Enable pprof for redo applier to simplify troubleshooting.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
