### PR TITLE
sorter(cdc): fix a bug that Pebble sorter can be stucked when closing a processor

### DIFF
--- a/cdc/processor/sourcemanager/sorter/pebble/event_sorter.go
+++ b/cdc/processor/sourcemanager/sorter/pebble/event_sorter.go
@@ -495,7 +495,11 @@ func (s *EventSorter) handleEvents(
 		if !ok {
 			return
 		}
-		batchCh <- batchEvent
+		select {
+		case <-s.closed:
+			return
+		case batchCh <- batchEvent:
+		}
 	}
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11278 

### What is changed and how it works?

Fix a bug that Pebble sorter can be stucked when closing a processor.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
