### PR TITLE
mysql(ticdc): do not check downstream ddl job status when create table

### DIFF
--- a/cdc/owner/ddl_sink.go
+++ b/cdc/owner/ddl_sink.go
@@ -238,7 +238,8 @@ func (s *ddlSinkImpl) writeDDLEvent(ctx context.Context, ddl *model.DDLEvent) er
 	log.Info("begin emit ddl event",
 		zap.String("namespace", s.changefeedID.Namespace),
 		zap.String("changefeed", s.changefeedID.ID),
-		zap.Any("DDL", ddl))
+		zap.Uint64("commitTs", ddl.CommitTs),
+		zap.String("DDL", ddl.Query))
 
 	doWrite := func() (err error) {
 		if err = s.makeSinkReady(ctx); err == nil {
@@ -251,14 +252,16 @@ func (s *ddlSinkImpl) writeDDLEvent(ctx context.Context, ddl *model.DDLEvent) er
 			log.Error("Execute DDL failed",
 				zap.String("namespace", s.changefeedID.Namespace),
 				zap.String("changefeed", s.changefeedID.ID),
-				zap.Any("DDL", ddl),
+				zap.Uint64("commitTs", ddl.CommitTs),
+				zap.String("DDL", ddl.Query),
 				zap.Error(err))
 		} else {
 			ddl.Done.Store(true)
 			log.Info("Execute DDL succeeded",
 				zap.String("namespace", s.changefeedID.Namespace),
 				zap.String("changefeed", s.changefeedID.ID),
-				zap.Any("DDL", ddl))
+				zap.Uint64("commitTs", ddl.CommitTs),
+				zap.String("DDL", ddl.Query))
 		}
 		return
 	}

--- a/cdc/puller/ddl_puller.go
+++ b/cdc/puller/ddl_puller.go
@@ -329,8 +329,10 @@ func (p *ddlJobPullerImpl) handleJob(job *timodel.Job) (skip bool, err error) {
 			zap.String("table", job.TableName),
 			zap.Uint64("startTs", job.StartTS),
 			zap.Uint64("finishedTs", job.BinlogInfo.FinishedTS),
-			zap.String("query", job.Query),
-			zap.Uint64("pullerResolvedTs", p.getResolvedTs()))
+			zap.Uint64("pullerResolvedTs", p.getResolvedTs()),
+			zap.Int64("jobSchemaVersion", job.BinlogInfo.SchemaVersion),
+			zap.Int64("schemaVersion", p.schemaVersion),
+			zap.String("query", job.Query))
 		return true, nil
 	}
 

--- a/cdc/sink/ddlsink/mysql/async_ddl.go
+++ b/cdc/sink/ddlsink/mysql/async_ddl.go
@@ -150,9 +150,9 @@ func (m *DDLSink) doCheck(ctx context.Context, table model.TableName) (done bool
 				zap.String("changefeed", m.id.ID),
 				zap.String("ddlType", ddlType.String()))
 		}
-		log.Info("async ddl is done, since not in the cache", zap.Any("table", table), zap.Duration("duration", time.Since(start)))
 		return true
 	}
+	log.Info("async ddl not in the cache", zap.Any("table", table), zap.Duration("duration", time.Since(start)))
 
 	ret := m.db.QueryRowContext(ctx, fmt.Sprintf(checkRunningAddIndexSQL, table.Schema, table.Table))
 	if ret.Err() != nil {
@@ -162,6 +162,8 @@ func (m *DDLSink) doCheck(ctx context.Context, table model.TableName) (done bool
 			zap.Error(ret.Err()))
 		return true
 	}
+	log.Info("async ddl query success", zap.Any("table", table), zap.Duration("duration", time.Since(start)))
+
 	var jobID, jobType, schemaState, schemaID, tableID, state, query string
 	if err := ret.Scan(&jobID, &jobType, &schemaState, &schemaID, &tableID, &state, &query); err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11521 

### What is changed and how it works?

* do not check async ddl status for the create table ddl

<img width="1236" alt="image" src="https://github.com/user-attachments/assets/a03ec614-ff60-43f7-9a88-ff7176037ae3">

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None`
```
