### PR TITLE
s3(ticdc): do not report unretryable error when initializing s3 storage

### DIFF
--- a/pkg/redo/config.go
+++ b/pkg/redo/config.go
@@ -202,12 +202,12 @@ func initExternalStorageForTest(ctx context.Context, uri url.URL) (storage.Exter
 	if ConsistentStorage(uri.Scheme) == consistentStorageS3 && len(uri.Host) == 0 {
 		// TODO: this branch is compatible with previous s3 logic and will be removed
 		// in the future.
-		return nil, errors.WrapChangefeedUnretryableErr(errors.ErrStorageInitialize,
+		return nil, errors.WrapError(errors.ErrStorageInitialize,
 			errors.Errorf("please specify the bucket for %+v", uri))
 	}
 	s, err := util.GetExternalStorageFromURI(ctx, uri.String())
 	if err != nil {
-		return nil, errors.WrapChangefeedUnretryableErr(errors.ErrStorageInitialize, err)
+		return nil, errors.WrapError(errors.ErrStorageInitialize, err)
 	}
 	return s, nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11311

### What is changed and how it works?
do not report unretryable error when initializing s3 storage, because this kind of error is retryale,  return ErrStorageInitialize if the external storage initialization fails.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
