### PR TITLE
pkg/causality(cdc): refactor and simplify conflict detector

### DIFF
--- a/cdc/sink/dmlsink/txn/event.go
+++ b/cdc/sink/dmlsink/txn/event.go
@@ -16,7 +16,6 @@ package txn
 import (
 	"encoding/binary"
 	"hash/fnv"
-	"sort"
 	"strings"
 	"time"
 
@@ -41,51 +40,17 @@ func (e *txnEvent) OnConflictResolved() {
 	e.conflictResolved = time.Now()
 }
 
-// GenSortedDedupKeysHash implements causality.txnEvent interface.
-func (e *txnEvent) GenSortedDedupKeysHash(numSlots uint64) []uint64 {
-	hashes := genTxnKeys(e.TxnCallbackableEvent.Event)
-
-	// Sort and dedup hashes.
-	// Sort hashes by `hash % numSlots` to avoid deadlock, and then dedup
-	// hashes, so the same txn will not check confict with the same hash twice to
-	// prevent potential cyclic self dependency in the causality dependency
-	// graph.
-	return sortAndDedupHashes(hashes, numSlots)
+// ConflictKeys implements causality.txnEvent interface.
+func (e *txnEvent) ConflictKeys() []uint64 {
+	return genTxnKeys(e.TxnCallbackableEvent.Event)
 }
 
-func sortAndDedupHashes(hashes []uint64, numSlots uint64) []uint64 {
-	if len(hashes) == 0 {
-		return nil
-	}
-
-	// Sort hashes by `hash % numSlots` to avoid deadlock.
-	sort.Slice(hashes, func(i, j int) bool { return hashes[i]%numSlots < hashes[j]%numSlots })
-
-	// Dedup hashes
-	last := hashes[0]
-	j := 1
-	for i, hash := range hashes {
-		if i == 0 {
-			// skip first one, start checking duplication from 2nd one
-			continue
-		}
-		if hash == last {
-			continue
-		}
-		last = hash
-		hashes[j] = hash
-		j++
-	}
-	hashes = hashes[:j]
-
-	return hashes
-}
-
-// genTxnKeys returns hash keys for `txn`.
+// genTxnKeys returns deduplicated hash keys of a transaction.
 func genTxnKeys(txn *model.SingleTableTxn) []uint64 {
 	if len(txn.Rows) == 0 {
 		return nil
 	}
+
 	hashRes := make(map[uint64]struct{}, len(txn.Rows))
 	hasher := fnv.New32a()
 	for _, row := range txn.Rows {

--- a/cdc/sink/dmlsink/txn/event_test.go
+++ b/cdc/sink/dmlsink/txn/event_test.go
@@ -199,30 +199,3 @@ func TestGenKeys(t *testing.T) {
 		require.Equal(t, tc.expected, keys)
 	}
 }
-
-func TestSortAndDedupHash(t *testing.T) {
-	// If a transaction contains multiple rows, these rows may generate the same hash
-	// in some rare cases. We should dedup these hashes to avoid unnecessary self cyclic
-	// dependency in the causality dependency graph.
-	t.Parallel()
-	testCases := []struct {
-		hashes   []uint64
-		expected []uint64
-	}{{
-		// No duplicate hashes
-		hashes:   []uint64{1, 2, 3, 4, 5},
-		expected: []uint64{1, 2, 3, 4, 5},
-	}, {
-		// Duplicate hashes
-		hashes:   []uint64{1, 2, 3, 4, 5, 1, 2, 3, 4, 5},
-		expected: []uint64{1, 2, 3, 4, 5},
-	}, {
-		// Has hash value larger than slots count, should sort by `hash % numSlots` first.
-		hashes:   []uint64{4, 9, 9, 3},
-		expected: []uint64{9, 3, 4},
-	}}
-
-	for _, tc := range testCases {
-		require.Equal(t, tc.expected, sortAndDedupHashes(tc.hashes, 8))
-	}
-}

--- a/pkg/causality/conflict_detector.go
+++ b/pkg/causality/conflict_detector.go
@@ -83,7 +83,7 @@ func (d *ConflictDetector[Txn]) Add(txn Txn) {
 			// After this transaction is executed, we can remove the node from the graph,
 			// and resolve related dependencies for these transacitons which depend on this
 			// executed transaction.
-			d.slots.Free(node)
+			d.slots.Remove(node)
 		},
 	}
 	node.TrySendToTxnCache = func(cacheID int64) bool {

--- a/pkg/causality/conflict_detector.go
+++ b/pkg/causality/conflict_detector.go
@@ -34,7 +34,7 @@ type ConflictDetector[Txn txnEvent] struct {
 
 	// slots are used to find all unfinished transactions
 	// conflicting with an incoming transactions.
-	slots    *internal.Slots[*internal.Node]
+	slots    *internal.Slots
 	numSlots uint64
 
 	// nextWorkerID is used to dispatch transactions round-robin.
@@ -53,7 +53,7 @@ func NewConflictDetector[Txn txnEvent](
 ) *ConflictDetector[Txn] {
 	ret := &ConflictDetector[Txn]{
 		resolvedTxnCaches: make([]txnCache[Txn], opt.Count),
-		slots:             internal.NewSlots[*internal.Node](numSlots),
+		slots:             internal.NewSlots(numSlots),
 		numSlots:          numSlots,
 		notifiedNodes:     chann.NewAutoDrainChann[func()](),
 		garbageNodes:      chann.NewAutoDrainChann[*internal.Node](),

--- a/pkg/causality/conflict_detector.go
+++ b/pkg/causality/conflict_detector.go
@@ -75,10 +75,10 @@ func NewConflictDetector[Txn txnEvent](
 // Add pushes a transaction to the ConflictDetector.
 //
 // NOTE: if multiple threads access this concurrently,
-// Txn.GenSortedDedupKeysHash must be sorted by the slot index.
+// Txn.ConflictKeys must be sorted by the slot index.
 func (d *ConflictDetector[Txn]) Add(txn Txn) {
-	sortedKeysHash := txn.GenSortedDedupKeysHash(d.numSlots)
-	node := internal.NewNode(sortedKeysHash)
+	sortedKeysHash := txn.ConflictKeys()
+	node := internal.NewNode(sortedKeysHash, d.numSlots)
 	txnWithNotifier := TxnWithNotifier[Txn]{
 		TxnEvent: txn,
 		PostTxnExecuted: func() {

--- a/pkg/causality/internal/main_test.go
+++ b/pkg/causality/internal/main_test.go
@@ -1,0 +1,24 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/pingcap/tiflow/pkg/leakutil"
+)
+
+func TestMain(m *testing.M) {
+	leakutil.SetUpLeakTest(m)
+}

--- a/pkg/causality/internal/node.go
+++ b/pkg/causality/internal/node.go
@@ -221,7 +221,7 @@ func (n *Node) maybeResolve() {
 			log.Panic("invalid cache ID", zap.Uint64("cacheID", uint64(cacheID)))
 		}
 
-		if cacheID >= 0 {
+		if cacheID != assignedToAny {
 			n.tryAssignTo(cacheID)
 			return
 		}

--- a/pkg/causality/internal/node.go
+++ b/pkg/causality/internal/node.go
@@ -85,10 +85,10 @@ type Node struct {
 }
 
 // NewNode creates a new node.
-func NewNode(sortedDedupKeysHash []uint64) (ret *Node) {
+func NewNode(hashes []uint64, numSlots uint64) (ret *Node) {
 	defer func() {
 		ret.id = genNextNodeID()
-		ret.sortedDedupKeysHash = sortedDedupKeysHash
+		ret.sortedDedupKeysHash = sortAndDedupHashes(hashes, numSlots)
 		ret.TrySendToTxnCache = nil
 		ret.RandCacheID = nil
 		ret.totalDependencies = 0

--- a/pkg/causality/internal/node.go
+++ b/pkg/causality/internal/node.go
@@ -148,8 +148,7 @@ func (n *Node) dependOn(dependencyNodes map[int64]*Node, noDependencyKeyCnt int)
 	n.maybeResolve()
 }
 
-// Remove implements interface internal.SlotNode.
-func (n *Node) Remove() {
+func (n *Node) remove() {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
@@ -164,23 +163,6 @@ func (n *Node) Remove() {
 		n.dependers.Clear(true)
 		n.dependers = nil
 	}
-}
-
-// free must be called if a node is no longer used.
-func (n *Node) free() {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	if n.id == invalidNodeID {
-		log.Panic("double free")
-	}
-
-	n.id = invalidNodeID
-	n.TrySendToTxnCache = nil
-
-	// TODO: reuse node if necessary. Currently it's impossible if async-notify is used.
-	// The reason is a node can step functions `assignTo`, `Remove`, `free`, then `assignTo`.
-	// again. In the last `assignTo`, it can never know whether the node has been reused
-	// or not.
 }
 
 // tryAssignTo assigns a node to a cache. Returns `true` on success.

--- a/pkg/causality/internal/node.go
+++ b/pkg/causality/internal/node.go
@@ -90,9 +90,6 @@ func (n *Node) dependOn(dependencyNodes map[int64]*Node) {
 	resolvedDependencies := int32(0)
 
 	depend := func(target *Node) {
-		if target == nil {
-			log.Panic("node cannot depend on nil")
-		}
 		if target.id == n.id {
 			log.Panic("node cannot depend on itself")
 		}

--- a/pkg/causality/internal/node.go
+++ b/pkg/causality/internal/node.go
@@ -103,18 +103,11 @@ func NewNode(hashes []uint64, numSlots uint64) (ret *Node) {
 	return
 }
 
-// NodeID implements interface internal.SlotNode.
-func (n *Node) NodeID() int64 {
+func (n *Node) nodeID() int64 {
 	return n.id
 }
 
-// Hashes implements interface internal.SlotNode.
-func (n *Node) Hashes() []uint64 {
-	return n.sortedDedupKeysHash
-}
-
-// DependOn implements interface internal.SlotNode.
-func (n *Node) DependOn(dependencyNodes map[int64]*Node, noDependencyKeyCnt int) {
+func (n *Node) dependOn(dependencyNodes map[int64]*Node, noDependencyKeyCnt int) {
 	resolvedDependencies := int32(0)
 
 	depend := func(target *Node) {
@@ -192,10 +185,8 @@ func (n *Node) Remove() {
 	}
 }
 
-// Free implements interface internal.SlotNode.
-// It must be called if a node is no longer used.
-// We are using sync.Pool to lessen the burden of GC.
-func (n *Node) Free() {
+// free must be called if a node is no longer used.
+func (n *Node) free() {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	if n.id == invalidNodeID {
@@ -206,7 +197,7 @@ func (n *Node) Free() {
 	n.TrySendToTxnCache = nil
 
 	// TODO: reuse node if necessary. Currently it's impossible if async-notify is used.
-	// The reason is a node can step functions `assignTo`, `Remove`, `Free`, then `assignTo`.
+	// The reason is a node can step functions `assignTo`, `Remove`, `free`, then `assignTo`.
 	// again. In the last `assignTo`, it can never know whether the node has been reused
 	// or not.
 }

--- a/pkg/causality/internal/node.go
+++ b/pkg/causality/internal/node.go
@@ -84,25 +84,6 @@ type Node struct {
 	dependers *btree.BTreeG[*Node]
 }
 
-// NewNode creates a new node.
-func NewNode(hashes []uint64, numSlots uint64) (ret *Node) {
-	defer func() {
-		ret.id = genNextNodeID()
-		ret.sortedDedupKeysHash = sortAndDedupHashes(hashes, numSlots)
-		ret.TrySendToTxnCache = nil
-		ret.RandCacheID = nil
-		ret.totalDependencies = 0
-		ret.resolvedDependencies = 0
-		ret.removedDependencies = 0
-		ret.resolvedList = nil
-		ret.assignedTo = unassigned
-		ret.removed = false
-	}()
-
-	ret = new(Node)
-	return
-}
-
 func (n *Node) nodeID() int64 {
 	return n.id
 }

--- a/pkg/causality/internal/node.go
+++ b/pkg/causality/internal/node.go
@@ -157,11 +157,6 @@ func (n *Node) DependOn(dependencyNodes map[int64]*Node, noDependencyKeyCnt int)
 		}
 	}
 
-	// Re-allocate ID in `DependOn` instead of creating the node, because the node can be
-	// pending in slots after it's created.
-	// ?: why gen new ID here?
-	n.id = genNextNodeID()
-
 	// `totalDependencies` and `resolvedList` must be initialized before depending on any targets.
 	n.totalDependencies = int32(len(dependencyNodes) + noDependencyKeyCnt)
 	n.resolvedList = make([]int64, 0, n.totalDependencies)

--- a/pkg/causality/internal/node_test.go
+++ b/pkg/causality/internal/node_test.go
@@ -48,7 +48,7 @@ func TestNodeDependOn(t *testing.T) {
 	nodeA := newNodeForTest()
 	nodeB := newNodeForTest()
 
-	nodeA.dependOn(map[int64]*Node{nodeB.nodeID(): nodeB}, 999)
+	nodeA.dependOn(map[int64]*Node{nodeB.nodeID(): nodeB})
 	require.Equal(t, nodeA.dependerCount(), 0)
 	require.Equal(t, nodeB.dependerCount(), 1)
 }
@@ -56,22 +56,22 @@ func TestNodeDependOn(t *testing.T) {
 func TestNodeSingleDependency(t *testing.T) {
 	t.Parallel()
 
-	// Node B depends on A, without any other resolved dependencies.
+	// Node B depends on A
 	nodeA := newNodeForTest()
 	nodeB := newNodeForTest()
-	nodeB.dependOn(map[int64]*Node{nodeA.nodeID(): nodeA}, 0)
+	nodeB.dependOn(map[int64]*Node{nodeA.nodeID(): nodeA})
 	require.True(t, nodeA.tryAssignTo(1))
 	require.Equal(t, cacheID(1), nodeA.assignedWorkerID())
 	require.Equal(t, cacheID(1), nodeB.assignedWorkerID())
 
-	// Node D depends on C, with some other resolved dependencies.
+	// Node D depends on C
 	nodeC := newNodeForTest()
 	nodeD := newNodeForTest()
-	nodeD.dependOn(map[int64]*Node{nodeA.nodeID(): nodeC}, 999)
+	nodeD.dependOn(map[int64]*Node{nodeA.nodeID(): nodeC})
 	require.True(t, nodeC.tryAssignTo(2))
 	require.Equal(t, cacheID(2), nodeC.assignedWorkerID())
 	nodeC.remove()
-	require.Equal(t, cacheID(100), nodeD.assignedWorkerID())
+	require.Equal(t, cacheID(2), nodeD.assignedWorkerID())
 }
 
 func TestNodeMultipleDependencies(t *testing.T) {
@@ -86,7 +86,7 @@ func TestNodeMultipleDependencies(t *testing.T) {
 	nodeB := newNodeForTest()
 	nodeC := newNodeForTest()
 
-	nodeC.dependOn(map[int64]*Node{nodeA.nodeID(): nodeA, nodeB.nodeID(): nodeB}, 999)
+	nodeC.dependOn(map[int64]*Node{nodeA.nodeID(): nodeA, nodeB.nodeID(): nodeB})
 
 	require.True(t, nodeA.tryAssignTo(1))
 	require.True(t, nodeB.tryAssignTo(2))
@@ -103,7 +103,7 @@ func TestNodeResolveImmediately(t *testing.T) {
 
 	// Node A depends on 0 unresolved dependencies and some resolved dependencies.
 	nodeA := newNodeForTest()
-	nodeA.dependOn(nil, 999)
+	nodeA.dependOn(nil)
 	require.Equal(t, cacheID(100), nodeA.assignedWorkerID())
 
 	// Node D depends on B and C, all of them are assigned to 1.
@@ -112,14 +112,14 @@ func TestNodeResolveImmediately(t *testing.T) {
 	nodeC := newNodeForTest()
 	require.True(t, nodeC.tryAssignTo(1))
 	nodeD := newNodeForTest()
-	nodeD.dependOn(map[int64]*Node{nodeB.nodeID(): nodeB, nodeC.nodeID(): nodeC}, 0)
+	nodeD.dependOn(map[int64]*Node{nodeB.nodeID(): nodeB, nodeC.nodeID(): nodeC})
 	require.Equal(t, cacheID(1), nodeD.assignedWorkerID())
 
 	// Node E depends on B and C and some other resolved dependencies.
 	nodeB.remove()
 	nodeC.remove()
 	nodeE := newNodeForTest()
-	nodeE.dependOn(map[int64]*Node{nodeB.nodeID(): nodeB, nodeC.nodeID(): nodeC}, 999)
+	nodeE.dependOn(map[int64]*Node{nodeB.nodeID(): nodeB, nodeC.nodeID(): nodeC})
 	require.Equal(t, cacheID(100), nodeE.assignedWorkerID())
 }
 
@@ -128,7 +128,7 @@ func TestNodeDependOnSelf(t *testing.T) {
 
 	nodeA := newNodeForTest()
 	require.Panics(t, func() {
-		nodeA.dependOn(map[int64]*Node{nodeA.nodeID(): nodeA}, 999)
+		nodeA.dependOn(map[int64]*Node{nodeA.nodeID(): nodeA})
 	})
 }
 

--- a/pkg/causality/internal/node_test.go
+++ b/pkg/causality/internal/node_test.go
@@ -32,23 +32,6 @@ func newNodeForTest(hashes ...uint64) *Node {
 	}
 }
 
-func TestNodefree(t *testing.T) {
-	// This case should not be run parallel to
-	// others, for fear that the use-after-free
-	// will race with newNodeForTest() in other cases.
-
-	nodeA := newNodeForTest()
-	nodeA.free()
-
-	nodeA = newNodeForTest()
-	nodeA.free()
-
-	// Double freeing should panic.
-	require.Panics(t, func() {
-		nodeA.free()
-	})
-}
-
 func TestNodeEquals(t *testing.T) {
 	t.Parallel()
 
@@ -87,7 +70,7 @@ func TestNodeSingleDependency(t *testing.T) {
 	nodeD.dependOn(map[int64]*Node{nodeA.nodeID(): nodeC}, 999)
 	require.True(t, nodeC.tryAssignTo(2))
 	require.Equal(t, cacheID(2), nodeC.assignedWorkerID())
-	nodeC.Remove()
+	nodeC.remove()
 	require.Equal(t, cacheID(100), nodeD.assignedWorkerID())
 }
 
@@ -110,8 +93,8 @@ func TestNodeMultipleDependencies(t *testing.T) {
 
 	require.Equal(t, unassigned, nodeC.assignedWorkerID())
 
-	nodeA.Remove()
-	nodeB.Remove()
+	nodeA.remove()
+	nodeB.remove()
 	require.Equal(t, int64(100), nodeC.assignedWorkerID())
 }
 
@@ -133,8 +116,8 @@ func TestNodeResolveImmediately(t *testing.T) {
 	require.Equal(t, cacheID(1), nodeD.assignedWorkerID())
 
 	// Node E depends on B and C and some other resolved dependencies.
-	nodeB.Remove()
-	nodeC.Remove()
+	nodeB.remove()
+	nodeC.remove()
 	nodeE := newNodeForTest()
 	nodeE.dependOn(map[int64]*Node{nodeB.nodeID(): nodeB, nodeC.nodeID(): nodeC}, 999)
 	require.Equal(t, cacheID(100), nodeE.assignedWorkerID())

--- a/pkg/causality/internal/node_test.go
+++ b/pkg/causality/internal/node_test.go
@@ -19,13 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	// DefaultConflictDetectorSlots indicates the default slot count of conflict detector.
-	DefaultConflictDetectorSlots uint64 = 16 * 1024
-)
-
 func newNodeForTest() *Node {
-	node := NewNode(nil, DefaultConflictDetectorSlots)
+	node := &Node{}
 	node.OnNotified = func(callback func()) {
 		// run the callback immediately
 		callback()

--- a/pkg/causality/internal/node_test.go
+++ b/pkg/causality/internal/node_test.go
@@ -19,10 +19,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	// DefaultConflictDetectorSlots indicates the default slot count of conflict detector.
+	DefaultConflictDetectorSlots uint64 = 16 * 1024
+)
+
 var _ SlotNode[*Node] = &Node{} // Asserts that *Node implements SlotNode[*Node].
 
 func newNodeForTest() *Node {
-	node := NewNode(nil)
+	node := NewNode(nil, DefaultConflictDetectorSlots)
 	node.OnNotified = func(callback func()) {
 		// run the callback immediately
 		callback()

--- a/pkg/causality/internal/slots.go
+++ b/pkg/causality/internal/slots.go
@@ -103,9 +103,9 @@ func (s *Slots) Add(elem *Node) {
 	}
 }
 
-// Free removes an element from the Slots.
-func (s *Slots) Free(elem *Node) {
-	elem.Remove()
+// Remove removes an element from the Slots.
+func (s *Slots) Remove(elem *Node) {
+	elem.remove()
 	hashes := elem.sortedDedupKeysHash
 	for _, hash := range hashes {
 		slotIdx := getSlot(hash, s.numSlots)
@@ -118,7 +118,6 @@ func (s *Slots) Free(elem *Node) {
 		}
 		s.slots[slotIdx].mu.Unlock()
 	}
-	elem.free()
 }
 
 func getSlot(hash, numSlots uint64) uint64 {

--- a/pkg/causality/internal/slots.go
+++ b/pkg/causality/internal/slots.go
@@ -61,7 +61,6 @@ func (s *Slots) AllocNode(hashes []uint64) *Node {
 func (s *Slots) Add(elem *Node) {
 	hashes := elem.sortedDedupKeysHash
 	dependencyNodes := make(map[int64]*Node, len(hashes))
-	noDependecyCnt := 0
 
 	var lastSlot uint64 = math.MaxUint64
 	for _, hash := range hashes {
@@ -79,8 +78,6 @@ func (s *Slots) Add(elem *Node) {
 			// If there are multiple hashes conflicts with the same node, we only need to
 			// depend on the node once.
 			dependencyNodes[prevID] = prevNode
-		} else {
-			noDependecyCnt += 1
 		}
 		// Add this node to the slot, make sure new coming nodes with the same hash should
 		// depend on this node.
@@ -89,7 +86,7 @@ func (s *Slots) Add(elem *Node) {
 
 	// Construct the dependency graph based on collected `dependencyNodes` and with corresponding
 	// slots locked.
-	elem.dependOn(dependencyNodes, noDependecyCnt)
+	elem.dependOn(dependencyNodes)
 
 	// Lock those slots one by one and then unlock them one by one, so that
 	// we can avoid 2 transactions get executed interleaved.

--- a/pkg/causality/internal/slots.go
+++ b/pkg/causality/internal/slots.go
@@ -15,6 +15,7 @@ package internal
 
 import (
 	"math"
+	"sort"
 	"sync"
 )
 
@@ -122,4 +123,37 @@ func (s *Slots[E]) Free(elem E) {
 
 func getSlot(hash, numSlots uint64) uint64 {
 	return hash % numSlots
+}
+
+// Sort and dedup hashes.
+// Sort hashes by `hash % numSlots` to avoid deadlock, and then dedup
+// hashes, so the same node will not check confict with the same hash
+// twice to prevent potential cyclic self dependency in the causality
+// dependency graph.
+func sortAndDedupHashes(hashes []uint64, numSlots uint64) []uint64 {
+	if len(hashes) == 0 {
+		return nil
+	}
+
+	// Sort hashes by `hash % numSlots` to avoid deadlock.
+	sort.Slice(hashes, func(i, j int) bool { return hashes[i]%numSlots < hashes[j]%numSlots })
+
+	// Dedup hashes
+	last := hashes[0]
+	j := 1
+	for i, hash := range hashes {
+		if i == 0 {
+			// skip first one, start checking duplication from 2nd one
+			continue
+		}
+		if hash == last {
+			continue
+		}
+		last = hash
+		hashes[j] = hash
+		j++
+	}
+	hashes = hashes[:j]
+
+	return hashes
 }

--- a/pkg/causality/internal/slots_test.go
+++ b/pkg/causality/internal/slots_test.go
@@ -30,8 +30,7 @@ func TestSlotsTrivial(t *testing.T) {
 	nodes := make([]*Node, 0, 1000)
 
 	for i := 0; i < count; i++ {
-		node := slots.AllocNode([]uint64{1, 2, 3, 4, 5})
-		node.RandCacheID = func() cacheID { return 100 }
+		node := newNodeForTest(1, 2, 3, 4, 5)
 		slots.Add(node)
 		nodes = append(nodes, node)
 	}
@@ -54,13 +53,8 @@ func TestSlotsConcurrentOps(t *testing.T) {
 	slots := NewSlots(8)
 	freeNodeChan := make(chan *Node, N)
 	inuseNodeChan := make(chan *Node, N)
-	newNode := func() *Node {
-		node := slots.AllocNode([]uint64{1, 9, 17, 25, 33})
-		node.RandCacheID = func() cacheID { return 100 }
-		return node
-	}
 	for i := 0; i < N; i++ {
-		freeNodeChan <- newNode()
+		freeNodeChan <- newNodeForTest(1, 9, 17, 25, 33)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
@@ -93,7 +87,7 @@ func TestSlotsConcurrentOps(t *testing.T) {
 			case node := <-inuseNodeChan:
 				// keys belong to the same slot after hash, since slot num is 8
 				slots.Free(node)
-				freeNodeChan <- newNode()
+				freeNodeChan <- newNodeForTest(1, 9, 17, 25, 33)
 			}
 		}
 	}()

--- a/pkg/causality/internal/slots_test.go
+++ b/pkg/causality/internal/slots_test.go
@@ -30,7 +30,7 @@ func TestSlotsTrivial(t *testing.T) {
 	nodes := make([]*Node, 0, 1000)
 
 	for i := 0; i < count; i++ {
-		node := NewNode([]uint64{1, 2, 3, 4, 5}, DefaultConflictDetectorSlots)
+		node := slots.AllocNode([]uint64{1, 2, 3, 4, 5})
 		node.RandCacheID = func() cacheID { return 100 }
 		slots.Add(node)
 		nodes = append(nodes, node)
@@ -55,7 +55,7 @@ func TestSlotsConcurrentOps(t *testing.T) {
 	freeNodeChan := make(chan *Node, N)
 	inuseNodeChan := make(chan *Node, N)
 	newNode := func() *Node {
-		node := NewNode([]uint64{1, 9, 17, 25, 33}, DefaultConflictDetectorSlots)
+		node := slots.AllocNode([]uint64{1, 9, 17, 25, 33})
 		node.RandCacheID = func() cacheID { return 100 }
 		return node
 	}

--- a/pkg/causality/internal/slots_test.go
+++ b/pkg/causality/internal/slots_test.go
@@ -30,7 +30,7 @@ func TestSlotsTrivial(t *testing.T) {
 	nodes := make([]*Node, 0, 1000)
 
 	for i := 0; i < count; i++ {
-		node := NewNode([]uint64{1, 2, 3, 4, 5})
+		node := NewNode([]uint64{1, 2, 3, 4, 5}, DefaultConflictDetectorSlots)
 		node.RandCacheID = func() cacheID { return 100 }
 		slots.Add(node)
 		nodes = append(nodes, node)
@@ -55,7 +55,7 @@ func TestSlotsConcurrentOps(t *testing.T) {
 	freeNodeChan := make(chan *Node, N)
 	inuseNodeChan := make(chan *Node, N)
 	newNode := func() *Node {
-		node := NewNode([]uint64{1, 9, 17, 25, 33})
+		node := NewNode([]uint64{1, 9, 17, 25, 33}, DefaultConflictDetectorSlots)
 		node.RandCacheID = func() cacheID { return 100 }
 		return node
 	}
@@ -99,4 +99,31 @@ func TestSlotsConcurrentOps(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+func TestSortAndDedupHash(t *testing.T) {
+	// If a transaction contains multiple rows, these rows may generate the same hash
+	// in some rare cases. We should dedup these hashes to avoid unnecessary self cyclic
+	// dependency in the causality dependency graph.
+	t.Parallel()
+	testCases := []struct {
+		hashes   []uint64
+		expected []uint64
+	}{{
+		// No duplicate hashes
+		hashes:   []uint64{1, 2, 3, 4, 5},
+		expected: []uint64{1, 2, 3, 4, 5},
+	}, {
+		// Duplicate hashes
+		hashes:   []uint64{1, 2, 3, 4, 5, 1, 2, 3, 4, 5},
+		expected: []uint64{1, 2, 3, 4, 5},
+	}, {
+		// Has hash value larger than slots count, should sort by `hash % numSlots` first.
+		hashes:   []uint64{4, 9, 9, 3},
+		expected: []uint64{9, 3, 4},
+	}}
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.expected, sortAndDedupHashes(tc.hashes, 8))
+	}
 }

--- a/pkg/causality/internal/slots_test.go
+++ b/pkg/causality/internal/slots_test.go
@@ -36,7 +36,7 @@ func TestSlotsTrivial(t *testing.T) {
 	}
 
 	for i := 0; i < count; i++ {
-		slots.Free(nodes[i])
+		slots.Remove(nodes[i])
 	}
 
 	require.Equal(t, 0, len(slots.slots[1].nodes))
@@ -86,7 +86,7 @@ func TestSlotsConcurrentOps(t *testing.T) {
 				return
 			case node := <-inuseNodeChan:
 				// keys belong to the same slot after hash, since slot num is 8
-				slots.Free(node)
+				slots.Remove(node)
 				freeNodeChan <- newNodeForTest(1, 9, 17, 25, 33)
 			}
 		}

--- a/pkg/causality/internal/slots_test.go
+++ b/pkg/causality/internal/slots_test.go
@@ -26,7 +26,7 @@ func TestSlotsTrivial(t *testing.T) {
 	t.Parallel()
 
 	const count = 1000
-	slots := NewSlots[*Node](8)
+	slots := NewSlots(8)
 	nodes := make([]*Node, 0, 1000)
 
 	for i := 0; i < count; i++ {
@@ -51,7 +51,7 @@ func TestSlotsConcurrentOps(t *testing.T) {
 	t.Parallel()
 
 	const N = 256
-	slots := NewSlots[*Node](8)
+	slots := NewSlots(8)
 	freeNodeChan := make(chan *Node, N)
 	inuseNodeChan := make(chan *Node, N)
 	newNode := func() *Node {

--- a/pkg/causality/tests/integration_test.go
+++ b/pkg/causality/tests/integration_test.go
@@ -40,7 +40,7 @@ func TestConflictBasics(t *testing.T) {
 		numWorkers, numSlots, newUniformGenerator(workingSetSize, batchSize, numSlots),
 	).WithExecFunc(
 		func(txn *txnForTest) error {
-			for _, key := range txn.GenSortedDedupKeysHash(numSlots) {
+			for _, key := range txn.ConflictKeys() {
 				// Access a position in the array without synchronization,
 				// so that if causality check is buggy, the Go race detection would fail.
 				conflictArray[key]++

--- a/pkg/causality/tests/worker.go
+++ b/pkg/causality/tests/worker.go
@@ -28,7 +28,7 @@ type txnForTest struct {
 
 func (t *txnForTest) OnConflictResolved() {}
 
-func (t *txnForTest) GenSortedDedupKeysHash(numSlots uint64) []uint64 {
+func (t *txnForTest) ConflictKeys() []uint64 {
 	return t.keys
 }
 

--- a/pkg/causality/txn_cache.go
+++ b/pkg/causality/txn_cache.go
@@ -1,4 +1,4 @@
-// Copyright 2022 PingCAP, Inc.
+// Copyright 2024 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/causality/txn_cache_test.go
+++ b/pkg/causality/txn_cache_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 PingCAP, Inc.
+// Copyright 2024 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/causality/txn_cache_test.go
+++ b/pkg/causality/txn_cache_test.go
@@ -24,7 +24,7 @@ type mockTxnEvent struct{}
 func (m mockTxnEvent) OnConflictResolved() {
 }
 
-func (m mockTxnEvent) GenSortedDedupKeysHash(numSlots uint64) []uint64 {
+func (m mockTxnEvent) ConflictKeys() []uint64 {
 	return nil
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10973

### What is changed and how it works?
- Remove some [useless and redundant logic](https://github.com/pingcap/tiflow/pull/10954/files#diff-641e339f15eae87ec78b7587b36a9a3382d5146711891ca9fedb978795ef48fbL160-L166).
- Move `sortAndDedupHashes` to [`pkg/causality/internal/slots.go`](https://github.com/pingcap/tiflow/pull/10954/files#diff-b49550d6a0ca757c148ad5d5d447be44db187d60d460f7af731f7aec369b1542R55), since it is used to solve the false positive problem caused by hash conflicts in slots. 
- For `txnEvent` interface, rename `GenSortedDedupKeysHash` to `ConflictKeys` to ensure semantic consistency, because the implementers should not care about internal implementations of conflict_detector. 

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
