### PR TITLE
config, scheduler(ticdc): add MaxTableCount and AddTableBatchSize to ChangefeedSchedulerConfig

### DIFF
--- a/cdc/api/v2/model.go
+++ b/cdc/api/v2/model.go
@@ -502,6 +502,8 @@ func (c *ReplicaConfig) toInternalReplicaConfigWithOriginConfig(
 	}
 	if c.Scheduler != nil {
 		res.Scheduler = &config.ChangefeedSchedulerConfig{
+			AddTableBatchSize:      c.Scheduler.AddTableBatchSize,
+			MaxTableCount:          c.Scheduler.MaxTableCount,
 			EnableTableAcrossNodes: c.Scheduler.EnableTableAcrossNodes,
 			RegionThreshold:        c.Scheduler.RegionThreshold,
 			WriteKeyThreshold:      c.Scheduler.WriteKeyThreshold,
@@ -817,6 +819,8 @@ func ToAPIReplicaConfig(c *config.ReplicaConfig) *ReplicaConfig {
 	}
 	if cloned.Scheduler != nil {
 		res.Scheduler = &ChangefeedSchedulerConfig{
+			AddTableBatchSize:      cloned.Scheduler.AddTableBatchSize,
+			MaxTableCount:          cloned.Scheduler.MaxTableCount,
 			EnableTableAcrossNodes: cloned.Scheduler.EnableTableAcrossNodes,
 			RegionThreshold:        cloned.Scheduler.RegionThreshold,
 			WriteKeyThreshold:      cloned.Scheduler.WriteKeyThreshold,
@@ -1018,6 +1022,10 @@ type ConsistentMemoryUsage struct {
 // ChangefeedSchedulerConfig is per changefeed scheduler settings.
 // This is a duplicate of config.ChangefeedSchedulerConfig
 type ChangefeedSchedulerConfig struct {
+	// AddTableBatchSize is the batch size of adding tables on each tick.
+	AddTableBatchSize int `json:"add_table_batch_size"`
+	// MaxTableCount is the maximum number of tables that a capture can be scheduled.
+	MaxTableCount int `json:"max_table_count"`
 	// EnableTableAcrossNodes set true to split one table to multiple spans and
 	// distribute to multiple TiCDC nodes.
 	EnableTableAcrossNodes bool `toml:"enable_table_across_nodes" json:"enable_table_across_nodes"`

--- a/cdc/api/v2/model_test.go
+++ b/cdc/api/v2/model_test.go
@@ -80,6 +80,8 @@ var defaultAPIConfig = &ReplicaConfig{
 		},
 	},
 	Scheduler: &ChangefeedSchedulerConfig{
+		AddTableBatchSize: config.DefaultAddTableBatchSize,
+		MaxTableCount:     config.DefaultMaxTableCount,
 		EnableTableAcrossNodes: config.GetDefaultReplicaConfig().
 			Scheduler.EnableTableAcrossNodes,
 		RegionThreshold: config.GetDefaultReplicaConfig().

--- a/cdc/scheduler/internal/v3/scheduler/scheduler_basic_test.go
+++ b/cdc/scheduler/internal/v3/scheduler/scheduler_basic_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tiflow/cdc/processor/tablepb"
 	"github.com/pingcap/tiflow/cdc/scheduler/internal/v3/member"
 	"github.com/pingcap/tiflow/cdc/scheduler/internal/v3/replication"
+	"github.com/pingcap/tiflow/pkg/config"
 	"github.com/pingcap/tiflow/pkg/spanz"
 	"github.com/stretchr/testify/require"
 )
@@ -42,7 +43,7 @@ func TestSchedulerBasic(t *testing.T) {
 	// Initial table dispatch.
 	// AddTable only
 	replications := mapToSpanMap(map[model.TableID]*replication.ReplicationSet{})
-	b := newBasicScheduler(2, model.ChangeFeedID{})
+	b := newBasicScheduler(2, config.DefaultMaxTableCount, model.ChangeFeedID{})
 
 	// one capture stopping, another one is initialized
 	captures["a"].State = member.CaptureStateStopping
@@ -224,7 +225,7 @@ func BenchmarkSchedulerBasicAddTables(b *testing.B) {
 		}
 		replications = mapToSpanMap(map[model.TableID]*replication.ReplicationSet{})
 		name = fmt.Sprintf("AddTable %d", total)
-		sched = newBasicScheduler(50, model.ChangeFeedID{})
+		sched = newBasicScheduler(50, config.DefaultMaxTableCount, model.ChangeFeedID{})
 		return name, currentTables, captures, replications, sched
 	})
 }
@@ -251,7 +252,7 @@ func BenchmarkSchedulerBasicRemoveTables(b *testing.B) {
 				})
 		}
 		name = fmt.Sprintf("RemoveTable %d", total)
-		sched = newBasicScheduler(50, model.ChangeFeedID{})
+		sched = newBasicScheduler(50, config.DefaultMaxTableCount, model.ChangeFeedID{})
 		return name, currentTables, captures, replications, sched
 	})
 }
