### PR TITLE
sink(cdc): conflict detector hashes transactions into different table spaces

### DIFF
--- a/cdc/sink/dmlsink/txn/event.go
+++ b/cdc/sink/dmlsink/txn/event.go
@@ -52,7 +52,7 @@ func genTxnKeys(txn *model.SingleTableTxn) []uint64 {
 		return nil
 	}
 
-	keys := make([]uint64, 0, 128)
+	keys := make([]uint64, 0, len(txn.Rows))
 	hasher := fnv.New32a()
 	for _, row := range txn.Rows {
 		if uint64(row.GetTableID()) > uint64(math.MaxUint32) {

--- a/cdc/sink/dmlsink/txn/event_test.go
+++ b/cdc/sink/dmlsink/txn/event_test.go
@@ -117,7 +117,7 @@ func TestGenKeys(t *testing.T) {
 				},
 			},
 		},
-		expected: []uint64{2072713494, 3710968706},
+		expected: []uint64{203936176406, 205574431618},
 	}, {
 		txn: &model.SingleTableTxn{
 			Rows: []*model.RowChangedEvent{
@@ -154,7 +154,7 @@ func TestGenKeys(t *testing.T) {
 				},
 			},
 		},
-		expected: []uint64{318190470, 2109733718, 2658640457, 2989258527},
+		expected: []uint64{202181653382, 203973196630, 204522103369, 204852721439},
 	}, {
 		txn: &model.SingleTableTxn{
 			Rows: []*model.RowChangedEvent{
@@ -191,7 +191,7 @@ func TestGenKeys(t *testing.T) {
 				},
 			},
 		},
-		expected: []uint64{318190470, 2095136920, 2658640457},
+		expected: []uint64{202181653382, 203958599832, 204522103369},
 	}}
 	for _, tc := range testCases {
 		keys := genTxnKeys(tc.txn)

--- a/cdc/sink/dmlsink/txn/worker.go
+++ b/cdc/sink/dmlsink/txn/worker.go
@@ -46,6 +46,8 @@ type worker struct {
 	flushInterval            time.Duration
 	hasPending               bool
 	postTxnExecutedCallbacks []func()
+
+	lastSlowConflictDetectLog map[model.TableID]time.Time
 }
 
 func newWorker(ctx context.Context, changefeedID model.ChangeFeedID,
@@ -70,6 +72,8 @@ func newWorker(ctx context.Context, changefeedID model.ChangeFeedID,
 		flushInterval:            backend.MaxFlushInterval(),
 		hasPending:               false,
 		postTxnExecutedCallbacks: make([]func(), 0, 1024),
+
+		lastSlowConflictDetectLog: make(map[model.TableID]time.Time),
 	}
 }
 
@@ -87,6 +91,9 @@ func (w *worker) runLoop(txnCh <-chan causality.TxnWithNotifier[*txnEvent]) erro
 		zap.String("changefeedID", w.changefeed),
 		zap.Int("workerID", w.ID))
 
