### PR TITLE
mysql sink(ticdc): Refactor DB Connection Creation to Facilitate Unit Testing

### DIFF
--- a/cdc/sink/ddlsink/mysql/async_ddl_test.go
+++ b/cdc/sink/ddlsink/mysql/async_ddl_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -33,18 +32,13 @@ import (
 )
 
 func TestWaitAsynExecDone(t *testing.T) {
-	var dbIndex int32 = 0
-	GetDBConnImpl = func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		defer func() {
-			atomic.AddInt32(&dbIndex, 1)
-		}()
-		if atomic.LoadInt32(&dbIndex) == 0 {
-			// test db
-			db, err := pmysql.MockTestDB()
-			require.Nil(t, err)
-			return db, nil
-		}
-		// normal db
+	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
+	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
+		db, err := pmysql.MockTestDB()
+		require.Nil(t, err)
+		return db, nil
+	})
+	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.Nil(t, err)
 		mock.ExpectQuery("select tidb_version()").
@@ -71,7 +65,8 @@ func TestWaitAsynExecDone(t *testing.T) {
 
 		mock.ExpectClose()
 		return db, nil
-	}
+	})
+	GetDBConnImpl = &dbConnFactory
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -116,18 +111,13 @@ func TestWaitAsynExecDone(t *testing.T) {
 
 func TestAsyncExecAddIndex(t *testing.T) {
 	ddlExecutionTime := time.Second * 15
-	var dbIndex int32 = 0
-	GetDBConnImpl = func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		defer func() {
-			atomic.AddInt32(&dbIndex, 1)
-		}()
-		if atomic.LoadInt32(&dbIndex) == 0 {
-			// test db
-			db, err := pmysql.MockTestDB()
-			require.Nil(t, err)
-			return db, nil
-		}
-		// normal db
+	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
+	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
+		db, err := pmysql.MockTestDB()
+		require.Nil(t, err)
+		return db, nil
+	})
+	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.Nil(t, err)
 		mock.ExpectQuery("select tidb_version()").
@@ -145,7 +135,8 @@ func TestAsyncExecAddIndex(t *testing.T) {
 		mock.ExpectCommit()
 		mock.ExpectClose()
 		return db, nil
-	}
+	})
+	GetDBConnImpl = &dbConnFactory
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cdc/sink/ddlsink/mysql/async_ddl_test.go
+++ b/cdc/sink/ddlsink/mysql/async_ddl_test.go
@@ -32,12 +32,7 @@ import (
 )
 
 func TestWaitAsynExecDone(t *testing.T) {
-	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
-	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		db, err := pmysql.MockTestDB()
-		require.Nil(t, err)
-		return db, nil
-	})
+	dbConnFactory := pmysql.NewDBConnectionFactoryForTest()
 	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.Nil(t, err)
@@ -66,7 +61,7 @@ func TestWaitAsynExecDone(t *testing.T) {
 		mock.ExpectClose()
 		return db, nil
 	})
-	GetDBConnImpl = &dbConnFactory
+	GetDBConnImpl = dbConnFactory
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -111,12 +106,7 @@ func TestWaitAsynExecDone(t *testing.T) {
 
 func TestAsyncExecAddIndex(t *testing.T) {
 	ddlExecutionTime := time.Second * 15
-	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
-	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		db, err := pmysql.MockTestDB()
-		require.Nil(t, err)
-		return db, nil
-	})
+	dbConnFactory := pmysql.NewDBConnectionFactoryForTest()
 	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.Nil(t, err)
@@ -136,7 +126,7 @@ func TestAsyncExecAddIndex(t *testing.T) {
 		mock.ExpectClose()
 		return db, nil
 	})
-	GetDBConnImpl = &dbConnFactory
+	GetDBConnImpl = dbConnFactory
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cdc/sink/ddlsink/mysql/mysql_ddl_sink.go
+++ b/cdc/sink/ddlsink/mysql/mysql_ddl_sink.go
@@ -46,7 +46,7 @@ const (
 
 // GetDBConnImpl is the implementation of pmysql.Factory.
 // Exported for testing.
-var GetDBConnImpl pmysql.Factory = pmysql.CreateMySQLDBConn
+var GetDBConnImpl pmysql.ConnectionFactory = pmysql.CreateMySQLDBConn
 
 // Assert Sink implementation
 var _ ddlsink.Sink = (*DDLSink)(nil)

--- a/cdc/sink/ddlsink/mysql/mysql_ddl_sink.go
+++ b/cdc/sink/ddlsink/mysql/mysql_ddl_sink.go
@@ -44,9 +44,9 @@ const (
 	networkDriftDuration = 5 * time.Second
 )
 
-// GetDBConnImpl is the implementation of pmysql.Factory.
+// GetDBConnImpl is the implementation of pmysql.IDBConnectionFactory.
 // Exported for testing.
-var GetDBConnImpl pmysql.ConnectionFactory = pmysql.CreateMySQLDBConn
+var GetDBConnImpl pmysql.IDBConnectionFactory = &pmysql.DBConnectionFactory{}
 
 // Assert Sink implementation
 var _ ddlsink.Sink = (*DDLSink)(nil)
@@ -81,12 +81,12 @@ func NewDDLSink(
 		return nil, err
 	}
 
-	dsnStr, err := pmysql.GenerateDSN(ctx, sinkURI, cfg, GetDBConnImpl)
+	dsnStr, err := pmysql.GenerateDSN(ctx, sinkURI, cfg, GetDBConnImpl.CreateTemporaryConnection)
 	if err != nil {
 		return nil, err
 	}
 
-	db, err := GetDBConnImpl(ctx, dsnStr)
+	db, err := GetDBConnImpl.CreateStandardConnection(ctx, dsnStr)
 	if err != nil {
 		return nil, err
 	}

--- a/cdc/sink/ddlsink/mysql/mysql_ddl_sink_test.go
+++ b/cdc/sink/ddlsink/mysql/mysql_ddl_sink_test.go
@@ -30,12 +30,7 @@ import (
 )
 
 func TestWriteDDLEvent(t *testing.T) {
-	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
-	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		db, err := pmysql.MockTestDB()
-		require.Nil(t, err)
-		return db, nil
-	})
+	dbConnFactory := pmysql.NewDBConnectionFactoryForTest()
 	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 		require.Nil(t, err)
