### PR TITLE
alter(ticdc): fix alter calculation for cdc_multiple_owners and cdc_no_owners

### DIFF
--- a/metrics/alertmanager/ticdc.rules.yml
+++ b/metrics/alertmanager/ticdc.rules.yml
@@ -3,24 +3,24 @@ groups:
   rules:
   # server related alter rules
   - alert: cdc_multiple_owners
-    expr: sum(rate(ticdc_owner_ownership_counter[240s])) >= 0.125
+    expr: sum(rate(ticdc_owner_ownership_counter[240s])) >= 2
     for: 1m
     labels:
       env: ENV_LABELS_ENV
       level: warning
-      expr: sum(rate(ticdc_owner_ownership_counter[240s])) >= 0.125
+      expr: sum(rate(ticdc_owner_ownership_counter[240s])) >= 2
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values: {{ $value }}'
       value: '{{ $value }}'
       summary: cdc cluster has multiple owners
 
   - alert: cdc_no_owner
-    expr: sum(rate(ticdc_owner_ownership_counter[240s])) < 0.0625
+    expr: sum(rate(ticdc_owner_ownership_counter[240s])) < 0.5
     for: 10m
     labels:
       env: ENV_LABELS_ENV
       level: warning
-      expr: sum(rate(ticdc_owner_ownership_counter[240s])) < 0.0625
+      expr: sum(rate(ticdc_owner_ownership_counter[240s])) < 0.5
     annotations:
       description: 'cluster: ENV_LABELS_ENV, instance: {{ $labels.instance }}, values: {{ $value }}'
       value: '{{ $value }}'


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/10796

### What is changed and how it works?
Fix alter calculation for cdc_multiple_owners and cdc_no_owners

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
