### PR TITLE
*(cdc): accept access denied error when query tidb_version

### DIFF
--- a/cdc/sinkv2/eventsink/txn/mysql/mysql_test.go
+++ b/cdc/sinkv2/eventsink/txn/mysql/mysql_test.go
@@ -83,9 +83,10 @@ func newTestMockDB(t *testing.T) (db *sql.DB, mock sqlmock.Sqlmock) {
 		Number:  1305,
 		Message: "FUNCTION test.tidb_version does not exist",
 	})
+	// mock a different possible error for the second query
 	mock.ExpectQuery("select tidb_version()").WillReturnError(&dmysql.MySQLError{
-		Number:  1305,
-		Message: "FUNCTION test.tidb_version does not exist",
+		Number:  1044,
+		Message: "Access denied for user 'cdc'@'%' to database 'information_schema'",
 	})
 	require.Nil(t, err)
 	return

--- a/pkg/sink/mysql/db_helper.go
+++ b/pkg/sink/mysql/db_helper.go
@@ -320,7 +320,7 @@ func CheckIsTiDB(ctx context.Context, db *sql.DB) (bool, error) {
 		log.Error("check tidb version error", zap.Error(err))
 		// downstream is not TiDB, do nothing
 		if mysqlErr, ok := errors.Cause(err).(*dmysql.MySQLError); ok && (mysqlErr.Number == tmysql.ErrNoDB ||
-			mysqlErr.Number == tmysql.ErrSpDoesNotExist) {
+			mysqlErr.Number == tmysql.ErrSpDoesNotExist || mysqlErr.Number == tmysql.ErrDBaccessDenied) {
 			return false, nil
 		}
 		return false, errors.Trace(err)


### PR DESCRIPTION
…#11140)

close pingcap/tiflow#11128

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11128 

### What is changed and how it works?
When the downstream is a mysql cluster behind a workload balancer on the cloud, the workload balancer may provide an access point using domain name;
When cdc access the downstream using the domain name, the connection will use database `information_schema` automatically. In this case, when query `select tidb_version()`, the downstream will report error for non-root user like: Access denied for user xxx to database 'information_schema'.
![image](https://github.com/pingcap/tiflow/assets/47731263/6cbc68e0-f607-411e-9496-ccbe1622652a)

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