@@ -62,7 +57,7 @@ func TestWriteDDLEvent(t *testing.T) {
 		mock.ExpectClose()
 		return db, nil
 	})
-	GetDBConnImpl = &dbConnFactory
+	GetDBConnImpl = dbConnFactory
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cdc/sink/dmlsink/txn/mysql/mysql.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql.go
@@ -86,7 +86,7 @@ func NewMySQLBackends(
 	changefeedID model.ChangeFeedID,
 	sinkURI *url.URL,
 	replicaConfig *config.ReplicaConfig,
-	dbConnFactory pmysql.ConnectionFactory,
+	dbConnFactory pmysql.IDBConnectionFactory,
 	statistics *metrics.Statistics,
 ) ([]*mysqlBackend, error) {
 	changefeed := fmt.Sprintf("%s.%s", changefeedID.Namespace, changefeedID.ID)
@@ -97,12 +97,12 @@ func NewMySQLBackends(
 		return nil, err
 	}
 
-	dsnStr, err := pmysql.GenerateDSN(ctx, sinkURI, cfg, dbConnFactory)
+	dsnStr, err := pmysql.GenerateDSN(ctx, sinkURI, cfg, dbConnFactory.CreateTemporaryConnection)
 	if err != nil {
 		return nil, err
 	}
 
-	db, err := dbConnFactory(ctx, dsnStr)
+	db, err := dbConnFactory.CreateStandardConnection(ctx, dsnStr)
 	if err != nil {
 		return nil, err
 	}

--- a/cdc/sink/dmlsink/txn/mysql/mysql.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql.go
@@ -86,7 +86,7 @@ func NewMySQLBackends(
 	changefeedID model.ChangeFeedID,
 	sinkURI *url.URL,
 	replicaConfig *config.ReplicaConfig,
-	dbConnFactory pmysql.Factory,
+	dbConnFactory pmysql.ConnectionFactory,
 	statistics *metrics.Statistics,
 ) ([]*mysqlBackend, error) {
 	changefeed := fmt.Sprintf("%s.%s", changefeedID.Namespace, changefeedID.ID)

--- a/cdc/sink/dmlsink/txn/mysql/mysql_test.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql_test.go
@@ -68,7 +68,7 @@ func newMySQLBackend(
 	changefeedID model.ChangeFeedID,
 	sinkURI *url.URL,
 	replicaConfig *config.ReplicaConfig,
-	dbConnFactory pmysql.Factory,
+	dbConnFactory pmysql.ConnectionFactory,
 ) (*mysqlBackend, error) {
 	ctx1, cancel := context.WithCancel(ctx)
 	statistics := metrics.NewStatistics(ctx1, changefeedID, sink.TxnSink)

--- a/cdc/sink/dmlsink/txn/mysql/mysql_test.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql_test.go
@@ -205,12 +205,7 @@ func TestAdjustSQLMode(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
-	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		db, err := pmysql.MockTestDB()
-		require.Nil(t, err)
-		return db, nil
-	})
+	dbConnFactory := pmysql.NewDBConnectionFactoryForTest()
 	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectClose()
@@ -222,7 +217,7 @@ func TestAdjustSQLMode(t *testing.T) {
 		"&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed),
-		sinkURI, config.GetDefaultReplicaConfig(), &dbConnFactory)
+		sinkURI, config.GetDefaultReplicaConfig(), dbConnFactory)
 	require.Nil(t, err)
 	require.Nil(t, sink.Close())
 }
@@ -291,12 +286,7 @@ func TestNewMySQLTimeout(t *testing.T) {
 
 // Test OnTxnEvent and Flush interfaces. Event callbacks should be called correctly after flush.
 func TestNewMySQLBackendExecDML(t *testing.T) {
-	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
-	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		db, err := pmysql.MockTestDB()
-		require.Nil(t, err)
-		return db, nil
-	})
+	dbConnFactory := pmysql.NewDBConnectionFactoryForTest()
 	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectBegin()
@@ -319,7 +309,7 @@ func TestNewMySQLBackendExecDML(t *testing.T) {
 		"mysql://127.0.0.1:4000/?time-zone=UTC&worker-count=1&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), &dbConnFactory)
+		config.GetDefaultReplicaConfig(), dbConnFactory)
 	require.Nil(t, err)
 
 	tableInfo := model.BuildTableInfo("s1", "t1", []*model.Column{
@@ -423,12 +413,7 @@ func TestExecDMLRollbackErrDatabaseNotExists(t *testing.T) {
 		Number: uint16(infoschema.ErrDatabaseNotExists.Code()),
 	}
 
-	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
-	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		db, err := pmysql.MockTestDB()
-		require.Nil(t, err)
-		return db, nil
-	})
+	dbConnFactory := pmysql.NewDBConnectionFactoryForTest()
 	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectBegin()
@@ -447,7 +432,7 @@ func TestExecDMLRollbackErrDatabaseNotExists(t *testing.T) {
 		"mysql://127.0.0.1:4000/?time-zone=UTC&worker-count=1&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), &dbConnFactory)
+		config.GetDefaultReplicaConfig(), dbConnFactory)
 	require.Nil(t, err)
 
 	_ = sink.OnTxnEvent(&dmlsink.TxnCallbackableEvent{
@@ -495,12 +480,7 @@ func TestExecDMLRollbackErrTableNotExists(t *testing.T) {
 		Number: uint16(infoschema.ErrTableNotExists.Code()),
 	}
 
-	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
-	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		db, err := pmysql.MockTestDB()
-		require.Nil(t, err)
-		return db, nil
-	})
+	dbConnFactory := pmysql.NewDBConnectionFactoryForTest()
 	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectBegin()
