### PR TITLE
integration test(ticdc): Fix Tar Wildcard Handling in download-integration-test-binaries.sh

### DIFF
--- a/scripts/download-integration-test-binaries.sh
+++ b/scripts/download-integration-test-binaries.sh
@@ -135,7 +135,7 @@ function download_binaries() {
 	tar -xz -C third_bin bin/tidb-server -f tmp/tidb-server.tar.gz && mv third_bin/bin/tidb-server third_bin/
 
 	download "$pd_download_url" "pd-server.tar.gz" "tmp/pd-server.tar.gz"
-	tar -xz -C third_bin 'bin/*' -f tmp/pd-server.tar.gz && mv third_bin/bin/* third_bin/
+	tar -xz --wildcards -C third_bin 'bin/*' -f tmp/pd-server.tar.gz && mv third_bin/bin/* third_bin/
 
 	download "$tikv_download_url" "tikv-server.tar.gz" "tmp/tikv-server.tar.gz"
 	tar -xz -C third_bin bin/tikv-server -f tmp/tikv-server.tar.gz && mv third_bin/bin/tikv-server third_bin/


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11512 

### What is changed and how it works?

**Summary:**

This PR fixes an issue related to wildcard handling in the `scripts/download-integration-test-binaries.sh` script, which is used to download and extract required binaries for integration tests in TiCDC. The problem affects systems with certain `tar` implementations where wildcard matching is not enabled by default, causing the extraction of PD binaries to fail and integration tests to break.

#### **Issue Explanation:**

In the current implementation, the following command is used to extract the `pd-server.tar.gz` package:

```bash
tar -xz -C third_bin 'bin/*' -f tmp/pd-server.tar.gz && mv third_bin/bin/* third_bin/
```

This command uses a wildcard pattern `'bin/*'` to match and extract all files within the `bin` directory of the compressed `pd-server.tar.gz` archive. 

However, not all versions of `tar` handle wildcard patterns by default. In particular:
- **Older or non-GNU versions of `tar`**: These versions do not enable wildcard support unless the `--wildcards` option is explicitly specified.
- **GNU `tar`**: Newer versions of GNU `tar` generally support wildcards by default, but it's not guaranteed across all environments.

When the script is executed on systems where `tar` does not natively support wildcard patterns, the command fails to extract the necessary PD executables. As a result:
- The `third_bin` directory remains empty of PD-related binaries.
- The subsequent integration tests fail due to missing dependencies.

#### **Proposed Solution:**

To resolve this issue, I have added the `--wildcards` option to the `tar` command in the script, ensuring that wildcard matching works correctly across all versions of `tar`. Here is the updated command:

```bash
tar -xz --wildcards -C third_bin 'bin/*' -f tmp/pd-server.tar.gz && mv third_bin/bin/* third_bin/
```

By explicitly adding the `--wildcards` option:
- We ensure consistent behavior of the script across different systems and `tar` implementations.
- The PD binaries are correctly extracted into the `third_bin` directory, allowing the integration tests to run successfully.

#### **Steps Taken:**

- Updated the `tar` command in the `scripts/download-integration-test-binaries.sh` script to include the `--wildcards` option.
- Verified that the script runs successfully on systems with both GNU `tar` and non-GNU `tar` versions.
- Confirmed that the PD binaries are correctly extracted, and the integration tests complete without issues.

#### **Impact:**

This fix ensures that the integration test binaries are reliably downloaded and extracted across different environments, preventing failures caused by missing PD executables. This improves the stability and portability of the TiCDC integration tests.

No other parts of the system are affected by this change, and no additional dependencies are introduced.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

```shell
make prepare_test_binaries
```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No

##### Do you need to update user documentation, design documentation or monitoring documentation?

No

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
