### PR TITLE
changefeed(ticdc): fix barrier ts set incorrectly cause monitor become year

### DIFF
--- a/cdc/owner/barrier.go
+++ b/cdc/owner/barrier.go
@@ -22,10 +22,8 @@ import (
 type barrierType int
 
 const (
-	// noneBarrier denotes there is no barrier.
-	noneBarrier barrierType = iota
 	// syncPointBarrier denotes a barrier for snapshot replication.
-	syncPointBarrier
+	syncPointBarrier barrierType = iota
 	// finishBarrier denotes a barrier for changefeed finished.
 	finishBarrier
 )

--- a/cdc/owner/barrier.go
+++ b/cdc/owner/barrier.go
@@ -22,8 +22,10 @@ import (
 type barrierType int
 
 const (
+	// noneBarrier denotes there is no barrier.
+	noneBarrier barrierType = iota
 	// syncPointBarrier denotes a barrier for snapshot replication.
-	syncPointBarrier barrierType = iota
+	syncPointBarrier
 	// finishBarrier denotes a barrier for changefeed finished.
 	finishBarrier
 )

--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -927,11 +927,6 @@ func (c *changefeed) handleBarrier(ctx context.Context,
 	barrier *schedulepb.BarrierWithMinTs,
 ) error {
 	barrierTp, barrierTs := c.barriers.Min()
-	if barrierTp == noneBarrier {
-		return nil
-	}
-
-	c.metricsChangefeedBarrierTsGauge.Set(float64(oracle.ExtractPhysical(barrierTs)))
 	// It means:
 	//   1. All data before the barrierTs was sent to downstream.
 	//   2. No more data after barrierTs was sent to downstream.
@@ -973,6 +968,7 @@ func (c *changefeed) handleBarrier(ctx context.Context,
 		barrier.MinTableBarrierTs = barrierTs
 	}
 
+	c.metricsChangefeedBarrierTsGauge.Set(float64(oracle.ExtractPhysical(barrier.GlobalBarrierTs)))
 	return nil
 }
 

--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -968,6 +968,7 @@ func (c *changefeed) handleBarrier(ctx context.Context,
 		barrier.MinTableBarrierTs = barrierTs
 	}
 
+	// MinTableBarrierTs is always the next barrier that blocking the global resolvedTs.
 	c.metricsChangefeedBarrierTsGauge.Set(float64(oracle.ExtractPhysical(barrier.MinTableBarrierTs)))
 	return nil
 }

--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -968,7 +968,7 @@ func (c *changefeed) handleBarrier(ctx context.Context,
 		barrier.MinTableBarrierTs = barrierTs
 	}
 
-	c.metricsChangefeedBarrierTsGauge.Set(float64(oracle.ExtractPhysical(barrier.GlobalBarrierTs)))
+	c.metricsChangefeedBarrierTsGauge.Set(float64(oracle.ExtractPhysical(barrier.MinTableBarrierTs)))
 	return nil
 }
 

--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -927,8 +927,11 @@ func (c *changefeed) handleBarrier(ctx context.Context,
 	barrier *schedulepb.BarrierWithMinTs,
 ) error {
 	barrierTp, barrierTs := c.barriers.Min()
-	c.metricsChangefeedBarrierTsGauge.Set(float64(oracle.ExtractPhysical(barrierTs)))
+	if barrierTp == noneBarrier {
+		return nil
+	}
 
+	c.metricsChangefeedBarrierTsGauge.Set(float64(oracle.ExtractPhysical(barrierTs)))
 	// It means:
 	//   1. All data before the barrierTs was sent to downstream.
 	//   2. No more data after barrierTs was sent to downstream.


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11553 

### What is changed and how it works?

* use `MinTableBarrierTs` as the checkpoint barrier.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