@@ -519,7 +499,7 @@ func TestExecDMLRollbackErrTableNotExists(t *testing.T) {
 		"mysql://127.0.0.1:4000/?time-zone=UTC&worker-count=1&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), &dbConnFactory)
+		config.GetDefaultReplicaConfig(), dbConnFactory)
 	require.Nil(t, err)
 
 	_ = sink.OnTxnEvent(&dmlsink.TxnCallbackableEvent{
@@ -567,12 +547,7 @@ func TestExecDMLRollbackErrRetryable(t *testing.T) {
 		Number: mysql.ErrLockDeadlock,
 	}
 
-	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
-	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		db, err := pmysql.MockTestDB()
-		require.Nil(t, err)
-		return db, nil
-	})
+	dbConnFactory := pmysql.NewDBConnectionFactoryForTest()
 	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		for i := 0; i < 2; i++ {
@@ -593,7 +568,7 @@ func TestExecDMLRollbackErrRetryable(t *testing.T) {
 		"mysql://127.0.0.1:4000/?time-zone=UTC&worker-count=1&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), &dbConnFactory)
+		config.GetDefaultReplicaConfig(), dbConnFactory)
 	require.Nil(t, err)
 	sink.setDMLMaxRetry(2)
 
@@ -631,12 +606,7 @@ func TestMysqlSinkNotRetryErrDupEntry(t *testing.T) {
 		},
 	}
 
-	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
-	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		db, err := pmysql.MockTestDB()
-		require.Nil(t, err)
-		return db, nil
-	})
+	dbConnFactory := pmysql.NewDBConnectionFactoryForTest()
 	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectBegin()
@@ -657,7 +627,7 @@ func TestMysqlSinkNotRetryErrDupEntry(t *testing.T) {
 			"&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), &dbConnFactory)
+		config.GetDefaultReplicaConfig(), dbConnFactory)
 	require.Nil(t, err)
 	sink.setDMLMaxRetry(1)
 	_ = sink.OnTxnEvent(&dmlsink.TxnCallbackableEvent{
@@ -678,12 +648,7 @@ func TestNeedSwitchDB(t *testing.T) {
 }
 
 func TestNewMySQLBackend(t *testing.T) {
-	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
-	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		db, err := pmysql.MockTestDB()
-		require.Nil(t, err)
-		return db, nil
-	})
+	dbConnFactory := pmysql.NewDBConnectionFactoryForTest()
 	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectClose()
@@ -698,7 +663,7 @@ func TestNewMySQLBackend(t *testing.T) {
 		"&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), &dbConnFactory)
+		config.GetDefaultReplicaConfig(), dbConnFactory)
 
 	require.Nil(t, err)
 	require.Nil(t, sink.Close())
@@ -707,12 +672,7 @@ func TestNewMySQLBackend(t *testing.T) {
 }
 
 func TestNewMySQLBackendWithIPv6Address(t *testing.T) {
-	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
-	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		db, err := pmysql.MockTestDB()
-		require.Nil(t, err)
-		return db, nil
-	})
+	dbConnFactory := pmysql.NewDBConnectionFactoryForTest()
 	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectClose()
@@ -727,18 +687,13 @@ func TestNewMySQLBackendWithIPv6Address(t *testing.T) {
 		"&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), &dbConnFactory)
+		config.GetDefaultReplicaConfig(), dbConnFactory)
 	require.Nil(t, err)
 	require.Nil(t, sink.Close())
 }
 
 func TestGBKSupported(t *testing.T) {
-	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
-	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		db, err := pmysql.MockTestDB()
-		require.Nil(t, err)
-		return db, nil
-	})
+	dbConnFactory := pmysql.NewDBConnectionFactoryForTest()
 	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectClose()
@@ -758,7 +713,7 @@ func TestGBKSupported(t *testing.T) {
 		"&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), &dbConnFactory)
+		config.GetDefaultReplicaConfig(), dbConnFactory)
 	require.Nil(t, err)
 
 	// no gbk-related warning log will be output because GBK charset is supported
@@ -788,12 +743,7 @@ func TestHolderString(t *testing.T) {
 }
 
 func TestMySQLSinkExecDMLError(t *testing.T) {
-	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
-	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		db, err := pmysql.MockTestDB()
-		require.Nil(t, err)
-		return db, nil
-	})
+	dbConnFactory := pmysql.NewDBConnectionFactoryForTest()
 	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectBegin()
@@ -810,7 +760,7 @@ func TestMySQLSinkExecDMLError(t *testing.T) {
 		"mysql://127.0.0.1:4000/?time-zone=UTC&worker-count=1&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), &dbConnFactory)
+		config.GetDefaultReplicaConfig(), dbConnFactory)
 	require.Nil(t, err)
 
 	tableInfo := model.BuildTableInfo("s1", "t1", []*model.Column{

--- a/cdc/sink/dmlsink/txn/mysql/mysql_test.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql_test.go
@@ -68,7 +68,7 @@ func newMySQLBackend(
 	changefeedID model.ChangeFeedID,
 	sinkURI *url.URL,
 	replicaConfig *config.ReplicaConfig,
-	dbConnFactory pmysql.ConnectionFactory,
+	dbConnFactory pmysql.IDBConnectionFactory,
 ) (*mysqlBackend, error) {
 	ctx1, cancel := context.WithCancel(ctx)
 	statistics := metrics.NewStatistics(ctx1, changefeedID, sink.TxnSink)
@@ -205,29 +205,24 @@ func TestAdjustSQLMode(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	dbIndex := 0
-	mockGetDBConn := func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		defer func() { dbIndex++ }()
-
-		if dbIndex == 0 {
-			// test db
-			db, err := pmysql.MockTestDB()
-			require.Nil(t, err)
-			return db, nil
-		}
-
-		// normal db
+	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
+	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
+		db, err := pmysql.MockTestDB()
+		require.Nil(t, err)
+		return db, nil
+	})
+	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectClose()
 		return db, nil
-	}
+	})
 
 	changefeed := "test-changefeed"
 	sinkURI, err := url.Parse("mysql://127.0.0.1:4000/?time-zone=UTC&worker-count=1" +
 		"&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed),
-		sinkURI, config.GetDefaultReplicaConfig(), mockGetDBConn)
+		sinkURI, config.GetDefaultReplicaConfig(), &dbConnFactory)
 	require.Nil(t, err)
 	require.Nil(t, sink.Close())
 }
@@ -290,24 +285,19 @@ func TestNewMySQLTimeout(t *testing.T) {
 	sinkURI, err := url.Parse(fmt.Sprintf("mysql://%s/?read-timeout=1s&timeout=1s", addr))
 	require.Nil(t, err)
 	_, err = newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), pmysql.CreateMySQLDBConn)
