### PR TITLE
ddl(ticdc): Remove pulling ddl change from DDLJobList and DDLJobAddIdxList

### DIFF
--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build intest
-// +build intest
-
 package entry
 
 import (

--- a/cdc/entry/schema_storage_test.go
+++ b/cdc/entry/schema_storage_test.go
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build intest
-// +build intest
-
 package entry
 
 import (

--- a/cdc/entry/schema_test.go
+++ b/cdc/entry/schema_test.go
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build intest
-// +build intest
-
 package entry
 
 import (

--- a/cdc/puller/ddl_puller_test.go
+++ b/cdc/puller/ddl_puller_test.go
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build intest
-// +build intest
-
 package puller
 
 import (

--- a/cdc/sink/dmlsink/mq/transformer/columnselector/column_selector_test.go
+++ b/cdc/sink/dmlsink/mq/transformer/columnselector/column_selector_test.go
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build intest
-// +build intest
-
 package columnselector
 
 import (

--- a/pkg/sink/codec/debezium/debezium_test.go
+++ b/pkg/sink/codec/debezium/debezium_test.go
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build intest
-// +build intest
-
 package debezium
 
 import (

--- a/pkg/spanz/span.go
+++ b/pkg/spanz/span.go
@@ -60,51 +60,15 @@ func GetTableRange(tableID int64) (startKey, endKey []byte) {
 	return start, end
 }
 
-// getDDLRange returns the span to watch for DDL related events
-// Note that returned keys are not in memcomparable format.
-func getDDLRange() (startKey, endKey []byte) {
-	return getMetaListKey("DDLJobList")
-}
-
-// getAddIndexDDLRange returns the span to watch for Add Index DDL related events
-// Note that returned keys are not in memcomparable format.
-func getAddIndexDDLRange() (startKey, endKey []byte) {
-	return getMetaListKey("DDLJobAddIdxList")
-}
-
 // GetAllDDLSpan return all cdc interested spans for DDL.
 func GetAllDDLSpan() []tablepb.Span {
-	spans := make([]tablepb.Span, 0, 3)
-	start, end := getDDLRange()
-	spans = append(spans, tablepb.Span{
-		StartKey: ToComparableKey(start),
-		EndKey:   ToComparableKey(end),
-	})
-	start, end = getAddIndexDDLRange()
-	spans = append(spans, tablepb.Span{
-		StartKey: ToComparableKey(start),
-		EndKey:   ToComparableKey(end),
-	})
-	start, end = GetTableRange(JobTableID)
+	spans := make([]tablepb.Span, 0, 1)
+	start, end := GetTableRange(JobTableID)
 	spans = append(spans, tablepb.Span{
 		StartKey: ToComparableKey(start),
 		EndKey:   ToComparableKey(end),
 	})
 	return spans
-}
-
-func getMetaListKey(key string) (startKey, endKey []byte) {
-	metaPrefix := []byte("m")
-	metaKey := []byte(key)
-	listData := 'l'
-	start := make([]byte, 0, len(metaPrefix)+len(metaKey)+8)
-	start = append(start, metaPrefix...)
-	start = codec.EncodeBytes(start, metaKey)
-	start = codec.EncodeUint(start, uint64(listData))
-	end := make([]byte, len(start))
-	copy(end, start)
-	end[len(end)-1]++
-	return start, end
 }
 
 // KeyInSpan check if k in the span range.

--- a/pkg/version/check.go
+++ b/pkg/version/check.go
@@ -37,13 +37,15 @@ import (
 
 var (
 	// minPDVersion is the version of the minimal compatible PD.
-	minPDVersion = semver.New("5.1.0-alpha")
+	// The min version should be 7.x because we adapt to tidb concurrency ddl implementations.
+	minPDVersion = semver.New("7.1.0-alpha")
 	// maxPDVersion is the version of the maximum compatible PD.
 	// Compatible versions are in [minPDVersion, maxPDVersion)
 	maxPDVersion = semver.New("10.0.0")
 
 	// MinTiKVVersion is the version of the minimal compatible TiKV.
-	MinTiKVVersion = semver.New("5.1.0-alpha")
+	// The min version should be 7.x because we adapt to tidb concurrency ddl implementations.
+	MinTiKVVersion = semver.New("7.1.0-alpha")
 	// maxTiKVVersion is the version of the maximum compatible TiKV.
 	// Compatible versions are in [MinTiKVVersion, maxTiKVVersion)
 	maxTiKVVersion = semver.New("10.0.0")


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref https://github.com/pingcap/tiflow/issues/10908

### What is changed and how it works?
Remove pulling ddl change from DDLJobList and DDLJobAddIdxList, which is an too old version ddl implementations(in 5.x). 

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
