### PR TITLE
sink(ticdc): only enable batch dml for more than one row

### DIFF
--- a/cdc/sink/dmlsink/txn/mysql/dml.go
+++ b/cdc/sink/dmlsink/txn/mysql/dml.go
@@ -42,9 +42,9 @@ func prepareUpdate(quoteTable string, preCols, cols []*model.Column, forceReplic
 	}
 	for i, column := range columnNames {
 		if i == len(columnNames)-1 {
-			builder.WriteString("`" + quotes.EscapeName(column) + "`=?")
+			builder.WriteString("`" + quotes.EscapeName(column) + "` = ?")
 		} else {
-			builder.WriteString("`" + quotes.EscapeName(column) + "`=?,")
+			builder.WriteString("`" + quotes.EscapeName(column) + "` = ?, ")
 		}
 	}
 
@@ -60,7 +60,7 @@ func prepareUpdate(quoteTable string, preCols, cols []*model.Column, forceReplic
 		if wargs[i] == nil {
 			builder.WriteString(quotes.QuoteName(colNames[i]) + " IS NULL")
 		} else {
-			builder.WriteString(quotes.QuoteName(colNames[i]) + "=?")
+			builder.WriteString(quotes.QuoteName(colNames[i]) + " = ?")
 			args = append(args, wargs[i])
 		}
 	}

--- a/cdc/sink/dmlsink/txn/mysql/dml_test.go
+++ b/cdc/sink/dmlsink/txn/mysql/dml_test.go
@@ -63,7 +63,7 @@ func TestPrepareUpdate(t *testing.T) {
 				},
 				{Name: "b", Type: mysql.TypeVarchar, Flag: 0, Value: "test2"},
 			},
-			expectedSQL:  "UPDATE `test`.`t1` SET `a`=?,`b`=? WHERE `a`=? LIMIT 1",
+			expectedSQL:  "UPDATE `test`.`t1` SET `a` = ?, `b` = ? WHERE `a` = ? LIMIT 1",
 			expectedArgs: []interface{}{1, "test2", 1},
 		},
 		{
@@ -107,7 +107,7 @@ func TestPrepareUpdate(t *testing.T) {
 					Value: 100,
 				},
 			},
-			expectedSQL:  "UPDATE `test`.`t1` SET `a`=?,`b`=? WHERE `a`=? AND `b`=? LIMIT 1",
+			expectedSQL:  "UPDATE `test`.`t1` SET `a` = ?, `b` = ? WHERE `a` = ? AND `b` = ? LIMIT 1",
 			expectedArgs: []interface{}{2, "test2", 1, "test"},
 		},
 		{
@@ -151,7 +151,7 @@ func TestPrepareUpdate(t *testing.T) {
 					Value: 100,
 				},
 			},
-			expectedSQL:  "UPDATE `test`.`t1` SET `a`=?,`b`=? WHERE `a`=? AND `b`=? LIMIT 1",
+			expectedSQL:  "UPDATE `test`.`t1` SET `a` = ?, `b` = ? WHERE `a` = ? AND `b` = ? LIMIT 1",
 			expectedArgs: []interface{}{2, []byte("世界"), 1, []byte("你好")},
 		},
 		{
@@ -198,7 +198,7 @@ func TestPrepareUpdate(t *testing.T) {
 					Value: 100,
 				},
 			},
-			expectedSQL:  "UPDATE `test`.`t1` SET `a`=?,`b`=? WHERE `a`=? AND `b`=? LIMIT 1",
+			expectedSQL:  "UPDATE `test`.`t1` SET `a` = ?, `b` = ? WHERE `a` = ? AND `b` = ? LIMIT 1",
 			expectedArgs: []interface{}{2, []byte("世界"), 1, []byte("你好")},
 		},
 		{
@@ -245,7 +245,7 @@ func TestPrepareUpdate(t *testing.T) {
 					Value: 100,
 				},
 			},
