### PR TITLE
docs(ticdc): Update Integration Test Documentation to Avoid Version Mismatch Issues in TiCDC

### DIFF
--- a/tests/integration_tests/README.md
+++ b/tests/integration_tests/README.md
@@ -3,7 +3,9 @@
 ### Run integration tests locally
 
 1. Run `make prepare_test_binaries` to download TiCDC related binaries for integration test.
-If you need to specify a version, os or arch, you can use, for example: `make prepare_test_binaries community=true ver=v7.0.0 os=linux arch=amd64`. (NOTE: the `community=true` option is necessary when you need to specify a version, arch or whatever.)
+If you need to specify a version, os or arch, you can use, for example: `make prepare_test_binaries community=true ver=v7.0.0 os=linux arch=amd64`. (The `community=true` option is necessary when you need to specify a version, arch or whatever.)
+
+   > Note: Please be aware that if you manually specify the versions of the TiDB-related components during the download process, there is a potential risk of incompatibility if the specified versions do not match the current TiCDC version. For example, see issue #11507 where version mismatches caused incompatibility problems during integration tests.
 
    You should find these executables in the `tiflow/bin` directory after downloading successfully.
    * `tidb-server` # version >= 6.0.0-rc.1

--- a/tests/integration_tests/README.md
+++ b/tests/integration_tests/README.md
@@ -2,8 +2,8 @@
 
 ### Run integration tests locally
 
-1. Run `make prepare_test_binaries community=true` to download TiCDC related binaries for integration test.
-You can specify version and arch, for example: `make prepare_test_binaries community=true ver=v7.0.0 arch=amd64`.
+1. Run `make prepare_test_binaries` to download TiCDC related binaries for integration test.
+If you need to specify a version, os or arch, use `make prepare_test_binaries community=true ver=v7.0.0 os=linux arch=amd64`. (NOTE: the `community=true` option is necessary when you need to specify a version, arch or whatever.)
 
    You should find these executables in the `tiflow/bin` directory after downloading successfully.
    * `tidb-server` # version >= 6.0.0-rc.1

--- a/tests/integration_tests/README.md
+++ b/tests/integration_tests/README.md
@@ -3,7 +3,7 @@
 ### Run integration tests locally
 
 1. Run `make prepare_test_binaries` to download TiCDC related binaries for integration test.
-If you need to specify a version, os or arch, use `make prepare_test_binaries community=true ver=v7.0.0 os=linux arch=amd64`. (NOTE: the `community=true` option is necessary when you need to specify a version, arch or whatever.)
+If you need to specify a version, os or arch, you can use, for example: `make prepare_test_binaries community=true ver=v7.0.0 os=linux arch=amd64`. (NOTE: the `community=true` option is necessary when you need to specify a version, arch or whatever.)
 
    You should find these executables in the `tiflow/bin` directory after downloading successfully.
    * `tidb-server` # version >= 6.0.0-rc.1
@@ -20,7 +20,7 @@ If you need to specify a version, os or arch, use `make prepare_test_binaries co
 
    > You could download these binaries by yourself from [tidb-community-toolkit](https://download.pingcap.org/tidb-community-toolkit-v6.0.0-linux-amd64.tar.gz) and [tidb-community-server](https://download.pingcap.org/tidb-community-server-v6.0.0-linux-amd64.tar.gz).
 
-2. These are programs/packages need be installed.
+2. These are programs/packages need be installed manually.
    * [mysql](https://dev.mysql.com/doc/mysql-installation-excerpt/5.7/en/) (the MySQL cli client,
      currently [mysql client 8.0 is not supported](https://github.com/pingcap/tidb/issues/14021))
    * [s3cmd](https://s3tools.org/download)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11508 

### What is changed and how it works?

#### Description:  
This PR updates the official documentation regarding integration tests for TiCDC to address a potential issue with version mismatches between TiCDC and related TiDB ecosystem components such as TiDB, TiKV, and PD.

#### Problem:
Previously, the documentation recommended running:
```bash
make prepare_test_binaries community=true
```
to download TiCDC-related binaries for integration testing. This command triggers the `scripts/download-integration-test-binaries.sh` script, which, if no version is specified, defaults to downloading version 8.1.0 of TiDB, TiKV, and PD. However, when TiCDC releases new versions, the script is not always updated promptly. As a result, TiCDC may end up running tests with outdated TiDB components, leading to potential incompatibility issues.

#### Solution:
This PR modifies the documentation to recommend using:
```bash
make prepare_test_binaries
```
without the `community=true` option. When this command is run without the flag, the script fetches the latest versions of TiDB-related components from their master branches, ensuring that the versions are compatible with the current TiCDC version and minimizing the risk of version mismatch.

#### Changes:
- Updated the integration test section of the official documentation to replace `make prepare_test_binaries community=true` with `make prepare_test_binaries`.
- Added an explanation about potential incompatibility issues that can arise when using outdated versions of TiDB-related components in integration tests.

#### Impact:
This update helps ensure that developers working on TiCDC always have compatible versions of TiDB-related components for their integration tests, preventing potential errors due to version mismatches and improving the overall reliability of integration testing.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No

##### Do you need to update user documentation, design documentation or monitoring documentation?

Yes and updated.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
