### PR TITLE
sink(ticdc): remove duplicate sort about open protocol

### DIFF
--- a/pkg/sink/codec/open/open_protocol_message.go
+++ b/pkg/sink/codec/open/open_protocol_message.go
@@ -27,28 +27,6 @@ import (
 	"github.com/pingcap/tiflow/pkg/sink/codec/internal"
 )
 
-type columnsArray []*model.Column
-
-func (a columnsArray) Len() int {
-	return len(a)
-}
-
-func (a columnsArray) Less(i, j int) bool {
-	return a[i].Name < a[j].Name
-}
-
-func (a columnsArray) Swap(i, j int) {
-	a[i], a[j] = a[j], a[i]
-}
-
-// sortColumnArrays sort column arrays by name
-func sortColumnArrays(arrays ...[]*model.Column) {
-	for _, array := range arrays {
-		if array != nil {
-			sort.Sort(columnsArray(array))
-		}
-	}
-}
 
 type messageRow struct {
 	Update     map[string]internal.Column `json:"u,omitempty"`
@@ -174,15 +152,12 @@ func msgToRowChange(key *internal.MessageKey, value *messageRow) *model.RowChang
 
 	if len(value.Delete) != 0 {
 		preCols := codecColumns2RowChangeColumns(value.Delete)
-		sortColumnArrays(preCols)
 		indexColumns := model.GetHandleAndUniqueIndexOffsets4Test(preCols)
 		e.TableInfo = model.BuildTableInfo(key.Schema, key.Table, preCols, indexColumns)
 		e.PreColumns = model.Columns2ColumnDatas(preCols, e.TableInfo)
 	} else {
 		cols := codecColumns2RowChangeColumns(value.Update)
 		preCols := codecColumns2RowChangeColumns(value.PreColumns)
-		sortColumnArrays(cols)
-		sortColumnArrays(preCols)
 		indexColumns := model.GetHandleAndUniqueIndexOffsets4Test(cols)
 		e.TableInfo = model.BuildTableInfo(key.Schema, key.Table, cols, indexColumns)
 		e.Columns = model.Columns2ColumnDatas(cols, e.TableInfo)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #10913

### What is changed and how it works?
Repeat with the following code
https://github.com/pingcap/tiflow/blob/45c831ae03b066caf7b23d1542cdb57e6c28028e/pkg/sink/codec/open/open_protocol_message.go#L229-L231

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
