### PR TITLE
parser(dm): support ALTER DATABASE default database

### DIFF
--- a/dm/pkg/parser/common.go
+++ b/dm/pkg/parser/common.go
@@ -201,6 +201,10 @@ func SplitDDL(stmt ast.StmtNode, schema string) (sqls []string, err error) {
 	case *ast.AlterSequenceStmt:
 	case *ast.DropSequenceStmt:
 	case *ast.AlterDatabaseStmt:
+		if v.AlterDefaultDatabase {
+			v.AlterDefaultDatabase = false
+			v.Name = schemaName
+		}
 	case *ast.CreateDatabaseStmt:
 		v.IfNotExists = true
 	case *ast.DropDatabaseStmt:

--- a/dm/pkg/parser/common_test.go
+++ b/dm/pkg/parser/common_test.go
@@ -66,7 +66,8 @@ var testCases = []testCase{
 		[][]*filter.Table{{genTableName("s1", "")}},
 		[][]*filter.Table{{genTableName("xs1", "")}},
 		[]string{"DROP DATABASE IF EXISTS `xs1`"},
-	}, {
+	},
+	{
 		"alter database collate utf8mb4_general_ci",
 		[]string{"ALTER DATABASE `test` COLLATE = utf8mb4_general_ci"},
 		[][]*filter.Table{{genTableName("test", "")}},

--- a/dm/pkg/parser/common_test.go
+++ b/dm/pkg/parser/common_test.go
@@ -66,6 +66,12 @@ var testCases = []testCase{
 		[][]*filter.Table{{genTableName("s1", "")}},
 		[][]*filter.Table{{genTableName("xs1", "")}},
 		[]string{"DROP DATABASE IF EXISTS `xs1`"},
+	}, {
+		"alter database collate utf8mb4_general_ci",
+		[]string{"ALTER DATABASE `test` COLLATE = utf8mb4_general_ci"},
+		[][]*filter.Table{{genTableName("test", "")}},
+		[][]*filter.Table{{genTableName("xtest", "")}},
+		[]string{"ALTER DATABASE `xtest` COLLATE = utf8mb4_general_ci"},
 	},
 	{
 		"drop table `Ss1`.`tT1`",


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11503

### What is changed and how it works?

> If the database name is omitted, the statement applies to the default database. In that case, an error occurs if there is no default database.

https://dev.mysql.com/doc/refman/8.4/en/alter-database.html

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
DM sync unit support ALTER DATABASE default database SQL
```
