### PR TITLE
sorter: fix the bug that value can be corrupted when accessing sorter

### DIFF
--- a/cdc/processor/sourcemanager/engine/pebble/event_sorter.go
+++ b/cdc/processor/sourcemanager/engine/pebble/event_sorter.go
@@ -311,14 +311,16 @@ func (s *EventIter) Next() (event *model.PolymorphicEvent, pos engine.Position, 
 	valid := s.iter != nil && s.iter.Valid()
 	var value []byte
 	for valid {
-		nextStart := time.Now()
-		value, valid = s.iter.Value(), s.iter.Next()
-		s.nextDuration.Observe(time.Since(nextStart).Seconds())
-
+		value = s.iter.Value()
 		event = &model.PolymorphicEvent{}
 		if _, err = s.serde.Unmarshal(event, value); err != nil {
 			return
 		}
+
+		nextStart := time.Now()
+		valid = s.iter.Next()
+		s.nextDuration.Observe(time.Since(nextStart).Seconds())
+
 		if s.headItem != nil {
 			break
 		}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflow/issues/6367
Issue Number: close https://github.com/pingcap/tiflow/issues/10853

### What is changed and how it works?

This PR is extracted from #10899 , which fixes the bug that value can be corrupted when accessing sorter.

It's hard to construct a test case for the change because the value corruption can't be reproduced stable. So we just ignore it.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
