### PR TITLE
schema(ticdc): remove the useless indices offset field from the table info

### DIFF
--- a/cdc/model/schema_storage.go
+++ b/cdc/model/schema_storage.go
@@ -52,8 +52,6 @@ type TableInfo struct {
 	Version uint64
 	// ColumnID -> offset in model.TableInfo.Columns
 	columnsOffset map[int64]int
-	// ColumnID -> offset in model.TableInfo.Indices
-	indicesOffset map[int64]int
 	// Column name -> ColumnID
 	nameToColID map[string]int64
 
@@ -112,7 +110,6 @@ func WrapTableInfo(schemaID int64, schemaName string, version uint64, info *mode
 		hasUniqueColumn:  false,
 		Version:          version,
 		columnsOffset:    make(map[int64]int, len(info.Columns)),
-		indicesOffset:    make(map[int64]int, len(info.Indices)),
 		nameToColID:      make(map[string]int64, len(info.Columns)),
 		RowColumnsOffset: make(map[int64]int, len(info.Columns)),
 		ColumnsFlag:      make(map[int64]*ColumnFlagType, len(info.Columns)),
@@ -160,8 +157,7 @@ func WrapTableInfo(schemaID int64, schemaName string, version uint64, info *mode
 		ti.rowColFieldTps[col.ID] = ti.rowColInfos[i].Ft
 	}
 
-	for i, idx := range ti.Indices {
-		ti.indicesOffset[idx.ID] = i
+	for _, idx := range ti.Indices {
 		if ti.IsIndexUnique(idx) {
 			ti.hasUniqueColumn = true
 		}

--- a/cdc/model/schema_storage_test.go
+++ b/cdc/model/schema_storage_test.go
@@ -381,7 +381,6 @@ func TestBuildTiDBTableInfoWithIntPrimaryKey(t *testing.T) {
 	require.Equal(t, "test", tableInfo.TableName.Schema)
 	require.Equal(t, "t", tableInfo.TableName.Table)
 	require.Equal(t, 3, len(tableInfo.columnsOffset))
-	require.Equal(t, 1, len(tableInfo.indicesOffset))
 	require.Equal(t, 3, len(tableInfo.Columns))
 
 	require.Equal(t, tableInfo.Columns[0].ID, tableInfo.ForceGetColumnIDByName("a1"))
@@ -428,7 +427,6 @@ func TestBuildTiDBTableInfoWithCommonPrimaryKey(t *testing.T) {
 	require.Equal(t, "test", tableInfo.TableName.Schema)
 	require.Equal(t, "t", tableInfo.TableName.Table)
 	require.Equal(t, 4, len(tableInfo.columnsOffset))
-	require.Equal(t, 3, len(tableInfo.indicesOffset))
 	require.Equal(t, 4, len(tableInfo.Columns))
 
 	require.Equal(t, tableInfo.Columns[0].ID, tableInfo.ForceGetColumnIDByName("a1"))
@@ -481,7 +479,6 @@ func TestBuildTiDBTableInfoWithUniqueKey(t *testing.T) {
 	require.Equal(t, "test", tableInfo.TableName.Schema)
 	require.Equal(t, "t", tableInfo.TableName.Table)
 	require.Equal(t, 4, len(tableInfo.columnsOffset))
-	require.Equal(t, 2, len(tableInfo.indicesOffset))
 	require.Equal(t, 4, len(tableInfo.Columns))
 
 	require.Equal(t, tableInfo.Columns[0].ID, tableInfo.ForceGetColumnIDByName("a1"))


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11179 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
