### PR TITLE
snapshot (ticdc): reduce list tables time consumption

### DIFF
--- a/cdc/entry/schema/snapshot.go
+++ b/cdc/entry/schema/snapshot.go
@@ -167,16 +167,30 @@ func NewSnapshotFromMeta(
 		vname := newVersionedEntityName(-1, dbinfo.Name.O, tag) // -1 means the entity is a schema.
 		vname.target = dbinfo.ID
 		snap.inner.schemaNameToID.ReplaceOrInsert(vname)
-
-		tableInfos, err := meta.ListTables(dbinfo.ID)
+		// get all tables Name
+		tableNames, err := meta.ListSimpleTables(dbinfo.ID)
 		if err != nil {
 			return nil, cerror.WrapError(cerror.ErrMetaListDatabases, err)
 		}
-		for _, tableInfo := range tableInfos {
-			if filter.ShouldIgnoreTable(dbinfo.Name.O, tableInfo.Name.O) {
-				log.Debug("ignore table", zap.String("table", tableInfo.Name.O))
+		tableNeeded := make([]*timodel.TableNameInfo, 0, len(tableNames))
+		// filter tables
+		for _, table := range tableNames {
+			if filter.ShouldIgnoreTable(dbinfo.Name.O, table.Name.O) {
+				log.Debug("ignore table", zap.String("table", table.Name.O))
 				continue
 			}
+			tableNeeded = append(tableNeeded, table)
+		}
+		tableInfos := make([]*timodel.TableInfo, 0, len(tableNeeded))
+		for _, table := range tableNeeded {
+			tableInfo, err := meta.GetTable(dbinfo.ID, table.ID)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			tableInfos = append(tableInfos, tableInfo)
+		}
+
+		for _, tableInfo := range tableInfos {
 			tableInfo := model.WrapTableInfo(dbinfo.ID, dbinfo.Name.O, currentTs, tableInfo)
 			snap.inner.tables.ReplaceOrInsert(versionedID{
 				id:     tableInfo.ID,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number:  close #11124 

ref #11109

### What is changed and how it works?

1. Use [[ListSimpleTables](https://github.com/pingcap/tidb/blob/master/pkg/meta/meta.go?rgh-link-date=2024-05-15T10%3A54%3A07Z#L1026)]([pingcap/tidb@master/pkg/meta/meta.go#L1026](https://github.com/pingcap/tidb/blob/master/pkg/meta/meta.go?rgh-link-date=2024-05-15T10%3A54%3A07Z#L1026)) to retrieve TableNameInfo. This only includes the name and ID of a table, making it smaller than TableInfo.
2. Apply a filter to the retrieved TableNameInfos to locate the tables of interest.
3. Use [[GetTable](https://github.com/pingcap/tidb/blob/master/pkg/meta/meta.go?rgh-link-date=2024-05-15T10%3A54%3A07Z#L1219)]([pingcap/tidb@master/pkg/meta/meta.go#L1219](https://github.com/pingcap/tidb/blob/master/pkg/meta/meta.go?rgh-link-date=2024-05-15T10%3A54%3A07Z#L1219)) to acquire the schema of the selected tables.

This approach can reduce time costs by minimizing the amount of data that needs to be loaded.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test 
 Covered by existed unit tests.
 - Manual test (add detailed scripts or steps below)

**Test Environment**

1 TiDB cluster(4000 tables in database `test`), 1 TiCDC.

**Test Result**

Create 100 changefeeds using the configuration provided below:

```toml
[filter]
rules = ['test.*100*','test.*101*','test.*102*','test.*103*']

```

Each changefeed will replicate 56 tables.

**Before this PR**, when the CDC server was restarted, the lag for changefeeds increased to approximately 1.5 minutes.

It took around **2.5 seconds** to initialize the schema snapshot for each changefeed, as shown in the log below:

```go
[2024/05/14 18:25:55.952 +08:00] [INFO] [snapshot.go:219] ["schema snapshot created"] [changefeed=default/test-74] [currentTs=449755804227862532] [cost=2.523837041]

```

**After implementing this PR**, the lag for changefeeds increased to about 50 seconds when the CDC server was restarted.

It now takes approximately **1.4 seconds** to initialize the schema snapshot for each changefeed. The log for this will be shown below.

```go
[2024/05/14 18:20:53.578 +08:00] [INFO] [snapshot.go:233] ["schema snapshot created"] [changefeed=default/test-15] [currentTs=449755753175580674] [cost=1.418892458]
```

**However**, if the changefeed aims to replicate all 4000 tables in db, this PR might be slightly slower by **0.5s** compared to the version without this PR, as it needs to load the raw table schemas twice. This issue can be addressed by solution 2, as elaborated in #11109, which I will implement later.

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Reduce the time consumption of changefeed initialization. 
```
