### PR TITLE
mysql(ticdc): remove error filter when check isTiDB in backend init

### DIFF
--- a/pkg/sink/mysql/db_helper.go
+++ b/pkg/sink/mysql/db_helper.go
@@ -303,7 +303,7 @@ func CheckIsTiDB(ctx context.Context, db *sql.DB) (bool, error) {
 	err := row.Scan(&tidbVer)
 	if err != nil {
 		log.Error("check tidb version error", zap.Error(err))
-		return false, errors.Trace(err)
+		return false, nil
 	}
 	return true, nil
 }

--- a/pkg/sink/mysql/db_helper.go
+++ b/pkg/sink/mysql/db_helper.go
@@ -303,11 +303,6 @@ func CheckIsTiDB(ctx context.Context, db *sql.DB) (bool, error) {
 	err := row.Scan(&tidbVer)
 	if err != nil {
 		log.Error("check tidb version error", zap.Error(err))
-		// downstream is not TiDB, do nothing
-		if mysqlErr, ok := errors.Cause(err).(*dmysql.MySQLError); ok && (mysqlErr.Number == tmysql.ErrNoDB ||
-			mysqlErr.Number == tmysql.ErrSpDoesNotExist || mysqlErr.Number == tmysql.ErrDBaccessDenied) {
-			return false, nil
-		}
 		return false, errors.Trace(err)
 	}
 	return true, nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11213

### What is changed and how it works?

remove error detection in `checkIsTiDB` to avoid unexcept error when the downstream is different mysql-class server


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
