### PR TITLE
consumer(ticdc): do not panic the consumer if read previous offset message

### DIFF
--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -388,7 +388,7 @@ func (w *writer) WriteMessage(ctx context.Context, message *kafka.Message) bool 
 				// if commit message failed, the consumer may read previous message,
 				// just ignore this message should be fine, otherwise panic.
 				if message.TopicPartition.Offset > progress.watermarkOffset {
-					log.Panic("RowChangedEvent fallback row, ignore it",
+					log.Panic("RowChangedEvent fallback row",
 						zap.Uint64("commitTs", row.CommitTs), zap.Any("offset", message.TopicPartition.Offset),
 						zap.Uint64("watermark", watermark), zap.Any("watermarkOffset", progress.watermarkOffset),
 						zap.Int32("partition", partition), zap.Int64("tableID", tableID),

--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -384,7 +384,7 @@ func (w *writer) WriteMessage(ctx context.Context, message *kafka.Message) bool 
 			watermark := atomic.LoadUint64(&progress.watermark)
 			// if the kafka cluster is normal, this should not hit.
 			// else if the cluster is abnormal, the consumer may consume old message, then cause the watermark fallback.
-			if row.CommitTs < watermark && message.TopicPartition.Offset > progress.watermarkOffset {
+			if row.CommitTs < watermark {
 				if message.TopicPartition.Offset > progress.watermarkOffset {
 					log.Panic("RowChangedEvent fallback row, ignore it",
 						zap.Uint64("commitTs", row.CommitTs), zap.Any("offset", message.TopicPartition.Offset),

--- a/cmd/kafka-consumer/writer.go
+++ b/cmd/kafka-consumer/writer.go
@@ -385,6 +385,8 @@ func (w *writer) WriteMessage(ctx context.Context, message *kafka.Message) bool 
 			// if the kafka cluster is normal, this should not hit.
 			// else if the cluster is abnormal, the consumer may consume old message, then cause the watermark fallback.
 			if row.CommitTs < watermark {
+				// if commit message failed, the consumer may read previous message,
+				// just ignore this message should be fine, otherwise panic.
 				if message.TopicPartition.Offset > progress.watermarkOffset {
 					log.Panic("RowChangedEvent fallback row, ignore it",
 						zap.Uint64("commitTs", row.CommitTs), zap.Any("offset", message.TopicPartition.Offset),


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11386 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
