### PR TITLE
codec(ticdc): simple decoder set the table id on handle key only event and make consumer more strict on the ts order

### DIFF
--- a/cmd/kafka-consumer/main.go
+++ b/cmd/kafka-consumer/main.go
@@ -636,7 +636,7 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 				}
 
 				partitionResolvedTs := atomic.LoadUint64(&sink.resolvedTs)
-				if ddl.CommitTs <= partitionResolvedTs {
+				if ddl.CommitTs < partitionResolvedTs {
 					log.Panic("DDL event commit-ts less than the resolved ts",
 						zap.Int32("partition", partition),
 						zap.Uint64("partitionResolvedTs", partitionResolvedTs),
@@ -678,7 +678,7 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 				}
 
 				partitionResolvedTs := atomic.LoadUint64(&sink.resolvedTs)
-				if row.CommitTs <= partitionResolvedTs {
+				if row.CommitTs < partitionResolvedTs {
 					log.Panic("RowChangedEvent fallback row, ignore it",
 						zap.Uint64("commitTs", row.CommitTs),
 						zap.Uint64("partitionResolvedTs", partitionResolvedTs),

--- a/cmd/kafka-consumer/main.go
+++ b/cmd/kafka-consumer/main.go
@@ -211,7 +211,7 @@ func main() {
 	flag.StringVar(&consumerOption.upstreamTiDBDSN, "upstream-tidb-dsn", "", "upstream TiDB DSN")
 	flag.StringVar(&consumerOption.groupID, "consumer-group-id", groupID, "consumer group id")
 	flag.StringVar(&consumerOption.logPath, "log-file", "cdc_kafka_consumer.log", "log file path")
-	flag.StringVar(&consumerOption.logLevel, "log-level", "debug", "log file path")
+	flag.StringVar(&consumerOption.logLevel, "log-level", "info", "log file path")
 	flag.StringVar(&consumerOption.timezone, "tz", "System", "Specify time zone of Kafka consumer")
 	flag.StringVar(&consumerOption.ca, "ca", "", "CA certificate path for Kafka SSL connection")
 	flag.StringVar(&consumerOption.cert, "cert", "", "Certificate path for Kafka SSL connection")

--- a/cmd/kafka-consumer/main.go
+++ b/cmd/kafka-consumer/main.go
@@ -639,12 +639,15 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 				if ddl.CommitTs < partitionResolvedTs {
 					log.Panic("DDL event commit-ts less than the resolved ts",
 						zap.Int32("partition", partition),
+						zap.Int64("offset", message.Offset),
 						zap.Uint64("partitionResolvedTs", partitionResolvedTs),
 						zap.Uint64("commitTs", ddl.CommitTs),
 						zap.String("DDL", ddl.Query))
 				}
 				atomic.StoreUint64(&sink.resolvedTs, ddl.CommitTs)
 				log.Info("partition resolved ts updated by the DDL event",
+					zap.Int32("partition", partition),
+					zap.Int64("offset", message.Offset),
 					zap.Uint64("oldResolvedTs", partitionResolvedTs),
 					zap.Uint64("resolvedTs", ddl.CommitTs))
 
@@ -670,9 +673,10 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 				}
 				if partition != target {
 					log.Panic("RowChangedEvent dispatched to wrong partition",
+						zap.Int32("partition", partition),
+						zap.Int64("offset", message.Offset),
 						zap.Int32("obtained", partition),
 						zap.Int32("expected", target),
-						zap.Int32("partitionNum", c.option.partitionNum),
 						zap.Any("row", row),
 					)
 				}
@@ -680,9 +684,10 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 				partitionResolvedTs := atomic.LoadUint64(&sink.resolvedTs)
 				if row.CommitTs < partitionResolvedTs {
 					log.Panic("RowChangedEvent commit-ts less than the resolved ts",
+						zap.Int32("partition", partition),
+						zap.Int64("offset", message.Offset),
 						zap.Uint64("commitTs", row.CommitTs),
 						zap.Uint64("partitionResolvedTs", partitionResolvedTs),
-						zap.Int32("partition", partition),
 						zap.Any("row", row))
 				}
 
@@ -715,9 +720,10 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 				partitionResolvedTs := atomic.LoadUint64(&sink.resolvedTs)
 				if ts < partitionResolvedTs {
 					log.Panic("partition resolved ts fallback",
+						zap.Int32("partition", partition),
+						zap.Int64("offset", message.Offset),
 						zap.Uint64("ts", ts),
-						zap.Uint64("partitionResolvedTs", partitionResolvedTs),
-						zap.Int32("partition", partition))
+						zap.Uint64("partitionResolvedTs", partitionResolvedTs))
 				}
 				atomic.StoreUint64(&sink.resolvedTs, ts)
 

--- a/pkg/sink/codec/simple/decoder.go
+++ b/pkg/sink/codec/simple/decoder.go
@@ -210,6 +210,7 @@ func (d *Decoder) assembleHandleKeyOnlyRowChangedEvent(m *message) (*model.RowCh
 		Version:       defaultVersion,
 		Schema:        m.Schema,
 		Table:         m.Table,
+		TableID:       m.TableID,
 		Type:          m.Type,
 		CommitTs:      m.CommitTs,
 		SchemaVersion: m.SchemaVersion,

--- a/pkg/sink/codec/simple/message.go
+++ b/pkg/sink/codec/simple/message.go
@@ -319,42 +319,28 @@ func newTableSchema(tableInfo *model.TableInfo) *TableSchema {
 func newTableInfo(m *TableSchema) *model.TableInfo {
 	var (
 		database      string
-		table         string
-		tableID       int64
 		schemaVersion uint64
 	)
+
+	tidbTableInfo := &timodel.TableInfo{}
 	if m != nil {
 		database = m.Schema
-		table = m.Table
-		tableID = m.TableID
 		schemaVersion = m.Version
-	}
-	tidbTableInfo := &timodel.TableInfo{
-		ID:       tableID,
-		Name:     timodel.NewCIStr(table),
-		UpdateTS: schemaVersion,
-	}
 
-	if m == nil {
-		return &model.TableInfo{
-			TableName: model.TableName{
-				Schema:  database,
-				Table:   table,
-				TableID: tableID,
-			},
-			TableInfo: tidbTableInfo,
+		tidbTableInfo.ID = m.TableID
+		tidbTableInfo.Name = timodel.NewCIStr(m.Table)
+		tidbTableInfo.UpdateTS = m.Version
+
+		nextMockID := int64(100)
+		for _, col := range m.Columns {
+			tiCol := newTiColumnInfo(col, nextMockID, m.Indexes)
+			nextMockID += 100
+			tidbTableInfo.Columns = append(tidbTableInfo.Columns, tiCol)
 		}
-	}
-
-	nextMockID := int64(100)
-	for _, col := range m.Columns {
-		tiCol := newTiColumnInfo(col, nextMockID, m.Indexes)
-		nextMockID += 100
-		tidbTableInfo.Columns = append(tidbTableInfo.Columns, tiCol)
-	}
-	for _, idx := range m.Indexes {
-		index := newTiIndexInfo(idx)
-		tidbTableInfo.Indices = append(tidbTableInfo.Indices, index)
+		for _, idx := range m.Indexes {
+			index := newTiIndexInfo(idx)
+			tidbTableInfo.Indices = append(tidbTableInfo.Indices, index)
+		}
 	}
 	return model.WrapTableInfo(100, database, schemaVersion, tidbTableInfo)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11088

### What is changed and how it works?

* set the table id when decode the handle key only event
* consumer panics if commit-ts less than the resolved ts
* update resolved ts after receive resolved ts event and ddl event.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
