### PR TITLE
sink(ticdc): quick fail on create table error without primary key when downstream sql_require_primary_key is set

### DIFF
--- a/pkg/errorutil/util.go
+++ b/pkg/errorutil/util.go
@@ -18,6 +18,7 @@ import (
 
 	gmysql "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
@@ -139,7 +140,8 @@ func IsRetryableDDLError(err error) bool {
 		mysql.ErrKeyColumnDoesNotExits,
 		mysql.ErrWrongColumnName,
 		mysql.ErrPartitionMgmtOnNonpartitioned,
-		mysql.ErrNonuniqTable:
+		mysql.ErrNonuniqTable,
+		errno.ErrTableWithoutPrimaryKey:
 		return false
 	}
 	return true

--- a/pkg/errorutil/util_test.go
+++ b/pkg/errorutil/util_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/pingcap/tidb/pkg/errno"
 	"github.com/pingcap/tidb/pkg/infoschema"
 	tmysql "github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tiflow/dm/pkg/terror"
@@ -109,6 +110,7 @@ func TestIsRetryableDDLError(t *testing.T) {
 		{newMysqlErr(tmysql.ErrPartitionMgmtOnNonpartitioned, "xx"), false},
 		{newMysqlErr(tmysql.ErrNonuniqTable, "xx"), false},
 		{newMysqlErr(tmysql.ErrBadDB, "xx"), false},
+		{newMysqlErr(errno.ErrTableWithoutPrimaryKey, "Unable to create or change a table without a primary key"), false},
 		{mysql.ErrInvalidConn, true},
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11143 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
1. create a changefeed;
2. run set global sql_require_primary_key=true; on downstream tidb cluster;
3. run create table t (a int, b varchar(200) not null unique key); on upstream tidb cluster;
4. check the changefeed state to see whether is reports a warning or error quickly;

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
