### PR TITLE
sink(ticdc): split update event also set the checksum field to 0

### DIFF
--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -1255,10 +1255,16 @@ func SplitUpdateEvent(
 	// so it won't have an impact and no more full deep copy wastes memory.
 	deleteEvent := *updateEvent
 	deleteEvent.Columns = nil
+	if deleteEvent.Checksum != nil {
+		deleteEvent.Checksum.Current = 0
+	}
 
 	insertEvent := *updateEvent
 	// NOTICE: clean up pre cols for insert event.
 	insertEvent.PreColumns = nil
+	if insertEvent.Checksum != nil {
+		insertEvent.Checksum.Previous = 0
+	}
 
 	return &deleteEvent, &insertEvent, nil
 }

--- a/cdc/model/sink_test.go
+++ b/cdc/model/sink_test.go
@@ -14,13 +14,13 @@
 package model
 
 import (
-	"github.com/pingcap/tiflow/pkg/integrity"
 	"sort"
 	"testing"
 
 	timodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/types"
+	"github.com/pingcap/tiflow/pkg/integrity"
 	"github.com/pingcap/tiflow/pkg/sink"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/cdc/model/sink_test.go
+++ b/cdc/model/sink_test.go
@@ -14,6 +14,7 @@
 package model
 
 import (
+	"github.com/pingcap/tiflow/pkg/integrity"
 	"sort"
 	"testing"
 
@@ -485,13 +486,21 @@ func TestTrySplitAndSortUpdateEvent(t *testing.T) {
 					Value: "col2-value",
 				},
 			}, tableInfoWithPrimaryKey),
+			Checksum: &integrity.Checksum{
+				Current:   1,
+				Previous:  2,
+				Corrupted: false,
+				Version:   0,
+			},
 		},
 	}
 	result, err := trySplitAndSortUpdateEvent(events)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(result))
 	require.True(t, result[0].IsDelete())
+	require.Zero(t, result[0].Checksum.Current)
 	require.True(t, result[1].IsInsert())
+	require.Zero(t, result[1].Checksum.Previous)
 
 	// Update unique key.
 	tableInfoWithUniqueKey := BuildTableInfo("test", "t", []*Column{


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11402 

### What is changed and how it works?

* set the checksum field to 0 after split the update event

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
fix the checksum field not set to 0 after split update event
```
