### PR TITLE
Cli(ticdc): add safepoint command

### DIFF
--- a/cdc/api/v2/api.go
+++ b/cdc/api/v2/api.go
@@ -91,4 +91,9 @@ func RegisterOpenAPIV2Routes(router *gin.Engine, api OpenAPIV2) {
 
 	// common APIs
 	v2.POST("/tso", api.QueryTso)
+
+	// safepoint APIs
+	v2.GET("/safepoint", api.querySafePoint)
+	v2.POST("/safepoint", api.setSafePoint)
+	v2.DELETE("/safepoint", api.deleteSafePoint)
 }

--- a/cdc/api/v2/api_helpers_mock.go
+++ b/cdc/api/v2/api_helpers_mock.go
@@ -11,7 +11,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	kv "github.com/pingcap/tidb/pkg/kv"
-	capture "github.com/pingcap/tiflow/cdc/capture"
 	model "github.com/pingcap/tiflow/cdc/model"
 	owner "github.com/pingcap/tiflow/cdc/owner"
 	config "github.com/pingcap/tiflow/pkg/config"
@@ -89,7 +88,7 @@ func (mr *MockAPIV2HelpersMockRecorder) getPDClient(ctx, pdAddrs, credential int
 }
 
 // getPDSafepoint mocks base method.