+		config.GetDefaultReplicaConfig(), &pmysql.DBConnectionFactory{})
 	require.Equal(t, driver.ErrBadConn, errors.Cause(err))
 }
 
 // Test OnTxnEvent and Flush interfaces. Event callbacks should be called correctly after flush.
 func TestNewMySQLBackendExecDML(t *testing.T) {
-	dbIndex := 0
-	mockGetDBConn := func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		defer func() { dbIndex++ }()
-
-		if dbIndex == 0 {
-			// test db
-			db, err := pmysql.MockTestDB()
-			require.Nil(t, err)
-			return db, nil
-		}
-
-		// normal db
+	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
+	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
+		db, err := pmysql.MockTestDB()
+		require.Nil(t, err)
+		return db, nil
+	})
+	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectBegin()
 		mock.ExpectExec("INSERT INTO `s1`.`t1` (`a`,`b`) VALUES (?,?),(?,?)").
@@ -316,7 +306,7 @@ func TestNewMySQLBackendExecDML(t *testing.T) {
 		mock.ExpectCommit()
 		mock.ExpectClose()
 		return db, nil
-	}
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -329,7 +319,7 @@ func TestNewMySQLBackendExecDML(t *testing.T) {
 		"mysql://127.0.0.1:4000/?time-zone=UTC&worker-count=1&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), mockGetDBConn)
+		config.GetDefaultReplicaConfig(), &dbConnFactory)
 	require.Nil(t, err)
 
 	tableInfo := model.BuildTableInfo("s1", "t1", []*model.Column{
@@ -433,18 +423,13 @@ func TestExecDMLRollbackErrDatabaseNotExists(t *testing.T) {
 		Number: uint16(infoschema.ErrDatabaseNotExists.Code()),
 	}
 
-	dbIndex := 0
-	mockGetDBConnErrDatabaseNotExists := func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		defer func() { dbIndex++ }()
-
-		if dbIndex == 0 {
-			// test db
-			db, err := pmysql.MockTestDB()
-			require.Nil(t, err)
-			return db, nil
-		}
-
-		// normal db
+	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
+	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
+		db, err := pmysql.MockTestDB()
+		require.Nil(t, err)
+		return db, nil
+	})
+	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectBegin()
 		mock.ExpectExec("REPLACE INTO `s1`.`t1` (`a`) VALUES (?),(?)").
@@ -453,7 +438,7 @@ func TestExecDMLRollbackErrDatabaseNotExists(t *testing.T) {
 		mock.ExpectRollback()
 		mock.ExpectClose()
 		return db, nil
-	}
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -462,7 +447,7 @@ func TestExecDMLRollbackErrDatabaseNotExists(t *testing.T) {
 		"mysql://127.0.0.1:4000/?time-zone=UTC&worker-count=1&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), mockGetDBConnErrDatabaseNotExists)
+		config.GetDefaultReplicaConfig(), &dbConnFactory)
 	require.Nil(t, err)
 
 	_ = sink.OnTxnEvent(&dmlsink.TxnCallbackableEvent{
@@ -510,18 +495,13 @@ func TestExecDMLRollbackErrTableNotExists(t *testing.T) {
 		Number: uint16(infoschema.ErrTableNotExists.Code()),
 	}
 
-	dbIndex := 0
-	mockGetDBConnErrDatabaseNotExists := func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		defer func() { dbIndex++ }()
-
-		if dbIndex == 0 {
-			// test db
-			db, err := pmysql.MockTestDB()
-			require.Nil(t, err)
-			return db, nil
-		}
-
-		// normal db
+	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
+	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
+		db, err := pmysql.MockTestDB()
+		require.Nil(t, err)
+		return db, nil
+	})
+	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectBegin()
 		mock.ExpectExec("REPLACE INTO `s1`.`t1` (`a`) VALUES (?),(?)").
@@ -530,7 +510,7 @@ func TestExecDMLRollbackErrTableNotExists(t *testing.T) {
 		mock.ExpectRollback()
 		mock.ExpectClose()
 		return db, nil
-	}
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -539,7 +519,7 @@ func TestExecDMLRollbackErrTableNotExists(t *testing.T) {
 		"mysql://127.0.0.1:4000/?time-zone=UTC&worker-count=1&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), mockGetDBConnErrDatabaseNotExists)
+		config.GetDefaultReplicaConfig(), &dbConnFactory)
 	require.Nil(t, err)
 
 	_ = sink.OnTxnEvent(&dmlsink.TxnCallbackableEvent{
@@ -587,18 +567,13 @@ func TestExecDMLRollbackErrRetryable(t *testing.T) {
 		Number: mysql.ErrLockDeadlock,
 	}
 
-	dbIndex := 0
-	mockGetDBConnErrDatabaseNotExists := func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		defer func() { dbIndex++ }()
-
-		if dbIndex == 0 {
-			// test db
-			db, err := pmysql.MockTestDB()
-			require.Nil(t, err)
-			return db, nil
-		}
-
-		// normal db
+	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
+	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
+		db, err := pmysql.MockTestDB()
+		require.Nil(t, err)
+		return db, nil
+	})
+	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		for i := 0; i < 2; i++ {
 			mock.ExpectBegin()
@@ -609,7 +584,7 @@ func TestExecDMLRollbackErrRetryable(t *testing.T) {
 		}
 		mock.ExpectClose()
 		return db, nil
-	}
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -618,7 +593,7 @@ func TestExecDMLRollbackErrRetryable(t *testing.T) {
 		"mysql://127.0.0.1:4000/?time-zone=UTC&worker-count=1&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), mockGetDBConnErrDatabaseNotExists)
+		config.GetDefaultReplicaConfig(), &dbConnFactory)
 	require.Nil(t, err)
 	sink.setDMLMaxRetry(2)
 
@@ -656,18 +631,13 @@ func TestMysqlSinkNotRetryErrDupEntry(t *testing.T) {
 		},
 	}
 
