### PR TITLE
kvclient(ticdc): add table id to kv client logs

### DIFF
--- a/cdc/kv/region_state.go
+++ b/cdc/kv/region_state.go
@@ -45,7 +45,7 @@ type regionInfo struct {
 	lockedRangeState *regionlock.LockedRangeState
 }
 
-func (s regionInfo) isStoped() bool {
+func (s regionInfo) isStopped() bool {
 	// lockedRange only nil when the region's subscribedTable is stopped.
 	return s.lockedRangeState == nil
 }

--- a/cdc/kv/shared_client.go
+++ b/cdc/kv/shared_client.go
@@ -293,9 +293,7 @@ func (s *SharedClient) Subscribe(subID SubscriptionID, span tablepb.Span, startT
 		zap.String("namespace", s.changefeed.Namespace),
 		zap.String("changefeed", s.changefeed.ID),
 		zap.Any("subscriptionID", rt.subscriptionID),
-		zap.Int64("tableID", rt.span.TableID),
-		zap.Any("startKey", rt.span.StartKey),
-		zap.Any("endKey", rt.span.EndKey))
+		zap.String("span", rt.span.String()))
 }
 
 // Unsubscribe the given table span. All covered regions will be deregistered asynchronously.
@@ -311,9 +309,7 @@ func (s *SharedClient) Unsubscribe(subID SubscriptionID) {
 			zap.String("namespace", s.changefeed.Namespace),
 			zap.String("changefeed", s.changefeed.ID),
 			zap.Any("subscriptionID", rt.subscriptionID),
-			zap.Int64("tableID", rt.span.TableID),
-			zap.Any("startKey", rt.span.StartKey),
-			zap.Any("endKey", rt.span.EndKey))
+			zap.String("span", rt.span.String()))
 		return
 	}
 	log.Warn("event feed unsubscribes table, but not found",
@@ -449,10 +445,8 @@ func (s *SharedClient) handleRegions(ctx context.Context, eg *errgroup.Group) er
 				zap.String("changefeed", s.changefeed.ID),
 				zap.Uint64("streamID", stream.streamID),
 				zap.Any("subscriptionID", region.subscribedTable.subscriptionID),
-				zap.Int64("tableID", region.span.TableID),
 				zap.Uint64("regionID", region.verID.GetID()),
-				zap.Any("startKey", region.span.StartKey),
-				zap.Any("endKey", region.span.EndKey),
+				zap.String("span", region.span.String()),
 				zap.Uint64("storeID", store.storeID),
 				zap.String("addr", store.storeAddr))
 		}
@@ -566,9 +560,7 @@ func (s *SharedClient) divideSpanAndScheduleRegionRequests(
 				zap.String("namespace", s.changefeed.Namespace),
 				zap.String("changefeed", s.changefeed.ID),
 				zap.Any("subscriptionID", subscribedTable.subscriptionID),
-				zap.Int64("tableID", nextSpan.TableID),
-				zap.Any("startKey", nextSpan.StartKey),
-				zap.Any("endKey", nextSpan.EndKey),
+				zap.String("span", nextSpan.String()),
 				zap.Error(err))
 			backoffBeforeLoad = true
 			continue
@@ -586,9 +578,7 @@ func (s *SharedClient) divideSpanAndScheduleRegionRequests(
 				zap.String("namespace", s.changefeed.Namespace),
 				zap.String("changefeed", s.changefeed.ID),
 				zap.Any("subscriptionID", subscribedTable.subscriptionID),
-				zap.Int64("tableID", nextSpan.TableID),
-				zap.Any("startKey", nextSpan.StartKey),
-				zap.Any("endKey", nextSpan.EndKey))
+				zap.String("span", nextSpan.String()))
 			backoffBeforeLoad = true
 			continue
 		}
@@ -607,9 +597,7 @@ func (s *SharedClient) divideSpanAndScheduleRegionRequests(
 					zap.String("namespace", s.changefeed.Namespace),
 					zap.String("changefeed", s.changefeed.ID),
 					zap.Any("subscriptionID", subscribedTable.subscriptionID),
-					zap.Int64("tableID", nextSpan.TableID),
-					zap.Any("startKey", nextSpan.StartKey),
-					zap.Any("endKey", nextSpan.EndKey))
+					zap.String("span", nextSpan.String()))
 			}
 
 			verID := tikv.NewRegionVerID(regionMeta.Id, regionMeta.RegionEpoch.ConfVer, regionMeta.RegionEpoch.Version)