-func (m *MockAPIV2Helpers) getPDSafepoint(arg0 capture.Capture) (*SafePoint, error) {
+func (m *MockAPIV2Helpers) getPDSafepoint(arg0 []string) (*SafePoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "getPDSafepoint", arg0)
 	ret0, _ := ret[0].(*SafePoint)

--- a/cdc/api/v2/api_helpers_mock.go
+++ b/cdc/api/v2/api_helpers_mock.go
@@ -11,6 +11,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	kv "github.com/pingcap/tidb/pkg/kv"
+	capture "github.com/pingcap/tiflow/cdc/capture"
 	model "github.com/pingcap/tiflow/cdc/model"
 	owner "github.com/pingcap/tiflow/cdc/owner"
 	config "github.com/pingcap/tiflow/pkg/config"
@@ -85,6 +86,21 @@ func (m *MockAPIV2Helpers) getPDClient(ctx context.Context, pdAddrs []string, cr
 func (mr *MockAPIV2HelpersMockRecorder) getPDClient(ctx, pdAddrs, credential interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getPDClient", reflect.TypeOf((*MockAPIV2Helpers)(nil).getPDClient), ctx, pdAddrs, credential)
+}
+
+// getPDSafepoint mocks base method.
+func (m *MockAPIV2Helpers) getPDSafepoint(arg0 capture.Capture) (*SafePoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getPDSafepoint", arg0)
+	ret0, _ := ret[0].(*SafePoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getPDSafepoint indicates an expected call of getPDSafepoint.
+func (mr *MockAPIV2HelpersMockRecorder) getPDSafepoint(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getPDSafepoint", reflect.TypeOf((*MockAPIV2Helpers)(nil).getPDSafepoint), arg0)
 }
 
 // getVerifiedTables mocks base method.

--- a/cdc/api/v2/model.go
+++ b/cdc/api/v2/model.go
@@ -1327,3 +1327,31 @@ type OpenProtocolConfig struct {
 type DebeziumConfig struct {
 	OutputOldValue bool `json:"output_old_value"`
 }
+
+// ServiceSafePoint is the safepoint for a specific service
+// NOTE: This type is a copy of github.com/tikv/pd/pkg/storage/endpoint.ServiceSafePoint.
+// To reduce dependency tree, we do not import the api package directly.
+type ServiceSafePoint struct {
+	ServiceID string `json:"service_id"`
+	ExpiredAt int64  `json:"expired_at"`
+	SafePoint uint64 `json:"safe_point"`
+}
+
+// ListServiceGCSafepoint is the response for list service GC safepoint.
+// NOTE: This type is a copy of github.com/tikv/pd/server/api.ListServiceGCSafepoint.
+// To reduce dependency tree, we do not import the api package directly.
+type ListServiceGCSafepoint struct {
+	ServiceGCSafepoints   []*ServiceSafePoint `json:"service_gc_safe_points"`
+	MinServiceGcSafepoint uint64              `json:"min_service_gc_safe_point,omitempty"`
+	GCSafePoint           uint64              `json:"gc_safe_point"`
+}
+
+// SafePointConfig represents the configurations for safepoint
+type SafePointConfig struct {
+	StartTs         uint64 `json:"start-ts"`
+	TTL             int64  `json:"ttl"`
+	ServiceIdSuffix string `json:"service-id-suffix"`
+}
+type SafePoint struct {
+	ListServiceGCSafepoint
+}

--- a/cdc/api/v2/safe_point_test.go
+++ b/cdc/api/v2/safe_point_test.go
@@ -1,0 +1,211 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	mock_capture "github.com/pingcap/tiflow/cdc/capture/mock"
+	"github.com/pingcap/tiflow/cdc/model"
+	cerrors "github.com/pingcap/tiflow/pkg/errors"
+	"github.com/pingcap/tiflow/pkg/upstream"
+	"github.com/stretchr/testify/require"
+	pd "github.com/tikv/pd/client"
+)
+
+type mockPDClient4SafePoint struct {
+	pd.Client
+	err error
+}
+
+var (
+	startTs       uint64 = 451560023174938623
+	ttl           int64  = 86400
+	serviceID     string = "user-defined"
+	expiredAt     int64  = 1722651185
+	mockSafePoint        = SafePoint{
+		ListServiceGCSafepoint: ListServiceGCSafepoint{
+			ServiceGCSafepoints: []*ServiceSafePoint{
+				{
+					ServiceID: serviceID,
+					ExpiredAt: expiredAt,
+					SafePoint: startTs,
+				},
+			},
+		},
+	}
+)
+
+func (m *mockPDClient4Tso) UpdateServiceGCSafePoint(ctx context.Context, serviceID string, TTL int64, safePoint uint64) (uint64, error) {
+	return startTs, m.err
+}
+
+func TestQuerySafePoint(t *testing.T) {
+	safepoint := testCase{url: "/api/v2/safepoint", method: "GET"}
+
+	cp := mock_capture.NewMockCapture(gomock.NewController(t))
+	helpers := NewMockAPIV2Helpers(gomock.NewController(t))
+	cp.EXPECT().IsOwner().Return(true).AnyTimes()
+	cp.EXPECT().IsReady().Return(true).AnyTimes()
+	helpers.EXPECT().getPDSafepoint(cp).Return(mockSafePoint, nil).AnyTimes()
+
+	apiV2 := NewOpenAPIV2ForTest(cp, helpers)
+	router := newRouter(apiV2)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(),
+		safepoint.method, safepoint.url, nil)
+	router.ServeHTTP(w, req)
+	resp := SafePoint{}
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSetSafePoint(t *testing.T) {
+	t.Parallel()
+
+	mockPDClient := &mockPDClient4Tso{}
+	mockManager := upstream.NewManager4Test(mockPDClient)
+
+	safepoint := testCase{url: "/api/v2/safepoint", method: "POST"}
+	cp := mock_capture.NewMockCapture(gomock.NewController(t))
+	helpers := NewMockAPIV2Helpers(gomock.NewController(t))
+	cp.EXPECT().IsOwner().Return(true).AnyTimes()
+	cp.EXPECT().IsReady().Return(true).AnyTimes()
+	cp.EXPECT().GetUpstreamManager().Return(mockManager, nil).AnyTimes()
+	helpers.EXPECT().getPDSafepoint(cp).Return(mockSafePoint, nil).AnyTimes()
+
+	apiV2 := NewOpenAPIV2ForTest(cp, helpers)
+	router := newRouter(apiV2)
+
+	// case 1: json format mismatches with the spec.
+	errConfig := struct {
+		StartTs         uint64 `json:"start-ts"`
+		TTL             int64  `json:"ttl"` // should bigger than zero
+		ServiceIdSuffix string `json:"service-id-suffix"`
+	}{
+		StartTs: startTs,
+		TTL:     -1,
+	}
+	bodyErr, err := json.Marshal(&errConfig)
+	require.Nil(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(),
+		safepoint.method, safepoint.url, bytes.NewReader(bodyErr))
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	respErr := model.HTTPError{}
+	err = json.NewDecoder(w.Body).Decode(&respErr)
+	require.Nil(t, err)
+	require.Contains(t, respErr.Code, "ErrAPIInvalidParam")
+
+	// case 2: get safepoint failed
+	mockPDClient.err = cerrors.ErrAPIGetPDClientFailed
+	sfConfig := SafePointConfig{
+		TTL: ttl,
+	}
+	body, err := json.Marshal(&sfConfig)
+	require.Nil(t, err)
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequestWithContext(context.Background(),
+		safepoint.method, safepoint.url, bytes.NewReader(body))
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	respErr = model.HTTPError{}
+	err = json.NewDecoder(w.Body).Decode(&respErr)
+	require.Nil(t, err)
+	require.Contains(t, respErr.Code, "ErrInternalServerError")
+
+	// case 3: set safepoint less than minServiceSafePoint
+	mockPDClient.err = nil
+	sfConfig = SafePointConfig{
+		StartTs: startTs - 1,
+		TTL:     ttl,
+	}
+	body, err = json.Marshal(&sfConfig)
+	require.Nil(t, err)
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequestWithContext(context.Background(),
+		safepoint.method, safepoint.url, bytes.NewReader(body))
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	respErr = model.HTTPError{}
+	err = json.NewDecoder(w.Body).Decode(&respErr)
+	require.Nil(t, err)
+	require.Contains(t, respErr.Code, "ErrCliInvalidServiceSafePoint")
+
+	// case4: success
+	w = httptest.NewRecorder()
+	sfConfig = SafePointConfig{
+		StartTs: startTs,
+		TTL:     ttl,
+	}
+	req, _ = http.NewRequestWithContext(context.Background(),
+		safepoint.method, safepoint.url, bytes.NewReader(body))
+	router.ServeHTTP(w, req)
+	resp := SafePoint{}
+	err = json.NewDecoder(w.Body).Decode(&resp)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestDeleteSafePoint(t *testing.T) {
+	t.Parallel()
+
+	mockPDClient := &mockPDClient4Tso{}
+	mockManager := upstream.NewManager4Test(mockPDClient)
+
+	safepoint := testCase{url: "/api/v2/safepoint", method: "DELETE"}
+
+	cp := mock_capture.NewMockCapture(gomock.NewController(t))
+	helpers := NewMockAPIV2Helpers(gomock.NewController(t))
+	cp.EXPECT().IsOwner().Return(true).AnyTimes()
+	cp.EXPECT().IsReady().Return(true).AnyTimes()
+	cp.EXPECT().GetUpstreamManager().Return(mockManager, nil).AnyTimes()
+	helpers.EXPECT().getPDSafepoint(cp).Return(mockSafePoint, nil).AnyTimes()
+
+	apiV2 := NewOpenAPIV2ForTest(cp, helpers)
+	router := newRouter(apiV2)
+
+	// case 1: json format mismatches with the spec.
+	errConfig := struct {
+		StartTs         uint64 `json:"start-ts"`
+		TTL             string `json:"ttl"` // shoule be int64
+		ServiceIdSuffix string `json:"service-id-suffix"`
+	}{
+		StartTs: startTs,
+		TTL:     "ttl",
+	}
+	bodyErr, err := json.Marshal(&errConfig)
+	require.Nil(t, err)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(),
+		safepoint.method, safepoint.url, bytes.NewReader(bodyErr))
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	respErr := model.HTTPError{}
+	err = json.NewDecoder(w.Body).Decode(&respErr)
+	require.Nil(t, err)
+	require.Contains(t, respErr.Code, "ErrAPIInvalidParam")
+
+}

--- a/cdc/api/v2/safepoint.go
+++ b/cdc/api/v2/safepoint.go
@@ -1,0 +1,212 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+	cerror "github.com/pingcap/tiflow/pkg/errors"
+	pd "github.com/tikv/pd/client"
+)
+
+var (
+	serviceGCSafepointPrefix = "/pd/api/v1/gc/safepoint"
+)
+
+func queryListServiceGCSafepoint(endpoint string) (ListServiceGCSafepoint, error) {
+	var safepoint ListServiceGCSafepoint
+	safepointURL, err := url.Parse(endpoint + serviceGCSafepointPrefix)
+	if err != nil {
+		return safepoint, err
+	}
+	resp, err := http.Get(safepointURL.String())
+	if err != nil {
+		return safepoint, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		var msg []byte
+		msg, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return safepoint, err
+		}
+		return safepoint, fmt.Errorf("failed to get response: \"[%d] %s", resp.StatusCode, msg)
+	}
+
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return safepoint, err
+	}
+	if err := json.Unmarshal([]byte(content), &safepoint); err != nil {
+		return safepoint, err
+	}
+	return safepoint, nil
+}
+
+func (h *OpenAPIV2) getServiceID(ServiceIdSuffix string) string {
+	tag := "-" + ServiceIdSuffix
+	return h.capture.GetEtcdClient().GetEnsureGCServiceID(tag)
+}
+
+// querySafePoint request and returns safepoints from PD
+// @Summary Get the safepoint information of a TiCDC node
+// @Description This API is a synchronous interface. If the request is successful,
+// the safepoint information of the corresponding pd is returned.
+//
+// @Tags common,v2
+// @Accept json
+// @Produce json
+// @Success 200 {object} SafePoint
+// @Failure 500,400 {object} model.HTTPError
+// @Router	/api/v2/safepoint [get]
+func (h *OpenAPIV2) querySafePoint(c *gin.Context) {
+	safePointConfig := &SafePointConfig{}
+	if err := c.BindJSON(safePointConfig); err != nil {
+		_ = c.Error(cerror.WrapError(cerror.ErrAPIInvalidParam, err))
+		return
+	}
+	safePoint, err := h.helpers.getPDSafepoint(h.capture)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+	c.IndentedJSON(http.StatusOK, safePoint)
+}
+
+// setSafePoint request and returns safepoints from PD
+// @Summary Set the safepoint information of a TiCDC node
+// @Description This API is a synchronous interface. If the request is successful,
+// the safepoint information of the corresponding pd is returned.
+//
+// @Tags common,v2
+// @Accept json
+// @Produce json
+// @Success 200 {object} SafePoint
+// @Failure 500,400 {object} model.HTTPError
+// @Router	/api/v2/safepoint [post]
+func (h *OpenAPIV2) setSafePoint(c *gin.Context) {
+
+	ctx := c.Request.Context()
+
+	safePointConfig := &SafePointConfig{}
+	if err := c.BindJSON(safePointConfig); err != nil {
+		_ = c.Error(cerror.WrapError(cerror.ErrAPIInvalidParam, err))
+		return
+	}
+	if safePointConfig.TTL <= 0 {
+		_ = c.Error(cerror.WrapError(cerror.ErrAPIInvalidParam, errors.New("can't set ttl<=0")))
+		return
+	}
+	serviceID := h.getServiceID(safePointConfig.ServiceIdSuffix)
+
+	resp := &SafePoint{}
+	err := h.withUpstreamConfig(ctx, &UpstreamConfig{},
+		func(ctx context.Context, client pd.Client) error {
+			minServiceSafePoint, err := client.UpdateServiceGCSafePoint(ctx, serviceID, safePointConfig.TTL, safePointConfig.StartTs)
+			if err != nil {
+				return err
+			}
+			if minServiceSafePoint > safePointConfig.StartTs {
+				// query safepoint for update
+				// safePoint, err := h.getPDSafepoint()
+				// if err == nil {
+				// 	for _, s := range safePoint.ServiceGCSafepoints {
+				// 		if s.ServiceID == serviceID {
+				// 			if _, err := client.UpdateServiceGCSafePoint(ctx, serviceID, safePointConfig.TTL, safePointConfig.StartTs); err != nil {
+				// 				return err
+				// 			}
+				// 			break
+				// 		}
+				// 	}
+				// }
+				return cerror.ErrCliInvalidServiceSafePoint.GenWithStackByArgs(minServiceSafePoint, safePointConfig.StartTs)
+			}
+			safePoint, err := h.helpers.getPDSafepoint(h.capture)
+			if err != nil {
+				return err
+			}
+			resp = safePoint
+			return nil
+		})
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+	c.IndentedJSON(http.StatusOK, resp)
+}
+
+// deleteSafePoint request and returns safepoints from PD
+// @Summary Delete the safepoint information of a TiCDC node
+// @Description This API is a synchronous interface. If the request is successful,
+// the safepoint information of the corresponding pd is returned.
+//
+// @Tags common,v2
+// @Accept json
+// @Produce json
+// @Success 200 {object} SafePoint
+// @Failure 500,400 {object} model.HTTPError
+// @Router	/api/v2/safepoint [delete]
+func (h *OpenAPIV2) deleteSafePoint(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	safePointConfig := &SafePointConfig{}
+	if err := c.BindJSON(safePointConfig); err != nil {
+		_ = c.Error(cerror.WrapError(cerror.ErrAPIInvalidParam, err))
+		return
+	}
+	serviceID := h.getServiceID(safePointConfig.ServiceIdSuffix)
+
+	resp := &SafePoint{}
+	err := h.withUpstreamConfig(ctx, &UpstreamConfig{},
+		func(ctx context.Context, client pd.Client) error {
+			// set ttl equal zero
+			minServiceSafePoint, err := client.UpdateServiceGCSafePoint(ctx, serviceID, 0, safePointConfig.StartTs)
+			if err != nil {
+				return err
+			}
+			if minServiceSafePoint > safePointConfig.StartTs {
+				// query safepoint for delete
+				// safePoint, err := h.getPDSafepoint()
+				// if err == nil {
+				// 	for _, s := range safePoint.ServiceGCSafepoints {
+				// 		if s.ServiceID == serviceID {
+				// 			if _, err := client.UpdateServiceGCSafePoint(ctx, serviceID, 0, safePointConfig.StartTs); err != nil {
+				// 				return err
+				// 			}
+				// 			break
+				// 		}
+				// 	}
+				// }
+				return cerror.ErrCliInvalidServiceSafePoint.GenWithStackByArgs(minServiceSafePoint, safePointConfig.StartTs)
+			}
+			safePoint, err := h.helpers.getPDSafepoint(h.capture)
+			if err != nil {
+				return err
+			}
+			resp = safePoint
+			return nil
+		})
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+	c.IndentedJSON(http.StatusOK, resp)
+}

--- a/cdc/api/v2/safepoint.go
+++ b/cdc/api/v2/safepoint.go
@@ -66,6 +66,14 @@ func (h *OpenAPIV2) getServiceID(ServiceIdSuffix string) string {
 	return h.capture.GetEtcdClient().GetEnsureGCServiceID(tag)
 }
 
+func (h *OpenAPIV2) getPDSafepoint() (*SafePoint, error) {
+	up, err := getCaptureDefaultUpstream(h.capture)
+	if err != nil {
+		return nil, err
+	}
+	return h.helpers.getPDSafepoint(up.PdEndpoints)
+}
+
 // querySafePoint request and returns safepoints from PD
 // @Summary Get the safepoint information of a TiCDC node
 // @Description This API is a synchronous interface. If the request is successful,
@@ -83,7 +91,7 @@ func (h *OpenAPIV2) querySafePoint(c *gin.Context) {
 		_ = c.Error(cerror.WrapError(cerror.ErrAPIInvalidParam, err))
 		return
 	}
-	safePoint, err := h.helpers.getPDSafepoint(h.capture)
+	safePoint, err := h.getPDSafepoint()
 	if err != nil {
 		_ = c.Error(err)
 		return
@@ -139,7 +147,7 @@ func (h *OpenAPIV2) setSafePoint(c *gin.Context) {
 				// }
 				return cerror.ErrCliInvalidServiceSafePoint.GenWithStackByArgs(minServiceSafePoint, safePointConfig.StartTs)
 			}
-			safePoint, err := h.helpers.getPDSafepoint(h.capture)
+			safePoint, err := h.getPDSafepoint()
 			if err != nil {
 				return err
 			}
@@ -197,7 +205,7 @@ func (h *OpenAPIV2) deleteSafePoint(c *gin.Context) {
 				// }
 				return cerror.ErrCliInvalidServiceSafePoint.GenWithStackByArgs(minServiceSafePoint, safePointConfig.StartTs)
 			}
-			safePoint, err := h.helpers.getPDSafepoint(h.capture)
+			safePoint, err := h.getPDSafepoint()
 			if err != nil {
 				return err
 			}

--- a/pkg/api/v2/api_client.go
+++ b/pkg/api/v2/api_client.go
@@ -27,6 +27,7 @@ type APIV2Interface interface {
 	RESTClient() rest.CDCRESTInterface
 	ChangefeedsGetter
 	TsoGetter
+	SafePointGetter
 	UnsafeGetter
 	StatusGetter
 	CapturesGetter
@@ -53,6 +54,14 @@ func (c *APIV2Client) Tso() TsoInterface {
 		return nil
 	}
 	return newTso(c)
+}
+
+// Tso returns a TsoInterface to communicate with cdc api
+func (c *APIV2Client) SafePoint() SafePointInterface {
+	if c == nil {
+		return nil
+	}
+	return newSafePoint(c)
 }
 
 // Unsafe returns a UnsafeInterface to communicate with cdc api

--- a/pkg/api/v2/safepoint.go
+++ b/pkg/api/v2/safepoint.go
@@ -1,0 +1,78 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"context"
+
+	v2 "github.com/pingcap/tiflow/cdc/api/v2"
+	"github.com/pingcap/tiflow/pkg/api/internal/rest"
+)
+
+// SafePointGetter has a method to return a StatusInterface.
+type SafePointGetter interface {
+	SafePoint() SafePointInterface
+}
+
+// SafePointInterface has methods to work with status api
+type SafePointInterface interface {
+	Query(ctx context.Context, config *v2.SafePointConfig) (*v2.SafePoint, error)
+	Set(ctx context.Context, config *v2.SafePointConfig) (*v2.SafePoint, error)
+	Delete(ctx context.Context, config *v2.SafePointConfig) (*v2.SafePoint, error)
+}
+
+// SafePoint implements StatusGetter
+type SafePoint struct {
+	client rest.CDCRESTInterface
+}
+
+// newSafePoint returns SafePoint
+func newSafePoint(c *APIV2Client) *SafePoint {
+	return &SafePoint{
+		client: c.RESTClient(),
+	}
+}
+
+// Query returns the pd SafePoint
+func (c *SafePoint) Query(ctx context.Context, config *v2.SafePointConfig) (*v2.SafePoint, error) {
+	result := new(v2.SafePoint)
+	err := c.client.Get().
+		WithURI("safepoint").
+		WithBody(config).
+		Do(ctx).
+		Into(result)
+	return result, err
+}
+
+// Set returns the pd SafePoint
+func (c *SafePoint) Set(ctx context.Context, config *v2.SafePointConfig) (*v2.SafePoint, error) {
+	result := new(v2.SafePoint)
+	err := c.client.Post().
+		WithURI("safepoint").
+		WithBody(config).
+		Do(ctx).
+		Into(result)
+	return result, err
+}
+
+// Delete returns the pd SafePoint
+func (c *SafePoint) Delete(ctx context.Context, config *v2.SafePointConfig) (*v2.SafePoint, error) {
+	result := new(v2.SafePoint)
+	err := c.client.Delete().
+		WithURI("safepoint").
+		WithBody(config).
+		Do(ctx).
+		Into(result)
+	return result, err
+}

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -56,6 +56,7 @@ func NewCmdCli() *cobra.Command {
 	cmds.AddCommand(newCmdChangefeed(f))
 	cmds.AddCommand(newCmdProcessor(f))
 	cmds.AddCommand(newCmdTso(f))
+	cmds.AddCommand(newCmdSafePoint(f))
 	cmds.AddCommand(newCmdUnsafe(f))
 	cmds.AddCommand(newConfigureCredentials())
 

--- a/pkg/cmd/cli/cli_safepoint.go
+++ b/pkg/cmd/cli/cli_safepoint.go
@@ -1,0 +1,33 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/pingcap/tiflow/pkg/cmd/factory"
+	"github.com/spf13/cobra"
+)
+
+// newCmdSafePoint creates the `cli safepoint` command.
+func newCmdSafePoint(f factory.Factory) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "safepoint",
+		Short: "Manage safepoint",
+	}
+
+	command.AddCommand(newCmdQuerySafePoint(f))
+	command.AddCommand(newCmdSetSafePoint(f))
+	command.AddCommand(newCmdDeleteSafePoint(f))
+
+	return command
+}

