### PR TITLE
mysql(ticdc): remove returned error and modify the log in `CheckIsTiDB `

### DIFF
--- a/cdc/sink/ddlsink/mysql/mysql_ddl_sink.go
+++ b/cdc/sink/ddlsink/mysql/mysql_ddl_sink.go
@@ -91,10 +91,7 @@ func NewDDLSink(
 		return nil, err
 	}
 
-	cfg.IsTiDB, err = pmysql.CheckIsTiDB(ctx, db)
-	if err != nil {
-		return nil, err
-	}
+	cfg.IsTiDB = pmysql.CheckIsTiDB(ctx, db)
 
 	cfg.IsWriteSourceExisted, err = pmysql.CheckIfBDRModeIsSupported(ctx, db)
 	if err != nil {

--- a/cdc/sink/dmlsink/txn/mysql/mysql.go
+++ b/cdc/sink/dmlsink/txn/mysql/mysql.go
@@ -107,10 +107,7 @@ func NewMySQLBackends(
 		return nil, err
 	}
 
-	cfg.IsTiDB, err = pmysql.CheckIsTiDB(ctx, db)
-	if err != nil {
-		return nil, err
-	}
+	cfg.IsTiDB = pmysql.CheckIsTiDB(ctx, db)
 
 	cfg.IsWriteSourceExisted, err = pmysql.CheckIfBDRModeIsSupported(ctx, db)
 	if err != nil {

--- a/cdc/syncpointstore/mysql_syncpoint_store.go
+++ b/cdc/syncpointstore/mysql_syncpoint_store.go
@@ -64,10 +64,7 @@ func newMySQLSyncPointStore(
 		return nil, err
 	}
 
-	cfg.IsTiDB, err = pmysql.CheckIsTiDB(ctx, syncDB)
-	if err != nil {
-		return nil, err
-	}
+	cfg.IsTiDB = pmysql.CheckIsTiDB(ctx, syncDB)
 
 	cfg.IsWriteSourceExisted, err = pmysql.CheckIfBDRModeIsSupported(ctx, syncDB)
 	if err != nil {

--- a/pkg/sink/observer/observer.go
+++ b/pkg/sink/observer/observer.go
@@ -92,10 +92,7 @@ func NewObserver(
 		db.SetMaxIdleConns(2)
 		db.SetMaxOpenConns(2)
 
-		isTiDB, err := pmysql.CheckIsTiDB(ctx, db)
-		if err != nil {
-			return nil, err
-		}
+		isTiDB := pmysql.CheckIsTiDB(ctx, db)
 		if isTiDB {
 			return NewTiDBObserver(db), nil
 		}


### PR DESCRIPTION

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11505

### What is changed and how it works?

**Description**:
This PR refactors the `CheckIsTiDB` function in response to internal discussions. Previously, the function returned an `error` which was not necessary, as the external callers should not care about the error of the `CheckIsTiDB` function due to https://github.com/pingcap/tiflow/issues/11213.

**Changes**:
1. Removed the `error` return type from `CheckIsTiDB`.
2. Replaced the error log with a warning to handle cases where querying the TiDB version fails.
3. Updated comments to explain the background and rationale for the change.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No

##### Do you need to update user documentation, design documentation or monitoring documentation?

No

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