--- a/cdc/kv/shared_stream.go
+++ b/cdc/kv/shared_stream.go
@@ -76,7 +76,7 @@ func newStream(ctx context.Context, c *SharedClient, g *errgroup.Group, r *reque
 			case <-ctx.Done():
 				return ctx.Err()
 			case region := <-stream.requests.Out():
-				if !region.isStoped() {
+				if !region.isStopped() {
 					stream.preFetchForConnecting = new(regionInfo)
 					*stream.preFetchForConnecting = region
 					return nil
@@ -104,7 +104,7 @@ func newStream(ctx context.Context, c *SharedClient, g *errgroup.Group, r *reque
 			// Why we need to re-schedule pending regions? This because the store can
 			// fail forever, and all regions are scheduled to other stores.
 			for _, region := range stream.clearPendingRegions() {
-				if region.isStoped() {
+				if region.isStopped() {
 					// It means it's a special task for stopping the table.
 					continue
 				}
@@ -254,30 +254,6 @@ func (s *requestedStream) receive(
 }
 
 func (s *requestedStream) send(ctx context.Context, c *SharedClient, rs *requestedStore) (err error) {
-	doSend := func(cc *sharedconn.ConnAndClient, req *cdcpb.ChangeDataRequest, subscriptionID SubscriptionID) error {
-		if err := cc.Client().Send(req); err != nil {
-			log.Warn("event feed send request to grpc stream failed",
-				zap.String("namespace", c.changefeed.Namespace),
-				zap.String("changefeed", c.changefeed.ID),
-				zap.Uint64("streamID", s.streamID),
-				zap.Any("subscriptionID", subscriptionID),
-				zap.Uint64("regionID", req.RegionId),
-				zap.Uint64("storeID", rs.storeID),
-				zap.String("addr", rs.storeAddr),
-				zap.Error(err))
-			return errors.Trace(err)
-		}
-		log.Debug("event feed send request to grpc stream success",
-			zap.String("namespace", c.changefeed.Namespace),
-			zap.String("changefeed", c.changefeed.ID),
-			zap.Uint64("streamID", s.streamID),
-			zap.Any("subscriptionID", subscriptionID),
-			zap.Uint64("regionID", req.RegionId),
-			zap.Uint64("storeID", rs.storeID),
-			zap.String("addr", rs.storeAddr))
-		return nil
-	}
-
 	fetchMoreReq := func() (regionInfo, error) {
 		waitReqTicker := time.NewTicker(60 * time.Second)
 		defer waitReqTicker.Stop()
@@ -329,23 +305,24 @@ func (s *requestedStream) send(ctx context.Context, c *SharedClient, rs *request
 	s.preFetchForConnecting = nil
 	for {
 		subscriptionID := region.subscribedTable.subscriptionID
-		log.Debug("event feed gets a singleRegionInfo",
-			zap.String("namespace", c.changefeed.Namespace),
-			zap.String("changefeed", c.changefeed.ID),
-			zap.Uint64("streamID", s.streamID),
-			zap.Any("subscriptionID", subscriptionID),
-			zap.Uint64("regionID", region.verID.GetID()),
-			zap.Uint64("storeID", rs.storeID),
-			zap.String("addr", rs.storeAddr))
 		// It means it's a special task for stopping the table.
-		if region.isStoped() {
+		if region.isStopped() {
 			if s.multiplexing != nil {
 				req := &cdcpb.ChangeDataRequest{
 					RequestId: uint64(subscriptionID),
 					Request:   &cdcpb.ChangeDataRequest_Deregister_{},
 				}
-				if err = doSend(s.multiplexing, req, subscriptionID); err != nil {
-					return err
+				if err = s.multiplexing.Client().Send(req); err != nil {
+					log.Warn("event feed send deregister request to grpc stream failed",
+						zap.String("namespace", c.changefeed.Namespace),
+						zap.String("changefeed", c.changefeed.ID),
+						zap.Uint64("streamID", s.streamID),
+						zap.Any("subscriptionID", subscriptionID),
+						zap.Int64("tableID", region.span.TableID),
+						zap.Uint64("regionID", req.RegionId),
+						zap.Uint64("storeID", rs.storeID),
+						zap.String("addr", rs.storeAddr),
+						zap.Error(err))
 				}
 			} else if cc := tableExclusives[subscriptionID]; cc != nil {
 				delete(tableExclusives, subscriptionID)
@@ -385,8 +362,17 @@ func (s *requestedStream) send(ctx context.Context, c *SharedClient, rs *request
 			} else if cc, err = getTableExclusiveConn(subscriptionID); err != nil {
 				return err
 			}
-			if err = doSend(cc, c.createRegionRequest(region), subscriptionID); err != nil {
-				return err
+			if err = cc.Client().Send(c.createRegionRequest(region)); err != nil {
+				log.Warn("event feed send request to grpc stream failed",
+					zap.String("namespace", c.changefeed.Namespace),
+					zap.String("changefeed", c.changefeed.ID),
+					zap.Uint64("streamID", s.streamID),
+					zap.Any("subscriptionID", subscriptionID),
+					zap.Uint64("regionID", region.verID.GetID()),
+					zap.Int64("tableID", region.span.TableID),
+					zap.Uint64("storeID", rs.storeID),
+					zap.String("addr", rs.storeAddr),
+					zap.Error(err))
 			}
 		}
 

--- a/cdc/kv/shared_stream.go
+++ b/cdc/kv/shared_stream.go
@@ -469,14 +469,19 @@ func (s *requestedStream) sendRegionChangeEvents(
 		state := s.getState(subscriptionID, regionID)
 		switch x := event.Event.(type) {
 		case *cdcpb.Event_Error:
-			s.logRegionDetails("event feed receives a region error",
+			fields := []zap.Field{
 				zap.String("namespace", c.changefeed.Namespace),
 				zap.String("changefeed", c.changefeed.ID),
 				zap.Uint64("streamID", s.streamID),
 				zap.Any("subscriptionID", subscriptionID),
 				zap.Uint64("regionID", event.RegionId),
 				zap.Bool("stateIsNil", state == nil),
-				zap.Any("error", x.Error))
+				zap.Any("error", x.Error),
+			}
+			if state != nil {
+				fields = append(fields, zap.Int64("tableID", state.region.span.TableID))
+			}
+			s.logRegionDetails("event feed receives a region error", fields...)
 		}
 
 		if state != nil {

--- a/cdc/processor/tablepb/table.go
+++ b/cdc/processor/tablepb/table.go
@@ -72,30 +72,30 @@ func (k Key) MarshalJSON() ([]byte, error) {
 }
 
 var (
-	_ encoding.TextMarshaler = Span{}
+	_ encoding.TextMarshaler = &Span{}
 	_ encoding.TextMarshaler = (*Span)(nil)
 )
 
 // MarshalText implements encoding.TextMarshaler (used in proto.CompactTextString).
 // It is helpful to format span in log.
-func (s Span) MarshalText() ([]byte, error) {
+func (s *Span) MarshalText() ([]byte, error) {
 	return []byte(s.String()), nil
 }
 
 func (s *Span) String() string {
-	length := len("{table_id:,start_key:,end_key:}")
+	length := len("{tableID:, startKey:, endKey:}")
 	length += 8 // for TableID
 	length += len(s.StartKey) + len(s.EndKey)
-	b := strings.Builder{}
+	var b strings.Builder
 	b.Grow(length)
-	b.Write([]byte("{table_id:"))
+	b.Write([]byte("{tableID:"))
 	b.Write([]byte(strconv.Itoa(int(s.TableID))))
 	if len(s.StartKey) > 0 {
-		b.Write([]byte(",start_key:"))
+		b.Write([]byte(", startKey:"))
 		b.Write([]byte(s.StartKey.String()))
 	}
 	if len(s.EndKey) > 0 {
-		b.Write([]byte(",end_key:"))
+		b.Write([]byte(", endKey:"))
 		b.Write([]byte(s.EndKey.String()))
 	}
 	b.Write([]byte("}"))


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11621 

### What is changed and how it works?

* add table id to kv client logs, so we can know the region corresponding table

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
