### PR TITLE
model(ticdc): add one method to get the row changed event corresponding table id

### DIFF
--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -435,10 +435,7 @@ func (e txnRows) Swap(i, j int) {
 
 // GetTableID returns the table ID of the event.
 func (r *RowChangedEvent) GetTableID() int64 {
-	if r.TableInfo.IsPartitionTable() {
-		return r.PhysicalTableID
-	}
-	return r.TableInfo.ID
+	return r.PhysicalTableID
 }
 
 // GetCommitTs returns the commit timestamp of this event.

--- a/cdc/model/sink_test.go
+++ b/cdc/model/sink_test.go
@@ -654,7 +654,7 @@ func TestToRedoLog(t *testing.T) {
 	eventInRedoLog := event.ToRedoLog()
 	require.Equal(t, event.StartTs, eventInRedoLog.RedoRow.Row.StartTs)
 	require.Equal(t, event.CommitTs, eventInRedoLog.RedoRow.Row.CommitTs)
-	require.Equal(t, event.PhysicalTableID, eventInRedoLog.RedoRow.Row.Table.TableID)
+	require.Equal(t, event.GetTableID(), eventInRedoLog.RedoRow.Row.Table.TableID)
 	require.Equal(t, event.TableInfo.GetSchemaName(), eventInRedoLog.RedoRow.Row.Table.Schema)
 	require.Equal(t, event.TableInfo.GetTableName(), eventInRedoLog.RedoRow.Row.Table.Table)
 	require.Equal(t, event.Columns, Columns2ColumnDatas(eventInRedoLog.RedoRow.Row.Columns, tableInfo))

--- a/cdc/sink/dmlsink/event_appender.go
+++ b/cdc/sink/dmlsink/event_appender.go
@@ -115,7 +115,7 @@ func (t *TxnEventAppender) createSingleTableTxn(
 	txn := &model.SingleTableTxn{
 		StartTs:         row.StartTs,
 		CommitTs:        row.CommitTs,
-		PhysicalTableID: row.PhysicalTableID,
+		PhysicalTableID: row.GetTableID(),
 		TableInfo:       row.TableInfo,
 	}
 	if row.TableInfo != nil {

--- a/cdc/sink/dmlsink/txn/event.go
+++ b/cdc/sink/dmlsink/txn/event.go
@@ -73,7 +73,7 @@ func genRowKeys(row *model.RowChangedEvent) [][]byte {
 	var keys [][]byte
 	if len(row.Columns) != 0 {
 		for iIdx, idxCol := range row.TableInfo.IndexColumnsOffset {
-			key := genKeyList(row.GetColumns(), iIdx, idxCol, row.PhysicalTableID)
+			key := genKeyList(row.GetColumns(), iIdx, idxCol, row.GetTableID())
 			if len(key) == 0 {
 				continue
 			}
@@ -82,7 +82,7 @@ func genRowKeys(row *model.RowChangedEvent) [][]byte {
 	}
 	if len(row.PreColumns) != 0 {
 		for iIdx, idxCol := range row.TableInfo.IndexColumnsOffset {
-			key := genKeyList(row.GetPreColumns(), iIdx, idxCol, row.PhysicalTableID)
+			key := genKeyList(row.GetPreColumns(), iIdx, idxCol, row.GetTableID())
 			if len(key) == 0 {
 				continue
 			}
@@ -92,9 +92,9 @@ func genRowKeys(row *model.RowChangedEvent) [][]byte {
 	if len(keys) == 0 {
 		// use table ID as key if no key generated (no PK/UK),
 		// no concurrence for rows in the same table.
-		log.Debug("Use table id as the key", zap.Int64("tableID", row.PhysicalTableID))
+		log.Debug("Use table id as the key", zap.Int64("tableID", row.GetTableID()))
 		tableKey := make([]byte, 8)
-		binary.BigEndian.PutUint64(tableKey, uint64(row.PhysicalTableID))
+		binary.BigEndian.PutUint64(tableKey, uint64(row.GetTableID()))
 		keys = [][]byte{tableKey}
 	}
 	return keys

--- a/cmd/kafka-consumer/main.go
+++ b/cmd/kafka-consumer/main.go
@@ -625,7 +625,7 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 				if simple, ok := decoder.(*simple.Decoder); ok {
 					cachedEvents := simple.GetCachedEvents()
 					for _, row := range cachedEvents {
-						tableID := row.PhysicalTableID
+						tableID := row.GetTableID()
 						group, ok := eventGroups[tableID]
 						if !ok {
 							group = newEventsGroup()
@@ -692,12 +692,12 @@ func (c *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim saram
 						zap.Any("row", row))
 				}
 
-				tableID := row.PhysicalTableID
+				tableID := row.GetTableID()
 				// simple protocol decoder should have set the table id already.
 				if c.option.protocol != config.ProtocolSimple {
 					var partitionID int64
 					if row.TableInfo.IsPartitionTable() {
-						partitionID = row.PhysicalTableID
+						partitionID = row.GetTableID()
 					}
 					tableID = c.fakeTableIDGenerator.
 						generateFakeTableID(row.TableInfo.GetSchemaName(), row.TableInfo.GetTableName(), partitionID)

--- a/cmd/pulsar-consumer/main.go
+++ b/cmd/pulsar-consumer/main.go
@@ -526,7 +526,7 @@ func (c *Consumer) HandleMsg(msg pulsar.Message) error {
 			}
 			var partitionID int64
 			if row.TableInfo.IsPartitionTable() {
-				partitionID = row.PhysicalTableID
+				partitionID = row.GetTableID()
 			}
 			// use schema, table and tableID to identify a table
 			tableID := c.fakeTableIDGenerator.

--- a/pkg/applier/redo.go
+++ b/pkg/applier/redo.go
@@ -310,7 +310,7 @@ func (ra *RedoApplier) applyRow(
 	}
 	ra.pendingQuota -= rowSize
 
-	tableID := row.PhysicalTableID
+	tableID := row.GetTableID()
 	if _, ok := ra.tableSinks[tableID]; !ok {
 		tableSink := ra.sinkFactory.CreateTableSink(
 			model.DefaultChangeFeedID(applierChangefeed),

--- a/pkg/sink/codec/bootstraper.go
+++ b/pkg/sink/codec/bootstraper.go
@@ -107,7 +107,7 @@ func (b *bootstrapWorker) addEvent(
 	key model.TopicPartitionKey,
 	row *model.RowChangedEvent,
 ) error {
-	table, ok := b.activeTables.Load(row.PhysicalTableID)
+	table, ok := b.activeTables.Load(row.GetTableID())
 	if !ok {
 		tb := newTableStatistic(key, row)
 		b.activeTables.Store(tb.id, tb)
@@ -220,7 +220,7 @@ type tableStatistic struct {
 
 func newTableStatistic(key model.TopicPartitionKey, row *model.RowChangedEvent) *tableStatistic {
 	res := &tableStatistic{
-		id:    row.PhysicalTableID,
+		id:    row.GetTableID(),
 		topic: key.Topic,
 	}
 	res.totalPartition.Store(key.TotalPartition)

--- a/pkg/sink/codec/craft/model.go
+++ b/pkg/sink/codec/craft/model.go
@@ -469,7 +469,7 @@ func (b *RowChangedEventBuffer) Encode() []byte {
 func (b *RowChangedEventBuffer) AppendRowChangedEvent(ev *model.RowChangedEvent, onlyHandleKeyColumns bool) (rows, size int) {
 	var partition int64 = -1
 	if ev.TableInfo.IsPartitionTable() {
-		partition = ev.PhysicalTableID
+		partition = ev.GetTableID()
 	}
 
 	var schema, table *string

--- a/pkg/sink/codec/maxwell/maxwell_message.go
+++ b/pkg/sink/codec/maxwell/maxwell_message.go
@@ -44,15 +44,15 @@ func (m *maxwellMessage) encode() ([]byte, error) {
 }
 
 func rowChangeToMaxwellMsg(e *model.RowChangedEvent, onlyHandleKeyColumns bool) (*internal.MessageKey, *maxwellMessage) {
-	var partition *int64
+	var partition int64
 	if e.TableInfo.IsPartitionTable() {
-		partition = &e.PhysicalTableID
+		partition = e.GetTableID()
 	}
 	key := &internal.MessageKey{
 		Ts:        e.CommitTs,
 		Schema:    e.TableInfo.GetSchemaName(),
 		Table:     e.TableInfo.GetTableName(),
-		Partition: partition,
+		Partition: &partition,
 		Type:      model.MessageTypeRow,
 	}
 	value := &maxwellMessage{

--- a/pkg/sink/codec/maxwell/maxwell_message.go
+++ b/pkg/sink/codec/maxwell/maxwell_message.go
@@ -44,15 +44,16 @@ func (m *maxwellMessage) encode() ([]byte, error) {
 }
 
 func rowChangeToMaxwellMsg(e *model.RowChangedEvent, onlyHandleKeyColumns bool) (*internal.MessageKey, *maxwellMessage) {
-	var partition int64
+	var partition *int64
 	if e.TableInfo.IsPartitionTable() {
-		partition = e.GetTableID()
+		tableID := e.GetTableID()
+		partition = &tableID
 	}
 	key := &internal.MessageKey{
 		Ts:        e.CommitTs,
 		Schema:    e.TableInfo.GetSchemaName(),
 		Table:     e.TableInfo.GetTableName(),
-		Partition: &partition,
+		Partition: partition,
 		Type:      model.MessageTypeRow,
 	}
 	value := &maxwellMessage{

--- a/pkg/sink/codec/open/open_protocol_message.go
+++ b/pkg/sink/codec/open/open_protocol_message.go
@@ -123,16 +123,16 @@ func rowChangeToMsg(
 	e *model.RowChangedEvent,
 	config *common.Config,
 	largeMessageOnlyHandleKeyColumns bool) (*internal.MessageKey, *messageRow, error) {
-	var partition *int64
+	var partition int64
 	if e.TableInfo.IsPartitionTable() {
-		partition = &e.PhysicalTableID
+		partition = e.GetTableID()
 	}
 	key := &internal.MessageKey{
 		Ts:            e.CommitTs,
 		Schema:        e.TableInfo.GetSchemaName(),
 		Table:         e.TableInfo.GetTableName(),
 		RowID:         e.RowID,
-		Partition:     partition,
+		Partition:     &partition,
 		Type:          model.MessageTypeRow,
 		OnlyHandleKey: largeMessageOnlyHandleKeyColumns,
 	}

--- a/pkg/sink/codec/open/open_protocol_message.go
+++ b/pkg/sink/codec/open/open_protocol_message.go
@@ -123,16 +123,17 @@ func rowChangeToMsg(
 	e *model.RowChangedEvent,
 	config *common.Config,
 	largeMessageOnlyHandleKeyColumns bool) (*internal.MessageKey, *messageRow, error) {
-	var partition int64
+	var partition *int64
 	if e.TableInfo.IsPartitionTable() {
-		partition = e.GetTableID()
+		tableID := e.GetTableID()
+		partition = &tableID
 	}
 	key := &internal.MessageKey{
 		Ts:            e.CommitTs,
 		Schema:        e.TableInfo.GetSchemaName(),
 		Table:         e.TableInfo.GetTableName(),
 		RowID:         e.RowID,
-		Partition:     &partition,
+		Partition:     partition,
 		Type:          model.MessageTypeRow,
 		OnlyHandleKey: largeMessageOnlyHandleKeyColumns,
 	}

--- a/pkg/sink/codec/simple/encoder_test.go
+++ b/pkg/sink/codec/simple/encoder_test.go
@@ -1310,7 +1310,7 @@ func TestEncodeLargeEventsNormal(t *testing.T) {
 				require.Equal(t, decodedRow.CommitTs, event.CommitTs)
 				require.Equal(t, decodedRow.TableInfo.GetSchemaName(), event.TableInfo.GetSchemaName())
 				require.Equal(t, decodedRow.TableInfo.GetTableName(), event.TableInfo.GetTableName())
-				require.Equal(t, decodedRow.PhysicalTableID, event.PhysicalTableID)
+				require.Equal(t, decodedRow.GetTableID(), event.GetTableID())
 
 				decodedColumns := make(map[string]*model.ColumnData, len(decodedRow.Columns))
 				for _, column := range decodedRow.Columns {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11194

### What is changed and how it works?

* add one method `GetTableID() int64` to the `RowChangedEvent` struct

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
