### PR TITLE
cdc: reduce seek CPU usage on PebbleDB sorter

### DIFF
--- a/cdc/processor/sourcemanager/sorter/factory/pebble.go
+++ b/cdc/processor/sourcemanager/sorter/factory/pebble.go
@@ -48,7 +48,7 @@ func createPebbleDBs(
 	}()
 
 	cache = pebble.NewCache(int64(memQuotaInBytes))
-	tableCache := pebble.NewTableCache(cache, 8, int(cache.MaxSize()/2))
+	tableCache := pebble.NewTableCache(cache, 8, int(cache.MaxSize()))
 	for id := 0; id < cfg.Count; id++ {
 		ws := writeStalls[id]
 		adjust := func(opts *pebble.Options) {
@@ -84,7 +84,7 @@ func createPebbleDBs(
 			zap.Uint64("sharedCacheSize", memQuotaInBytes))
 		dbs = append(dbs, db)
 	}
-	tableCache.Unref()
+	err = tableCache.Unref()
 	return
 }
 

--- a/cdc/processor/sourcemanager/sorter/factory/pebble.go
+++ b/cdc/processor/sourcemanager/sorter/factory/pebble.go
@@ -48,6 +48,7 @@ func createPebbleDBs(
 	}()
 
 	cache = pebble.NewCache(int64(memQuotaInBytes))
+	tableCache := pebble.NewTableCache(cache, 8, int(cache.MaxSize()/2))
 	for id := 0; id < cfg.Count; id++ {
 		ws := writeStalls[id]
 		adjust := func(opts *pebble.Options) {
@@ -74,7 +75,7 @@ func createPebbleDBs(
 		}
 
 		var db *pebble.DB
-		if db, err = epebble.OpenPebble(id, dir, cfg, cache, adjust); err != nil {
+		if db, err = epebble.OpenPebble(id, dir, cfg, cache, tableCache, adjust); err != nil {
 			log.Error("create pebble fails", zap.String("dir", dir), zap.Int("id", id), zap.Error(err))
 			return
 		}
@@ -83,6 +84,7 @@ func createPebbleDBs(
 			zap.Uint64("sharedCacheSize", memQuotaInBytes))
 		dbs = append(dbs, db)
 	}
+	tableCache.Unref()
 	return
 }
 

--- a/cdc/processor/sourcemanager/sorter/pebble/db.go
+++ b/cdc/processor/sourcemanager/sorter/pebble/db.go
@@ -81,6 +81,7 @@ func iterTable(
 			tableMaxCRTs, _ := strconv.Atoi(userProps[maxTableCRTsLabel])
 			return uint64(tableMaxCRTs) >= lowerBound.CommitTs && uint64(tableMinCRTs) <= upperBound.CommitTs
 		},
+		UseL6Filters: true,
 	})
 	if err != nil {
 		log.Panic("fail to create iterator")
@@ -94,6 +95,7 @@ func iterTable(
 func OpenPebble(
 	id int, path string, cfg *config.DBConfig,
 	cache *pebble.Cache,
+	tableCache *pebble.TableCache,
 	adjusts ...func(*pebble.Options),
 ) (db *pebble.DB, err error) {
 	dbDir := filepath.Join(path, fmt.Sprintf("%04d", id))
@@ -104,6 +106,7 @@ func OpenPebble(
 
 	opts := buildPebbleOption(cfg)
 	opts.Cache = cache
+	opts.TableCache = tableCache
 	for _, adjust := range adjusts {
 		adjust(opts)
 	}

--- a/cdc/processor/sourcemanager/sorter/pebble/db_test.go
+++ b/cdc/processor/sourcemanager/sorter/pebble/db_test.go
@@ -31,6 +31,7 @@ func TestIteratorWithTableFilter(t *testing.T) {
 	db, err := OpenPebble(
 		1, dbPath, &config.DBConfig{Count: 1},
 		nil,
+		nil,
 		// Disable auto compactions to make the case more stable.
 		func(opts *pebble.Options) { opts.DisableAutomaticCompactions = true },
 	)

--- a/cdc/processor/sourcemanager/sorter/pebble/event_sorter_test.go
+++ b/cdc/processor/sourcemanager/sorter/pebble/event_sorter_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestTableOperations(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), t.Name())
-	db, err := OpenPebble(1, dbPath, &config.DBConfig{Count: 1}, nil)
+	db, err := OpenPebble(1, dbPath, &config.DBConfig{Count: 1}, nil, nil)
 	require.Nil(t, err)
 	defer func() { _ = db.Close() }()
 
@@ -53,7 +53,7 @@ func TestTableOperations(t *testing.T) {
 // TestNoResolvedTs tests resolved timestamps shouldn't be emitted.
 func TestNoResolvedTs(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), t.Name())
-	db, err := OpenPebble(1, dbPath, &config.DBConfig{Count: 1}, nil)
+	db, err := OpenPebble(1, dbPath, &config.DBConfig{Count: 1}, nil, nil)
 	require.Nil(t, err)
 	defer func() { _ = db.Close() }()
 
@@ -84,7 +84,7 @@ func TestNoResolvedTs(t *testing.T) {
 // TestEventFetch tests events can be sorted correctly.
 func TestEventFetch(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), t.Name())
-	db, err := OpenPebble(1, dbPath, &config.DBConfig{Count: 1}, nil)
+	db, err := OpenPebble(1, dbPath, &config.DBConfig{Count: 1}, nil, nil)
 	require.Nil(t, err)
 	defer func() { _ = db.Close() }()
 
@@ -167,7 +167,7 @@ func TestEventFetch(t *testing.T) {
 
 func TestCleanData(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), t.Name())
-	db, err := OpenPebble(1, dbPath, &config.DBConfig{Count: 1}, nil)
+	db, err := OpenPebble(1, dbPath, &config.DBConfig{Count: 1}, nil, nil)
 	require.Nil(t, err)
 	defer func() { _ = db.Close() }()
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10933 

### What is changed and how it works?

Custom some options for PebbleDB.

This PR specified an instance-shared table cache with a suitable size. So seek operations can cache some blocks instead of reading them from disk every time.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Idle CPU Usage (before):
<img width="333" alt="图片" src="https://github.com/pingcap/tiflow/assets/8407317/450fbd75-88c6-465f-8591-2ba46fd88761">

Idle CPU Usage (after):
<img width="331" alt="图片" src="https://github.com/pingcap/tiflow/assets/8407317/628c0f4e-1449-4e11-ad2e-481b04cb4d4c">


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
