### PR TITLE
schema(ticdc): use node level schema storage

### DIFF
--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -155,7 +155,7 @@ type changefeed struct {
 	downstreamObserver observer.Observer
 	observerLastTick   *atomic.Time
 
-	newDDLPuller func(ctx context.Context,
+	newDDLPuller func(
 		up *upstream.Upstream,
 		startTs uint64,
 		changefeed model.ChangeFeedID,
@@ -234,7 +234,7 @@ func newChangefeed4Test(
 	cfInfo *model.ChangeFeedInfo,
 	cfStatus *model.ChangeFeedStatus,
 	cfstateManager FeedStateManager, up *upstream.Upstream,
-	newDDLPuller func(ctx context.Context,
+	newDDLPuller func(
 		up *upstream.Upstream,
 		startTs uint64,
 		changefeed model.ChangeFeedID,

--- a/cdc/owner/changefeed_test.go
+++ b/cdc/owner/changefeed_test.go
@@ -53,7 +53,7 @@ type mockDDLPuller struct {
 	schemaStorage entry.SchemaStorage
 }
 
-func (m *mockDDLPuller) PopFrontDDL() (uint64, *timodel.Job) {
+func (m *mockDDLPuller) PopPendingDDLs() (uint64, *timodel.Job) {
 	if len(m.ddlQueue) > 0 {
 		job := m.ddlQueue[0]
 		m.ddlQueue = m.ddlQueue[1:]

--- a/cdc/owner/changefeed_test.go
+++ b/cdc/owner/changefeed_test.go
@@ -209,7 +209,7 @@ func createChangefeed4Test(globalVars *vars.GlobalVars,
 	cf := newChangefeed4Test(model.DefaultChangeFeedID(changefeedInfo.ID),
 		state.Info, state.Status, NewFeedStateManager(up, state), up,
 		// new ddl puller
-		func(ctx context.Context,
+		func(
 			up *upstream.Upstream,
 			startTs uint64,
 			changefeed model.ChangeFeedID,

--- a/cdc/owner/ddl_manager.go
+++ b/cdc/owner/ddl_manager.go
@@ -564,7 +564,7 @@ func (m *ddlManager) cleanCache(msg string) {
 	// Set it to nil first to accelerate GC.
 	m.pendingDDLs[tableName][0] = nil
 	m.pendingDDLs[tableName] = m.pendingDDLs[tableName][1:]
-	m.schema.DoGC(m.executingDDL.CommitTs - 1)
+	// m.schema.DoGC(m.executingDDL.CommitTs - 1)
 	m.justSentDDL = m.executingDDL
 	m.executingDDL = nil
 

--- a/cdc/owner/owner_test.go
+++ b/cdc/owner/owner_test.go
@@ -61,7 +61,7 @@ var _ gc.Manager = (*mockManager)(nil)
 
 // newOwner4Test creates a new Owner for test
 func newOwner4Test(
-	newDDLPuller func(ctx context.Context,
+	newDDLPuller func(
 		up *upstream.Upstream,
 		startTs uint64,
 		changefeed model.ChangeFeedID,
@@ -108,7 +108,7 @@ func createOwner4Test(globalVars *vars.GlobalVars, t *testing.T) (*ownerImpl, *o
 
 	owner := newOwner4Test(
 		// new ddl puller
-		func(ctx context.Context,
+		func(
 			up *upstream.Upstream,
 			startTs uint64,
 			changefeed model.ChangeFeedID,

--- a/cdc/puller/ddl_puller.go
+++ b/cdc/puller/ddl_puller.go
@@ -72,10 +72,9 @@ type ddlJobPullerImpl struct {
 	outputCh chan *model.DDLJobEntry
 }
 
-// NewDDLJobPuller creates a new NewDDLJobPuller,
+// newDDLJobPuller creates a new newDDLJobPuller,
 // which fetches ddl events starting from checkpointTs.
-func NewDDLJobPuller(
-	ctx context.Context,
+func newDDLJobPuller(
 	up *upstream.Upstream,
 	checkpointTs uint64,
 	cfg *config.ServerConfig,
@@ -623,7 +622,7 @@ type ddlPullerImpl struct {
 }
 
 // NewDDLPuller return a puller for DDL Event
-func NewDDLPuller(ctx context.Context,
+func NewDDLPuller(
 	up *upstream.Upstream,
 	startTs uint64,
 	changefeed model.ChangeFeedID,
@@ -634,8 +633,8 @@ func NewDDLPuller(ctx context.Context,
 	// storage can be nil only in the test
 	if up.KVStorage != nil {
 		changefeed.ID += "_owner_ddl_puller"
-		puller = NewDDLJobPuller(
-			ctx, up, startTs, config.GetGlobalServerConfig(),
+		puller = newDDLJobPuller(
+			up, startTs, config.GetGlobalServerConfig(),
 			changefeed, schemaStorage, filter)
 	}
 

--- a/cdc/puller/ddl_puller.go
+++ b/cdc/puller/ddl_puller.go
@@ -148,12 +148,6 @@ func (p *ddlJobPullerImpl) Run(ctx context.Context, _ ...chan<- error) error {
 	return eg.Wait()
 }
 
-// WaitForReady implements util.Runnable.
-func (p *ddlJobPullerImpl) WaitForReady(_ context.Context) {}
-
-// Close implements util.Runnable.
-func (p *ddlJobPullerImpl) Close() {}
-
 // Output implements*ddlJobPullerImpl, it returns the output channel of DDL job.
 func (p *ddlJobPullerImpl) Output() <-chan *model.DDLJobEntry {
 	return p.outputCh

--- a/cdc/puller/ddl_puller_test.go
+++ b/cdc/puller/ddl_puller_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
@@ -29,13 +30,13 @@ import (
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/processor/tablepb"
 	"github.com/pingcap/tiflow/cdc/puller/memorysorter"
-	"github.com/pingcap/tiflow/cdc/vars"
 	"github.com/pingcap/tiflow/pkg/config"
 	"github.com/pingcap/tiflow/pkg/filter"
 	"github.com/pingcap/tiflow/pkg/retry"
 	"github.com/pingcap/tiflow/pkg/upstream"
 	"github.com/pingcap/tiflow/pkg/util"
 	"github.com/stretchr/testify/require"
+	"github.com/tikv/client-go/v2/oracle"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
@@ -553,7 +554,11 @@ func TestHandleJob(t *testing.T) {
 func TestDDLPuller(t *testing.T) {
 	startTs := uint64(10)
 
-	_, changefeedInfo := vars.NewGlobalVarsAndChangefeedInfo4Test()
+	changefeedInfo := &model.ChangeFeedInfo{
+		ID:      "changefeed-id-test",
+		StartTs: oracle.GoTimeToTS(time.Now()),
+		Config:  config.GetDefaultReplicaConfig(),
+	}
 	ctx := context.Background()
 	up := upstream.NewUpstream4Test(nil)
 	f, err := filter.NewFilter(changefeedInfo.Config, "")
@@ -683,7 +688,11 @@ func TestResolvedTsStuck(t *testing.T) {
 
 	startTs := uint64(10)
 
-	_, changefeedInfo := vars.NewGlobalVarsAndChangefeedInfo4Test()
+	changefeedInfo := &model.ChangeFeedInfo{
+		ID:      "changefeed-id-test",
+		StartTs: oracle.GoTimeToTS(time.Now()),
+		Config:  config.GetDefaultReplicaConfig(),
+	}
 	ctx := context.Background()
 	up := upstream.NewUpstream4Test(nil)
 	f, err := filter.NewFilter(config.GetDefaultReplicaConfig(), "")

--- a/cdc/puller/ddl_puller_test.go
+++ b/cdc/puller/ddl_puller_test.go
@@ -571,7 +571,7 @@ func TestDDLPuller(t *testing.T) {
 		f,
 	)
 	require.Nil(t, err)
-	puller := NewDDLPuller(ctx, up, startTs, model.DefaultChangeFeedID(changefeedInfo.ID), schemaStorage, f)
+	puller := NewDDLPuller(up, startTs, model.DefaultChangeFeedID(changefeedInfo.ID), schemaStorage, f)
 	p := puller.(*ddlPullerImpl)
 	p.ddlJobPuller, _ = newMockDDLJobPuller(t, false)
 	ddlJobPullerImpl := p.ddlJobPuller
@@ -704,7 +704,7 @@ func TestResolvedTsStuck(t *testing.T) {
 		f,
 	)
 	require.Nil(t, err)
-	p := NewDDLPuller(ctx, up, startTs, model.DefaultChangeFeedID(changefeedInfo.ID), schemaStorage, f)
+	p := NewDDLPuller(up, startTs, model.DefaultChangeFeedID(changefeedInfo.ID), schemaStorage, f)
 
 	p.(*ddlPullerImpl).ddlJobPuller, _ = newMockDDLJobPuller(t, false)
 	ddlJobPullerImpl := p.(*ddlPullerImpl).ddlJobPuller

--- a/cdc/schema/main_test.go
+++ b/cdc/schema/main_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/pingcap/tiflow/pkg/leakutil"
+)
+
+func TestMain(m *testing.M) {
+	leakutil.SetUpLeakTest(m)
+}

--- a/cdc/schema/schema_manager.go
+++ b/cdc/schema/schema_manager.go
@@ -167,7 +167,7 @@ func (w *storageWrapper) init(cfg *StorageWrapperConfig) (err error) {
 		return err
 	}
 
-	w.ddlPuller = puller.NewDDLPuller(ctx, cfg.Upstream, cfg.StartTs, cfg.ID, w.storage, cfg.Filter)
+	w.ddlPuller = puller.NewDDLPuller(cfg.Upstream, cfg.StartTs, cfg.ID, w.storage, cfg.Filter)
 	w.wg.Add(1)
 	go func() {
 		defer w.wg.Done()
@@ -243,7 +243,7 @@ func (w *storageWrapper) doGC() (ok bool) {
 
 	if gcTs != math.MaxUint64 {
 		w.storage.DoGC(gcTs)
-		// w.ddlPuller.DoGC(gcTs)
+		w.ddlPuller.DoGC(gcTs)
 		return true
 	}
 	return false

--- a/cdc/schema/schema_manager.go
+++ b/cdc/schema/schema_manager.go
@@ -1,0 +1,250 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/pingcap/log"
+	"github.com/pingcap/tiflow/cdc/entry"
+	"github.com/pingcap/tiflow/cdc/model"
+	"github.com/pingcap/tiflow/cdc/puller"
+	"github.com/pingcap/tiflow/pkg/filter"
+	"github.com/pingcap/tiflow/pkg/upstream"
+	"github.com/pingcap/tiflow/pkg/util"
+	"go.uber.org/zap"
+)
+
+const DefaultGCInterval = 10 * time.Second
+
+type SchemaManager struct {
+	storageWrapperMap sync.Map
+}
+
+// Reset closes all schema storages and clear the map.
+func (m *SchemaManager) Reset() {
+	m.storageWrapperMap.Range(func(key, value interface{}) bool {
+		w := value.(*storageWrapper)
+		w.close(nil, "schema storage manager reset")
+		return true
+	})
+	m.storageWrapperMap = sync.Map{}
+}
+
+// GetOrCreateSchemaStorage returns the schema storage and ddl puller for the specified changefeed.
+func (m *SchemaManager) GetOrCreateSchemaStorage(
+	cfg *StorageWrapperConfig,
+) (p puller.DDLPuller, s entry.SchemaStorage, err error) {
+	wrapper, _ := m.storageWrapperMap.LoadOrStore(cfg.ID, &storageWrapper{
+		id: cfg.ID,
+	})
+
+	w := wrapper.(*storageWrapper)
+	if err = w.register(cfg); err != nil {
+		return nil, nil, err
+	}
+	return w.ddlPuller, w.storage, err
+}
+
+// ReleaseSchemaStorage closes the schema storage and ddl puller for the specified changefeed.
+func (m *SchemaManager) ReleaseSchemaStorage(id model.ChangeFeedID, role util.Role) {
+	wrapper, ok := m.storageWrapperMap.Load(id)
+	if !ok {
+		log.Warn("schema storage not found",
+			zap.String("namespace", id.Namespace),
+			zap.String("changefeed", id.ID))
+		return
+	}
+
+	w := wrapper.(*storageWrapper)
+	closed := w.deregister(role)
+	if closed {
+		m.storageWrapperMap.Delete(id)
+	}
+}
+
+// UpdateGCTs updates the GC ts for the specified changefeed.
+func (m *SchemaManager) UpdateGCTs(id model.ChangeFeedID, role util.Role, ts uint64) {
+	wrapper, ok := m.storageWrapperMap.Load(id)
+	if !ok {
+		log.Warn("schema storage not found",
+			zap.String("namespace", id.Namespace),
+			zap.String("changefeed", id.ID))
+		return
+	}
+
+	w := wrapper.(*storageWrapper)
+	w.updateGCTs(role, ts)
+}
+
+type StorageWrapperConfig struct {
+	ID         model.ChangeFeedID
+	Role       util.Role
+	ErrHandler func(error)
+	GCInterval time.Duration
+
+	ForceReplicate bool
+	Filter         filter.Filter
+	StartTs        uint64
+	Upstream       *upstream.Upstream
+}
+
+type storageWrapper struct {
+	id     model.ChangeFeedID
+	wg     sync.WaitGroup
+	cancel context.CancelFunc
+
+	mu          sync.RWMutex
+	initialized bool
+	isClosed    bool
+
+	// cancel releated context when the storage return error
+	onErrorCallbacks map[util.Role]func(error)
+	gcTsMap          sync.Map
+
+	ddlPuller puller.DDLPuller
+	storage   entry.SchemaStorage
+}
+
+func (w *storageWrapper) register(cfg *StorageWrapperConfig) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.isClosed {
+		return errors.New("register on closed storage wrapper, it is a temporal error, please resume the changefeed")
+	}
+
+	if !w.initialized {
+		if err := w.init(cfg); err != nil {
+			w.isClosed = true
+			return err
+		}
+	}
+
+	w.updateGCTs(cfg.Role, cfg.StartTs)
+	w.onErrorCallbacks[cfg.Role] = cfg.ErrHandler
+	return nil
+}
+
+func (w *storageWrapper) deregister(role util.Role) (closed bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	delete(w.onErrorCallbacks, role)
+	w.gcTsMap.Delete(role)
+
+	// close the storage wrapper if all roles are deregistered
+	if len(w.onErrorCallbacks) == 0 {
+		w.close(nil, "storage wrapper closed since idle")
+		return true
+	}
+	return false
+}
+
+// init must be called with lock
+func (w *storageWrapper) init(cfg *StorageWrapperConfig) (err error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	w.cancel = cancel
+	w.onErrorCallbacks = make(map[util.Role]func(error))
+
+	w.storage, err = entry.NewSchemaStorage(cfg.Upstream.KVStorage, cfg.StartTs, cfg.ForceReplicate, cfg.ID, cfg.Role, cfg.Filter)
+	if err != nil {
+		return err
+	}
+
+	w.ddlPuller = puller.NewDDLPuller(ctx, cfg.Upstream, cfg.StartTs, cfg.ID, w.storage, cfg.Filter)
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+
+		defer w.ddlPuller.Close()
+		err := w.ddlPuller.Run(ctx)
+		if err != nil {
+			w.close(err, "ddl puller meet error")
+		}
+	}()
+
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+
+		ticker := time.NewTicker(cfg.GCInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				w.doGC()
+			}
+		}
+	}()
+
+	w.initialized = true
+	return nil
+}
+
+func (w *storageWrapper) close(err error, reason string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	log.Warn("schema wrapper closing",
+		zap.String("namespace", w.id.Namespace),
+		zap.String("changefeed", w.id.ID),
+		zap.String("reason", reason),
+		zap.Error(err))
+
+	if err != nil {
+		for _, cb := range w.onErrorCallbacks {
+			cb(err)
+		}
+	}
+
+	w.cancel()
+	w.isClosed = true
+	w.wg.Wait()
+	log.Warn("schema wrapper closed",
+		zap.String("namespace", w.id.Namespace),
+		zap.String("changefeed", w.id.ID))
+}
+
+func (w *storageWrapper) updateGCTs(role util.Role, ts uint64) {
+	old, ok := w.gcTsMap.Swap(role, ts)
+	if ok && old.(uint64) > ts {
+		log.Panic("gcTs regression in schema storage, please report a bug",
+			zap.Uint64("old", old.(uint64)), zap.Uint64("new", ts))
+	}
+}
+
+func (w *storageWrapper) doGC() (ok bool) {
+	var gcTs uint64 = math.MaxUint64
+	w.gcTsMap.Range(func(key, value interface{}) bool {
+		ts := value.(uint64)
+		if ts > gcTs {
+			gcTs = ts
+		}
+		return true
+	})
+
+	if gcTs != math.MaxUint64 {
+		w.storage.DoGC(gcTs)
+		// w.ddlPuller.DoGC(gcTs)
+		return true
+	}
+	return false
+}

--- a/cdc/vars/vars.go
+++ b/cdc/vars/vars.go
@@ -64,6 +64,7 @@ func NewGlobalVars4Test() *GlobalVars {
 			ClusterID: etcd.DefaultCDCClusterID,
 		},
 		ChangefeedThreadPool: &NonAsyncPool{},
+		SchemaManager:        &schema.SchemaManager{},
 	}
 }
 

--- a/cdc/vars/vars.go
+++ b/cdc/vars/vars.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/processor/sourcemanager/sorter/factory"
+	"github.com/pingcap/tiflow/cdc/schema"
 	"github.com/pingcap/tiflow/pkg/config"
 	"github.com/pingcap/tiflow/pkg/etcd"
 	"github.com/pingcap/tiflow/pkg/p2p"
@@ -28,7 +29,7 @@ import (
 
 // GlobalVars contains some vars which can be used anywhere in a pipeline
 // the lifecycle of vars in the GlobalVars should be aligned with the ticdc server process.
-// All field in Vars should be READ-ONLY and THREAD-SAFE
+// All field in Vars should be READ-ONLY and THREAD-SAFE.
 type GlobalVars struct {
 	CaptureInfo *model.CaptureInfo
 	EtcdClient  etcd.CDCEtcdClient
@@ -39,12 +40,15 @@ type GlobalVars struct {
 	// OwnerRevision is the Etcd revision when the owner got elected.
 	OwnerRevision int64
 
-	// MessageServer and MessageRouter are for peer-messaging
+	// MessageServer and MessageRouter are for peer-messaging.
 	MessageServer *p2p.MessageServer
 	MessageRouter p2p.MessageRouter
 
-	// ChangefeedThreadPool is the thread pool for changefeed initialization
+	// ChangefeedThreadPool is the thread pool for changefeed initialization.
 	ChangefeedThreadPool workerpool.AsyncPool
+
+	// SchemaManager manages one schema storage and ddl puller for each changefeed.
+	SchemaManager *schema.SchemaManager
 }
 
 // NewGlobalVars4Test returns a GlobalVars for test,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #xxx

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 
 Scenario: incremental scan
 Deploy ticdc cluster(7 nodes, 8c16g, replicating 150k tables, 1 changefeed) with the following configuration:
```toml
[debug.scheduler]
add-table-batch-size = 1000
```

1. Before this pr: The maximum memory of the owner node is 15.6GB
https://snapshots.raintank.io/dashboard/snapshot/LbadunzKLNNUuKz9jN5xwWfdFdfK8Uph
![image](https://github.com/pingcap/tiflow/assets/61726649/9812aef5-a390-428c-90c4-ed595651aca6)

2. This pr: The maximum memory of the owner node is 11GB
https://snapshots.raintank.io/dashboard/snapshot/siOmwwftr3h7jYaoruECv7hb8Vl4bHwZ
![image](https://github.com/pingcap/tiflow/assets/61726649/730fd586-acd4-41f8-bdf1-7b35b054db72)


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`Optimize the memory usage of the ticdc owner node in the scenario of synchronizing a large number of tables`.
```
