### PR TITLE
syncpoint(ticdc): set write source before creating SyncTable

### DIFF
--- a/cdc/owner/ddl_sink.go
+++ b/cdc/owner/ddl_sink.go
@@ -130,7 +130,7 @@ func ddlSinkInitializer(ctx context.Context, a *ddlSinkImpl) error {
 func (s *ddlSinkImpl) makeSyncPointStoreReady(ctx context.Context) error {
 	if util.GetOrZero(s.info.Config.EnableSyncPoint) && s.syncPointStore == nil {
 		syncPointStore, err := syncpointstore.NewSyncPointStore(
-			ctx, s.changefeedID, s.info.SinkURI, util.GetOrZero(s.info.Config.SyncPointRetention))
+			ctx, s.changefeedID, s.info.SinkURI, s.info.Config)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cdc/syncpointstore/syncpoint_store.go
+++ b/cdc/syncpointstore/syncpoint_store.go
@@ -17,9 +17,9 @@ import (
 	"context"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/pingcap/tiflow/cdc/model"
+	"github.com/pingcap/tiflow/pkg/config"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 )
 
@@ -40,7 +40,7 @@ func NewSyncPointStore(
 	ctx context.Context,
 	changefeedID model.ChangeFeedID,
 	sinkURIStr string,
-	syncPointRetention time.Duration,
+	replicaConfig *config.ReplicaConfig,
 ) (SyncPointStore, error) {
 	// parse sinkURI as a URI
 	sinkURI, err := url.Parse(sinkURIStr)
@@ -49,7 +49,7 @@ func NewSyncPointStore(
 	}
 	switch strings.ToLower(sinkURI.Scheme) {
 	case "mysql", "tidb", "mysql+ssl", "tidb+ssl":
-		return newMySQLSyncPointStore(ctx, changefeedID, sinkURI, syncPointRetention)
+		return newMySQLSyncPointStore(ctx, changefeedID, sinkURI, replicaConfig)
 	default:
 		return nil, cerror.ErrSinkURIInvalid.
 			GenWithStack("the sink scheme (%s) is not supported", sinkURI.Scheme)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11375

### What is changed and how it works?
TiDB  in the BDR secondary role forbids all ddl writes. Therefore, SyncTable cannot be created when syncpoint is enabled on the changefeed from the primary to the secondary.  This problem can be solved by setting the writesource before executing the create ddl.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)
 


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
