### PR TITLE
puller(ticdc): fix wrong update splitting behavior after table scheduling

### DIFF
--- a/cdc/model/kv.go
+++ b/cdc/model/kv.go
@@ -110,3 +110,9 @@ func (v *RawKVEntry) String() string {
 func (v *RawKVEntry) ApproximateDataSize() int64 {
 	return int64(len(v.Key) + len(v.Value) + len(v.OldValue))
 }
+
+// ShouldSplitKVEntry checks whether the raw kv entry should be splitted.
+type ShouldSplitKVEntry func(raw *RawKVEntry) bool
+
+// SplitUpdateKVEntry splits the raw kv entry into a delete entry and an insert entry.
+type SplitUpdateKVEntry func(raw *RawKVEntry) (*RawKVEntry, *RawKVEntry, error)

--- a/cdc/model/kv.go
+++ b/cdc/model/kv.go
@@ -16,6 +16,7 @@
 package model
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/pingcap/tiflow/cdc/processor/tablepb"
@@ -115,4 +116,15 @@ func (v *RawKVEntry) ApproximateDataSize() int64 {
 type ShouldSplitKVEntry func(raw *RawKVEntry) bool
 
 // SplitUpdateKVEntry splits the raw kv entry into a delete entry and an insert entry.
-type SplitUpdateKVEntry func(raw *RawKVEntry) (*RawKVEntry, *RawKVEntry, error)
+func SplitUpdateKVEntry(raw *RawKVEntry) (*RawKVEntry, *RawKVEntry, error) {
+	if raw == nil {
+		return nil, nil, errors.New("nil event cannot be split")
+	}
+	deleteKVEntry := *raw
+	deleteKVEntry.Value = nil
+
+	insertKVEntry := *raw
+	insertKVEntry.OldValue = nil
+
+	return &deleteKVEntry, &insertKVEntry, nil
+}

--- a/cdc/processor/processor.go
+++ b/cdc/processor/processor.go
@@ -220,7 +220,10 @@ func (p *processor) AddTableSpan(
 	if p.redo.r.Enabled() {
 		p.redo.r.AddTable(span, startTs)
 	}
-	p.sourceManager.r.AddTable(span, p.getTableName(ctx, span.TableID), startTs)
+	err := p.sourceManager.r.AddTable(span, p.getTableName(ctx, span.TableID), startTs)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
 
 	return true, nil
 }

--- a/cdc/processor/sinkmanager/manager.go
+++ b/cdc/processor/sinkmanager/manager.go
@@ -130,6 +130,9 @@ type SinkManager struct {
 	// wg is used to wait for all workers to exit.
 	wg sync.WaitGroup
 
+	// isMysqlBackend indicates whether the backend is MySQL compatible.
+	isMysqlBackend bool
+
 	// Metric for table sink.
 	metricsTableSinkTotalRows prometheus.Counter
 
@@ -145,6 +148,7 @@ func New(
 	schemaStorage entry.SchemaStorage,
 	redoDMLMgr redo.DMLManager,
 	sourceManager *sourcemanager.SourceManager,
+	isMysqlBackend bool,
 ) *SinkManager {
 	m := &SinkManager{
 		changefeedID:        changefeedID,
@@ -158,7 +162,7 @@ func New(
 		sinkTaskChan:        make(chan *sinkTask),
 		sinkWorkerAvailable: make(chan struct{}, 1),
 		sinkRetry:           retry.NewInfiniteErrorRetry(),
-
+		isMysqlBackend:      isMysqlBackend,
 		metricsTableSinkTotalRows: tablesinkmetrics.TotalRowsCountCounter.
 			WithLabelValues(changefeedID.Namespace, changefeedID.ID),
 
@@ -303,6 +307,11 @@ func (m *SinkManager) Run(ctx context.Context, warnings ...chan<- error) (err er
 
 			// For duplicate entry error, we fast fail to restart changefeed.
 			if cerror.IsDupEntryError(err) {
+				return errors.Trace(err)
+			}
+
+			if m.isMysqlBackend {
+				// For MySQL backend, we should restart sink. Let owner to handle the error.
 				return errors.Trace(err)
 			}
 		}
@@ -840,7 +849,7 @@ func (m *SinkManager) UpdateBarrierTs(globalBarrierTs model.Ts, tableBarrier map
 }
 
 // AddTable adds a table(TableSink) to the sink manager.
-func (m *SinkManager) AddTable(span tablepb.Span, startTs model.Ts, targetTs model.Ts) {
+func (m *SinkManager) AddTable(span tablepb.Span, startTs model.Ts, targetTs model.Ts) *tableSinkWrapper {
 	sinkWrapper := newTableSinkWrapper(
 		m.changefeedID,
 		span,
@@ -868,7 +877,6 @@ func (m *SinkManager) AddTable(span tablepb.Span, startTs model.Ts, targetTs mod
 			zap.String("namespace", m.changefeedID.Namespace),
 			zap.String("changefeed", m.changefeedID.ID),
 			zap.Stringer("span", &span))
-		return
 	}
 	m.sinkMemQuota.AddTable(span)
 	m.redoMemQuota.AddTable(span)
@@ -878,6 +886,7 @@ func (m *SinkManager) AddTable(span tablepb.Span, startTs model.Ts, targetTs mod
 		zap.Stringer("span", &span),
 		zap.Uint64("startTs", startTs),
 		zap.Uint64("version", sinkWrapper.version))
+	return sinkWrapper
 }
 
 // StartTable sets the table(TableSink) state to replicating.

--- a/cdc/processor/sinkmanager/manager_test.go
+++ b/cdc/processor/sinkmanager/manager_test.go
@@ -355,7 +355,8 @@ func TestSinkManagerRunWithErrors(t *testing.T) {
 
 	span := spanz.TableIDToComparableSpan(1)
 
-	source.AddTable(span, "test", 100)
+	err := source.AddTable(span, "test", 100)
+	require.Nil(t, err)
 	manager.AddTable(span, 100, math.MaxUint64)
 	manager.StartTable(span, 100)
 	source.Add(span, model.NewResolvedPolymorphicEvent(0, 101))

--- a/cdc/processor/sinkmanager/manager_test.go
+++ b/cdc/processor/sinkmanager/manager_test.go
@@ -355,8 +355,7 @@ func TestSinkManagerRunWithErrors(t *testing.T) {
 
 	span := spanz.TableIDToComparableSpan(1)
 
-	err := source.AddTable(span, "test", 100)
-	require.Nil(t, err)
+	source.AddTable(span, "test", 100)
 	manager.AddTable(span, 100, math.MaxUint64)
 	manager.StartTable(span, 100)
 	source.Add(span, model.NewResolvedPolymorphicEvent(0, 101))

--- a/cdc/processor/sinkmanager/manager_test.go
+++ b/cdc/processor/sinkmanager/manager_test.go
@@ -129,7 +129,7 @@ func TestAddTable(t *testing.T) {
 	require.Equal(t, 0, manager.sinkProgressHeap.len(), "Not started table shout not in progress heap")
 	err := manager.StartTable(span, 1)
 	require.NoError(t, err)
-	require.Equal(t, uint64(0x7ffffffffffbffff), tableSink.(*tableSinkWrapper).replicateTs)
+	require.Equal(t, uint64(0x7ffffffffffbffff), tableSink.(*tableSinkWrapper).replicateTs.Load())
 
 	progress := manager.sinkProgressHeap.pop()
 	require.Equal(t, span, progress.span)
@@ -355,7 +355,7 @@ func TestSinkManagerRunWithErrors(t *testing.T) {
 
 	span := spanz.TableIDToComparableSpan(1)
 
-	source.AddTable(span, "test", 100)
+	source.AddTable(span, "test", 100, func() model.Ts { return 0 })
 	manager.AddTable(span, 100, math.MaxUint64)
 	manager.StartTable(span, 100)
 	source.Add(span, model.NewResolvedPolymorphicEvent(0, 101))

--- a/cdc/processor/sinkmanager/manager_test_helper.go
+++ b/cdc/processor/sinkmanager/manager_test_helper.go
@@ -71,7 +71,7 @@ func CreateManagerWithMemEngine(
 	sourceManager.WaitForReady(ctx)
 
 	sinkManager := New(changefeedID, changefeedInfo.SinkURI,
-		changefeedInfo.Config, up, schemaStorage, nil, sourceManager)
+		changefeedInfo.Config, up, schemaStorage, nil, sourceManager, false)
 	go func() { handleError(sinkManager.Run(ctx)) }()
 	sinkManager.WaitForReady(ctx)
 
@@ -92,6 +92,6 @@ func NewManagerWithMemEngine(
 	schemaStorage := &entry.MockSchemaStorage{Resolved: math.MaxUint64}
 	sourceManager := sourcemanager.NewForTest(changefeedID, up, mg, sortEngine, false)
 	sinkManager := New(changefeedID, changefeedInfo.SinkURI,
-		changefeedInfo.Config, up, schemaStorage, redoMgr, sourceManager)
+		changefeedInfo.Config, up, schemaStorage, redoMgr, sourceManager, false)
 	return sinkManager, sourceManager, sortEngine
 }

--- a/cdc/processor/sinkmanager/redo_log_worker.go
+++ b/cdc/processor/sinkmanager/redo_log_worker.go
@@ -141,7 +141,7 @@ func (w *redoWorker) handleTask(ctx context.Context, task *redoTask) (finalErr e
 		// NOTICE: The event can be filtered by the event filter.
 		if e.Row != nil {
 			// For all events, we add table replicate ts, so mysql sink can determine safe-mode.
-			e.Row.ReplicatingTs = task.tableSink.replicateTs
+			e.Row.ReplicatingTs = task.tableSink.replicateTs.Load()
 			x, size = handleRowChangedEvents(w.changefeedID, task.span, e)
 			advancer.appendEvents(x, size)
 		}

--- a/cdc/processor/sinkmanager/table_sink_worker.go
+++ b/cdc/processor/sinkmanager/table_sink_worker.go
@@ -237,7 +237,7 @@ func (w *sinkWorker) handleTask(ctx context.Context, task *sinkTask) (finalErr e
 		// NOTICE: The event can be filtered by the event filter.
 		if e.Row != nil {
 			// For all rows, we add table replicate ts, so mysql sink can determine safe-mode.
-			e.Row.ReplicatingTs = task.tableSink.replicateTs.Load()
+			e.Row.ReplicatingTs = task.tableSink.GetReplicaTs()
 			x, size := handleRowChangedEvents(w.changefeedID, task.span, e)
 			advancer.appendEvents(x, size)
 			allEventSize += size

--- a/cdc/processor/sinkmanager/table_sink_worker.go
+++ b/cdc/processor/sinkmanager/table_sink_worker.go
@@ -237,7 +237,7 @@ func (w *sinkWorker) handleTask(ctx context.Context, task *sinkTask) (finalErr e
 		// NOTICE: The event can be filtered by the event filter.
 		if e.Row != nil {
 			// For all rows, we add table replicate ts, so mysql sink can determine safe-mode.
-			e.Row.ReplicatingTs = task.tableSink.replicateTs
+			e.Row.ReplicatingTs = task.tableSink.replicateTs.Load()
 			x, size := handleRowChangedEvents(w.changefeedID, task.span, e)
 			advancer.appendEvents(x, size)
 			allEventSize += size

--- a/cdc/processor/sinkmanager/table_sink_wrapper.go
+++ b/cdc/processor/sinkmanager/table_sink_wrapper.go
@@ -143,7 +143,7 @@ func newTableSinkWrapper(
 }
 
 func (t *tableSinkWrapper) start(ctx context.Context, startTs model.Ts) (err error) {
-	if t.replicateTs.Load() != 0 {
+	if t.replicateTs.Load() != math.MaxUint64 {
 		log.Panic("The table sink has already started",
 			zap.String("namespace", t.changefeed.Namespace),
 			zap.String("changefeed", t.changefeed.ID),

--- a/cdc/processor/sinkmanager/table_sink_wrapper.go
+++ b/cdc/processor/sinkmanager/table_sink_wrapper.go
@@ -15,6 +15,7 @@ package sinkmanager
 
 import (
 	"context"
+	"math"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -77,7 +78,7 @@ type tableSinkWrapper struct {
 	receivedSorterResolvedTs atomic.Uint64
 
 	// replicateTs is the ts that the table sink has started to replicate.
-	replicateTs    model.Ts
+	replicateTs    atomic.Uint64
 	genReplicateTs func(ctx context.Context) (model.Ts, error)
 
 	// lastCleanTime indicates the last time the table has been cleaned.
@@ -88,6 +89,11 @@ type tableSinkWrapper struct {
 	// events in the range (rangeEventCounts[i-1].lastPos, rangeEventCounts[i].lastPos].
 	rangeEventCounts   []rangeEventCount
 	rangeEventCountsMu sync.Mutex
+}
+
+// GetReplicaTs returns the replicate ts of the table sink.
+func (t *tableSinkWrapper) GetReplicaTs() model.Ts {
+	return t.replicateTs.Load()
 }
 
 type rangeEventCount struct {
@@ -132,31 +138,34 @@ func newTableSinkWrapper(
 
 	res.receivedSorterResolvedTs.Store(startTs)
 	res.barrierTs.Store(startTs)
+	res.replicateTs.Store(math.MaxUint64)
 	return res
 }
 
 func (t *tableSinkWrapper) start(ctx context.Context, startTs model.Ts) (err error) {
-	if t.replicateTs != 0 {
+	if t.replicateTs.Load() != 0 {
 		log.Panic("The table sink has already started",
 			zap.String("namespace", t.changefeed.Namespace),
 			zap.String("changefeed", t.changefeed.ID),
 			zap.Stringer("span", &t.span),
 			zap.Uint64("startTs", startTs),
-			zap.Uint64("oldReplicateTs", t.replicateTs),
+			zap.Uint64("oldReplicateTs", t.replicateTs.Load()),
 		)
 	}
 
 	// FIXME(qupeng): it can be re-fetched later instead of fails.
-	if t.replicateTs, err = t.genReplicateTs(ctx); err != nil {
+	ts, err := t.genReplicateTs(ctx)
+	if err != nil {
 		return errors.Trace(err)
 	}
+	t.replicateTs.Store(ts)
 
 	log.Info("Sink is started",
 		zap.String("namespace", t.changefeed.Namespace),
 		zap.String("changefeed", t.changefeed.ID),
 		zap.Stringer("span", &t.span),
 		zap.Uint64("startTs", startTs),
-		zap.Uint64("replicateTs", t.replicateTs),
+		zap.Uint64("replicateTs", ts),
 	)
 
 	// This start ts maybe greater than the initial start ts of the table sink.
@@ -379,14 +388,16 @@ func (t *tableSinkWrapper) checkTableSinkHealth() (err error) {
 // committed at downstream but we don't know. So we need to update `replicateTs`
 // of the table so that we can re-send those events later.
 func (t *tableSinkWrapper) restart(ctx context.Context) (err error) {
-	if t.replicateTs, err = t.genReplicateTs(ctx); err != nil {
+	ts, err := t.genReplicateTs(ctx)
+	if err != nil {
 		return errors.Trace(err)
 	}
+	t.replicateTs.Store(ts)
 	log.Info("Sink is restarted",
 		zap.String("namespace", t.changefeed.Namespace),
 		zap.String("changefeed", t.changefeed.ID),
 		zap.Stringer("span", &t.span),
-		zap.Uint64("replicateTs", t.replicateTs))
+		zap.Uint64("replicateTs", ts))
 	return nil
 }
 

--- a/cdc/processor/sourcemanager/manager.go
+++ b/cdc/processor/sourcemanager/manager.go
@@ -142,7 +142,7 @@ func newSourceManager(
 }
 
 // AddTable adds a table to the source manager. Start puller and register table to the engine.
-func (m *SourceManager) AddTable(span tablepb.Span, tableName string, startTs model.Ts, getReplicaTs func() model.Ts) error {
+func (m *SourceManager) AddTable(span tablepb.Span, tableName string, startTs model.Ts, getReplicaTs func() model.Ts) {
 	// Add table to the engine first, so that the engine can receive the events from the puller.
 	m.engine.AddTable(span, startTs)
 
@@ -152,13 +152,12 @@ func (m *SourceManager) AddTable(span tablepb.Span, tableName string, startTs mo
 
 	if m.multiplexing {
 		m.multiplexingPuller.puller.Subscribe([]tablepb.Span{span}, startTs, tableName, shouldSplitKVEntry)
-		return nil
+		return
 	}
 
 	p := m.tablePullers.pullerWrapperCreator(m.changefeedID, span, tableName, startTs, m.bdrMode, shouldSplitKVEntry)
 	p.Start(m.tablePullers.ctx, m.up, m.engine, m.tablePullers.errChan)
 	m.tablePullers.Store(span, p)
-	return nil
 }
 
 // RemoveTable removes a table from the source manager. Stop puller and unregister table from the engine.

--- a/cdc/processor/sourcemanager/puller/dummy_puller_wrapper.go
+++ b/cdc/processor/sourcemanager/puller/dummy_puller_wrapper.go
@@ -35,7 +35,6 @@ func NewPullerWrapperForTest(
 	startTs model.Ts,
 	bdrMode bool,
 	shouldSplitKVEntry model.ShouldSplitKVEntry,
-	splitUpdateKVEntry model.SplitUpdateKVEntry,
 ) Wrapper {
 	return &dummyPullerWrapper{}
 }

--- a/cdc/processor/sourcemanager/puller/dummy_puller_wrapper.go
+++ b/cdc/processor/sourcemanager/puller/dummy_puller_wrapper.go
@@ -34,8 +34,8 @@ func NewPullerWrapperForTest(
 	tableName string,
 	startTs model.Ts,
 	bdrMode bool,
-	shouldSplitKVEntry ShouldSplitKVEntry,
-	splitUpdateKVEntry SplitUpdateKVEntry,
+	shouldSplitKVEntry model.ShouldSplitKVEntry,
+	splitUpdateKVEntry model.SplitUpdateKVEntry,
 ) Wrapper {
 	return &dummyPullerWrapper{}
 }

--- a/cdc/processor/sourcemanager/puller/multiplexing_puller_wrapper.go
+++ b/cdc/processor/sourcemanager/puller/multiplexing_puller_wrapper.go
@@ -37,10 +37,8 @@ func NewMultiplexingPullerWrapper(
 	client *kv.SharedClient,
 	eventSortEngine engine.SortEngine,
 	frontiers int,
-	shouldSplitKVEntry ShouldSplitKVEntry,
-	splitUpdateKVEntry SplitUpdateKVEntry,
 ) *MultiplexingWrapper {
-	consume := func(ctx context.Context, raw *model.RawKVEntry, spans []tablepb.Span) error {
+	consume := func(ctx context.Context, raw *model.RawKVEntry, spans []tablepb.Span, shouldSplitKVEntry model.ShouldSplitKVEntry, splitUpdateKVEntry model.SplitUpdateKVEntry) error {
 		if len(spans) > 1 {
 			log.Panic("DML puller subscribes multiple spans",
 				zap.String("namespace", changefeed.Namespace),

--- a/cdc/processor/sourcemanager/puller/multiplexing_puller_wrapper.go
+++ b/cdc/processor/sourcemanager/puller/multiplexing_puller_wrapper.go
@@ -38,7 +38,7 @@ func NewMultiplexingPullerWrapper(
 	eventSortEngine engine.SortEngine,
 	frontiers int,
 ) *MultiplexingWrapper {
-	consume := func(ctx context.Context, raw *model.RawKVEntry, spans []tablepb.Span, shouldSplitKVEntry model.ShouldSplitKVEntry, splitUpdateKVEntry model.SplitUpdateKVEntry) error {
+	consume := func(ctx context.Context, raw *model.RawKVEntry, spans []tablepb.Span, shouldSplitKVEntry model.ShouldSplitKVEntry) error {
 		if len(spans) > 1 {
 			log.Panic("DML puller subscribes multiple spans",
 				zap.String("namespace", changefeed.Namespace),
@@ -46,7 +46,7 @@ func NewMultiplexingPullerWrapper(
 		}
 		if raw != nil {
 			if shouldSplitKVEntry(raw) {
-				deleteKVEntry, insertKVEntry, err := splitUpdateKVEntry(raw)
+				deleteKVEntry, insertKVEntry, err := model.SplitUpdateKVEntry(raw)
 				if err != nil {
 					return err
 				}

--- a/cdc/processor/sourcemanager/puller/puller_wrapper.go
+++ b/cdc/processor/sourcemanager/puller/puller_wrapper.go
@@ -50,7 +50,6 @@ type WrapperImpl struct {
 	bdrMode    bool
 
 	shouldSplitKVEntry model.ShouldSplitKVEntry
-	splitUpdateKVEntry model.SplitUpdateKVEntry
 
 	// cancel is used to cancel the puller when remove or close the table.
 	cancel context.CancelFunc
@@ -66,7 +65,6 @@ func NewPullerWrapper(
 	startTs model.Ts,
 	bdrMode bool,
 	shouldSplitKVEntry model.ShouldSplitKVEntry,
-	splitUpdateKVEntry model.SplitUpdateKVEntry,
 ) Wrapper {
 	return &WrapperImpl{
 		changefeed:         changefeed,
@@ -75,7 +73,6 @@ func NewPullerWrapper(
 		startTs:            startTs,
 		bdrMode:            bdrMode,
 		shouldSplitKVEntry: shouldSplitKVEntry,
-		splitUpdateKVEntry: splitUpdateKVEntry,
 	}
 }
 
@@ -134,7 +131,7 @@ func (n *WrapperImpl) Start(
 					continue
 				}
 				if n.shouldSplitKVEntry(rawKV) {
-					deleteKVEntry, insertKVEntry, err := n.splitUpdateKVEntry(rawKV)
+					deleteKVEntry, insertKVEntry, err := model.SplitUpdateKVEntry(rawKV)
 					if err != nil {
 						return err
 					}

--- a/cdc/processor/sourcemanager/puller/puller_wrapper.go
+++ b/cdc/processor/sourcemanager/puller/puller_wrapper.go
@@ -40,12 +40,6 @@ type Wrapper interface {
 	Close()
 }
 
-// ShouldSplitKVEntry checks whether the raw kv entry should be splitted.
-type ShouldSplitKVEntry func(raw *model.RawKVEntry) bool
-
-// SplitUpdateKVEntry splits the raw kv entry into a delete entry and an insert entry.
-type SplitUpdateKVEntry func(raw *model.RawKVEntry) (*model.RawKVEntry, *model.RawKVEntry, error)
-
 // WrapperImpl is a wrapper of puller used by source manager.
 type WrapperImpl struct {
 	changefeed model.ChangeFeedID
@@ -55,8 +49,8 @@ type WrapperImpl struct {
 	startTs    model.Ts
 	bdrMode    bool
 
-	shouldSplitKVEntry ShouldSplitKVEntry
-	splitUpdateKVEntry SplitUpdateKVEntry
+	shouldSplitKVEntry model.ShouldSplitKVEntry
+	splitUpdateKVEntry model.SplitUpdateKVEntry
 
 	// cancel is used to cancel the puller when remove or close the table.
 	cancel context.CancelFunc
@@ -71,8 +65,8 @@ func NewPullerWrapper(
 	tableName string,
 	startTs model.Ts,
 	bdrMode bool,
-	shouldSplitKVEntry ShouldSplitKVEntry,
-	splitUpdateKVEntry SplitUpdateKVEntry,
+	shouldSplitKVEntry model.ShouldSplitKVEntry,
+	splitUpdateKVEntry model.SplitUpdateKVEntry,
 ) Wrapper {
 	return &WrapperImpl{
 		changefeed:         changefeed,

--- a/cdc/puller/ddl_puller.go
+++ b/cdc/puller/ddl_puller.go
@@ -624,10 +624,7 @@ func NewDDLJobPuller(
 		slots, hasher := 1, func(tablepb.Span, int) int { return 0 }
 		mp.MultiplexingPuller = NewMultiplexingPuller(changefeed, client, consume, slots, hasher, 1)
 
-		shouldSplitKVEntry := func(raw *model.RawKVEntry) bool {
-			return false
-		}
-		mp.Subscribe(spans, checkpointTs, memorysorter.DDLPullerTableName, shouldSplitKVEntry)
+		mp.Subscribe(spans, checkpointTs, memorysorter.DDLPullerTableName, func(_ *model.RawKVEntry) bool { return false })
 	} else {
 		jobPuller.puller.Puller = New(
 			ctx, pdCli, up.GrpcPool, regionCache, kvStorage, pdClock,

--- a/cdc/puller/ddl_puller.go
+++ b/cdc/puller/ddl_puller.go
@@ -613,7 +613,7 @@ func NewDDLJobPuller(
 			txnutil.NewLockerResolver(kvStorage.(tikv.Storage), changefeed),
 		)
 
-		consume := func(ctx context.Context, raw *model.RawKVEntry, _ []tablepb.Span, _ model.ShouldSplitKVEntry, _ model.SplitUpdateKVEntry) error {
+		consume := func(ctx context.Context, raw *model.RawKVEntry, _ []tablepb.Span, _ model.ShouldSplitKVEntry) error {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -627,10 +627,7 @@ func NewDDLJobPuller(
 		shouldSplitKVEntry := func(raw *model.RawKVEntry) bool {
 			return false
 		}
-		splitUpdateKVEntry := func(raw *model.RawKVEntry) (*model.RawKVEntry, *model.RawKVEntry, error) {
-			return nil, nil, nil
-		}
-		mp.Subscribe(spans, checkpointTs, memorysorter.DDLPullerTableName, shouldSplitKVEntry, splitUpdateKVEntry)
+		mp.Subscribe(spans, checkpointTs, memorysorter.DDLPullerTableName, shouldSplitKVEntry)
 	} else {
 		jobPuller.puller.Puller = New(
 			ctx, pdCli, up.GrpcPool, regionCache, kvStorage, pdClock,

--- a/cdc/puller/multiplexing_puller.go
+++ b/cdc/puller/multiplexing_puller.go
@@ -75,7 +75,7 @@ type tableProgressWithSubID struct {
 type MultiplexingPuller struct {
 	changefeed model.ChangeFeedID
 	client     *kv.SharedClient
-	consume    func(context.Context, *model.RawKVEntry, []tablepb.Span) error
+	consume    func(context.Context, *model.RawKVEntry, []tablepb.Span, model.ShouldSplitKVEntry, model.SplitUpdateKVEntry) error
 	hasher     func(tablepb.Span, int) int
 	frontiers  int
 
@@ -106,7 +106,7 @@ type MultiplexingPuller struct {
 func NewMultiplexingPuller(
 	changefeed model.ChangeFeedID,
 	client *kv.SharedClient,
-	consume func(context.Context, *model.RawKVEntry, []tablepb.Span) error,
+	consume func(context.Context, *model.RawKVEntry, []tablepb.Span, model.ShouldSplitKVEntry, model.SplitUpdateKVEntry) error,
 	workers int,
 	hasher func(tablepb.Span, int) int,
 	frontiers int,
@@ -130,13 +130,25 @@ func NewMultiplexingPuller(
 }
 
 // Subscribe some spans. They will share one same resolved timestamp progress.
-func (p *MultiplexingPuller) Subscribe(spans []tablepb.Span, startTs model.Ts, tableName string) {
+func (p *MultiplexingPuller) Subscribe(
+	spans []tablepb.Span,
+	startTs model.Ts,
+	tableName string,
+	shouldSplitKVEntry model.ShouldSplitKVEntry,
+	splitUpdateKVEntry model.SplitUpdateKVEntry,
+) {
 	p.subscriptions.Lock()
 	defer p.subscriptions.Unlock()
-	p.subscribe(spans, startTs, tableName)
+	p.subscribe(spans, startTs, tableName, shouldSplitKVEntry, splitUpdateKVEntry)
 }
 
-func (p *MultiplexingPuller) subscribe(spans []tablepb.Span, startTs model.Ts, tableName string) []kv.SubscriptionID {
+func (p *MultiplexingPuller) subscribe(
+	spans []tablepb.Span,
+	startTs model.Ts,
+	tableName string,
+	shouldSplitKVEntry model.ShouldSplitKVEntry,
+	splitUpdateKVEntry model.SplitUpdateKVEntry,
+) []kv.SubscriptionID {
 	for _, span := range spans {
 		if _, exists := p.subscriptions.n.Get(span); exists {
 			log.Panic("redundant subscription",
@@ -164,7 +176,7 @@ func (p *MultiplexingPuller) subscribe(spans []tablepb.Span, startTs model.Ts, t
 		progress.consume.RLock()
 		defer progress.consume.RUnlock()
 		if !progress.consume.removed {
-			return p.consume(ctx, raw, spans)
+			return p.consume(ctx, raw, spans, shouldSplitKVEntry, splitUpdateKVEntry)
 		}
 		return nil
 	}

--- a/cdc/puller/multiplexing_puller_test.go
+++ b/cdc/puller/multiplexing_puller_test.go
@@ -28,7 +28,7 @@ import (
 
 func newMultiplexingPullerForTest(outputCh chan<- *model.RawKVEntry) *MultiplexingPuller {
 	client := kv.NewSharedClient(model.ChangeFeedID{}, nil, false, nil, nil, nil, nil, nil)
-	consume := func(ctx context.Context, e *model.RawKVEntry, _ []tablepb.Span) error {
+	consume := func(ctx context.Context, e *model.RawKVEntry, _ []tablepb.Span, _ model.ShouldSplitKVEntry) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/cdc/puller/multiplexing_puller_test.go
+++ b/cdc/puller/multiplexing_puller_test.go
@@ -81,7 +81,10 @@ func TestMultiplexingPullerResolvedForward(t *testing.T) {
 
 	spans := []tablepb.Span{spanz.ToSpan([]byte("t_a"), []byte("t_e"))}
 	spans[0].TableID = 1
-	subID := puller.subscribe(spans, 996, "test")[0]
+	shouldSplitKVEntry := func(raw *model.RawKVEntry) bool {
+		return false
+	}
+	subID := puller.subscribe(spans, 996, "test", shouldSplitKVEntry)[0]
 	for _, event := range events {
 		puller.inputChs[0] <- kv.MultiplexingEvent{RegionFeedEvent: event, SubscriptionID: subID}
 	}

--- a/pkg/sink/sink_type.go
+++ b/pkg/sink/sink_type.go
@@ -16,8 +16,6 @@ package sink
 import (
 	"net/url"
 	"strings"
-
-	cerror "github.com/pingcap/tiflow/pkg/errors"
 )
 
 // Type is the type of sink.
@@ -107,14 +105,4 @@ func IsBlackHoleScheme(scheme string) bool {
 // GetScheme returns the scheme of the url.
 func GetScheme(url *url.URL) string {
 	return strings.ToLower(url.Scheme)
-}
-
-// IsMysqlCompatibleBackend returns true if the sinkURIStr is mysql compatible.
-func IsMysqlCompatibleBackend(sinkURIStr string) (bool, error) {
-	sinkURI, err := url.Parse(sinkURIStr)
-	if err != nil {
-		return false, cerror.WrapError(cerror.ErrSinkURIInvalid, err)
-	}
-	scheme := GetScheme(sinkURI)
-	return IsMySQLCompatibleScheme(scheme), nil
 }

--- a/pkg/sink/sink_type.go
+++ b/pkg/sink/sink_type.go
@@ -16,6 +16,8 @@ package sink
 import (
 	"net/url"
 	"strings"
+
+	cerror "github.com/pingcap/tiflow/pkg/errors"
 )
 
 // Type is the type of sink.
@@ -105,4 +107,14 @@ func IsBlackHoleScheme(scheme string) bool {
 // GetScheme returns the scheme of the url.
 func GetScheme(url *url.URL) string {
 	return strings.ToLower(url.Scheme)
+}
+
+// IsMysqlCompatibleBackend returns true if the sinkURIStr is mysql compatible.
+func IsMysqlCompatibleBackend(sinkURIStr string) (bool, error) {
+	sinkURI, err := url.Parse(sinkURIStr)
+	if err != nil {
+		return false, cerror.WrapError(cerror.ErrSinkURIInvalid, err)
+	}
+	scheme := GetScheme(sinkURI)
+	return IsMySQLCompatibleScheme(scheme), nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11219

### What is changed and how it works?
After https://github.com/pingcap/tiflow/pull/11030, we introduce a mechanism to get the current timestamp `thresholdTS` from pd when changefeed starts, and split all update kv entries which `commitTS` is smaller than the `thresholdTS`. 

This mechanism has the following problem:
1. There are two cdc nodes `A` and `B`, and `B` start before `A`, that is `thresholdTSB` < `thresholdTSA`;
2. The sync task of table `t` is first on `A`;
3. Table `t` has an update event which `commitTS` is smaller than `thresholdTSA` and larger than `thresholdTSB`. So the update event is split to a delete event and an insert event on node `A`;
4. But the delete event and insert event cannot be send to the downstream in an atomic way. So if after the delete event is send to downstream and before the insert event being send, the table sync task is scheduling to node `B`, the update event are received by node `B` again;
5. The update event is not split by node `B` because its `commitTS` is larger than the `thresholdTSB`, and node `B` just send an update sql to downstream which cause data inconsistency;

And there is also another thing to notice that after scheduling, node `B` will send some events to downstream which are already send by node `A`; So node `B` must send these events in an idempotent way;
Previously, this is handled by getting a `replicateTS` in sink module when sink starts and split these events which `commitTS` is smaller than `replicateTS`. But this mechanism is also removed in https://github.com/pingcap/tiflow/pull/11030. So we need to handle this case in puller too.

In this pr, instead of maintaining a separate `thresholdTS` in sourcemanager, we try to get the `replicateTS` from sink when puller need to check whether to split the update event.
And since puller module starts working before sink module, so we give `replicateTS` a default value `MAXUInt64` which means to split all update events. After sink starts working, `replicateTS` will be set to the correct value.

The last thing to notice, when sink restarts due to some error, after restart, the sink may send some events downstream which are already send before restart. These events also need be send in an idempotent way. But these events are already in sorter, so just restart sink cannot accomplish this goal. So we forbid restarting sink in this pr and just restart the changefeed when meet error.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 1. deploy a cluster with three cdc nodes;
 2. kill all nodes occasionally while running workload and check whether the data is consistent;


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
