### PR TITLE
metrics(ticdc): Fix kafka compress ratio issue

### DIFF
--- a/metrics/grafana/ticdc.json
+++ b/metrics/grafana/ticdc.json
@@ -7800,7 +7800,7 @@
           },
           "yaxes": [
             {
-              "format": "none",
+              "format": "percent",
               "label": null,
               "logBase": 1,
               "max": null,

--- a/pkg/sink/codec/common/compress.go
+++ b/pkg/sink/codec/common/compress.go
@@ -28,7 +28,7 @@ func Compress(changefeedID model.ChangeFeedID, cc string, data []byte) ([]byte, 
 	}
 
 	newSize := len(compressed)
-	ratio := float64(oldSize) / float64(newSize)
+	ratio := float64(oldSize) / float64(newSize) * 100
 
 	compressionRatio.WithLabelValues(changefeedID.Namespace, changefeedID.ID).Observe(ratio)
 

--- a/pkg/sink/kafka/metrics_collector.go
+++ b/pkg/sink/kafka/metrics_collector.go
@@ -134,9 +134,9 @@ func (m *saramaMetricsCollector) collectProducerMetrics() {
 	if histogram, ok := compressionRatioMetric.(metrics.Histogram); ok {
 		compressionRatioGauge.
 			WithLabelValues(namespace, changefeedID, "avg").
-			Set(histogram.Snapshot().Mean() / 100)
+			Set(histogram.Snapshot().Mean())
 		compressionRatioGauge.WithLabelValues(namespace, changefeedID, p99).
-			Set(histogram.Snapshot().Percentile(0.99) / 100)
+			Set(histogram.Snapshot().Percentile(0.99))
 	}
 
 	recordsPerRequestMetric := m.registry.Get(recordsPerRequestMetricName)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11314

### What is changed and how it works?
follow the kafka producer compression ratio definition: https://pkg.go.dev/github.com/IBM/sarama#section-readme


```
compression ratio = Size of original data / Size of compressed data * 100
```


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