--- a/pkg/cmd/cli/cli_safepoint_delete.go
+++ b/pkg/cmd/cli/cli_safepoint_delete.go
@@ -1,0 +1,84 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	v2 "github.com/pingcap/tiflow/cdc/api/v2"
+	apiv2client "github.com/pingcap/tiflow/pkg/api/v2"
+	cmdcontext "github.com/pingcap/tiflow/pkg/cmd/context"
+	"github.com/pingcap/tiflow/pkg/cmd/factory"
+	"github.com/pingcap/tiflow/pkg/cmd/util"
+	"github.com/spf13/cobra"
+)
+
+// deleteSafePointOptions defines flags for the `cli safepoint query` command.
+type deleteSafePointOptions struct {
+	startTs         uint64
+	serviceIdSuffix string
+	clientV2        apiv2client.APIV2Interface
+}
+
+// newDeleteSafePointOptions creates new deleteSafePointOptions for the `cli safepoint query` command.
+func newDeleteSafePointOptions() *deleteSafePointOptions {
+	return &deleteSafePointOptions{}
+}
+
+// addFlags receives a *cobra.Command reference and binds
+// flags related to template printing to it.
+func (o *deleteSafePointOptions) addFlags(cmd *cobra.Command) {
+
+	cmd.PersistentFlags().StringVarP(&o.serviceIdSuffix, "service-id-suffix", "", "user-defined", "serviceIdSuffix")
+	cmd.PersistentFlags().Uint64Var(&o.startTs, "start-ts", 0, "set cdc safepoint start-ts")
+
+	// _ = cmd.MarkPersistentFlagRequired("start-ts")
+}
+
+// complete adapts from the command line args to the data and client required.
+func (o *deleteSafePointOptions) complete(f factory.Factory) error {
+	clientV2, err := f.APIV2Client()
+	if err != nil {
+		return err
+	}
+	o.clientV2 = clientV2
+	return nil
+}
+
+func (o *deleteSafePointOptions) deleteSafePoint(cmd *cobra.Command, f factory.Factory) error {
+	ctx := cmdcontext.GetDefaultContext()
+	safepoint, err := o.clientV2.SafePoint().Delete(ctx, &v2.SafePointConfig{
+		StartTs:         o.startTs,
+		ServiceIdSuffix: o.serviceIdSuffix,
+	})
+	if err != nil {
+		return err
+	}
+	return util.JSONPrint(cmd, safepoint)
+}
+
+// newCmdDeleteSafePoint creates the `cli safepoint delete` command.
+func newCmdDeleteSafePoint(f factory.Factory) *cobra.Command {
+	o := newDeleteSafePointOptions()
+	command := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete safepoint",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(o.complete(f))
+			util.CheckErr(o.deleteSafePoint(cmd, f))
+		},
+	}
+	o.addFlags(command)
+
+	return command
+}

