### PR TITLE
api(ticdc): Not show the error info during query the changefeed when state is stopped, finished and removed

### DIFF
--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -284,7 +284,7 @@ func (h *OpenAPIV2) listChangeFeeds(c *gin.Context) {
 
 		// if the state is normal, we shall not return the error info
 		// because changefeed will is retrying. errors will confuse the users
-		if commonInfo.FeedState == model.StateNormal || commonInfo.FeedState == model.StateStopped || commonInfo.FeedState == model.StateFinished || commonInfo.FeedState == model.StateRemoved {
+		if !shouldShowRunningError(commonInfo.FeedState) {
 			commonInfo.RunningError = nil
 		}
 
@@ -1025,6 +1025,19 @@ func (h *OpenAPIV2) synced(c *gin.Context) {
 	})
 }
 
+func shouldShowRunningError(state model.FeedState) bool {
+	switch state {
+	case model.StateNormal:
+	case model.StateStopped:
+	case model.StateFinished:
+	case model.StateRemoved:
+		return false
+	default:
+		return true
+	}
+	return true
+}
+
 func toAPIModel(
 	info *model.ChangeFeedInfo,
 	resolvedTs uint64,
@@ -1036,7 +1049,7 @@ func toAPIModel(
 
 	// if the state is normal, we shall not return the error info
 	// because changefeed will is retrying. errors will confuse the users
-	if info.Error != nil && info.State != model.StateNormal && info.State != model.StateStopped && info.State != model.StateFinished && info.State != model.StateRemoved {
+	if info.Error != nil && !shouldShowRunningError(info.State) {
 		runningError = &RunningError{
 			Addr:    info.Error.Addr,
 			Code:    info.Error.Code,

--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -284,7 +284,7 @@ func (h *OpenAPIV2) listChangeFeeds(c *gin.Context) {
 
 		// if the state is normal, we shall not return the error info
 		// because changefeed will is retrying. errors will confuse the users
-		if commonInfo.FeedState == model.StateNormal {
+		if commonInfo.FeedState == model.StateNormal || commonInfo.FeedState == model.StateStopped || commonInfo.FeedState == model.StateFinished || commonInfo.FeedState == model.StateRemoved {
 			commonInfo.RunningError = nil
 		}
 
@@ -1036,7 +1036,7 @@ func toAPIModel(
 
 	// if the state is normal, we shall not return the error info
 	// because changefeed will is retrying. errors will confuse the users
-	if info.State != model.StateNormal && info.Error != nil {
+	if info.Error != nil && info.State != model.StateNormal && info.State != model.StateStopped && info.State != model.StateFinished && info.State != model.StateRemoved {
 		runningError = &RunningError{
 			Addr:    info.Error.Addr,
 			Code:    info.Error.Code,

--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -1032,7 +1032,6 @@ func shouldShowRunningError(state model.FeedState) bool {
 	default:
 		return true
 	}
-	return true
 }
 
 func toAPIModel(

--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -1027,10 +1027,7 @@ func (h *OpenAPIV2) synced(c *gin.Context) {
 
 func shouldShowRunningError(state model.FeedState) bool {
 	switch state {
-	case model.StateNormal:
-	case model.StateStopped:
-	case model.StateFinished:
-	case model.StateRemoved:
+	case model.StateNormal, model.StateStopped, model.StateFinished, model.StateRemoved:
 		return false
 	default:
 		return true

--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -1049,7 +1049,7 @@ func toAPIModel(
 
 	// if the state is normal, we shall not return the error info
 	// because changefeed will is retrying. errors will confuse the users
-	if info.Error != nil && !shouldShowRunningError(info.State) {
+	if info.Error != nil && shouldShowRunningError(info.State) {
 		runningError = &RunningError{
 			Addr:    info.Error.Addr,
 			Code:    info.Error.Code,

--- a/tests/integration_tests/changefeed_error/run.sh
+++ b/tests/integration_tests/changefeed_error/run.sh
@@ -118,7 +118,7 @@ function run() {
 	run_cdc_cli changefeed create --start-ts=0 --sink-uri="$SINK_URI" -c $changefeedid_3
 	ensure $MAX_RETRIES check_changefeed_state http://${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid_3} "normal" "null" ""
 	run_cdc_cli changefeed pause -c $changefeedid_3
-	ensure $MAX_RETRIES check_changefeed_state http://${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid_3} "stopped" "changefeed new redo manager injected error" ""
+	ensure $MAX_RETRIES check_changefeed_state http://${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid_3} "stopped" "null" ""
 	run_cdc_cli changefeed resume -c $changefeedid_3
 	ensure $MAX_RETRIES check_changefeed_state http://${UP_PD_HOST_1}:${UP_PD_PORT_1} ${changefeedid_3} "normal" "null" ""
 	run_cdc_cli changefeed remove -c $changefeedid_3


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/11642

### What is changed and how it works?
Make the previous error message not return when changefeed state is stopped / finished / removed, to avoid confused.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
