### PR TITLE
codec(ticdc): simple decoder set column flag incorrectly since miss index id 

### DIFF
--- a/cdc/sink/dmlsink/mq/dispatcher/partition/index_value_test.go
+++ b/cdc/sink/dmlsink/mq/dispatcher/partition/index_value_test.go
@@ -14,11 +14,6 @@
 package partition
 
 import (
-	"context"
-	"github.com/pingcap/tiflow/cdc/entry"
-	"github.com/pingcap/tiflow/pkg/config"
-	"github.com/pingcap/tiflow/pkg/sink/codec/common"
-	"github.com/pingcap/tiflow/pkg/sink/codec/simple"
 	"testing"
 
 	timodel "github.com/pingcap/tidb/pkg/parser/model"
@@ -188,80 +183,4 @@ func TestIndexValueDispatcherWithIndexName(t *testing.T) {
 	index, _, err := p.DispatchRowChangedEvent(event, 16)
 	require.NoError(t, err)
 	require.Equal(t, int32(2), index)
-}
-
-func TestIndexValueDispatcherXXX(t *testing.T) {
-	helper := entry.NewSchemaTestHelper(t)
-	defer helper.Close()
-
-	createTableDDL := `CREATE TABLE test.sbtest3 (
-	  id int(11) NOT NULL,
-	  k int(11) NOT NULL DEFAULT '0',
-	  PRIMARY KEY (id),
-	  KEY k_3 (k)
-	)`
-	createTableDDLEvent := helper.DDL2Event(createTableDDL)
-
-	insertDML := `insert into test.sbtest3 values (3670739, 5015099)`
-	event := helper.DML2Event(insertDML, "test", "sbtest3")
-
-	p := NewIndexValueDispatcher("")
-	origin, _, err := p.DispatchRowChangedEvent(event, 4)
-	require.NoError(t, err)
-	require.Equal(t, origin, int32(2))
-
-	ctx := context.Background()
-	codecConfig := common.NewConfig(config.ProtocolSimple)
-	codecConfig.EncodingFormat = common.EncodingFormatAvro
-
-	builder, err := simple.NewBuilder(ctx, codecConfig)
-	require.NoError(t, err)
-	encoder := builder.Build()
-
-	decoder, err := simple.NewDecoder(ctx, codecConfig, nil)
-	require.NoError(t, err)
-
-	m, err := encoder.EncodeDDLEvent(createTableDDLEvent)
-	require.NoError(t, err)
-
-	err = decoder.AddKeyValue(m.Key, m.Value)
-	require.NoError(t, err)
-
-	ty, hasNext, err := decoder.HasNext()
-	require.NoError(t, err)
-	require.True(t, hasNext)
-	require.Equal(t, ty, model.MessageTypeDDL)
-
-	decodedDDL, err := decoder.NextDDLEvent()
-	require.NoError(t, err)
-
-	originFlags := createTableDDLEvent.TableInfo.ColumnsFlag
-	obtainedFlags := decodedDDL.TableInfo.ColumnsFlag
-
-	for colID, expected := range originFlags {
-		name := createTableDDLEvent.TableInfo.ForceGetColumnName(colID)
-		actualID := decodedDDL.TableInfo.ForceGetColumnIDByName(name)
-		actual := obtainedFlags[actualID]
-		require.Equal(t, expected, actual)
-	}
-
-	err = encoder.AppendRowChangedEvent(ctx, "", event, func() {})
-	require.NoError(t, err)
-
-	m = encoder.Build()[0]
-
-	err = decoder.AddKeyValue(m.Key, m.Value)
-	require.NoError(t, err)
-
-	ty, hasNext, err = decoder.HasNext()
-	require.NoError(t, err)
-	require.True(t, hasNext)
-	require.Equal(t, ty, model.MessageTypeRow)
-
-	decodedEvent, err := decoder.NextRowChangedEvent()
-	require.NoError(t, err)
-
-	obtained, _, err := p.DispatchRowChangedEvent(decodedEvent, 4)
-	require.NoError(t, err)
-	require.Equal(t, origin, obtained)
 }

--- a/pkg/sink/codec/simple/encoder_test.go
+++ b/pkg/sink/codec/simple/encoder_test.go
@@ -913,6 +913,62 @@ func TestEncodeDDLEvent(t *testing.T) {
 	}
 }
 