--- a/pkg/cmd/cli/cli_safepoint_query.go
+++ b/pkg/cmd/cli/cli_safepoint_query.go
@@ -1,0 +1,91 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+
+	v2 "github.com/pingcap/tiflow/cdc/api/v2"
+	apiv2client "github.com/pingcap/tiflow/pkg/api/v2"
+	cmdcontext "github.com/pingcap/tiflow/pkg/cmd/context"
+	"github.com/pingcap/tiflow/pkg/cmd/factory"
+	"github.com/pingcap/tiflow/pkg/cmd/util"
+	"github.com/spf13/cobra"
+)
+
+// querySafePointOptions defines flags for the `cli safepoint query` command.
+type querySafePointOptions struct {
+	onlyCDC  bool
+	clientV2 apiv2client.APIV2Interface
+}
+
+// querySafePointOptions creates new querySafePointOptions for the `cli safepoint query` command.
+func newQuerySafePointOptions() *querySafePointOptions {
+	return &querySafePointOptions{}
+}
+
+func (o *querySafePointOptions) addFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().BoolVar(&o.onlyCDC, "cdc", false, "show cdc only")
+}
+
+func (o *querySafePointOptions) finish(f factory.Factory) error {
+	clientV2, err := f.APIV2Client()
+	if err != nil {
+		return err
+	}
+	o.clientV2 = clientV2
+	return nil
+}
+
+// showSafePoints query pd to get all safepoints
+func (o *querySafePointOptions) showSafePoints(cmd *cobra.Command) error {
+	ctx := cmdcontext.GetDefaultContext()
+	safepoint, err := o.clientV2.SafePoint().Query(ctx, &v2.SafePointConfig{})
+	if err != nil {
+		return err
+	}
+	if o.onlyCDC {
+		points := make([]*v2.ServiceSafePoint, 0)
+		for _, point := range safepoint.ServiceGCSafepoints {
+			if strings.HasPrefix(point.ServiceID, "ticdc") {
+				points = append(points, point)
+			}
+		}
+		safepoint.ServiceGCSafepoints = points
+	}
+	data, err := json.MarshalIndent(safepoint, "", "  ")
+	if err != nil {
+		return err
+	}
+	cmd.Println(string(data))
+	return nil
+}
+
+// newCmdQuerySafePoint creates the `cli safepoint query` command.
+func newCmdQuerySafePoint(f factory.Factory) *cobra.Command {
+	o := newQuerySafePointOptions()
+	command := &cobra.Command{
+		Use:   "query",
+		Short: "Get safepoint from PD",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(o.finish(f))
+			util.CheckErr(o.showSafePoints(cmd))
+		},
+	}
+	o.addFlags(command)
+
+	return command
+}

