### PR TITLE
sink (ticdc): fix sourceID error

### DIFF
--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -654,7 +654,7 @@ func (p *processor) lazyInitImpl(etcdCtx context.Context) (err error) {
 	p.sourceManager.spawn(prcCtx)
 
 	p.sinkManager.r = sinkmanager.New(
-		p.changefeedID, p.latestInfo, p.upstream,
+		p.changefeedID, p.latestInfo.SinkURI, cfConfig, p.upstream,
 		p.ddlHandler.r.schemaStorage, p.redo.r, p.sourceManager.r)
 	p.sinkManager.name = "SinkManager"
 	p.sinkManager.changefeedID = p.changefeedID

--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -34,6 +34,7 @@ import (
 	tablesinkmetrics "github.com/pingcap/tiflow/cdc/sink/metrics/tablesink"
 	"github.com/pingcap/tiflow/cdc/sink/tablesink"
 	"github.com/pingcap/tiflow/pkg/config"
+	pconfig "github.com/pingcap/tiflow/pkg/config"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/retry"
 	"github.com/pingcap/tiflow/pkg/spanz"
@@ -66,7 +67,8 @@ type TableStats struct {
 type SinkManager struct {
 	changefeedID model.ChangeFeedID
 
-	changefeedInfo *model.ChangeFeedInfo
+	sinkURI string
+	config  *pconfig.ReplicaConfig
 
 	// up is the upstream and used to get the current pd time.
 	up *upstream.Upstream
@@ -135,19 +137,20 @@ type SinkManager struct {
 // New creates a new sink manager.
 func New(
 	changefeedID model.ChangeFeedID,
-	changefeedInfo *model.ChangeFeedInfo,
+	sinkURI string,
+	config *pconfig.ReplicaConfig,
 	up *upstream.Upstream,
 	schemaStorage entry.SchemaStorage,
 	redoDMLMgr redo.DMLManager,
 	sourceManager *sourcemanager.SourceManager,
 ) *SinkManager {
 	m := &SinkManager{
-		changefeedID:   changefeedID,
-		changefeedInfo: changefeedInfo,
-		up:             up,
-		schemaStorage:  schemaStorage,
-		sourceManager:  sourceManager,
-
+		changefeedID:        changefeedID,
+		up:                  up,
+		schemaStorage:       schemaStorage,
+		sourceManager:       sourceManager,
+		sinkURI:             sinkURI,
+		config:              config,
 		sinkProgressHeap:    newTableProgresses(),
 		sinkWorkers:         make([]*sinkWorker, 0, sinkWorkerNum),
 		sinkTaskChan:        make(chan *sinkTask),
@@ -161,7 +164,7 @@ func New(
 			WithLabelValues(changefeedID.Namespace, changefeedID.ID),
 	}
 
-	totalQuota := changefeedInfo.Config.MemoryQuota
+	totalQuota := config.MemoryQuota
 	if redoDMLMgr != nil && redoDMLMgr.Enabled() {
 		m.redoDMLMgr = redoDMLMgr
 		m.redoProgressHeap = newTableProgresses()
@@ -169,9 +172,9 @@ func New(
 		m.redoTaskChan = make(chan *redoTask)
 		m.redoWorkerAvailable = make(chan struct{}, 1)
 
-		consistentMemoryUsage := changefeedInfo.Config.Consistent.MemoryUsage
+		consistentMemoryUsage := m.config.Consistent.MemoryUsage
 		if consistentMemoryUsage == nil {
-			consistentMemoryUsage = config.GetDefaultReplicaConfig().Consistent.MemoryUsage
+			consistentMemoryUsage = pconfig.GetDefaultReplicaConfig().Consistent.MemoryUsage
 		}
 
 		redoQuota := totalQuota * consistentMemoryUsage.MemoryQuotaPercentage / 100
@@ -201,7 +204,7 @@ func (m *SinkManager) Run(ctx context.Context, warnings ...chan<- error) (err er
 			zap.Error(err))
 	}()
 
-	splitTxn := util.GetOrZero(m.changefeedInfo.Config.Sink.TxnAtomicity).ShouldSplitTxn()
+	splitTxn := util.GetOrZero(m.config.Sink.TxnAtomicity).ShouldSplitTxn()
 
 	gcErrors := make(chan error, 16)
 	sinkErrors := make(chan error, 16)
@@ -322,8 +325,8 @@ func (m *SinkManager) needsStuckCheck() bool {
 func (m *SinkManager) initSinkFactory() (chan error, uint64) {
 	m.sinkFactory.Lock()
 	defer m.sinkFactory.Unlock()
-	uri := m.changefeedInfo.SinkURI
-	cfg := m.changefeedInfo.Config
+	uri := m.sinkURI
+	cfg := m.config
 
 	if m.sinkFactory.f != nil {
 		return m.sinkFactory.errors, m.sinkFactory.version
@@ -1006,7 +1009,7 @@ func (m *SinkManager) GetTableStats(span tablepb.Span) TableStats {
 	m.sinkMemQuota.Release(span, checkpointTs)
 	m.redoMemQuota.Release(span, checkpointTs)
 
-	advanceTimeoutInSec := util.GetOrZero(m.changefeedInfo.Config.Sink.AdvanceTimeoutInSec)
+	advanceTimeoutInSec := util.GetOrZero(m.config.Sink.AdvanceTimeoutInSec)
 	if advanceTimeoutInSec <= 0 {
 		advanceTimeoutInSec = config.DefaultAdvanceTimeoutInSec
 	}

--- a/cdc/processor/sinkmanager/manager_test_helper.go
+++ b/cdc/processor/sinkmanager/manager_test_helper.go
@@ -70,7 +70,8 @@ func CreateManagerWithMemEngine(
 	go func() { handleError(sourceManager.Run(ctx)) }()
 	sourceManager.WaitForReady(ctx)
 
-	sinkManager := New(changefeedID, changefeedInfo, up, schemaStorage, nil, sourceManager)
+	sinkManager := New(changefeedID, changefeedInfo.SinkURI,
+		changefeedInfo.Config, up, schemaStorage, nil, sourceManager)
 	go func() { handleError(sinkManager.Run(ctx)) }()
 	sinkManager.WaitForReady(ctx)
 
@@ -90,6 +91,7 @@ func NewManagerWithMemEngine(
 	mg := &entry.MockMountGroup{}
 	schemaStorage := &entry.MockSchemaStorage{Resolved: math.MaxUint64}
 	sourceManager := sourcemanager.NewForTest(changefeedID, up, mg, sortEngine, false)
-	sinkManager := New(changefeedID, changefeedInfo, up, schemaStorage, redoMgr, sourceManager)
+	sinkManager := New(changefeedID, changefeedInfo.SinkURI,
+		changefeedInfo.Config, up, schemaStorage, redoMgr, sourceManager)
 	return sinkManager, sourceManager, sortEngine
 }

--- a/pkg/sink/mysql/config.go
+++ b/pkg/sink/mysql/config.go
@@ -208,7 +208,7 @@ func (c *Config) Apply(
 	// in BDR Mode cluster.
 	if replicaConfig.Sink.TiDBSourceID == 0 {
 		log.Error("The TiDB source ID should never be set to 0. Please report it as a bug. The default value will be used: 1.",
-			zap.Uint64("default", replicaConfig.Sink.TiDBSourceID))
+			zap.Uint64("tidbSourceID", replicaConfig.Sink.TiDBSourceID))
 		c.SourceID = config.DefaultTiDBSourceID
 	} else {
 		c.SourceID = replicaConfig.Sink.TiDBSourceID


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11022 

### What is changed and how it works?

Pass cloned `replicaConfig` instead of `lastInfo` to the `New` method of `sinkManager` to ensure the `sourceID` is set correctly.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