-	dbIndex := 0
-	mockDBInsertDupEntry := func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		defer func() { dbIndex++ }()
-
-		if dbIndex == 0 {
-			// test db
-			db, err := pmysql.MockTestDB()
-			require.Nil(t, err)
-			return db, nil
-		}
-
-		// normal db
+	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
+	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
+		db, err := pmysql.MockTestDB()
+		require.Nil(t, err)
+		return db, nil
+	})
+	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectBegin()
 		mock.ExpectExec("INSERT INTO `s1`.`t1` (`a`) VALUES (?)").
@@ -677,7 +647,7 @@ func TestMysqlSinkNotRetryErrDupEntry(t *testing.T) {
 			WillReturnError(errDup)
 		mock.ExpectClose()
 		return db, nil
-	}
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -687,7 +657,7 @@ func TestMysqlSinkNotRetryErrDupEntry(t *testing.T) {
 			"&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), mockDBInsertDupEntry)
+		config.GetDefaultReplicaConfig(), &dbConnFactory)
 	require.Nil(t, err)
 	sink.setDMLMaxRetry(1)
 	_ = sink.OnTxnEvent(&dmlsink.TxnCallbackableEvent{
@@ -708,22 +678,17 @@ func TestNeedSwitchDB(t *testing.T) {
 }
 
 func TestNewMySQLBackend(t *testing.T) {
-	dbIndex := 0
-	mockGetDBConn := func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		defer func() { dbIndex++ }()
-
-		if dbIndex == 0 {
-			// test db
-			db, err := pmysql.MockTestDB()
-			require.Nil(t, err)
-			return db, nil
-		}
-
-		// normal db
+	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
+	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
+		db, err := pmysql.MockTestDB()
+		require.Nil(t, err)
+		return db, nil
+	})
+	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectClose()
 		return db, nil
-	}
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -733,7 +698,7 @@ func TestNewMySQLBackend(t *testing.T) {
 		"&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), mockGetDBConn)
+		config.GetDefaultReplicaConfig(), &dbConnFactory)
 
 	require.Nil(t, err)
 	require.Nil(t, sink.Close())
@@ -742,23 +707,17 @@ func TestNewMySQLBackend(t *testing.T) {
 }
 
 func TestNewMySQLBackendWithIPv6Address(t *testing.T) {
-	dbIndex := 0
-	mockGetDBConn := func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		require.Contains(t, dsnStr, "root@tcp([::1]:3306)")
-		defer func() { dbIndex++ }()
-
-		if dbIndex == 0 {
-			// test db
-			db, err := pmysql.MockTestDB()
-			require.Nil(t, err)
-			return db, nil
-		}
-
-		// normal db
+	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
+	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
+		db, err := pmysql.MockTestDB()
+		require.Nil(t, err)
+		return db, nil
+	})
+	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectClose()
 		return db, nil
-	}
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -768,28 +727,23 @@ func TestNewMySQLBackendWithIPv6Address(t *testing.T) {
 		"&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), mockGetDBConn)
+		config.GetDefaultReplicaConfig(), &dbConnFactory)
 	require.Nil(t, err)
 	require.Nil(t, sink.Close())
 }
 
 func TestGBKSupported(t *testing.T) {
-	dbIndex := 0
-	mockGetDBConn := func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		defer func() { dbIndex++ }()
-
-		if dbIndex == 0 {
-			// test db
-			db, err := pmysql.MockTestDB()
-			require.Nil(t, err)
-			return db, nil
-		}
-
-		// normal db
+	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
+	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
+		db, err := pmysql.MockTestDB()
+		require.Nil(t, err)
+		return db, nil
+	})
+	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectClose()
 		return db, nil
-	}
+	})
 
 	zapcore, logs := observer.New(zap.WarnLevel)
 	conf := &log.Config{Level: "warn", File: log.FileLogConfig{}}
@@ -804,7 +758,7 @@ func TestGBKSupported(t *testing.T) {
 		"&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), mockGetDBConn)
+		config.GetDefaultReplicaConfig(), &dbConnFactory)
 	require.Nil(t, err)
 
 	// no gbk-related warning log will be output because GBK charset is supported
@@ -834,25 +788,20 @@ func TestHolderString(t *testing.T) {
 }
 
 func TestMySQLSinkExecDMLError(t *testing.T) {
-	dbIndex := 0
-	mockGetDBConn := func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		defer func() { dbIndex++ }()
-
-		if dbIndex == 0 {
-			// test db
-			db, err := pmysql.MockTestDB()
-			require.Nil(t, err)
-			return db, nil
-		}
-
-		// normal db
+	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
+	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
+		db, err := pmysql.MockTestDB()
+		require.Nil(t, err)
+		return db, nil
+	})
+	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		db, mock := newTestMockDB(t)
 		mock.ExpectBegin()
 		mock.ExpectExec("INSERT INTO `s1`.`t1` (`a`,`b`) VALUES (?,?),(?,?)").WillDelayFor(1 * time.Second).
 			WillReturnError(&dmysql.MySQLError{Number: mysql.ErrNoSuchTable})
 		mock.ExpectClose()
 		return db, nil