@@ -281,7 +282,7 @@ func BenchmarkSchedulerBasicAddRemoveTables(b *testing.B) {
 				})
 		}
 		name = fmt.Sprintf("AddRemoveTable %d", total)
-		sched = newBasicScheduler(50, model.ChangeFeedID{})
+		sched = newBasicScheduler(50, config.DefaultMaxTableCount, model.ChangeFeedID{})
 		return name, currentTables, captures, replications, sched
 	})
 }

--- a/cdc/scheduler/internal/v3/scheduler/scheduler_manager.go
+++ b/cdc/scheduler/internal/v3/scheduler/scheduler_manager.go
@@ -51,7 +51,7 @@ func NewSchedulerManager(
 	}
 
 	sm.schedulers[schedulerPriorityBasic] = newBasicScheduler(
-		cfg.AddTableBatchSize, changefeedID)
+		cfg.GetAddTableBatchSize(), cfg.GetMaxTableCount(), changefeedID)
 	sm.schedulers[schedulerPriorityDrainCapture] = newDrainCaptureScheduler(
 		cfg.MaxTaskConcurrency, changefeedID)
 	sm.schedulers[schedulerPriorityBalance] = newBalanceScheduler(

--- a/cdc/scheduler/internal/v3/scheduler/scheduler_manager_test.go
+++ b/cdc/scheduler/internal/v3/scheduler/scheduler_manager_test.go
@@ -28,8 +28,12 @@ import (
 func TestNewSchedulerManager(t *testing.T) {
 	t.Parallel()
 
-	m := NewSchedulerManager(model.DefaultChangeFeedID("test-changefeed"),
-		config.NewDefaultSchedulerConfig())
+	cfg := config.NewDefaultSchedulerConfig()
+	cfg.ChangefeedSettings = &config.ChangefeedSchedulerConfig{
+		AddTableBatchSize: config.DefaultAddTableBatchSize,
+		MaxTableCount:     config.DefaultMaxTableCount,
+	}
+	m := NewSchedulerManager(model.DefaultChangeFeedID("test-changefeed"), cfg)
 	require.NotNil(t, m)
 	require.NotNil(t, m.schedulers[schedulerPriorityBasic])
 	require.NotNil(t, m.schedulers[schedulerPriorityBalance])
@@ -42,6 +46,10 @@ func TestSchedulerManagerScheduler(t *testing.T) {
 	t.Parallel()
 
 	cfg := config.NewDefaultSchedulerConfig()
+	cfg.ChangefeedSettings = &config.ChangefeedSchedulerConfig{
+		AddTableBatchSize: config.DefaultAddTableBatchSize,
+		MaxTableCount:     config.DefaultMaxTableCount,
+	}
 	cfg.MaxTaskConcurrency = 1
 	m := NewSchedulerManager(model.DefaultChangeFeedID("test-changefeed"), cfg)
 

--- a/pkg/cmd/server/server_test.go
+++ b/pkg/cmd/server/server_test.go
@@ -198,7 +198,7 @@ func TestParseCfg(t *testing.T) {
 				CollectStatsTick:     200,
 				MaxTaskConcurrency:   10,
 				CheckBalanceInterval: 60000000000,
-				AddTableBatchSize:    50,
+				AddTableBatchSize:    0,
 			},
 			CDCV2: &config.CDCV2{
 				Enable:          false,
@@ -345,7 +345,7 @@ check-balance-interval = "10s"
 				CollectStatsTick:     201,
 				MaxTaskConcurrency:   11,
 				CheckBalanceInterval: config.TomlDuration(10 * time.Second),
-				AddTableBatchSize:    50,
+				AddTableBatchSize:    0,
 			},
 			CDCV2: &config.CDCV2{
 				Enable:          false,
@@ -484,7 +484,7 @@ cert-allowed-cn = ["dd","ee"]
 				CollectStatsTick:     200,
 				MaxTaskConcurrency:   10,
 				CheckBalanceInterval: 60000000000,
-				AddTableBatchSize:    50,
+				AddTableBatchSize:    0,
 			},
 			CDCV2: &config.CDCV2{
 				Enable:          false,
@@ -549,7 +549,7 @@ unknown3 = 3
 			CollectStatsTick:     200,
 			MaxTaskConcurrency:   10,
 			CheckBalanceInterval: 60000000000,
-			AddTableBatchSize:    50,
+			AddTableBatchSize:    0,
 		},
 		CDCV2: &config.CDCV2{
 			Enable:          false,

--- a/pkg/config/config_test_data.go
+++ b/pkg/config/config_test_data.go
@@ -93,6 +93,7 @@ const (
     }
   },
   "scheduler": {
+    "max-table-count": 30000,
     "enable-table-across-nodes": false,
     "region-threshold": 100000
   },
@@ -181,7 +182,7 @@ const (
       "collect-stats-tick": 200,
       "max-task-concurrency": 10,
       "check-balance-interval": 60000000000,
-      "add-table-batch-size": 50
+      "add-table-batch-size": 0
     },
     "cdc-v2": {
       "enable": false,
@@ -360,6 +361,8 @@ const (
     }
   },
   "scheduler": {
+    "add-table-batch-size": 0,
+    "max-table-count": 30000,
     "enable-table-across-nodes": true,
     "region-per-span": 0,
     "region-threshold": 100001,
@@ -534,6 +537,7 @@ const (
     }
   },
   "scheduler": {
+    "max-table-count": 30000,
     "enable-table-across-nodes": true,
     "region-threshold": 100001,
     "write-key-threshold": 100001

--- a/pkg/config/replica_config.go
+++ b/pkg/config/replica_config.go
@@ -96,6 +96,8 @@ var defaultReplicaConfig = &ReplicaConfig{
 		},
 	},
 	Scheduler: &ChangefeedSchedulerConfig{
+		AddTableBatchSize:      DefaultAddTableBatchSize,
+		MaxTableCount:          DefaultMaxTableCount,
 		EnableTableAcrossNodes: false,
 		RegionThreshold:        100_000,
 		WriteKeyThreshold:      0,

--- a/pkg/config/scheduler_config.go
+++ b/pkg/config/scheduler_config.go
@@ -138,16 +138,15 @@ func (c *SchedulerConfig) ValidateAndAdjust() error {
 // GetAddTableBatchSize is used to keep backward compatibility. And c.ChangefeedSettings.AddTableBatchSize
 // is take procedure over c.AddTableBatchSize, since the latter is deprecated.
 func (c *SchedulerConfig) GetAddTableBatchSize() int {
-	batch := c.ChangefeedSettings.AddTableBatchSize
-	if batch == 0 {
-		batch = c.AddTableBatchSize
+	if c.ChangefeedSettings == nil || c.ChangefeedSettings.AddTableBatchSize == 0 {
+		return c.AddTableBatchSize
 	}
-	return batch
+	return c.ChangefeedSettings.AddTableBatchSize
 }
 
 // GetMaxTableCount is used to keep backward compatibility.
 func (c *SchedulerConfig) GetMaxTableCount() int {
-	if c.ChangefeedSettings.MaxTableCount <= 0 {
+	if c.ChangefeedSettings == nil || c.ChangefeedSettings.MaxTableCount <= 0 {
 		return DefaultMaxTableCount
 	}
 	return c.ChangefeedSettings.MaxTableCount

--- a/pkg/config/server_config_test.go
+++ b/pkg/config/server_config_test.go
@@ -131,7 +131,7 @@ func TestSchedulerConfigValidateAndAdjust(t *testing.T) {
 	require.Error(t, conf.ValidateAndAdjust())
 
 	conf = GetDefaultServerConfig().Clone().Debug.Scheduler
-	conf.AddTableBatchSize = 0
+	conf.AddTableBatchSize = -1
 	require.Error(t, conf.ValidateAndAdjust())
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11216

### What is changed and how it works?
1. Move [AddTableBatchSize](https://github.com/pingcap/tiflow/pull/11197/files#diff-5efe37006daf176ecbb4df807539f64719314947957f5b78bb4bd3453c2ab881R47) from server to changefeed config.
2. Add [MaxTableCount](https://github.com/pingcap/tiflow/pull/11197/files#diff-46d391757d5e8384d6854c28080c8eb981dd84f96bdb317da51ad9c6bf7c1c5fR115-R122) to limit the max tables for each capture to avoid unbalance.
3. Auto adjust batchSize in [scheduler_basic](https://github.com/pingcap/tiflow/pull/11197/files#diff-46d391757d5e8384d6854c28080c8eb981dd84f96bdb317da51ad9c6bf7c1c5fR59-R74) if `AddTableBatchSize=0`. And the adjustment range is [50 to 1000](https://github.com/pingcap/tiflow/pull/11197/files#diff-5efe37006daf176ecbb4df807539f64719314947957f5b78bb4bd3453c2ab881R29-R32). 


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 - Before this PR: 
 The schedule has not been completed in 40 minutes.
![image](https://github.com/pingcap/tiflow/assets/61726649/2c651c87-e73d-435a-8be9-eea7ef38913d)

- This PR: The scheduling was completed in 10min
![image](https://github.com/pingcap/tiflow/assets/61726649/7e7bc7ed-6294-415d-8e50-12d9c868c50c)


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
