### PR TITLE
owner(ticdc): update changefeed configuration changefeed-error-stuck-duration correctly

### DIFF
--- a/cdc/owner/feed_state_manager.go
+++ b/cdc/owner/feed_state_manager.go
@@ -168,6 +168,15 @@ func (m *feedStateManager) Tick(resolvedTs model.Ts,
 		// `handleAdminJob` returns true means that some admin jobs are pending
 		// skip to the next tick until all the admin jobs is handled
 		adminJobPending = true
+		changefeedErrorStuckDuration := *m.state.GetChangefeedInfo().Config.ChangefeedErrorStuckDuration
+		if m.changefeedErrorStuckDuration != changefeedErrorStuckDuration {
+			log.Info("changefeed-error-stuck-duration update",
+				zap.Duration("old-changefeed-error-stuck-duration", m.changefeedErrorStuckDuration),
+				zap.Duration("new-changefeed-error-stuck-duration", changefeedErrorStuckDuration),
+			)
+		}
+		m.errBackoff.MaxElapsedTime = changefeedErrorStuckDuration
+		m.changefeedErrorStuckDuration = changefeedErrorStuckDuration
 		return
 	}
 

--- a/cdc/owner/feed_state_manager.go
+++ b/cdc/owner/feed_state_manager.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tiflow/cdc/model"
 	cerrors "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/upstream"
+	"github.com/pingcap/tiflow/pkg/util"
 	"github.com/tikv/client-go/v2/oracle"
 	pd "github.com/tikv/pd/client"
 	"go.uber.org/zap"
