### PR TITLE
ticdc : http & https support in pulsar schema for pulsar downstream type changefeed creation.

### DIFF
--- a/cdc/sink/ddlsink/factory/factory.go
+++ b/cdc/sink/ddlsink/factory/factory.go
@@ -60,7 +60,7 @@ func New(
 		return mysql.NewDDLSink(ctx, changefeedID, sinkURI, cfg)
 	case sink.S3Scheme, sink.FileScheme, sink.GCSScheme, sink.GSScheme, sink.AzblobScheme, sink.AzureScheme, sink.CloudStorageNoopScheme:
 		return cloudstorage.NewDDLSink(ctx, changefeedID, sinkURI, cfg)
-	case sink.PulsarScheme, sink.PulsarSSLScheme:
+	case sink.PulsarScheme, sink.PulsarSSLScheme, sink.PulsarHttpScheme, sink.PulsarHttpsScheme:
 		return mq.NewPulsarDDLSink(ctx, changefeedID, sinkURI, cfg, manager.NewPulsarTopicManager,
 			pulsarConfig.NewCreatorFactory, ddlproducer.NewPulsarProducer)
 	default:

--- a/cdc/sink/ddlsink/factory/factory.go
+++ b/cdc/sink/ddlsink/factory/factory.go
@@ -60,7 +60,7 @@ func New(
 		return mysql.NewDDLSink(ctx, changefeedID, sinkURI, cfg)
 	case sink.S3Scheme, sink.FileScheme, sink.GCSScheme, sink.GSScheme, sink.AzblobScheme, sink.AzureScheme, sink.CloudStorageNoopScheme:
 		return cloudstorage.NewDDLSink(ctx, changefeedID, sinkURI, cfg)
-	case sink.PulsarScheme, sink.PulsarSSLScheme, sink.PulsarHttpScheme, sink.PulsarHttpsScheme:
+	case sink.PulsarScheme, sink.PulsarSSLScheme, sink.PulsarHTTPScheme, sink.PulsarHTTPSScheme:
 		return mq.NewPulsarDDLSink(ctx, changefeedID, sinkURI, cfg, manager.NewPulsarTopicManager,
 			pulsarConfig.NewCreatorFactory, ddlproducer.NewPulsarProducer)
 	default:

--- a/cdc/sink/ddlsink/mq/pulsar_ddl_sink_test.go
+++ b/cdc/sink/ddlsink/mq/pulsar_ddl_sink_test.go
@@ -100,7 +100,6 @@ func TestNewPulsarDDLSink(t *testing.T) {
 		events := ddlSink.producer.(*ddlproducer.PulsarMockProducers).GetAllEvents()
 		require.Len(t, events, 1, "All topics and partitions should be broadcast")
 	}
-
 }
 
 // TestPulsarDDLSinkNewSuccess tests the NewPulsarDDLSink write a event to pulsar
@@ -123,7 +122,6 @@ func TestPulsarDDLSinkNewSuccess(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, s)
 	}
