### PR TITLE
processor(ticdc): Fix processor panic issue

### DIFF
--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -924,6 +924,10 @@ func (p *processor) cleanupMetrics() {
 
 // WriteDebugInfo write the debug info to Writer
 func (p *processor) WriteDebugInfo(w io.Writer) error {
+	if !p.initialized.Load() {
+		fmt.Fprintln(w, "processor is not initialized")
+		return nil
+	}
 	fmt.Fprintf(w, "%+v\n%+v\n", *p.latestInfo, *p.latestStatus)
 	spans := p.sinkManager.r.GetAllCurrentTableSpans()
 	for _, span := range spans {

--- a/cdc/processor/processor_test.go
+++ b/cdc/processor/processor_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"os"
 	"sync/atomic"
 	"testing"
 
@@ -794,4 +795,11 @@ func TestProcessorDostNotStuckInInit(t *testing.T) {
 
 	require.Nil(t, p.Close())
 	tester.MustApplyPatches()
+}
+
+func TestProcessorNotInitialized(t *testing.T) {
+	globalVars, changefeedVars := vars.NewGlobalVarsAndChangefeedInfo4Test()
+	liveness := model.LivenessCaptureAlive
+	p, _, _ := initProcessor4Test(t, &liveness, false, globalVars, changefeedVars)
+	require.Nil(t, p.WriteDebugInfo(os.Stdout))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10921

### What is changed and how it works?
If a processor is not initialized and then call writerDebugInfo command, ticdc will panic because of tableManager is nil
this PR will check if the processor is initialized or not, if not initialized, then print a log, false add a ut case to cover it.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