-	}
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -861,7 +810,7 @@ func TestMySQLSinkExecDMLError(t *testing.T) {
 		"mysql://127.0.0.1:4000/?time-zone=UTC&worker-count=1&cache-prep-stmts=false")
 	require.Nil(t, err)
 	sink, err := newMySQLBackend(ctx, model.DefaultChangeFeedID(changefeed), sinkURI,
-		config.GetDefaultReplicaConfig(), mockGetDBConn)
+		config.GetDefaultReplicaConfig(), &dbConnFactory)
 	require.Nil(t, err)
 
 	tableInfo := model.BuildTableInfo("s1", "t1", []*model.Column{

--- a/cdc/sink/dmlsink/txn/txn_dml_sink.go
+++ b/cdc/sink/dmlsink/txn/txn_dml_sink.go
@@ -58,11 +58,9 @@ type dmlSink struct {
 	scheme string
 }
 
-// GetDBConnImpl is the implementation of pmysql.Factory.
+// GetDBConnImpl is the implementation of pmysql.IDBConnectionFactory.
 // Exported for testing.
-// Maybe we can use a better way to do this. Because this is not thread-safe.
-// You can use `SetupSuite` and `TearDownSuite` to do this to get a better way.
-var GetDBConnImpl pmysql.ConnectionFactory = pmysql.CreateMySQLDBConn
+var GetDBConnImpl pmysql.IDBConnectionFactory = &pmysql.DBConnectionFactory{}
 
 // NewMySQLSink creates a mysql dmlSink with given parameters.
 func NewMySQLSink(

--- a/cdc/sink/dmlsink/txn/txn_dml_sink.go
+++ b/cdc/sink/dmlsink/txn/txn_dml_sink.go
@@ -62,7 +62,7 @@ type dmlSink struct {
 // Exported for testing.
 // Maybe we can use a better way to do this. Because this is not thread-safe.
 // You can use `SetupSuite` and `TearDownSuite` to do this to get a better way.
-var GetDBConnImpl pmysql.Factory = pmysql.CreateMySQLDBConn
+var GetDBConnImpl pmysql.ConnectionFactory = pmysql.CreateMySQLDBConn
 
 // NewMySQLSink creates a mysql dmlSink with given parameters.
 func NewMySQLSink(

--- a/errors.toml
+++ b/errors.toml
@@ -171,6 +171,11 @@ error = '''
 TiCDC cluster is unhealthy
 '''
 
+["CDC:ErrCodeNilFunction"]
+error = '''
+function is not initialized
+'''
+
 ["CDC:ErrCodecDecode"]
 error = '''
 codec decode error

--- a/pkg/applier/redo_test.go
+++ b/pkg/applier/redo_test.go
@@ -102,20 +102,15 @@ func TestApply(t *testing.T) {
 
 	// DML sink and DDL sink share the same db
 	db := getMockDB(t)
-	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
-	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		testDB, err := pmysql.MockTestDB()
-		require.Nil(t, err)
-		return testDB, nil
-	})
+	dbConnFactory := pmysql.NewDBConnectionFactoryForTest()
 	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		return db, nil
 	})
 
 	getDMLDBConnBak := txn.GetDBConnImpl
-	txn.GetDBConnImpl = &dbConnFactory
+	txn.GetDBConnImpl = dbConnFactory
 	getDDLDBConnBak := mysqlDDL.GetDBConnImpl
-	mysqlDDL.GetDBConnImpl = &dbConnFactory
+	mysqlDDL.GetDBConnImpl = dbConnFactory
 	createRedoReaderBak := createRedoReader
 	createRedoReader = createMockReader
 	defer func() {
@@ -321,20 +316,15 @@ func TestApplyBigTxn(t *testing.T) {
 
 	// DML sink and DDL sink share the same db
 	db := getMockDBForBigTxn(t)
-	dbConnFactory := pmysql.DBConnectionFactoryForTest{}
-	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
-		testDB, err := pmysql.MockTestDB()
-		require.Nil(t, err)
-		return testDB, nil
-	})
+	dbConnFactory := pmysql.NewDBConnectionFactoryForTest()
 	dbConnFactory.SetStandardConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
 		return db, nil
 	})
 
 	getDMLDBConnBak := txn.GetDBConnImpl
-	txn.GetDBConnImpl = &dbConnFactory
+	txn.GetDBConnImpl = dbConnFactory
 	getDDLDBConnBak := mysqlDDL.GetDBConnImpl
-	mysqlDDL.GetDBConnImpl = &dbConnFactory
+	mysqlDDL.GetDBConnImpl = dbConnFactory
 	createRedoReaderBak := createRedoReader
 	createRedoReader = createMockReader
 	defer func() {

--- a/pkg/errors/cdc_errors.go
+++ b/pkg/errors/cdc_errors.go
@@ -140,6 +140,11 @@ var (
 		"stop processor by admin command",
 		errors.RFCCodeText("CDC:ErrAdminStopProcessor"),
 	)
+	ErrCodeNilFunction = errors.Normalize(
+		"function is not initialized",
+		errors.RFCCodeText("CDC:ErrCodeNilFunction"),
+	)
+
 	// ErrVersionIncompatible is an error for running CDC on an incompatible Cluster.
 	ErrVersionIncompatible = errors.Normalize(
 		"version is incompatible: %s",

--- a/pkg/sink/mysql/db_helper.go
+++ b/pkg/sink/mysql/db_helper.go
@@ -33,8 +33,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// type
-
 // CreateMySQLDBConn creates a mysql database connection with the given dsn.
 func CreateMySQLDBConn(ctx context.Context, dsnStr string) (*sql.DB, error) {
 	db, err := sql.Open("mysql", dsnStr)
@@ -55,6 +53,13 @@ func CreateMySQLDBConn(ctx context.Context, dsnStr string) (*sql.DB, error) {
 }
 
 // GenerateDSN generates the dsn with the given config.
+// GenerateDSN uses the provided dbConnFactory to create a temporary connection
+// to the downstream database specified by the sinkURI. This temporary connection
+// is used to query important information from the downstream database, such as
+// version, charset, and other relevant details. After the required information
+// is retrieved, the temporary connection is closed. The retrieved data is then
+// used to populate additional parameters into the Sink URI, refining
+// the connection URL (dsnStr).
 func GenerateDSN(ctx context.Context, sinkURI *url.URL, cfg *Config, dbConnFactory ConnectionFactory) (dsnStr string, err error) {
 	// dsn format of the driver:
 	// [username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]

--- a/pkg/sink/mysql/db_helper.go
+++ b/pkg/sink/mysql/db_helper.go
@@ -33,6 +33,8 @@ import (
 	"go.uber.org/zap"
 )
 
+// type
+
 // CreateMySQLDBConn creates a mysql database connection with the given dsn.
 func CreateMySQLDBConn(ctx context.Context, dsnStr string) (*sql.DB, error) {
 	db, err := sql.Open("mysql", dsnStr)
@@ -53,7 +55,7 @@ func CreateMySQLDBConn(ctx context.Context, dsnStr string) (*sql.DB, error) {
 }
 
 // GenerateDSN generates the dsn with the given config.
-func GenerateDSN(ctx context.Context, sinkURI *url.URL, cfg *Config, dbConnFactory Factory) (dsnStr string, err error) {
+func GenerateDSN(ctx context.Context, sinkURI *url.URL, cfg *Config, dbConnFactory ConnectionFactory) (dsnStr string, err error) {
 	// dsn format of the driver:
 	// [username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]
 	dsn, err := GenBasicDSN(sinkURI, cfg)
@@ -216,7 +218,7 @@ func checkTiDBVariable(ctx context.Context, db *sql.DB, variableName, defaultVal
 
 // GetTestDB checks and adjusts the password of the given DSN,
 // it will return a DB instance opened with the adjusted password.
-func GetTestDB(ctx context.Context, dbConfig *dmysql.Config, dbConnFactory Factory) (*sql.DB, error) {
+func GetTestDB(ctx context.Context, dbConfig *dmysql.Config, dbConnFactory ConnectionFactory) (*sql.DB, error) {
 	password := dbConfig.Passwd
 	if dbConnFactory == nil {
 		dbConnFactory = CreateMySQLDBConn

--- a/pkg/sink/mysql/db_helper.go
+++ b/pkg/sink/mysql/db_helper.go
@@ -33,25 +33,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// CreateMySQLDBConn creates a mysql database connection with the given dsn.
-func CreateMySQLDBConn(ctx context.Context, dsnStr string) (*sql.DB, error) {
-	db, err := sql.Open("mysql", dsnStr)
-	if err != nil {
-		return nil, cerror.ErrMySQLConnectionError.Wrap(err).GenWithStack("fail to open MySQL connection")
-	}
-
-	err = db.PingContext(ctx)
-	if err != nil {
-		// close db to recycle resources
-		if closeErr := db.Close(); closeErr != nil {
-			log.Warn("close db failed", zap.Error(err))
-		}
-		return nil, cerror.ErrMySQLConnectionError.Wrap(err).GenWithStack("fail to open MySQL connection")
-	}
-
-	return db, nil
-}
-
 // GenerateDSN generates the dsn with the given config.
 // GenerateDSN uses the provided dbConnFactory to create a temporary connection
 // to the downstream database specified by the sinkURI. This temporary connection

--- a/pkg/sink/mysql/factory.go
+++ b/pkg/sink/mysql/factory.go
@@ -18,5 +18,10 @@ import (
 	"database/sql"
 )
 
-// Factory is the factory for creating db connection.
-type Factory func(ctx context.Context, dsnStr string) (*sql.DB, error)
+// ConnectionFactory is the factory for creating db connection.
+type ConnectionFactory func(ctx context.Context, dsnStr string) (*sql.DB, error)
+
+type IDBConnectionProvider interface {
+	CreateTemporaryConnection(ctx context.Context, dsnStr string) (*sql.DB, error)
+	CreatePersistentConnection(ctx context.Context, dsnStr string) (*sql.DB, error)
+}

--- a/pkg/sink/mysql/factory.go
+++ b/pkg/sink/mysql/factory.go
@@ -16,12 +16,102 @@ package mysql
 import (
 	"context"
 	"database/sql"
+
+	cerror "github.com/pingcap/tiflow/pkg/errors"
 )
 
-// ConnectionFactory is the factory for creating db connection.
-type ConnectionFactory func(ctx context.Context, dsnStr string) (*sql.DB, error)
-
-type IDBConnectionProvider interface {
+// IDBConnectionFactory is an interface designed specifically to facilitate unit testing
+// in scenarios where connections to downstream databases are required.
+//
+// In the process of creating a downstream database connection based on a Sink URI,
+// a temporary connection is first established. This temporary connection is used
+// to query information from the downstream database, such as version, charset, etc.
+// After retrieving this information, the temporary connection is closed.
+// The retrieved data is then used to populate additional parameters into the Sink URI,
+// and a more refined Sink URI is used to establish the final, standard connection that
+// the Sink will use for subsequent operations.
+//
+// During normal system operation, it's perfectly acceptable to create both of these
+// connections in the same manner. However, in the context of unit testing, where
+// it's not feasible to start an actual downstream database, we need to mock these
+// connections. Since both connections will send SQL requests, the unit tests require
+// mocking two different connections to handle each phase of the connection creation process.
+//
+// This interface addresses this issue by providing two distinct methods:
+// CreateTemporaryConnection, for creating the temporary connection, and
+// CreateStandardConnection, for creating the standard, persistent connection.
+// By using these separate methods, the interface allows for greater flexibility
+// in mocking and testing, ensuring that the two connections can be created differently
+// as needed during unit tests.
+type IDBConnectionFactory interface {
 	CreateTemporaryConnection(ctx context.Context, dsnStr string) (*sql.DB, error)
-	CreatePersistentConnection(ctx context.Context, dsnStr string) (*sql.DB, error)
+	CreateStandardConnection(ctx context.Context, dsnStr string) (*sql.DB, error)
 }
+
+// DBConnectionFactory is an implementation of the IDBConnectionFactory interface,
+// designed for use in normal system operations where only a single method of creating
+// database connections is required.
+//
+// In regular workflows, both the temporary connection (used for querying information
+// like version and charset) and the standard connection (used for subsequent operations)
+// can be created in the same manner. Therefore, DBConnectionFactory provides a unified
+// approach by implementing the IDBConnectionFactory interface and using the same
+// CreateMySQLDBConn function for both CreateTemporaryConnection and CreateStandardConnection.
+//
+// This struct simplifies the process for scenarios where unit testing is not a concern.
+// As long as you are not writing unit tests and do not need to mock different types
+// of connections, using DBConnectionFactory is perfectly suitable for establishing
+// the necessary database connections.
+type DBConnectionFactory struct{}
+
+func (d *DBConnectionFactory) CreateTemporaryConnection(ctx context.Context, dsnStr string) (*sql.DB, error) {
+	return CreateMySQLDBConn(ctx, dsnStr)
+}
+
+func (d *DBConnectionFactory) CreateStandardConnection(ctx context.Context, dsnStr string) (*sql.DB, error) {
+	return CreateMySQLDBConn(ctx, dsnStr)
+}
+
+// DBConnectionFactoryForTest is a utility implementation of the IDBConnectionFactory
+// interface designed to simplify the process of writing unit tests that require
+// different methods for creating database connections.
+//
+// Instead of implementing the IDBConnectionFactory interface from scratch in every
+// unit test, DBConnectionFactoryForTest allows developers to easily set up custom
+// connection creation methods. The SetTemporaryConnectionFactory and
+// SetStandardConnectionFactory methods allow you to define how the temporary and
+// standard connections should be created during testing.
+//
+// Once these methods are set, the system will automatically invoke CreateTemporaryConnection
+// and CreateStandardConnection to establish the respective connections during the
+// connection creation process. This approach provides flexibility and convenience
+// in unit testing scenarios, where different connection behaviors need to be mocked
+// or tested separately.
+type DBConnectionFactoryForTest struct {
+	temp     ConnectionFactory
+	standard ConnectionFactory
+}
+
+func (d *DBConnectionFactoryForTest) SetTemporaryConnectionFactory(f ConnectionFactory) {
+	d.temp = f
+}
+
+func (d *DBConnectionFactoryForTest) SetStandardConnectionFactory(f ConnectionFactory) {
+	d.standard = f
+}
+
+func (d *DBConnectionFactoryForTest) CreateTemporaryConnection(ctx context.Context, dsnStr string) (*sql.DB, error) {
+	if d.temp == nil {
+		return nil, cerror.ErrCodeNilFunction.GenWithStackByArgs()
+	}
+	return d.temp(ctx, dsnStr)
+}
+
+func (d *DBConnectionFactoryForTest) CreateStandardConnection(ctx context.Context, dsnStr string) (*sql.DB, error) {
+	if d.standard == nil {
+		return nil, cerror.ErrCodeNilFunction.GenWithStackByArgs()
+	}
+	return d.standard(ctx, dsnStr)
+}
+
+type ConnectionFactory func(ctx context.Context, dsnStr string) (*sql.DB, error)

--- a/pkg/sink/mysql/factory.go
+++ b/pkg/sink/mysql/factory.go
@@ -101,6 +101,21 @@ type DBConnectionFactoryForTest struct {
 	standard ConnectionFactory
 }
 
+// NewDBConnectionFactoryForTest creates a new instance of DBConnectionFactoryForTest
+// with a predefined temporary connection creation method. This method is initialized
+// to use a mock database connection, which is commonly required in the current unit tests.
+// By setting up the temporary connection creation logic directly in this constructor,
+// it eliminates the need to repeatedly call SetTemporaryConnectionFactory to set up
+// the temporary connection factory in each test. This streamlines the setup process
+// for unit tests that require a mock temporary connection.
+func NewDBConnectionFactoryForTest() *DBConnectionFactoryForTest {
+	dbConnFactory := &DBConnectionFactoryForTest{}
+	dbConnFactory.SetTemporaryConnectionFactory(func(ctx context.Context, dsnStr string) (*sql.DB, error) {
+		return MockTestDB()
+	})
+	return dbConnFactory
+}
+
 // SetTemporaryConnectionFactory sets the connection factory that will be used to
 // create the temporary connection during testing. This allows for custom behavior
 // during unit tests when different connection logic is required.

--- a/pkg/sink/mysql/factory.go
+++ b/pkg/sink/mysql/factory.go
@@ -135,4 +135,7 @@ func (d *DBConnectionFactoryForTest) CreateStandardConnection(ctx context.Contex
 	return d.standard(ctx, dsnStr)
 }
 
+// ConnectionFactory is a function type that takes a context and a DSN (Data Source Name) string
+// as input parameters, and returns a pointer to an sql.DB object and an error. This function type
+// is typically used to create and configure database connections.
 type ConnectionFactory func(ctx context.Context, dsnStr string) (*sql.DB, error)

--- a/pkg/sink/observer/observer.go
+++ b/pkg/sink/observer/observer.go
@@ -38,14 +38,14 @@ type Observer interface {
 
 // NewObserverOpt represents available options when creating a new observer.
 type NewObserverOpt struct {
-	dbConnFactory pmysql.Factory
+	dbConnFactory pmysql.ConnectionFactory
 }
 
 // NewObserverOption configures NewObserverOpt.
 type NewObserverOption func(*NewObserverOpt)
 
 // WithDBConnFactory specifies factory to create db connection.
-func WithDBConnFactory(factory pmysql.Factory) NewObserverOption {
+func WithDBConnFactory(factory pmysql.ConnectionFactory) NewObserverOption {
 	return func(opt *NewObserverOpt) {
 		opt.dbConnFactory = factory
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11490

### What is changed and how it works?

**Overview:**

This PR addresses the challenges associated with creating multiple database connections during the establishment of downstream connections using a Sink URI, particularly in the context of unit testing. The changes introduce a flexible interface and supporting implementations that allow for distinct handling of temporary and standard connections, simplifying the testing process.

**Key Changes:**

1. **Introduction of `IDBConnectionFactory` Interface:**
   - Defined an interface `IDBConnectionFactory` with two methods:
     - `CreateTemporaryConnection`: For creating a temporary connection to the downstream database.
     - `CreateStandardConnection`: For creating the standard connection used in normal operations.
   - This separation of concerns allows different connection creation strategies to be used during testing and in production.

2. **Implementation of `DBConnectionFactory`:**
   - Created a `DBConnectionFactory` struct that implements `IDBConnectionFactory`.
   - Both `CreateTemporaryConnection` and `CreateStandardConnection` methods use the same connection creation logic (`CreateMySQLDBConn`), making this implementation suitable for normal system operations where there’s no need to distinguish between connection types.

3. **Creation of `DBConnectionFactoryForTest`:**
   - Added a `DBConnectionFactoryForTest` struct to facilitate unit testing.
   - This struct allows separate connection factories to be set for temporary and standard connections via `SetTemporaryConnectionFactory` and `SetStandardConnectionFactory`.
   - During testing, `CreateTemporaryConnection` and `CreateStandardConnection` will use the specified mock connection factories, allowing distinct behaviors for each connection.

**Problem Solved:**

Prior to this refactor, unit tests were forced to use complicated and error-prone methods to mock the behavior of two distinct database connections. The introduction of the `IDBConnectionFactory` interface and its implementations significantly simplifies the mocking process, providing a clean and maintainable way to test different connection behaviors without resorting to complex or tricky code.

**Conclusion:**

This PR provides a robust solution to the issues faced during unit testing of connection creation logic. By introducing a clear interface and appropriate implementations, it allows for both production and testing environments to handle connection creation in a straightforward and maintainable manner.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No

##### Do you need to update user documentation, design documentation or monitoring documentation?

No

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
