### PR TITLE
ddl(ticdc): Add error handling for mismatched `Job.Query` and `Job.BinlogInfo.MultipleTableInfos` in TiCDC

### DIFF
--- a/cdc/puller/ddl_puller.go
+++ b/cdc/puller/ddl_puller.go
@@ -396,11 +396,12 @@ func (p *ddlJobPullerImpl) handleJob(job *timodel.Job) (skip bool, err error) {
 		// we only use multiTableInfos and Querys when we generate job event
 		// So if some table should be discard, we just need to delete the info from multiTableInfos and Querys
 		if strings.Count(job.Query, ";") != len(job.BinlogInfo.MultipleTableInfos) {
-			log.Panic("the number of queries in `Job.Query` is not equal to "+
+			log.Error("the number of queries in `Job.Query` is not equal to "+
 				"the number of `TableInfo` in `Job.BinlogInfo.MultipleTableInfos`",
 				zap.String("Job.Query", job.Query),
 				zap.Any("Job.BinlogInfo.MultipleTableInfos", job.BinlogInfo.MultipleTableInfos),
 				zap.Error(cerror.ErrTiDBUnexpectedJobMeta.GenWithStackByArgs()))
+			return false, cerror.ErrTiDBUnexpectedJobMeta.GenWithStackByArgs()
 		}
 
 		var newMultiTableInfos []*timodel.TableInfo

--- a/cdc/puller/ddl_puller.go
+++ b/cdc/puller/ddl_puller.go
@@ -397,7 +397,7 @@ func (p *ddlJobPullerImpl) handleJob(job *timodel.Job) (skip bool, err error) {
 		// So if some table should be discard, we just need to delete the info from multiTableInfos and Querys
 		if strings.Count(job.Query, ";") != len(job.BinlogInfo.MultipleTableInfos) {
 			log.Panic("the number of queries in `Job.Query` is not equal to "+
-				"the number of `TableInfo` in `Job.BinlogInfo.MultipleTableInfos`, ",
+				"the number of `TableInfo` in `Job.BinlogInfo.MultipleTableInfos`",
 				zap.String("Job.Query", job.Query),
 				zap.Any("Job.BinlogInfo.MultipleTableInfos", job.BinlogInfo.MultipleTableInfos),
 				zap.Error(cerror.ErrTiDBUnexpectedJobMeta.GenWithStackByArgs()))

--- a/cdc/puller/ddl_puller.go
+++ b/cdc/puller/ddl_puller.go
@@ -395,6 +395,14 @@ func (p *ddlJobPullerImpl) handleJob(job *timodel.Job) (skip bool, err error) {
 	case timodel.ActionCreateTables:
 		// we only use multiTableInfos and Querys when we generate job event
 		// So if some table should be discard, we just need to delete the info from multiTableInfos and Querys
+		if strings.Count(job.Query, ";") != len(job.BinlogInfo.MultipleTableInfos) {
+			log.Panic("the number of queries in `Job.Query` is not equal to "+
+				"the number of `TableInfo` in `Job.BinlogInfo.MultipleTableInfos`, ",
+				zap.String("Job.Query", job.Query),
+				zap.Any("Job.BinlogInfo.MultipleTableInfos", job.BinlogInfo.MultipleTableInfos),
+				zap.Error(cerror.ErrTiDBUnexpectedJobMeta.GenWithStackByArgs()))
+		}
+
 		var newMultiTableInfos []*timodel.TableInfo
 		var newQuerys []string
 
@@ -407,13 +415,13 @@ func (p *ddlJobPullerImpl) handleJob(job *timodel.Job) (skip bool, err error) {
 				continue
 			}
 			newMultiTableInfos = append(newMultiTableInfos, multiTableInfos[index])
-			newQuerys = append(newQuerys, querys[index])
+			newQuerys = append(newQuerys, querys[index]+";")
 		}
 
 		skip = len(newMultiTableInfos) == 0
 
 		job.BinlogInfo.MultipleTableInfos = newMultiTableInfos
-		job.Query = strings.Join(newQuerys, ";")
+		job.Query = strings.Join(newQuerys, "")
 	case timodel.ActionRenameTable:
 		oldTable, ok := snap.PhysicalTableByID(job.TableID)
 		if !ok {

--- a/errors.toml
+++ b/errors.toml
@@ -1011,6 +1011,11 @@ error = '''
 fail to create changefeed because target-ts %d is earlier than start-ts %d
 '''
 
+["CDC:ErrTiDBUnexpectedJobMeta"]
+error = '''
+unexpected `job_meta` from tidb
+'''
+
 ["CDC:ErrTiKVEventFeed"]
 error = '''
 tikv event feed failed

--- a/pkg/errors/cdc_errors.go
+++ b/pkg/errors/cdc_errors.go
@@ -145,6 +145,12 @@ var (
 		errors.RFCCodeText("CDC:ErrCodeNilFunction"),
 	)
 
+	// Errors caused by unexpected behavior from external systems
+	ErrTiDBUnexpectedJobMeta = errors.Normalize(
+		"unexpected `job_meta` from tidb",
+		errors.RFCCodeText("CDC:ErrTiDBUnexpectedJobMeta"),
+	)
+
 	// ErrVersionIncompatible is an error for running CDC on an incompatible Cluster.
 	ErrVersionIncompatible = errors.Normalize(
 		"version is incompatible: %s",


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11507

### What is changed and how it works?

**Description:**

This PR addresses an issue in TiCDC where a mismatch between the number of queries in `Job.Query` and the number of `TableInfo` entries in `Job.BinlogInfo.MultipleTableInfos` leads to an `index out of range` panic. This issue originates from TiDB's fast create table functionality, which previously merged multiple DDL jobs into a single batch but failed to correctly merge their corresponding queries. As a result, the length of `Job.Query` did not match the number of tables in `Job.BinlogInfo.MultipleTableInfos`, causing TiCDC to panic during DDL job processing.

This issue has been fixed in TiDB (see issue [tidb#53076](https://github.com/pingcap/tidb/issues/53076) and PR [tidb#53515](https://github.com/pingcap/tidb/pull/53515)). However, since TiCDC relies on external systems to provide consistent metadata, it is essential to add error handling to ensure these fields match before processing DDL jobs.

**Changes:**
1. Added error handling in TiCDC's puller to validate that the number of queries in `Job.Query` matches the number of `TableInfo` entries in `Job.BinlogInfo.MultipleTableInfos`.
2. If a mismatch is detected, TiCDC will log an error and panic to prevent further processing with inconsistent metadata. This allows easier identification of the root cause and ensures stability during job handling.

```go
if strings.Count(job.Query, ";") != len(job.BinlogInfo.MultipleTableInfos) {
    log.Panic("the number of queries in `Job.Query` is not equal to "+
        "the number of `TableInfo` in `Job.BinlogInfo.MultipleTableInfos`, ",
        zap.String("Job.Query", job.Query),
        zap.Any("Job.BinlogInfo.MultipleTableInfos", job.BinlogInfo.MultipleTableInfos),
        zap.Error(cerror.ErrTiDBUnexpectedJobMeta.GenWithStackByArgs()))
}
```

**Context:**
This bug surfaced due to TiDB's optimization in fast create table, which performs DDL batching by merging multiple jobs. The issue arose because TiDB did not correctly merge the associated queries for each job in this scenario. Since TiCDC directly consumes the metadata from TiDB, any inconsistency in the data structure leads to downstream errors.

By adding this validation, we ensure that TiCDC processes jobs only when the metadata is consistent and structured as expected. This is critical because TiCDC depends on external systems like TiDB to provide correct metadata for reliable replication. Adding error handling ensures that we detect anomalies earlier and prevent unexpected behavior that could potentially affect data replication.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

```shell
make prepare_test_binaries community=true ver=v8.1.0
make integration_test_build
make integration_test CASE=batch_add_table
```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
