### PR TITLE
integration test(ticdc): Reintroduce `--wildcards` Option in tar Command for download-integration-test-binaries.sh

### DIFF
--- a/scripts/download-integration-test-binaries.sh
+++ b/scripts/download-integration-test-binaries.sh
@@ -174,9 +174,9 @@ download_and_extract() {
 
 	download_file "$url" "$file_name" "${TMP_DIR}/$file_name"
 	if [ -n "$extract_path" ]; then
-		tar -xz -C ${THIRD_BIN_DIR} $extract_path -f ${TMP_DIR}/$file_name
+		tar -xz --wildcards -C ${THIRD_BIN_DIR} $extract_path -f ${TMP_DIR}/$file_name
 	else
-		tar -xz -C ${THIRD_BIN_DIR} -f ${TMP_DIR}/$file_name
+		tar -xz --wildcards -C ${THIRD_BIN_DIR} -f ${TMP_DIR}/$file_name
 	fi
 
 	# Move extracted files if necessary
@@ -206,6 +206,7 @@ cleanup() {
 
 setup() {
 	cleanup
+	rm -rf ${BIN_DIR}
 	mkdir -p ${THIRD_BIN_DIR} ${TMP_DIR} ${BIN_DIR}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11631

### What is changed and how it works?

**Description:**

This PR addresses the reoccurrence of the `tar` extraction issue in `scripts/download-integration-test-binaries.sh` following a refactor, where the `--wildcards` option was omitted. This option is necessary for wildcard pattern matching in certain versions of `tar` to correctly extract the required binaries for PD.

#### **Context:**

In a previous issue:#11512 and pr:#11513, a similar problem was identified and resolved by adding the `--wildcards` option to the `tar` command. However, during the refactoring of the script, this option was unintentionally removed, causing the issue to resurface.

The current command:

https://github.com/pingcap/tiflow/blob/4e177d94ca41d5f49a44c5545adfca1c72820f87/scripts/download-integration-test-binaries.sh#L156

https://github.com/pingcap/tiflow/blob/4e177d94ca41d5f49a44c5545adfca1c72820f87/scripts/download-integration-test-binaries.sh#L176-L180

fails on some systems due to lack of support for wildcard matching by default. Without the `--wildcards` option, the necessary binaries are not extracted, leading to test failures.

#### **Solution:**

To fix this issue, I have reintroduced the `--wildcards` option in the `tar` command, ensuring compatibility across different systems. 

This guarantees that `tar` will correctly interpret wildcard patterns, even in environments where it isn’t enabled by default.

#### **Impact:**

- Ensures consistent extraction of binaries across different environments and `tar` implementations.
- Prevents failures in the integration tests by ensuring the correct binaries are extracted and available.

This PR is related to the previous #11513 that addressed the same issue before the script refactor.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
```bash
make prepare_test_binaries
```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