+	cleanSlowLogHistory := time.NewTicker(time.Hour)
+	defer cleanSlowLogHistory.Stop()
+
 	start := time.Now()
 	for {
 		select {
@@ -95,6 +102,15 @@ func (w *worker) runLoop(txnCh <-chan causality.TxnWithNotifier[*txnEvent]) erro
 				zap.String("changefeedID", w.changefeed),
 				zap.Int("workerID", w.ID))
 			return nil
+		case <-cleanSlowLogHistory.C:
+			lastSlowConflictDetectLog := w.lastSlowConflictDetectLog
+			w.lastSlowConflictDetectLog = make(map[model.TableID]time.Time)
+			now := time.Now()
+			for tableID, lastLog := range lastSlowConflictDetectLog {
+				if now.Sub(lastLog) <= time.Minute {
+					w.lastSlowConflictDetectLog[tableID] = lastLog
+				}
+			}
 		case txn := <-txnCh:
 			// we get the data from txnCh until no more data here or reach the state that can be flushed.
 			// If no more data in txnCh, and also not reach the state that can be flushed,
@@ -151,8 +167,23 @@ func (w *worker) onEvent(txn *txnEvent, postTxnExecuted func()) bool {
 		return false
 	}
 
-	w.metricConflictDetectDuration.Observe(txn.conflictResolved.Sub(txn.start).Seconds())
+	conflictDetectTime := txn.conflictResolved.Sub(txn.start).Seconds()
+	w.metricConflictDetectDuration.Observe(conflictDetectTime)
 	w.metricQueueDuration.Observe(time.Since(txn.start).Seconds())
+
+	// Log slow conflict detect tables every minute.
+	if conflictDetectTime > float64(60) {
+		now := time.Now()
+		if lastLog, ok := w.lastSlowConflictDetectLog[txn.Event.PhysicalTableID]; !ok || now.Sub(lastLog) > time.Minute {
+			log.Warn("Transaction dmlSink finds a slow transaction in conflict detector",
+				zap.String("changefeedID", w.changefeed),
+				zap.Int("workerID", w.ID),
+				zap.Int64("TableID", txn.Event.PhysicalTableID),
+				zap.Float64("seconds", conflictDetectTime))
+			w.lastSlowConflictDetectLog[txn.Event.PhysicalTableID] = now
+		}
+	}
+
 	w.metricTxnWorkerHandledRows.Add(float64(len(txn.Event.Rows)))
 	w.postTxnExecutedCallbacks = append(w.postTxnExecutedCallbacks, postTxnExecuted)
 	return w.backend.OnTxnEvent(txn.TxnCallbackableEvent)

--- a/pkg/causality/conflict_detector.go
+++ b/pkg/causality/conflict_detector.go
@@ -72,8 +72,8 @@ func NewConflictDetector[Txn txnEvent](
 
 // Add pushes a transaction to the ConflictDetector.
 //
-// NOTE: if multiple threads access this concurrently,
-// Txn.ConflictKeys must be sorted by the slot index.
+// NOTE: if multiple threads access this concurrently, users need to ensure all concurrent Txns
+// won't have any same `ConflictKeys` results.
 func (d *ConflictDetector[Txn]) Add(txn Txn) {
 	hashes := txn.ConflictKeys()
 	node := d.slots.AllocNode(hashes)

--- a/pkg/causality/internal/node.go
+++ b/pkg/causality/internal/node.go
@@ -46,8 +46,8 @@ var (
 // in conflict detection.
 type Node struct {
 	// Immutable fields.
-	id                  int64
-	sortedDedupKeysHash []uint64
+	id           int64
+	conflictKeys []uint64
 
 	// Called when all dependencies are resolved.
 	TrySendToTxnCache func(id cacheID) bool

--- a/pkg/causality/internal/node_test.go
+++ b/pkg/causality/internal/node_test.go
@@ -21,10 +21,10 @@ import (
 
 func newNodeForTest(hashes ...uint64) *Node {
 	return &Node{
-		id:                  genNextNodeID(),
-		sortedDedupKeysHash: sortAndDedupHashes(hashes, 8),
-		assignedTo:          unassigned,
-		RandCacheID:         func() cacheID { return 100 },
+		id:           genNextNodeID(),
+		conflictKeys: hashes,
+		assignedTo:   unassigned,
+		RandCacheID:  func() cacheID { return 100 },
 		OnNotified: func(callback func()) {
 			// run the callback immediately
 			callback()

--- a/pkg/causality/internal/slots.go
+++ b/pkg/causality/internal/slots.go
@@ -14,8 +14,6 @@
 package internal
 
 import (
-	"math"
-	"sort"
 	"sync"
 )
 
@@ -51,29 +49,23 @@ func NewSlots(numSlots uint64) *Slots {
 // or not.
 func (s *Slots) AllocNode(hashes []uint64) *Node {
 	return &Node{
-		id:                  genNextNodeID(),
-		sortedDedupKeysHash: sortAndDedupHashes(hashes, s.numSlots),
-		assignedTo:          unassigned,
+		id:           genNextNodeID(),
+		conflictKeys: hashes,
+		assignedTo:   unassigned,
 	}
 }
 
 // Add adds an elem to the slots and calls DependOn for elem.
 func (s *Slots) Add(elem *Node) {
-	hashes := elem.sortedDedupKeysHash
-	dependencyNodes := make(map[int64]*Node, len(hashes))
+	dependencyNodes := make(map[int64]*Node, len(elem.conflictKeys))
 
-	var lastSlot uint64 = math.MaxUint64
-	for _, hash := range hashes {
-		// lock the slot that the node belongs to.
+	for _, hash := range elem.conflictKeys {
 		slotIdx := getSlot(hash, s.numSlots)
-		if lastSlot != slotIdx {
-			s.slots[slotIdx].mu.Lock()
-			lastSlot = slotIdx
-		}
+		s.slots[slotIdx].mu.Lock()
 
 		// If there is a node occpuied the same hash slot, we may have conflict with it.
 		// Add the conflict node to the dependencyNodes.
-		if prevNode, ok := s.slots[slotIdx].nodes[hash]; ok {
+		if prevNode, ok := s.slots[slotIdx].nodes[hash]; ok && prevNode.nodeID() != elem.nodeID() {
 			prevID := prevNode.nodeID()
 			// If there are multiple hashes conflicts with the same node, we only need to
 			// depend on the node once.
@@ -82,29 +74,19 @@ func (s *Slots) Add(elem *Node) {
 		// Add this node to the slot, make sure new coming nodes with the same hash should
 		// depend on this node.
 		s.slots[slotIdx].nodes[hash] = elem
+
+		s.slots[slotIdx].mu.Unlock()
 	}
 
 	// Construct the dependency graph based on collected `dependencyNodes` and with corresponding
 	// slots locked.
 	elem.dependOn(dependencyNodes)
-
-	// Lock those slots one by one and then unlock them one by one, so that
-	// we can avoid 2 transactions get executed interleaved.
-	lastSlot = math.MaxUint64
-	for _, hash := range hashes {
-		slotIdx := getSlot(hash, s.numSlots)
-		if lastSlot != slotIdx {
-			s.slots[slotIdx].mu.Unlock()
-			lastSlot = slotIdx
-		}
-	}
 }
 
 // Remove removes an element from the Slots.
 func (s *Slots) Remove(elem *Node) {
 	elem.remove()
-	hashes := elem.sortedDedupKeysHash
-	for _, hash := range hashes {
+	for _, hash := range elem.conflictKeys {
 		slotIdx := getSlot(hash, s.numSlots)
 		s.slots[slotIdx].mu.Lock()
 		// Remove the node from the slot.
@@ -119,37 +101,4 @@ func (s *Slots) Remove(elem *Node) {
 
 func getSlot(hash, numSlots uint64) uint64 {
 	return hash % numSlots
-}
-
-// Sort and dedup hashes.
-// Sort hashes by `hash % numSlots` to avoid deadlock, and then dedup
-// hashes, so the same node will not check confict with the same hash
-// twice to prevent potential cyclic self dependency in the causality
-// dependency graph.
-func sortAndDedupHashes(hashes []uint64, numSlots uint64) []uint64 {
-	if len(hashes) == 0 {
-		return nil
-	}
-
-	// Sort hashes by `hash % numSlots` to avoid deadlock.
-	sort.Slice(hashes, func(i, j int) bool { return hashes[i]%numSlots < hashes[j]%numSlots })
-
-	// Dedup hashes
-	last := hashes[0]
-	j := 1
-	for i, hash := range hashes {
-		if i == 0 {
-			// skip first one, start checking duplication from 2nd one
-			continue
-		}
-		if hash == last {
-			continue
-		}
-		last = hash
-		hashes[j] = hash
-		j++
-	}
-	hashes = hashes[:j]
-
-	return hashes
 }

--- a/pkg/causality/internal/slots_test.go
+++ b/pkg/causality/internal/slots_test.go
@@ -94,30 +94,3 @@ func TestSlotsConcurrentOps(t *testing.T) {
 
 	wg.Wait()
 }
-
-func TestSortAndDedupHash(t *testing.T) {
-	// If a transaction contains multiple rows, these rows may generate the same hash
-	// in some rare cases. We should dedup these hashes to avoid unnecessary self cyclic
-	// dependency in the causality dependency graph.
-	t.Parallel()
-	testCases := []struct {
-		hashes   []uint64
-		expected []uint64
-	}{{
-		// No duplicate hashes
-		hashes:   []uint64{1, 2, 3, 4, 5},
-		expected: []uint64{1, 2, 3, 4, 5},
-	}, {
-		// Duplicate hashes
-		hashes:   []uint64{1, 2, 3, 4, 5, 1, 2, 3, 4, 5},
-		expected: []uint64{1, 2, 3, 4, 5},
-	}, {
-		// Has hash value larger than slots count, should sort by `hash % numSlots` first.
-		hashes:   []uint64{4, 9, 9, 3},
-		expected: []uint64{9, 3, 4},
-	}}
-
-	for _, tc := range testCases {
-		require.Equal(t, tc.expected, sortAndDedupHashes(tc.hashes, 8))
-	}
-}

--- a/pkg/causality/txn_cache.go
+++ b/pkg/causality/txn_cache.go
@@ -35,6 +35,8 @@ type txnEvent interface {
 	// OnConflictResolved is called when the event leaves ConflictDetector.
 	OnConflictResolved()
 	// ConflictKeys returns the keys that the event conflicts with.
+	//
+	// Keys are not necessary to be sorted or deduped.
 	ConflictKeys() []uint64
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11246 

### What is changed and how it works?

* Make conflict detector hash transactions into different table spaces, to reduce mistake conflicts;
* Log slow conflict detect tables every 60s;
* Conflict detector doesn't need conflict keys to be sorted and deduped.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
