### PR TITLE
schematracker(dm): Increase max-index-length config for dm schema tracker

### DIFF
--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/pingcap/errors"
+	tidbConfig "github.com/pingcap/tidb/pkg/config"
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/ddl/schematracker"
 	"github.com/pingcap/tidb/pkg/executor"
@@ -135,6 +136,10 @@ func (tr *Tracker) Init(
 	}()
 
 	logger = logger.WithFields(zap.String("component", "schema-tracker"), zap.String("task", task))
+
+	tidbConfig.UpdateGlobal(func(conf *tidbConfig.Config) {
+		conf.MaxIndexLength = 3328
+	})
 
 	upTracker := schematracker.NewSchemaTracker(lowerCaseTableNames)
 	dsSession := mock.NewContext()

--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -137,6 +137,7 @@ func (tr *Tracker) Init(
 
 	logger = logger.WithFields(zap.String("component", "schema-tracker"), zap.String("task", task))
 
+	// set max-index-length to maximum allowable (3072*4)
 	tidbConfig.UpdateGlobal(func(conf *tidbConfig.Config) {
 		conf.MaxIndexLength = 12288
 	})

--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -138,7 +138,7 @@ func (tr *Tracker) Init(
 	logger = logger.WithFields(zap.String("component", "schema-tracker"), zap.String("task", task))
 
 	tidbConfig.UpdateGlobal(func(conf *tidbConfig.Config) {
-		conf.MaxIndexLength = 3328
+		conf.MaxIndexLength = 12288
 	})
 
 	upTracker := schematracker.NewSchemaTracker(lowerCaseTableNames)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11459

### What is changed and how it works?

DM schema tracker uses the default tidb max-index-length config (3072), regardless of the config value of the downstream tidb. If the downstream tidb configures a larger value, then ddls that execute successfully against the downstream TiDB could fail in the schema tracker.

While DM's schema tracker makes an effort to suppress these kinds of errors, it only applies to single column, non-unique indexes.

This change updates the config of DM schema tracker to use the maximum max-index-length, or 3072*4 (12288). Ideally, DM would use the config of the downstream TiDB directly. However, we already are less strict w/ queries against DM schema tracker (running queries in non-strict, suppressing errors), and can extend the max length to maximum allowable. This way, we can ensure that any DDLs that would execute successfully against the downstream TiDB would be successful in the schema tracker, while not necessarily guaranteeing that any DDLs that fail against the downstream TiDB necessarily fail against DM's schema tracker.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - [x] Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

N

##### Do you need to update user documentation, design documentation or monitoring documentation?

N

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix issue where DDLs could fail in DM schema tracker due to exceeding the default max-index-length
```