-
 }
 
 func TestPulsarWriteDDLEventToZeroPartition(t *testing.T) {

--- a/cdc/sink/ddlsink/mq/pulsar_ddl_sink_test.go
+++ b/cdc/sink/ddlsink/mq/pulsar_ddl_sink_test.go
@@ -54,6 +54,8 @@ func newPulsarConfig(t *testing.T, schema string) (*config.PulsarConfig, *url.UR
 // TestNewPulsarDDLSink tests the NewPulsarDDLSink
 func TestNewPulsarDDLSink(t *testing.T) {
 	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	for _, schema := range pulsarSchemaList {
 		_, sinkURI := newPulsarConfig(t, schema)
 		changefeedID := model.DefaultChangeFeedID("test")
@@ -61,9 +63,6 @@ func TestNewPulsarDDLSink(t *testing.T) {
 		replicaConfig.Sink = &config.SinkConfig{
 			Protocol: aws.String("canal-json"),
 		}
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
 
 		ctx = context.WithValue(ctx, "testing.T", t)
 		ddlSink, err := NewPulsarDDLSink(ctx, changefeedID, sinkURI, replicaConfig,
@@ -105,6 +104,9 @@ func TestNewPulsarDDLSink(t *testing.T) {
 // TestPulsarDDLSinkNewSuccess tests the NewPulsarDDLSink write a event to pulsar
 func TestPulsarDDLSinkNewSuccess(t *testing.T) {
 	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	for _, schema := range pulsarSchemaList {
 		_, sinkURI := newPulsarConfig(t, schema)
 		changefeedID := model.DefaultChangeFeedID("test")
@@ -112,9 +114,6 @@ func TestPulsarDDLSinkNewSuccess(t *testing.T) {
 		replicaConfig.Sink = &config.SinkConfig{
 			Protocol: aws.String("canal-json"),
 		}
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
 
 		ctx = context.WithValue(ctx, "testing.T", t)
 		s, err := NewPulsarDDLSink(ctx, changefeedID, sinkURI, replicaConfig, manager.NewMockPulsarTopicManager,
@@ -126,6 +125,9 @@ func TestPulsarDDLSinkNewSuccess(t *testing.T) {
 
 func TestPulsarWriteDDLEventToZeroPartition(t *testing.T) {
 	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	for _, schema := range pulsarSchemaList {
 		_, sinkURI := newPulsarConfig(t, schema)
 		changefeedID := model.DefaultChangeFeedID("test")
@@ -133,9 +135,6 @@ func TestPulsarWriteDDLEventToZeroPartition(t *testing.T) {
 		replicaConfig.Sink = &config.SinkConfig{
 			Protocol: aws.String("canal-json"),
 		}
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
 
 		ctx = context.WithValue(ctx, "testing.T", t)
 		ddlSink, err := NewPulsarDDLSink(ctx, changefeedID, sinkURI, replicaConfig,

--- a/cdc/sink/ddlsink/mq/pulsar_ddl_sink_test.go
+++ b/cdc/sink/ddlsink/mq/pulsar_ddl_sink_test.go
@@ -15,6 +15,7 @@ package mq
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"testing"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/pingcap/tiflow/cdc/sink/ddlsink/mq/ddlproducer"
 	"github.com/pingcap/tiflow/cdc/sink/dmlsink/mq/manager"
 	"github.com/pingcap/tiflow/pkg/config"
+	"github.com/pingcap/tiflow/pkg/sink"
 	pulsarConfig "github.com/pingcap/tiflow/pkg/sink/pulsar"
 	"github.com/stretchr/testify/require"
 )
@@ -33,17 +35,17 @@ const (
 	MockPulsarTopic = "pulsar_test"
 )
 
+var pulsarSchemaList = []string{sink.PulsarScheme, sink.PulsarSSLScheme, sink.PulsarHTTPScheme, sink.PulsarHTTPSScheme}
+
 // newPulsarConfig set config
-func newPulsarConfig(t *testing.T) (*config.PulsarConfig, *url.URL) {
-	sinkURL := "pulsar://127.0.0.1:6650/persistent://public/default/test?" +
+func newPulsarConfig(t *testing.T, schema string) (*config.PulsarConfig, *url.URL) {
+	sinkURL := fmt.Sprintf("%s://127.0.0.1:6650/persistent://public/default/test?", schema) +
 		"protocol=canal-json&pulsar-version=v2.10.0&enable-tidb-extension=true&" +
 		"authentication-token=eyJhbcGcixxxxxxxxxxxxxx"
-
 	sinkURI, err := url.Parse(sinkURL)
 	require.NoError(t, err)
 	replicaConfig := config.GetDefaultReplicaConfig()
 	require.NoError(t, replicaConfig.ValidateAndAdjust(sinkURI))
-	require.NoError(t, err)
 	c, err := pulsarConfig.NewPulsarConfig(sinkURI, replicaConfig.Sink.PulsarConfig)
 	require.NoError(t, err)
 	return c, sinkURI
@@ -52,110 +54,115 @@ func newPulsarConfig(t *testing.T) (*config.PulsarConfig, *url.URL) {
 // TestNewPulsarDDLSink tests the NewPulsarDDLSink
 func TestNewPulsarDDLSink(t *testing.T) {
 	t.Parallel()
+	for _, schema := range pulsarSchemaList {
+		_, sinkURI := newPulsarConfig(t, schema)
+		changefeedID := model.DefaultChangeFeedID("test")
+		replicaConfig := config.GetDefaultReplicaConfig()
+		replicaConfig.Sink = &config.SinkConfig{
+			Protocol: aws.String("canal-json"),
+		}
 
-	_, sinkURI := newPulsarConfig(t)
-	changefeedID := model.DefaultChangeFeedID("test")
-	replicaConfig := config.GetDefaultReplicaConfig()
-	replicaConfig.Sink = &config.SinkConfig{
-		Protocol: aws.String("canal-json"),
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ctx = context.WithValue(ctx, "testing.T", t)
+		ddlSink, err := NewPulsarDDLSink(ctx, changefeedID, sinkURI, replicaConfig,
+			manager.NewMockPulsarTopicManager, pulsarConfig.NewMockCreatorFactory, ddlproducer.NewMockPulsarProducerDDL)
+
+		require.NoError(t, err)
+		require.NotNil(t, ddlSink)
+
+		checkpointTs := uint64(417318403368288260)
+		tables := []*model.TableInfo{
+			{
+				TableName: model.TableName{
+					Schema: "cdc",
+					Table:  "person",
+				},
+			},
+			{
+				TableName: model.TableName{
+					Schema: "cdc",
+					Table:  "person1",
+				},
+			},
+			{
+				TableName: model.TableName{
+					Schema: "cdc",
+					Table:  "person2",
+				},
+			},
+		}
+
+		err = ddlSink.WriteCheckpointTs(ctx, checkpointTs, tables)
+		require.NoError(t, err)
+
+		events := ddlSink.producer.(*ddlproducer.PulsarMockProducers).GetAllEvents()
+		require.Len(t, events, 1, "All topics and partitions should be broadcast")
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	ctx = context.WithValue(ctx, "testing.T", t)
-	ddlSink, err := NewPulsarDDLSink(ctx, changefeedID, sinkURI, replicaConfig,
-		manager.NewMockPulsarTopicManager, pulsarConfig.NewMockCreatorFactory, ddlproducer.NewMockPulsarProducerDDL)
-
-	require.NoError(t, err)
-	require.NotNil(t, ddlSink)
-
-	checkpointTs := uint64(417318403368288260)
-	tables := []*model.TableInfo{
-		{
-			TableName: model.TableName{
-				Schema: "cdc",
-				Table:  "person",
-			},
-		},
-		{
-			TableName: model.TableName{
-				Schema: "cdc",
-				Table:  "person1",
-			},
-		},
-		{
-			TableName: model.TableName{
-				Schema: "cdc",
-				Table:  "person2",
-			},
-		},
-	}
-
-	err = ddlSink.WriteCheckpointTs(ctx, checkpointTs, tables)
-	require.NoError(t, err)
-
-	events := ddlSink.producer.(*ddlproducer.PulsarMockProducers).GetAllEvents()
-	require.Len(t, events, 1, "All topics and partitions should be broadcast")
 }
 
 // TestPulsarDDLSinkNewSuccess tests the NewPulsarDDLSink write a event to pulsar
 func TestPulsarDDLSinkNewSuccess(t *testing.T) {
 	t.Parallel()
+	for _, schema := range pulsarSchemaList {
+		_, sinkURI := newPulsarConfig(t, schema)
+		changefeedID := model.DefaultChangeFeedID("test")
+		replicaConfig := config.GetDefaultReplicaConfig()
+		replicaConfig.Sink = &config.SinkConfig{
+			Protocol: aws.String("canal-json"),
+		}
 
-	_, sinkURI := newPulsarConfig(t)
-	changefeedID := model.DefaultChangeFeedID("test")
-	replicaConfig := config.GetDefaultReplicaConfig()
-	replicaConfig.Sink = &config.SinkConfig{
-		Protocol: aws.String("canal-json"),
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ctx = context.WithValue(ctx, "testing.T", t)
+		s, err := NewPulsarDDLSink(ctx, changefeedID, sinkURI, replicaConfig, manager.NewMockPulsarTopicManager,
+			pulsarConfig.NewMockCreatorFactory, ddlproducer.NewMockPulsarProducerDDL)
+		require.NoError(t, err)
+		require.NotNil(t, s)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	ctx = context.WithValue(ctx, "testing.T", t)
-	s, err := NewPulsarDDLSink(ctx, changefeedID, sinkURI, replicaConfig, manager.NewMockPulsarTopicManager,
-		pulsarConfig.NewMockCreatorFactory, ddlproducer.NewMockPulsarProducerDDL)
-	require.NoError(t, err)
-	require.NotNil(t, s)
 }
 
 func TestPulsarWriteDDLEventToZeroPartition(t *testing.T) {
 	t.Parallel()
+	for _, schema := range pulsarSchemaList {
+		_, sinkURI := newPulsarConfig(t, schema)
+		changefeedID := model.DefaultChangeFeedID("test")
+		replicaConfig := config.GetDefaultReplicaConfig()
+		replicaConfig.Sink = &config.SinkConfig{
+			Protocol: aws.String("canal-json"),
+		}
 
-	_, sinkURI := newPulsarConfig(t)
-	changefeedID := model.DefaultChangeFeedID("test")
-	replicaConfig := config.GetDefaultReplicaConfig()
-	replicaConfig.Sink = &config.SinkConfig{
-		Protocol: aws.String("canal-json"),
-	}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+		ctx = context.WithValue(ctx, "testing.T", t)
+		ddlSink, err := NewPulsarDDLSink(ctx, changefeedID, sinkURI, replicaConfig,
+			manager.NewMockPulsarTopicManager, pulsarConfig.NewMockCreatorFactory, ddlproducer.NewMockPulsarProducerDDL)
 
-	ctx = context.WithValue(ctx, "testing.T", t)
-	ddlSink, err := NewPulsarDDLSink(ctx, changefeedID, sinkURI, replicaConfig,
-		manager.NewMockPulsarTopicManager, pulsarConfig.NewMockCreatorFactory, ddlproducer.NewMockPulsarProducerDDL)
+		require.NoError(t, err)
+		require.NotNil(t, ddlSink)
 
-	require.NoError(t, err)
-	require.NotNil(t, ddlSink)
-
-	ddl := &model.DDLEvent{
-		CommitTs: 417318403368288260,
-		TableInfo: &model.TableInfo{
-			TableName: model.TableName{
-				Schema: "cdc", Table: "person",
+		ddl := &model.DDLEvent{
+			CommitTs: 417318403368288260,
+			TableInfo: &model.TableInfo{
+				TableName: model.TableName{
+					Schema: "cdc", Table: "person",
+				},
 			},
-		},
-		Query: "create table person(id int, name varchar(32), primary key(id))",
-		Type:  mm.ActionCreateTable,
+			Query: "create table person(id int, name varchar(32), primary key(id))",
+			Type:  mm.ActionCreateTable,
+		}
+		err = ddlSink.WriteDDLEvent(ctx, ddl)
+		require.NoError(t, err)
+
+		err = ddlSink.WriteDDLEvent(ctx, ddl)
+		require.NoError(t, err)
+
+		require.Len(t, ddlSink.producer.(*ddlproducer.PulsarMockProducers).GetAllEvents(),
+			2, "Write DDL 2 Events")
 	}
-	err = ddlSink.WriteDDLEvent(ctx, ddl)
-	require.NoError(t, err)
-
-	err = ddlSink.WriteDDLEvent(ctx, ddl)
-	require.NoError(t, err)
-
-	require.Len(t, ddlSink.producer.(*ddlproducer.PulsarMockProducers).GetAllEvents(),
-		2, "Write DDL 2 Events")
 }

--- a/cdc/sink/dmlsink/factory/factory.go
+++ b/cdc/sink/dmlsink/factory/factory.go
@@ -112,7 +112,7 @@ func New(
 		bs := blackhole.NewDMLSink()
 		s.rowSink = bs
 		s.category = CategoryBlackhole
-	case sink.PulsarScheme, sink.PulsarSSLScheme:
+	case sink.PulsarScheme, sink.PulsarSSLScheme, sink.PulsarHttpScheme, sink.PulsarHttpsScheme:
 		mqs, err := mq.NewPulsarDMLSink(ctx, changefeedID, sinkURI, cfg, errCh,
 			manager.NewPulsarTopicManager,
 			pulsarConfig.NewCreatorFactory, dmlproducer.NewPulsarDMLProducer)

--- a/cdc/sink/dmlsink/factory/factory.go
+++ b/cdc/sink/dmlsink/factory/factory.go
@@ -112,7 +112,7 @@ func New(
 		bs := blackhole.NewDMLSink()
 		s.rowSink = bs
 		s.category = CategoryBlackhole
-	case sink.PulsarScheme, sink.PulsarSSLScheme, sink.PulsarHttpScheme, sink.PulsarHttpsScheme:
+	case sink.PulsarScheme, sink.PulsarSSLScheme, sink.PulsarHTTPScheme, sink.PulsarHTTPSScheme:
 		mqs, err := mq.NewPulsarDMLSink(ctx, changefeedID, sinkURI, cfg, errCh,
 			manager.NewPulsarTopicManager,
 			pulsarConfig.NewCreatorFactory, dmlproducer.NewPulsarDMLProducer)

--- a/cdc/sink/dmlsink/mq/dmlproducer/pulsar_dml_producer_test.go
+++ b/cdc/sink/dmlsink/mq/dmlproducer/pulsar_dml_producer_test.go
@@ -15,20 +15,24 @@ package dmlproducer
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/pkg/config"
+	"github.com/pingcap/tiflow/pkg/sink"
 	"github.com/pingcap/tiflow/pkg/sink/codec/common"
 	pulsarConfig "github.com/pingcap/tiflow/pkg/sink/pulsar"
 	"github.com/stretchr/testify/require"
 )
 
+var pulsarSchemaList = []string{sink.PulsarScheme, sink.PulsarSSLScheme, sink.PulsarHTTPScheme, sink.PulsarHTTPSScheme}
+
 // newPulsarConfig set config
-func newPulsarConfig(t *testing.T) (sinkURI *url.URL, replicaConfig *config.ReplicaConfig) {
-	sinkURL := "pulsar://127.0.0.1:6650/persistent://public/default/test?" +
+func newPulsarConfig(t *testing.T, schema string) (sinkURI *url.URL, replicaConfig *config.ReplicaConfig) {
+	sinkURL := fmt.Sprintf("%s://127.0.0.1:6650/persistent://public/default/test?", schema) +
 		"protocol=canal-json&pulsar-version=v2.10.0&enable-tidb-extension=true&" +
 		"authentication-token=eyJhbcGcixxxxxxxxxxxxxx"
 	var err error
@@ -45,59 +49,61 @@ func newPulsarConfig(t *testing.T) (sinkURI *url.URL, replicaConfig *config.Repl
 
 func TestNewPulsarDMLProducer(t *testing.T) {
 	t.Parallel()
+	for _, schema := range pulsarSchemaList {
+		sinkURI, rc := newPulsarConfig(t, schema)
+		replicaConfig := config.GetDefaultReplicaConfig()
+		replicaConfig.Sink = &config.SinkConfig{
+			Protocol: aws.String("canal-json"),
+		}
+		t.Logf(sinkURI.String())
 
-	sinkURI, rc := newPulsarConfig(t)
-	replicaConfig := config.GetDefaultReplicaConfig()
-	replicaConfig.Sink = &config.SinkConfig{
-		Protocol: aws.String("canal-json"),
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		errCh := make(chan error, 1)
+
+		ctx = context.WithValue(ctx, "testing.T", t)
+		changefeed := model.DefaultChangeFeedID("changefeed-test")
+
+		failpointCh := make(chan error, 1)
+
+		client, err := pulsarConfig.NewMockCreatorFactory(rc.Sink.PulsarConfig, changefeed, rc.Sink)
+		require.NoError(t, err)
+		dml, err := NewPulsarDMLProducerMock(ctx, changefeed, client, rc.Sink, errCh, failpointCh)
+		require.NoError(t, err)
+		require.NotNil(t, dml)
 	}
-	t.Logf(sinkURI.String())
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	errCh := make(chan error, 1)
-
-	ctx = context.WithValue(ctx, "testing.T", t)
-	changefeed := model.DefaultChangeFeedID("changefeed-test")
-
-	failpointCh := make(chan error, 1)
-
-	client, err := pulsarConfig.NewMockCreatorFactory(rc.Sink.PulsarConfig, changefeed, rc.Sink)
-	require.NoError(t, err)
-	dml, err := NewPulsarDMLProducerMock(ctx, changefeed, client, rc.Sink, errCh, failpointCh)
-	require.NoError(t, err)
-	require.NotNil(t, dml)
 }
 
 func Test_pulsarDMLProducer_AsyncSendMessage(t *testing.T) {
 	t.Parallel()
+	for _, schema := range pulsarSchemaList {
+		_, rc := newPulsarConfig(t, schema)
+		replicaConfig := config.GetDefaultReplicaConfig()
+		replicaConfig.Sink = &config.SinkConfig{
+			Protocol: aws.String("canal-json"),
+		}
 
-	_, rc := newPulsarConfig(t)
-	replicaConfig := config.GetDefaultReplicaConfig()
-	replicaConfig.Sink = &config.SinkConfig{
-		Protocol: aws.String("canal-json"),
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		errCh := make(chan error, 1)
+
+		ctx = context.WithValue(ctx, "testing.T", t)
+		changefeed := model.DefaultChangeFeedID("changefeed-test")
+
+		failpointCh := make(chan error, 1)
+
+		client, err := pulsarConfig.NewMockCreatorFactory(rc.Sink.PulsarConfig, changefeed, rc.Sink)
+		require.NoError(t, err)
+		dml, err := NewPulsarDMLProducerMock(ctx, changefeed, client, rc.Sink, errCh, failpointCh)
+		require.NoError(t, err)
+		require.NotNil(t, dml)
+
+		err = dml.AsyncSendMessage(ctx, "test", 0, &common.Message{
+			Value:        []byte("this value for test input data"),
+			PartitionKey: str2Pointer("test_key"),
+		})
+		require.NoError(t, err)
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	errCh := make(chan error, 1)
-
-	ctx = context.WithValue(ctx, "testing.T", t)
-	changefeed := model.DefaultChangeFeedID("changefeed-test")
-
-	failpointCh := make(chan error, 1)
-
-	client, err := pulsarConfig.NewMockCreatorFactory(rc.Sink.PulsarConfig, changefeed, rc.Sink)
-	require.NoError(t, err)
-	dml, err := NewPulsarDMLProducerMock(ctx, changefeed, client, rc.Sink, errCh, failpointCh)
-	require.NoError(t, err)
-	require.NotNil(t, dml)
-
-	err = dml.AsyncSendMessage(ctx, "test", 0, &common.Message{
-		Value:        []byte("this value for test input data"),
-		PartitionKey: str2Pointer("test_key"),
-	})
-	require.NoError(t, err)
 }

--- a/cdc/sink/dmlsink/mq/dmlproducer/pulsar_dml_producer_test.go
+++ b/cdc/sink/dmlsink/mq/dmlproducer/pulsar_dml_producer_test.go
@@ -49,6 +49,9 @@ func newPulsarConfig(t *testing.T, schema string) (sinkURI *url.URL, replicaConf
 
 func TestNewPulsarDMLProducer(t *testing.T) {
 	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	for _, schema := range pulsarSchemaList {
 		sinkURI, rc := newPulsarConfig(t, schema)
 		replicaConfig := config.GetDefaultReplicaConfig()
@@ -56,9 +59,6 @@ func TestNewPulsarDMLProducer(t *testing.T) {
 			Protocol: aws.String("canal-json"),
 		}
 		t.Logf(sinkURI.String())
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
 
 		errCh := make(chan error, 1)
 
@@ -77,15 +77,15 @@ func TestNewPulsarDMLProducer(t *testing.T) {
 
 func Test_pulsarDMLProducer_AsyncSendMessage(t *testing.T) {
 	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	for _, schema := range pulsarSchemaList {
 		_, rc := newPulsarConfig(t, schema)
 		replicaConfig := config.GetDefaultReplicaConfig()
 		replicaConfig.Sink = &config.SinkConfig{
 			Protocol: aws.String("canal-json"),
 		}
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
 
 		errCh := make(chan error, 1)
 

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -888,7 +888,7 @@ func (s *SinkConfig) ValidateProtocol(scheme string) error {
 	switch scheme {
 	case sink.KafkaScheme, sink.KafkaSSLScheme:
 		outputRawChangeEvent = s.KafkaConfig.GetOutputRawChangeEvent()
-	case sink.PulsarScheme, sink.PulsarSSLScheme:
+	case sink.PulsarScheme, sink.PulsarSSLScheme, sink.PulsarHttpScheme, sink.PulsarHttpsScheme:
 		outputRawChangeEvent = s.PulsarConfig.GetOutputRawChangeEvent()
 	default:
 		outputRawChangeEvent = s.CloudStorageConfig.GetOutputRawChangeEvent()

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -888,7 +888,7 @@ func (s *SinkConfig) ValidateProtocol(scheme string) error {
 	switch scheme {
 	case sink.KafkaScheme, sink.KafkaSSLScheme:
 		outputRawChangeEvent = s.KafkaConfig.GetOutputRawChangeEvent()
-	case sink.PulsarScheme, sink.PulsarSSLScheme, sink.PulsarHttpScheme, sink.PulsarHttpsScheme:
+	case sink.PulsarScheme, sink.PulsarSSLScheme, sink.PulsarHTTPScheme, sink.PulsarHTTPSScheme:
 		outputRawChangeEvent = s.PulsarConfig.GetOutputRawChangeEvent()
 	default:
 		outputRawChangeEvent = s.CloudStorageConfig.GetOutputRawChangeEvent()

--- a/pkg/sink/pulsar/config.go
+++ b/pkg/sink/pulsar/config.go
@@ -68,9 +68,9 @@ func NewPulsarConfig(sinkURI *url.URL, pulsarConfig *config.PulsarConfig) (*conf
 
 	brokerScheme := sinkURI.Scheme
 	switch brokerScheme {
-	case sink.PulsarHttpScheme:
+	case sink.PulsarHTTPScheme:
 		brokerScheme = "http"
-	case sink.PulsarHttpsScheme:
+	case sink.PulsarHTTPSScheme:
 		brokerScheme = "https"
 	}
 	c.SinkURI = sinkURI

--- a/pkg/sink/pulsar/config.go
+++ b/pkg/sink/pulsar/config.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/pkg/config"
+	"github.com/pingcap/tiflow/pkg/sink"
 	"go.uber.org/zap"
 )
 
@@ -65,8 +66,15 @@ func NewPulsarConfig(sinkURI *url.URL, pulsarConfig *config.PulsarConfig) (*conf
 		return nil, err
 	}
 
+	brokerScheme := sinkURI.Scheme
+	switch brokerScheme {
+	case sink.PulsarHttpScheme:
+		brokerScheme = "http"
+	case sink.PulsarHttpsScheme:
+		brokerScheme = "https"
+	}
 	c.SinkURI = sinkURI
-	c.BrokerURL = sinkURI.Scheme + "://" + sinkURI.Host
+	c.BrokerURL = brokerScheme + "://" + sinkURI.Host
 
 	if pulsarConfig == nil {
 		log.L().Debug("new pulsar config", zap.Any("config", c))

--- a/pkg/sink/pulsar/config.go
+++ b/pkg/sink/pulsar/config.go
@@ -65,7 +65,7 @@ func NewPulsarConfig(sinkURI *url.URL, pulsarConfig *config.PulsarConfig) (*conf
 	if err != nil {
 		return nil, err
 	}
-	//Adding an extra check to ensure that the scheme is a valid pulsar scheme
+	// Adding an extra check to ensure that the scheme is a valid pulsar scheme
 	if !sink.IsPulsarScheme(sinkURI.Scheme) {
 		return nil, fmt.Errorf("invalid pulsar scheme %s", sinkURI.Scheme)
 	}

--- a/pkg/sink/pulsar/config.go
+++ b/pkg/sink/pulsar/config.go
@@ -65,6 +65,10 @@ func NewPulsarConfig(sinkURI *url.URL, pulsarConfig *config.PulsarConfig) (*conf
 	if err != nil {
 		return nil, err
 	}
+	//Adding an extra check to ensure that the scheme is a valid pulsar scheme
+	if !sink.IsPulsarScheme(sinkURI.Scheme) {
+		return nil, fmt.Errorf("invalid pulsar scheme %s", sinkURI.Scheme)
+	}
 
 	brokerScheme := sinkURI.Scheme
 	switch brokerScheme {

--- a/pkg/sink/pulsar/config_test.go
+++ b/pkg/sink/pulsar/config_test.go
@@ -14,6 +14,7 @@
 package pulsar
 
 import (
+	"fmt"
 	"net/url"
 	"testing"
 	"time"
@@ -115,4 +116,18 @@ func TestGetDefaultTopicName(t *testing.T) {
 	sink, _ = url.Parse("pulsar://127.0.0.1:6650/persistent://tenant/namespace/test-topic")
 	config, _ = NewPulsarConfig(sink, replicaConfig.Sink.PulsarConfig)
 	assert.Equal(t, config.GetDefaultTopicName(), "persistent://tenant/namespace/test-topic")
+}
+
+func TestNewPulsarConfigFailure(t *testing.T) {
+	t.Parallel()
+	invalidPulsarSchema := "pulsar+htp"
+	sinkURL := fmt.Sprintf("%s://127.0.0.1:6650/persistent://public/default/test?", invalidPulsarSchema) +
+		"protocol=canal-json&pulsar-version=v2.10.0&enable-tidb-extension=true&" +
+		"authentication-token=eyJhbcGcixxxxxxxxxxxxxx"
+	sinkURI, err := url.Parse(sinkURL)
+	assert.NoError(t, err)
+	replicaConfig := config.GetDefaultReplicaConfig()
+	assert.NoError(t, replicaConfig.ValidateAndAdjust(sinkURI))
+	_, err = NewPulsarConfig(sinkURI, replicaConfig.Sink.PulsarConfig)
+	assert.Error(t, err)
 }

--- a/pkg/sink/sink_type.go
+++ b/pkg/sink/sink_type.go
@@ -72,6 +72,10 @@ const (
 	PulsarScheme = "pulsar"
 	// PulsarSSLScheme indicates the scheme is pulsar+ssl
 	PulsarSSLScheme = "pulsar+ssl"
+	//PulsarHttpScheme indicates the schema is pulsar with http protocol
+	PulsarHttpScheme = "pulsar+http"
+	//PulsarHttpsScheme indicates the schema is pulsar with https protocol
+	PulsarHttpsScheme = "pulsar+https"
 )
 
 // IsMQScheme returns true if the scheme belong to mq scheme.
@@ -94,7 +98,7 @@ func IsStorageScheme(scheme string) bool {
 
 // IsPulsarScheme returns true if the scheme belong to pulsar scheme.
 func IsPulsarScheme(scheme string) bool {
-	return scheme == PulsarScheme || scheme == PulsarSSLScheme
+	return scheme == PulsarScheme || scheme == PulsarSSLScheme || scheme == PulsarHttpsScheme || scheme == PulsarHttpScheme
 }
 
 // IsBlackHoleScheme returns true if the scheme belong to blackhole scheme.

--- a/pkg/sink/sink_type.go
+++ b/pkg/sink/sink_type.go
@@ -72,10 +72,10 @@ const (
 	PulsarScheme = "pulsar"
 	// PulsarSSLScheme indicates the scheme is pulsar+ssl
 	PulsarSSLScheme = "pulsar+ssl"
-	//PulsarHttpScheme indicates the schema is pulsar with http protocol
-	PulsarHttpScheme = "pulsar+http"
-	//PulsarHttpsScheme indicates the schema is pulsar with https protocol
-	PulsarHttpsScheme = "pulsar+https"
+	//PulsarHTTPScheme indicates the schema is pulsar with http protocol
+	PulsarHTTPScheme = "pulsar+http"
+	//PulsarHTTPSScheme indicates the schema is pulsar with https protocol
+	PulsarHTTPSScheme = "pulsar+https"
 )
 
 // IsMQScheme returns true if the scheme belong to mq scheme.
@@ -98,7 +98,7 @@ func IsStorageScheme(scheme string) bool {
 
 // IsPulsarScheme returns true if the scheme belong to pulsar scheme.
 func IsPulsarScheme(scheme string) bool {
-	return scheme == PulsarScheme || scheme == PulsarSSLScheme || scheme == PulsarHttpsScheme || scheme == PulsarHttpScheme
+	return scheme == PulsarScheme || scheme == PulsarSSLScheme || scheme == PulsarHTTPScheme || scheme == PulsarHTTPSScheme
 }
 
 // IsBlackHoleScheme returns true if the scheme belong to blackhole scheme.


### PR DESCRIPTION
### What problem does this PR solve?
Added support for HTTP and HTTPS schema for pulsar downstream. Currently, only pulsar and pulsar+ssl support is there.

Issue Number: close #11336 

### What is changed and how it works?
-> In addition to pulsar and pulsar+ssl schema types in pulsar changefeed creation , users will now will able to create changefeeds with HTTP and HTTPS  type as broker schema for pulsar client.   

Clients have to use: 
1. pulsar+http -> for creating pulsar changefeed with HTTP endpoint
2. pulsar+https -> for creating pulsar chnagefeed with HTTPS endpoint.



#### Tests 
1. Unit test
2. Feature test by deploying the image on  k8s environment and creating multiple changefeeds.


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
-> It should not cause any performance regression or break compatibility. It only addition schema addition for pulsar client creation.


##### Do you need to update user documentation, design documentation or monitoring documentation?

Documentation for pulsar sink should be update: https://docs.pingcap.com/tidb/dev/ticdc-sink-to-pulsar#sink-uri


```release-note
Support http and https schema in pulsar sink uri. 
```