+func TestColumnFlags(t *testing.T) {
+	helper := entry.NewSchemaTestHelper(t)
+	defer helper.Close()
+
+	createTableDDL := `create table test.t(
+		a bigint(20) unsigned not null,
+		b bigint(20) default null,
+		c varbinary(767) default null,
+		d int(11) unsigned not null,
+		e int(11) default null,
+		primary key (a),
+		key idx_c(c),
+		key idx_b(b),
+		unique key idx_de(d, e))`
+	createTableDDLEvent := helper.DDL2Event(createTableDDL)
+
+	ctx := context.Background()
+	codecConfig := common.NewConfig(config.ProtocolSimple)
+	for _, format := range []common.EncodingFormatType{
+		common.EncodingFormatAvro,
+		common.EncodingFormatJSON,
+	} {
+		codecConfig.EncodingFormat = format
+		b, err := NewBuilder(ctx, codecConfig)
+		require.NoError(t, err)
+		enc := b.Build()
+
+		m, err := enc.EncodeDDLEvent(createTableDDLEvent)
+		require.NoError(t, err)
+
+		dec, err := NewDecoder(ctx, codecConfig, nil)
+		require.NoError(t, err)
+
+		err = dec.AddKeyValue(m.Key, m.Value)
+		require.NoError(t, err)
+
+		messageType, hasNext, err := dec.HasNext()
+		require.NoError(t, err)
+		require.True(t, hasNext)
+		require.Equal(t, model.MessageTypeDDL, messageType)
+
+		decodedDDLEvent, err := dec.NextDDLEvent()
+		require.NoError(t, err)
+
+		originFlags := createTableDDLEvent.TableInfo.ColumnsFlag
+		obtainedFlags := decodedDDLEvent.TableInfo.ColumnsFlag
+
+		for colID, expected := range originFlags {
+			name := createTableDDLEvent.TableInfo.ForceGetColumnName(colID)
+			actualID := decodedDDLEvent.TableInfo.ForceGetColumnIDByName(name)
+			actual := obtainedFlags[actualID]
+			require.Equal(t, expected, actual)
+		}
+	}
+}
+
 func TestEncodeIntegerTypes(t *testing.T) {
 	replicaConfig := config.GetDefaultReplicaConfig()
 	replicaConfig.Integrity.IntegrityCheckLevel = integrity.CheckLevelCorrectness

--- a/pkg/sink/codec/simple/message.go
+++ b/pkg/sink/codec/simple/message.go
@@ -196,14 +196,16 @@ func newTiColumnInfo(
 	}
 
 	for _, index := range indexes {
-		if index.Primary {
-			for _, name := range index.Columns {
-				if name == column.Name {
+		for _, name := range index.Columns {
+			if name == column.Name {
+				if index.Primary {
 					col.AddFlag(mysql.PriKeyFlag)
-					break
+				} else if index.Unique {
+					col.AddFlag(mysql.UniqueKeyFlag)
+				} else {
+					col.AddFlag(mysql.MultipleKeyFlag)
 				}
 			}
-			break
 		}
 	}
 
@@ -242,7 +244,7 @@ func newIndexSchema(index *timodel.IndexInfo, columns []*timodel.ColumnInfo) *In
 }
 
 // newTiIndexInfo convert IndexSchema to a tidb index info.
-func newTiIndexInfo(indexSchema *IndexSchema, columns []*timodel.ColumnInfo) *timodel.IndexInfo {
+func newTiIndexInfo(indexSchema *IndexSchema, columns []*timodel.ColumnInfo, indexID int64) *timodel.IndexInfo {
 	indexColumns := make([]*timodel.IndexColumn, len(indexSchema.Columns))
 	for i, col := range indexSchema.Columns {
 		var offset int
@@ -259,6 +261,7 @@ func newTiIndexInfo(indexSchema *IndexSchema, columns []*timodel.ColumnInfo) *ti
 	}
 
 	return &timodel.IndexInfo{
+		ID:      indexID,
 		Name:    timodel.NewCIStr(indexSchema.Name),
 		Columns: indexColumns,
 		Unique:  indexSchema.Unique,
@@ -344,9 +347,12 @@ func newTableInfo(m *TableSchema) *model.TableInfo {
 			nextMockID += 100
 			tidbTableInfo.Columns = append(tidbTableInfo.Columns, tiCol)
 		}
+
+		mockIndexID := int64(1)
 		for _, idx := range m.Indexes {
-			index := newTiIndexInfo(idx, tidbTableInfo.Columns)
+			index := newTiIndexInfo(idx, tidbTableInfo.Columns, mockIndexID)
 			tidbTableInfo.Indices = append(tidbTableInfo.Indices, index)
+			mockIndexID += 1
 		}
 	}
 	return model.WrapTableInfo(100, database, schemaVersion, tidbTableInfo)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11236 

### What is changed and how it works?
* set index id to distinguish each index

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
