### PR TITLE
redo(ticdc): fix orderliness of redo

### DIFF
--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -290,6 +290,21 @@ type RedoRowChangedEvent struct {
 	Columns    []*RedoColumn    `msg:"columns"`
 }
 
+// IsDelete returns true if the row is a delete event
+func (r *RedoRowChangedEvent) IsDelete() bool {
+	return len(r.PreColumns) != 0 && len(r.Columns) == 0
+}
+
+// IsInsert returns true if the row is an insert event
+func (r *RedoRowChangedEvent) IsInsert() bool {
+	return len(r.PreColumns) == 0 && len(r.Columns) != 0
+}
+
+// IsUpdate returns true if the row is an update event
+func (r *RedoRowChangedEvent) IsUpdate() bool {
+	return len(r.PreColumns) != 0 && len(r.Columns) != 0
+}
+
 // RedoDDLEvent represents DDL event used in redo log persistent
 type RedoDDLEvent struct {
 	DDL       *DDLEvent `msg:"ddl"`

--- a/cdc/redo/reader/reader.go
+++ b/cdc/redo/reader/reader.go
@@ -382,11 +382,12 @@ func (h logHeap) Less(i, j int) bool {
 			return h[i].data.RedoRow.Row.StartTs < h[j].data.RedoRow.Row.StartTs
 		}
 		// in the same txn, we need to sort by delete/update/insert order
-		if h[i].data.RedoRow.Row.IsDelete() {
+		if h[i].data.RedoRow.IsDelete() {
 			return true
-		} else if h[i].data.RedoRow.Row.IsUpdate() {
-			return !h[j].data.RedoRow.Row.IsDelete()
+		} else if h[i].data.RedoRow.IsUpdate() {
+			return !h[j].data.RedoRow.IsDelete()
 		}
+
 		return false
 	}
 

--- a/cdc/redo/reader/reader_test.go
+++ b/cdc/redo/reader/reader_test.go
@@ -267,11 +267,16 @@ func TestLogHeapLess(t *testing.T) {
 									TableID:     1,
 									IsPartition: false,
 								},
-								PreColumns: []*model.Column{
-									{
+							},
+							PreColumns: []*model.RedoColumn{
+								{
+									Column: &model.Column{
 										Name:  "col-1",
 										Value: 1,
-									}, {
+									},
+								},
+								{
+									Column: &model.Column{
 										Name:  "col-2",
 										Value: 2,
 									},
@@ -292,20 +297,30 @@ func TestLogHeapLess(t *testing.T) {
 									TableID:     1,
 									IsPartition: false,
 								},
-								PreColumns: []*model.Column{
-									{
+							},
+							PreColumns: []*model.RedoColumn{
+								{
+									Column: &model.Column{
 										Name:  "col-1",
 										Value: 1,
-									}, {
+									},
+								},
+								{
+									Column: &model.Column{
 										Name:  "col-2",
 										Value: 2,
 									},
 								},
-								Columns: []*model.Column{
-									{
+							},
+							Columns: []*model.RedoColumn{
+								{
+									Column: &model.Column{
 										Name:  "col-1",
 										Value: 1,
-									}, {
+									},
+								},
+								{
+									Column: &model.Column{
 										Name:  "col-2",
 										Value: 3,
 									},
@@ -334,20 +349,30 @@ func TestLogHeapLess(t *testing.T) {
 									TableID:     1,
 									IsPartition: false,
 								},
-								PreColumns: []*model.Column{
-									{
+							},
+							PreColumns: []*model.RedoColumn{
+								{
+									Column: &model.Column{
 										Name:  "col-1",
 										Value: 1,
-									}, {
+									},
+								},
+								{
+									Column: &model.Column{
 										Name:  "col-2",
 										Value: 2,
 									},
 								},
-								Columns: []*model.Column{
-									{
+							},
+							Columns: []*model.RedoColumn{
+								{
+									Column: &model.Column{
 										Name:  "col-1",
 										Value: 1,
-									}, {
+									},
+								},
+								{
+									Column: &model.Column{
 										Name:  "col-2",
 										Value: 3,
 									},
@@ -401,20 +426,30 @@ func TestLogHeapLess(t *testing.T) {
 									TableID:     1,
 									IsPartition: false,
 								},
-								PreColumns: []*model.Column{
-									{
+							},
+							PreColumns: []*model.RedoColumn{
+								{
+									Column: &model.Column{
 										Name:  "col-1",
 										Value: 1,
-									}, {
+									},
+								},
+								{
+									Column: &model.Column{
 										Name:  "col-2",
 										Value: 2,
 									},
 								},
-								Columns: []*model.Column{
-									{
+							},
+							Columns: []*model.RedoColumn{
+								{
+									Column: &model.Column{
 										Name:  "col-1",
 										Value: 1,
-									}, {
+									},
+								},
+								{
+									Column: &model.Column{
 										Name:  "col-2",
 										Value: 3,
 									},
@@ -435,11 +470,16 @@ func TestLogHeapLess(t *testing.T) {
 									TableID:     1,
 									IsPartition: false,
 								},
-								PreColumns: []*model.Column{
-									{
+							},
+							PreColumns: []*model.RedoColumn{
+								{
+									Column: &model.Column{
 										Name:  "col-1",
 										Value: 1,
-									}, {
+									},
+								},
+								{
+									Column: &model.Column{
 										Name:  "col-2",
 										Value: 1,
 									},
@@ -468,20 +508,30 @@ func TestLogHeapLess(t *testing.T) {
 									TableID:     1,
 									IsPartition: false,
 								},
-								PreColumns: []*model.Column{
-									{
+							},
+							PreColumns: []*model.RedoColumn{
+								{
+									Column: &model.Column{
 										Name:  "col-1",
 										Value: 1,
-									}, {
+									},
+								},
+								{
+									Column: &model.Column{
 										Name:  "col-2",
 										Value: 2,
 									},
 								},
-								Columns: []*model.Column{
-									{
+							},
+							Columns: []*model.RedoColumn{
+								{
+									Column: &model.Column{
 										Name:  "col-1",
 										Value: 1,
-									}, {
+									},
+								},
+								{
+									Column: &model.Column{
 										Name:  "col-2",
 										Value: 3,
 									},
@@ -544,11 +594,16 @@ func TestLogHeapLess(t *testing.T) {
 									TableID:     1,
 									IsPartition: false,
 								},
-								PreColumns: []*model.Column{
-									{
+							},
+							PreColumns: []*model.RedoColumn{
+								{
+									Column: &model.Column{
 										Name:  "col-1",
 										Value: 1,
-									}, {
+									},
+								},
+								{
+									Column: &model.Column{
 										Name:  "col-2",
 										Value: 1,
 									},
@@ -684,20 +739,30 @@ func TestLogHeapLess(t *testing.T) {
 									TableID:     1,
 									IsPartition: false,
 								},
-								PreColumns: []*model.Column{
-									{
+							},
+							PreColumns: []*model.RedoColumn{
+								{
+									Column: &model.Column{
 										Name:  "col-1",
 										Value: 1,
-									}, {
+									},
+								},
+								{
+									Column: &model.Column{
 										Name:  "col-2",
 										Value: 2,
 									},
 								},
-								Columns: []*model.Column{
-									{
+							},
+							Columns: []*model.RedoColumn{
+								{
+									Column: &model.Column{
 										Name:  "col-1",
 										Value: 1,
-									}, {
+									},
+								},
+								{
+									Column: &model.Column{
 										Name:  "col-2",
 										Value: 3,
 									},
@@ -718,20 +783,30 @@ func TestLogHeapLess(t *testing.T) {
 									TableID:     1,
 									IsPartition: false,
 								},
-								PreColumns: []*model.Column{
-									{
+							},
+							PreColumns: []*model.RedoColumn{
+								{
+									Column: &model.Column{
 										Name:  "col-1",
 										Value: 1,
-									}, {
+									},
+								},
+								{
+									Column: &model.Column{
 										Name:  "col-2",
 										Value: 1,
 									},
 								},
-								Columns: []*model.Column{
-									{
+							},
+							Columns: []*model.RedoColumn{
+								{
+									Column: &model.Column{
 										Name:  "col-1",
 										Value: 1,
-									}, {
+									},
+								},
+								{
+									Column: &model.Column{
 										Name:  "col-2",
 										Value: 3,
 									},


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11096

### What is changed and how it works?
Considering the row info in 6.5 is not the same as 8.1, to support the comparation, we need to support related isUpdate/isDelete/isInsert

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
create mysql sink changefeed with redo log on
run gotpc workload
After 30m, pause changefeed and run redo apply

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