@@ -168,7 +169,7 @@ func (m *feedStateManager) Tick(resolvedTs model.Ts,
 		// `handleAdminJob` returns true means that some admin jobs are pending
 		// skip to the next tick until all the admin jobs is handled
 		adminJobPending = true
-		changefeedErrorStuckDuration := *m.state.GetChangefeedInfo().Config.ChangefeedErrorStuckDuration
+		changefeedErrorStuckDuration := util.GetOrZero(m.state.GetChangefeedInfo().Config.ChangefeedErrorStuckDuration)
 		if m.changefeedErrorStuckDuration != changefeedErrorStuckDuration {
 			log.Info("changefeedErrorStuckDuration update",
 				zap.Duration("oldChangefeedErrorStuckDuration", m.changefeedErrorStuckDuration),

--- a/cdc/owner/feed_state_manager.go
+++ b/cdc/owner/feed_state_manager.go
@@ -170,9 +170,9 @@ func (m *feedStateManager) Tick(resolvedTs model.Ts,
 		adminJobPending = true
 		changefeedErrorStuckDuration := *m.state.GetChangefeedInfo().Config.ChangefeedErrorStuckDuration
 		if m.changefeedErrorStuckDuration != changefeedErrorStuckDuration {
-			log.Info("changefeed-error-stuck-duration update",
-				zap.Duration("old-changefeed-error-stuck-duration", m.changefeedErrorStuckDuration),
-				zap.Duration("new-changefeed-error-stuck-duration", changefeedErrorStuckDuration),
+			log.Info("changefeedErrorStuckDuration update",
+				zap.Duration("oldChangefeedErrorStuckDuration", m.changefeedErrorStuckDuration),
+				zap.Duration("newChangefeedErrorStuckDuration", changefeedErrorStuckDuration),
 			)
 		}
 		m.errBackoff.MaxElapsedTime = changefeedErrorStuckDuration

--- a/cdc/owner/feed_state_manager.go
+++ b/cdc/owner/feed_state_manager.go
@@ -175,9 +175,9 @@ func (m *feedStateManager) Tick(resolvedTs model.Ts,
 				zap.Duration("oldChangefeedErrorStuckDuration", m.changefeedErrorStuckDuration),
 				zap.Duration("newChangefeedErrorStuckDuration", changefeedErrorStuckDuration),
 			)
+			m.errBackoff.MaxElapsedTime = changefeedErrorStuckDuration
+			m.changefeedErrorStuckDuration = changefeedErrorStuckDuration
 		}
-		m.errBackoff.MaxElapsedTime = changefeedErrorStuckDuration
-		m.changefeedErrorStuckDuration = changefeedErrorStuckDuration
 		return
 	}
 

--- a/cdc/owner/feed_state_manager_test.go
+++ b/cdc/owner/feed_state_manager_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tiflow/pkg/orchestrator"
 	"github.com/pingcap/tiflow/pkg/pdutil"
 	"github.com/pingcap/tiflow/pkg/upstream"
+	"github.com/pingcap/tiflow/pkg/util"
 	"github.com/stretchr/testify/require"
 	pd "github.com/tikv/pd/client"
 )
@@ -999,7 +1000,7 @@ func TestHandleWarningWhileAdvanceResolvedTs(t *testing.T) {
 	require.True(t, manager.ShouldRunning())
 
 	// 2. test when the changefeed is in warning state, and the resolvedTs and checkpointTs is not progressing,
-	// the changefeed state will remain warning whena new warning is encountered.
+	// the changefeed state will remain warning when a new warning is encountered.
 	time.Sleep(manager.changefeedErrorStuckDuration + 10)
 	state.PatchStatus(func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
 		require.NotNil(t, status)
@@ -1063,4 +1064,83 @@ func TestHandleWarningWhileAdvanceResolvedTs(t *testing.T) {
 	tester.MustApplyPatches()
 	require.Equal(t, model.StateFailed, state.Info.State)
 	require.False(t, manager.ShouldRunning())
+}
+
+func TestUpdateChangefeedWithChangefeedErrorStuckDuration(t *testing.T) {
+	globalVars, changefeedInfo := vars.NewGlobalVarsAndChangefeedInfo4Test()
+	manager := newFeedStateManager4Test(200, 1600, 0, 2.0)
+	state := orchestrator.NewChangefeedReactorState(etcd.DefaultCDCClusterID,
+		model.DefaultChangeFeedID(changefeedInfo.ID))
+	tester := orchestrator.NewReactorStateTester(t, state, nil)
+	state.PatchInfo(func(info *model.ChangeFeedInfo) (*model.ChangeFeedInfo, bool, error) {
+		require.Nil(t, info)
+		return &model.ChangeFeedInfo{SinkURI: "123", Config: &config.ReplicaConfig{}}, true, nil
+	})
+	state.PatchStatus(func(status *model.ChangeFeedStatus) (*model.ChangeFeedStatus, bool, error) {
+		require.Nil(t, status)
+		return &model.ChangeFeedStatus{}, true, nil
+	})
+	tester.MustApplyPatches()
+	manager.state = state
+	manager.Tick(0, state.Status, state.Info)
+	tester.MustApplyPatches()
+	require.True(t, manager.ShouldRunning())
+	// stop a changefeed
+	manager.PushAdminJob(&model.AdminJob{
+		CfID: model.DefaultChangeFeedID(changefeedInfo.ID),
+		Type: model.AdminStop,
+	})
+	manager.Tick(0, state.Status, state.Info)
+	tester.MustApplyPatches()
+	require.False(t, manager.ShouldRunning())
+	require.False(t, manager.ShouldRemoved())
+	require.Equal(t, state.Info.State, model.StateStopped)
+	require.Equal(t, state.Info.AdminJobType, model.AdminStop)
+	require.Equal(t, state.Status.AdminJobType, model.AdminStop)
+
+	// update ChangefeedErrorStuckDuration
+	stuckDuration := time.Second * 10
+	state.PatchInfo(func(info *model.ChangeFeedInfo) (*model.ChangeFeedInfo, bool, error) {
+		require.NotNil(t, info)
+		info.Config.ChangefeedErrorStuckDuration = util.AddressOf(stuckDuration)
+		return info, true, nil
+	})
+	tester.MustApplyPatches()
+
+	// resume the changefeed in stopped state
+	manager.PushAdminJob(&model.AdminJob{
+		CfID:                  model.DefaultChangeFeedID(changefeedInfo.ID),
+		Type:                  model.AdminResume,
+		OverwriteCheckpointTs: 100,
+	})
+
+	manager.Tick(0, state.Status, state.Info)
+	tester.MustApplyPatches()
+	require.True(t, manager.ShouldRunning())
+	require.False(t, manager.ShouldRemoved())
+	require.Equal(t, manager.changefeedErrorStuckDuration, stuckDuration)
+	require.Equal(t, state.Info.State, model.StateNormal)
+	require.Equal(t, state.Info.AdminJobType, model.AdminNone)
+	require.Equal(t, state.Status.AdminJobType, model.AdminNone)
+
+	state.PatchTaskPosition(globalVars.CaptureInfo.ID,
+		func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+			return &model.TaskPosition{Warning: &model.RunningError{
+				Addr:    globalVars.CaptureInfo.AdvertiseAddr,
+				Code:    "[CDC:ErrSinkManagerRunError]", // it is fake error
+				Message: "fake error for test",
+			}}, true, nil
+		})
+
+	time.Sleep(stuckDuration - 10)
+	manager.Tick(200, state.Status, state.Info)
+	tester.MustApplyPatches()
+	require.True(t, manager.ShouldRunning())
+	require.Equal(t, state.Info.State, model.StateNormal)
+
+	time.Sleep(stuckDuration)
+	manager.Tick(201, state.Status, state.Info)
+	tester.MustApplyPatches()
+	require.False(t, manager.ShouldRunning())
+	require.Equal(t, state.Info.State, model.StateFailed)
 }

--- a/cdc/owner/feed_state_manager_test.go
+++ b/cdc/owner/feed_state_manager_test.go
@@ -1085,21 +1085,25 @@ func TestUpdateChangefeedWithChangefeedErrorStuckDuration(t *testing.T) {
 	manager.Tick(0, state.Status, state.Info)
 	tester.MustApplyPatches()
 	require.True(t, manager.ShouldRunning())
-	// stop a changefeed
-	manager.PushAdminJob(&model.AdminJob{
-		CfID: model.DefaultChangeFeedID(changefeedInfo.ID),
-		Type: model.AdminStop,
-	})
-	manager.Tick(0, state.Status, state.Info)
+
+	stuckDuration := time.Second * 10
+	state.PatchTaskPosition(globalVars.CaptureInfo.ID,
+		func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
+			return &model.TaskPosition{Warning: &model.RunningError{
+				Addr:    globalVars.CaptureInfo.AdvertiseAddr,
+				Code:    "[CDC:ErrSinkManagerRunError]", // it is fake error
+				Message: "fake error for test",
+			}}, true, nil
+		})
+	tester.MustApplyPatches()
+	time.Sleep(stuckDuration - 10)
+	manager.Tick(100, state.Status, state.Info)
 	tester.MustApplyPatches()
 	require.False(t, manager.ShouldRunning())
-	require.False(t, manager.ShouldRemoved())
-	require.Equal(t, state.Info.State, model.StateStopped)
-	require.Equal(t, state.Info.AdminJobType, model.AdminStop)
-	require.Equal(t, state.Status.AdminJobType, model.AdminStop)
+	require.Less(t, manager.changefeedErrorStuckDuration, stuckDuration)
+	require.Equal(t, state.Info.State, model.StateFailed)
 
 	// update ChangefeedErrorStuckDuration
-	stuckDuration := time.Second * 10
 	state.PatchInfo(func(info *model.ChangeFeedInfo) (*model.ChangeFeedInfo, bool, error) {
 		require.NotNil(t, info)
 		info.Config.ChangefeedErrorStuckDuration = util.AddressOf(stuckDuration)
@@ -1114,7 +1118,7 @@ func TestUpdateChangefeedWithChangefeedErrorStuckDuration(t *testing.T) {
 		OverwriteCheckpointTs: 100,
 	})
 
-	manager.Tick(0, state.Status, state.Info)
+	manager.Tick(101, state.Status, state.Info)
 	tester.MustApplyPatches()
 	require.True(t, manager.ShouldRunning())
 	require.False(t, manager.ShouldRemoved())

--- a/cdc/owner/feed_state_manager_test.go
+++ b/cdc/owner/feed_state_manager_test.go
@@ -1086,7 +1086,7 @@ func TestUpdateChangefeedWithChangefeedErrorStuckDuration(t *testing.T) {
 	tester.MustApplyPatches()
 	require.True(t, manager.ShouldRunning())
 
-	stuckDuration := time.Second * 10
+	stuckDuration := manager.changefeedErrorStuckDuration + time.Second*3
 	state.PatchTaskPosition(globalVars.CaptureInfo.ID,
 		func(position *model.TaskPosition) (*model.TaskPosition, bool, error) {
 			return &model.TaskPosition{Warning: &model.RunningError{


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #10998

### What is changed and how it works?
When changefeed state has changed, reacquiring `changefeed-error-stuck-duration`. `feedStateManager` checks for new value about `changefeedErrorStuckDuration` every `feedStateManager.Tick` call so that it can sense the updated value.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
    1. start a CDC server
    2. run script
    ```bash
    bin/cdc cli changefeed create -c test --sink-uri "kafka://127.0.0.1:9092/test?topic=test&protocol=open-protocol&max-message-bytes=41943040&compressionType=ZLIB" --changefeed-id="test"
    bin/cdc cli changefeed pause --changefeed-id="test"
    bin/cdc cli changefeed update --changefeed-id="test" --config=changefeed.toml
    bin/cdc cli changefeed resume --changefeed-id="test"
    ```
    changefeed.toml
    ```toml
     changefeed-error-stuck-duration = "1h30m"
    ```
    3. check CDC log
    <img width="686" alt="Screenshot 2024-05-11 at 17 05 18" src="https://github.com/pingcap/tiflow/assets/55834428/2e3281cc-bae3-48b4-9343-0cda764ed169">


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
No
##### Do you need to update user documentation, design documentation or monitoring documentation?
No
### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