--- a/pkg/cmd/cli/cli_safepoint_query.go
+++ b/pkg/cmd/cli/cli_safepoint_query.go
@@ -78,7 +78,7 @@ func newCmdQuerySafePoint(f factory.Factory) *cobra.Command {
 	o := newQuerySafePointOptions()
 	command := &cobra.Command{
 		Use:   "query",
-		Short: "Get safepoint from PD",
+		Short: "Get safepoint",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			util.CheckErr(o.finish(f))

--- a/pkg/cmd/cli/cli_safepoint_set.go
+++ b/pkg/cmd/cli/cli_safepoint_set.go
@@ -1,0 +1,89 @@
+// Copyright 2024 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	v2 "github.com/pingcap/tiflow/cdc/api/v2"
+	apiv2client "github.com/pingcap/tiflow/pkg/api/v2"
+	cmdcontext "github.com/pingcap/tiflow/pkg/cmd/context"
+	"github.com/pingcap/tiflow/pkg/cmd/factory"
+	"github.com/pingcap/tiflow/pkg/cmd/util"
+	"github.com/spf13/cobra"
+)
+
+// setSafePointOptions defines flags for the `cli safepoint query` command.
+type setSafePointOptions struct {
+	startTs         uint64
+	ttl             int64
+	serviceIdSuffix string
+	clientV2        apiv2client.APIV2Interface
+}
+
+// newSetSafePointOptions creates new setSafePointOptions for the `cli safepoint query` command.
+func newSetSafePointOptions() *setSafePointOptions {
+	return &setSafePointOptions{}
+}
+
+// addFlags receives a *cobra.Command reference and binds
+// flags related to template printing to it.
+func (o *setSafePointOptions) addFlags(cmd *cobra.Command) {
+
+	cmd.PersistentFlags().StringVarP(&o.serviceIdSuffix, "service-id-suffix", "", "user-defined", "serviceIdSuffix")
+	cmd.PersistentFlags().Uint64Var(&o.startTs, "start-ts", 0, "set cdc safepoint start-ts")
+	cmd.PersistentFlags().Int64Var(&o.ttl, "ttl", 86400, "set gc-ttl")
+
+	// _ = cmd.MarkPersistentFlagRequired("service-id-suffix")
+	// _ = cmd.MarkPersistentFlagRequired("start-ts")
+	// _ = cmd.MarkPersistentFlagRequired("ttl")
+}
+
+// complete adapts from the command line args to the data and client required.
+func (o *setSafePointOptions) complete(f factory.Factory) error {
+	clientV2, err := f.APIV2Client()
+	if err != nil {
+		return err
+	}
+	o.clientV2 = clientV2
+	return nil
+}
+
+func (o *setSafePointOptions) setSafePoint(cmd *cobra.Command, f factory.Factory) error {
+	ctx := cmdcontext.GetDefaultContext()
+	safepoint, err := o.clientV2.SafePoint().Set(ctx, &v2.SafePointConfig{
+		StartTs:         o.startTs,
+		ServiceIdSuffix: o.serviceIdSuffix,
+		TTL:             o.ttl,
+	})
+	if err != nil {
+		return err
+	}
+	return util.JSONPrint(cmd, safepoint)
+}
+
+// newCmdSetSafePoint creates the `cli safepoint set` command.
+func newCmdSetSafePoint(f factory.Factory) *cobra.Command {
+	o := newSetSafePointOptions()
+	command := &cobra.Command{
+		Use:   "set",
+		Short: "Set safepoint",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			util.CheckErr(o.complete(f))
+			util.CheckErr(o.setSafePoint(cmd, f))
+		},
+	}
+	o.addFlags(command)
+
+	return command
+}

--- a/pkg/errors/cdc_errors.go
+++ b/pkg/errors/cdc_errors.go
@@ -907,6 +907,10 @@ var (
 		"command '%s' is aborted by user",
 		errors.RFCCodeText("CDC:ErrCliAborted"),
 	)
+	ErrCliInvalidServiceSafePoint = errors.Normalize(
+		"the minServiceSafePoint is bigger than servicesafepoint, minServiceSafePoint:%d StartTs:%d",
+		errors.RFCCodeText("CDC:ErrCliInvalidServiceSafePoint"),
+	)
 	// Filter error
 	ErrFailedToFilterDML = errors.Normalize(
 		"failed to filter dml event: %v, please report a bug",


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11470

### What is changed and how it works?
Add safepoint command which can query, set and delete servicesafepoint. It works by updating ttl with `pd.client.UpdateServiceGCSafePoint` and query [pd's API](https://github.com/tikv/pd/blob/5e0fdb84e587fe7e32cf5f21c776e2b1486ce428/tools/pd-ctl/pdctl/command/gc_safepoint_command.go#L27) to show all service gc safepoints.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?
need update user documentation
### Release note <!-- bugfixes or new features need a release note -->

```release-note
None.
```