-			expectedSQL:  "UPDATE `test`.`t1` SET `a`=?,`b`=? WHERE `a`=? AND `b`=? LIMIT 1",
+			expectedSQL:  "UPDATE `test`.`t1` SET `a` = ?, `b` = ? WHERE `a` = ? AND `b` = ? LIMIT 1",
 			expectedArgs: []interface{}{2, "世界", 1, "你好"},
 		},
 	}

--- a/cdc/sink/dmlsink/txn/mysql/mysql.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql.go
@@ -543,7 +543,7 @@ func (s *mysqlBackend) prepareDMLs() *preparedDMLs {
 		}
 
 		// Determine whether to use batch dml feature here.
-		if s.cfg.BatchDMLEnable {
+		if s.cfg.BatchDMLEnable && len(event.Event.Rows) > 1 {
 			tableColumns := firstRow.Columns
 			if firstRow.IsDelete() {
 				tableColumns = firstRow.PreColumns

--- a/cdc/sink/dmlsink/txn/mysql/mysql.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql.go
@@ -542,8 +542,10 @@ func (s *mysqlBackend) prepareDMLs() *preparedDMLs {
 			callbacks = append(callbacks, event.Callback)
 		}
 
+		// TODO: find a better threshold
+		enableBatchModeThreshold := 1
 		// Determine whether to use batch dml feature here.
-		if s.cfg.BatchDMLEnable && len(event.Event.Rows) > 1 {
+		if s.cfg.BatchDMLEnable && len(event.Event.Rows) > enableBatchModeThreshold {
 			tableColumns := firstRow.Columns
 			if firstRow.IsDelete() {
 				tableColumns = firstRow.PreColumns

--- a/cdc/sink/dmlsink/txn/mysql/mysql_test.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql_test.go
@@ -1033,12 +1033,12 @@ func TestMysqlSinkSafeModeOff(t *testing.T) {
 			expected: &preparedDMLs{
 				startTs: []model.Ts{418658114257813516},
 				sqls: []string{
-					"UPDATE `common_1`.`uk_without_pk` SET `a1`=?,`a3`=? " +
-						"WHERE `a1`=? AND `a3`=? LIMIT 1",
+					"UPDATE `common_1`.`uk_without_pk` SET `a1` = ?, `a3` = ? " +
+						"WHERE `a1` = ? AND `a3` = ? LIMIT 1",
 				},
 				values:          [][]interface{}{{3, 3, 2, 2}},
 				rowCount:        1,
-				approximateSize: 83,
+				approximateSize: 92,
 			},
 		}, {
 			name: "update with PK",
@@ -1066,11 +1066,11 @@ func TestMysqlSinkSafeModeOff(t *testing.T) {
 			},
 			expected: &preparedDMLs{
 				startTs: []model.Ts{418658114257813516},
-				sqls: []string{"UPDATE `common_1`.`pk` SET `a1`=?,`a3`=? " +
-					"WHERE `a1`=? AND `a3`=? LIMIT 1"},
+				sqls: []string{"UPDATE `common_1`.`pk` SET `a1` = ?, `a3` = ? " +
+					"WHERE `a1` = ? AND `a3` = ? LIMIT 1"},
 				values:          [][]interface{}{{3, 3, 2, 2}},
 				rowCount:        1,
-				approximateSize: 72,
+				approximateSize: 81,
 			},
 		}, {
 			name: "batch insert with PK",


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10972 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    run sysbench oltp_update_non_index and compare the performance.

![image](https://github.com/pingcap/tiflow/assets/47731263/a93e477e-741f-4977-b4fb-4d113e8d2052)
Sink throughput increase from 22k to 34k.


![image](https://github.com/pingcap/tiflow/assets/47731263/eb63d07c-b120-443a-af2a-b0c4129a99d2)
Downstream tidb cpu usage decrease from 1600% to 1300%.


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
