### PR TITLE
(redo)ticdc: fix the event orderliness in redo log

### DIFF
--- a/cdc/redo/reader/reader.go
+++ b/cdc/redo/reader/reader.go
@@ -365,10 +365,8 @@ func (h logHeap) Less(i, j int) bool {
 	}
 
 	if h[i].data.RedoRow.Row.CommitTs == h[j].data.RedoRow.Row.CommitTs {
-		if h[i].data.RedoRow.Row.StartTs < h[j].data.RedoRow.Row.StartTs {
-			return true
-		} else if h[i].data.RedoRow.Row.StartTs > h[j].data.RedoRow.Row.StartTs {
-			return false
+		if h[i].data.RedoRow.Row.StartTs != h[j].data.RedoRow.Row.StartTs {
+			return h[i].data.RedoRow.Row.StartTs < h[j].data.RedoRow.Row.StartTs
 		} else {
 			// in the same txn, we need to sort by delete/update/insert order
 			if h[i].data.RedoRow.Row.ToRowChangedEvent().IsDelete() {

--- a/cdc/redo/reader/reader.go
+++ b/cdc/redo/reader/reader.go
@@ -374,14 +374,9 @@ func (h logHeap) Less(i, j int) bool {
 			if h[i].data.RedoRow.Row.ToRowChangedEvent().IsDelete() {
 				return true
 			} else if h[i].data.RedoRow.Row.ToRowChangedEvent().IsUpdate() {
-				if h[j].data.RedoRow.Row.ToRowChangedEvent().IsDelete() {
-					return false
-				} else {
-					return true
-				}
-			} else {
-				return false
+				return !h[j].data.RedoRow.Row.ToRowChangedEvent().IsDelete()
 			}
+			return false
 		}
 	}
 

--- a/cdc/redo/reader/reader.go
+++ b/cdc/redo/reader/reader.go
@@ -367,15 +367,14 @@ func (h logHeap) Less(i, j int) bool {
 	if h[i].data.RedoRow.Row.CommitTs == h[j].data.RedoRow.Row.CommitTs {
 		if h[i].data.RedoRow.Row.StartTs != h[j].data.RedoRow.Row.StartTs {
 			return h[i].data.RedoRow.Row.StartTs < h[j].data.RedoRow.Row.StartTs
-		} else {
-			// in the same txn, we need to sort by delete/update/insert order
-			if h[i].data.RedoRow.Row.ToRowChangedEvent().IsDelete() {
-				return true
-			} else if h[i].data.RedoRow.Row.ToRowChangedEvent().IsUpdate() {
-				return !h[j].data.RedoRow.Row.ToRowChangedEvent().IsDelete()
-			}
-			return false
 		}
+		// in the same txn, we need to sort by delete/update/insert order
+		if h[i].data.RedoRow.Row.ToRowChangedEvent().IsDelete() {
+			return true
+		} else if h[i].data.RedoRow.Row.ToRowChangedEvent().IsUpdate() {
+			return !h[j].data.RedoRow.Row.ToRowChangedEvent().IsDelete()
+		}
+		return false
 	}
 
 	return h[i].data.RedoRow.Row.CommitTs < h[j].data.RedoRow.Row.CommitTs

--- a/cdc/redo/reader/reader.go
+++ b/cdc/redo/reader/reader.go
@@ -346,6 +346,7 @@ func (h logHeap) Len() int {
 }
 
 func (h logHeap) Less(i, j int) bool {
+	// we separate ddl and dml, so we only need to compare dml with dml, and ddl with ddl.
 	if h[i].data.Type == model.RedoLogTypeDDL {
 		if h[i].data.RedoDDL.DDL == nil {
 			return true
@@ -363,10 +364,27 @@ func (h logHeap) Less(i, j int) bool {
 		return false
 	}
 
-	if h[i].data.RedoRow.Row.CommitTs == h[j].data.RedoRow.Row.CommitTs &&
-		h[i].data.RedoRow.Row.StartTs < h[j].data.RedoRow.Row.StartTs {
-		return true
+	if h[i].data.RedoRow.Row.CommitTs == h[j].data.RedoRow.Row.CommitTs {
+		if h[i].data.RedoRow.Row.StartTs < h[j].data.RedoRow.Row.StartTs {
+			return true
+		} else if h[i].data.RedoRow.Row.StartTs > h[j].data.RedoRow.Row.StartTs {
+			return false
+		} else {
+			// in the same txn, we need to sort by delete/update/insert order
+			if h[i].data.RedoRow.Row.ToRowChangedEvent().IsDelete() {
+				return true
+			} else if h[i].data.RedoRow.Row.ToRowChangedEvent().IsUpdate() {
+				if h[j].data.RedoRow.Row.ToRowChangedEvent().IsDelete() {
+					return false
+				} else {
+					return true
+				}
+			} else {
+				return false
+			}
+		}
 	}
+
 	return h[i].data.RedoRow.Row.CommitTs < h[j].data.RedoRow.Row.CommitTs
 }
 

--- a/cdc/redo/reader/reader_test.go
+++ b/cdc/redo/reader/reader_test.go
@@ -396,6 +396,149 @@ func TestLogHeapLess(t *testing.T) {
 			expect: true,
 		},
 		{
+			name: "Update before Delete",
+			h: logHeap{
+				{
+					data: &model.RedoLog{
+						Type: model.RedoLogTypeRow,
+						RedoRow: model.RedoRowChangedEvent{
+							Row: &model.RowChangedEventInRedoLog{
+								CommitTs: 100,
+								Table: &model.TableName{
+									Schema:      "test",
+									Table:       "table",
+									TableID:     1,
+									IsPartition: false,
+								},
+								PreColumns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 2,
+									},
+								},
+								Columns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 3,
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					data: &model.RedoLog{
+						Type: model.RedoLogTypeRow,
+						RedoRow: model.RedoRowChangedEvent{
+							Row: &model.RowChangedEventInRedoLog{
+								CommitTs: 100,
+								Table: &model.TableName{
+									Schema:      "test",
+									Table:       "table",
+									TableID:     1,
+									IsPartition: false,
+								},
+								PreColumns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 1,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			i:      0,
+			j:      1,
+			expect: false,
+		},
+		{
+			name: "Update before Update",
+			h: logHeap{
+				{
+					data: &model.RedoLog{
+						Type: model.RedoLogTypeRow,
+						RedoRow: model.RedoRowChangedEvent{
+							Row: &model.RowChangedEventInRedoLog{
+								CommitTs: 100,
+								Table: &model.TableName{
+									Schema:      "test",
+									Table:       "table",
+									TableID:     1,
+									IsPartition: false,
+								},
+								PreColumns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 2,
+									},
+								},
+								Columns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 3,
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					data: &model.RedoLog{
+						Type: model.RedoLogTypeRow,
+						RedoRow: model.RedoRowChangedEvent{
+							Row: &model.RowChangedEventInRedoLog{
+								CommitTs: 100,
+								Table: &model.TableName{
+									Schema:      "test",
+									Table:       "table",
+									TableID:     1,
+									IsPartition: false,
+								},
+								PreColumns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 1,
+									},
+								},
+								Columns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 4,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			i:      0,
+			j:      1,
+			expect: true,
+		},
+		{
 			name: "Delete before Insert",
 			h: logHeap{
 				{

--- a/cdc/redo/reader/reader_test.go
+++ b/cdc/redo/reader/reader_test.go
@@ -252,3 +252,372 @@ func genMetaFile(t *testing.T, dir string, meta *common.LogMeta) {
 	_, err = f.Write(data)
 	require.Nil(t, err)
 }
+
+func TestLogHeapLess(t *testing.T) {
+	tests := []struct {
+		name   string
+		h      logHeap
+		i      int
+		j      int
+		expect bool
+	}{
+		{
+			name: "Delete before Update",
+			h: logHeap{
+				{
+					data: &model.RedoLog{
+						Type: model.RedoLogTypeRow,
+						RedoRow: model.RedoRowChangedEvent{
+							Row: &model.RowChangedEventInRedoLog{
+								CommitTs: 100,
+								Table: &model.TableName{
+									Schema:      "test",
+									Table:       "table",
+									TableID:     1,
+									IsPartition: false,
+								},
+								PreColumns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 2,
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					data: &model.RedoLog{
+						Type: model.RedoLogTypeRow,
+						RedoRow: model.RedoRowChangedEvent{
+							Row: &model.RowChangedEventInRedoLog{
+								CommitTs: 100,
+								Table: &model.TableName{
+									Schema:      "test",
+									Table:       "table",
+									TableID:     1,
+									IsPartition: false,
+								},
+								PreColumns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 2,
+									},
+								},
+								Columns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 3,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			i:      0,
+			j:      1,
+			expect: true,
+		},
+		{
+			name: "Update before Insert",
+			h: logHeap{
+				{
+					data: &model.RedoLog{
+						Type: model.RedoLogTypeRow,
+						RedoRow: model.RedoRowChangedEvent{
+							Row: &model.RowChangedEventInRedoLog{
+								CommitTs: 100,
+								Table: &model.TableName{
+									Schema:      "test",
+									Table:       "table",
+									TableID:     1,
+									IsPartition: false,
+								},
+								PreColumns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 2,
+									},
+								},
+								Columns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 3,
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					data: &model.RedoLog{
+						Type: model.RedoLogTypeRow,
+						RedoRow: model.RedoRowChangedEvent{
+							Row: &model.RowChangedEventInRedoLog{
+								CommitTs: 100,
+								Table: &model.TableName{
+									Schema:      "test",
+									Table:       "table",
+									TableID:     1,
+									IsPartition: false,
+								},
+								Columns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 1,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			i:      0,
+			j:      1,
+			expect: true,
+		},
+		{
+			name: "Delete before Insert",
+			h: logHeap{
+				{
+					data: &model.RedoLog{
+						Type: model.RedoLogTypeRow,
+						RedoRow: model.RedoRowChangedEvent{
+							Row: &model.RowChangedEventInRedoLog{
+								CommitTs: 100,
+								Table: &model.TableName{
+									Schema:      "test",
+									Table:       "table",
+									TableID:     1,
+									IsPartition: false,
+								},
+								PreColumns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 1,
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					data: &model.RedoLog{
+						Type: model.RedoLogTypeRow,
+						RedoRow: model.RedoRowChangedEvent{
+							Row: &model.RowChangedEventInRedoLog{
+								CommitTs: 100,
+								Table: &model.TableName{
+									Schema:      "test",
+									Table:       "table",
+									TableID:     1,
+									IsPartition: false,
+								},
+								Columns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 3,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			i:      0,
+			j:      1,
+			expect: true,
+		},
+		{
+			name: "Same type of operations, different commit ts",
+			h: logHeap{
+				{
+					data: &model.RedoLog{
+						Type: model.RedoLogTypeRow,
+						RedoRow: model.RedoRowChangedEvent{
+							Row: &model.RowChangedEventInRedoLog{
+								CommitTs: 100,
+								Table: &model.TableName{
+									Schema:      "test",
+									Table:       "table",
+									TableID:     1,
+									IsPartition: false,
+								},
+							},
+						},
+					},
+				},
+				{
+					data: &model.RedoLog{
+						Type: model.RedoLogTypeRow,
+						RedoRow: model.RedoRowChangedEvent{
+							Row: &model.RowChangedEventInRedoLog{
+								CommitTs: 200,
+								Table: &model.TableName{
+									Schema:      "test",
+									Table:       "table",
+									TableID:     1,
+									IsPartition: false,
+								},
+							},
+						},
+					},
+				},
+			},
+			i:      0,
+			j:      1,
+			expect: true,
+		},
+		{
+			name: "Same type of operations, same commit ts, different startTs",
+			h: logHeap{
+				{
+					data: &model.RedoLog{
+						Type: model.RedoLogTypeRow,
+						RedoRow: model.RedoRowChangedEvent{
+							Row: &model.RowChangedEventInRedoLog{
+								CommitTs: 100,
+								StartTs:  80,
+								Table: &model.TableName{
+									Schema:      "test",
+									Table:       "table",
+									TableID:     1,
+									IsPartition: false,
+								},
+							},
+						},
+					},
+				},
+				{
+					data: &model.RedoLog{
+						Type: model.RedoLogTypeRow,
+						RedoRow: model.RedoRowChangedEvent{
+							Row: &model.RowChangedEventInRedoLog{
+								CommitTs: 100,
+								StartTs:  90,
+								Table: &model.TableName{
+									Schema:      "test",
+									Table:       "table",
+									TableID:     1,
+									IsPartition: false,
+								},
+							},
+						},
+					},
+				},
+			},
+			i:      0,
+			j:      1,
+			expect: true,
+		},
+		{
+			name: "Same type of operations, same commit ts",
+			h: logHeap{
+				{
+					data: &model.RedoLog{
+						Type: model.RedoLogTypeRow,
+						RedoRow: model.RedoRowChangedEvent{
+							Row: &model.RowChangedEventInRedoLog{
+								CommitTs: 100,
+								Table: &model.TableName{
+									Schema:      "test",
+									Table:       "table",
+									TableID:     1,
+									IsPartition: false,
+								},
+								PreColumns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 2,
+									},
+								},
+								Columns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 3,
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					data: &model.RedoLog{
+						Type: model.RedoLogTypeRow,
+						RedoRow: model.RedoRowChangedEvent{
+							Row: &model.RowChangedEventInRedoLog{
+								CommitTs: 100,
+								Table: &model.TableName{
+									Schema:      "test",
+									Table:       "table",
+									TableID:     1,
+									IsPartition: false,
+								},
+								PreColumns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 1,
+									},
+								},
+								Columns: []*model.Column{
+									{
+										Name:  "col-1",
+										Value: 1,
+									}, {
+										Name:  "col-2",
+										Value: 3,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			i:      0,
+			j:      1,
+			expect: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.h.Less(tt.i, tt.j); got != tt.expect {
+				t.Errorf("logHeap.Less() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/11096

### What is changed and how it works?
1. Fix the less function of logHeap to make dml event of redo log in the same txn sorted as delete/update/insert.
2. use startTs instead of commitTs in redo apply to distinguish different txns.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
 
    create mysql sink changefeed with redo log on
    run gotpc workload
    After 30m, pause changefeed and run redo apply

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
