### PR TITLE
checker(dm): update gtidSet by checkpoint data in MetaPositionChecker

### DIFF
--- a/dm/checker/checker.go
+++ b/dm/checker/checker.go
@@ -51,6 +51,7 @@ import (
 	"github.com/pingcap/tiflow/dm/pkg/terror"
 	onlineddl "github.com/pingcap/tiflow/dm/syncer/online-ddl-tools"
 	"github.com/pingcap/tiflow/dm/unit"
+	"github.com/pingcap/tiflow/dm/worker"
 	pdhttp "github.com/tikv/pd/client/http"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
@@ -343,10 +344,16 @@ func (c *Checker) Init(ctx context.Context) (err error) {
 			checkMetaPos := len(instance.cfg.Meta.BinLogName) > 0 ||
 				(instance.cfg.EnableGTID && len(instance.cfg.Meta.BinLogGTID) > 0)
 			if _, ok := c.checkingItems[config.MetaPositionChecking]; checkMetaPos && ok {
+				// get position from global checkpoint
+				cpLock, err := worker.GetMinLocForSubTask(ctx, *instance.cfg)
+				if err != nil {
+					return err
+				}
 				c.checkList = append(c.checkList, checker.NewMetaPositionChecker(instance.sourceDB,
 					instance.cfg.From,
 					instance.cfg.EnableGTID,
-					instance.cfg.Meta))
+					instance.cfg.Meta,
+					cpLock))
 			}
 		}
 		if config.HasSync(instance.cfg.Mode) {

--- a/dm/checker/checker.go
+++ b/dm/checker/checker.go
@@ -345,7 +345,7 @@ func (c *Checker) Init(ctx context.Context) (err error) {
 				(instance.cfg.EnableGTID && len(instance.cfg.Meta.BinLogGTID) > 0)
 			if _, ok := c.checkingItems[config.MetaPositionChecking]; checkMetaPos && ok {
 				// get position from global checkpoint
-				cpLock, err := worker.GetMinLocForSubTask(ctx, *instance.cfg)
+				cpLoc, err := worker.GetMinLocForSubTask(ctx, *instance.cfg)
 				if err != nil {
 					return err
 				}
@@ -353,7 +353,7 @@ func (c *Checker) Init(ctx context.Context) (err error) {
 					instance.cfg.From,
 					instance.cfg.EnableGTID,
 					instance.cfg.Meta,
-					cpLock))
+					cpLoc))
 			}
 		}
 		if config.HasSync(instance.cfg.Mode) {

--- a/dm/pkg/checker/binlog.go
+++ b/dm/pkg/checker/binlog.go
@@ -285,8 +285,8 @@ type MetaPositionChecker struct {
 }
 
 // NewMetaPositionChecker returns a RealChecker.
-func NewMetaPositionChecker(db *conn.BaseDB, sourceCfg dbconfig.DBConfig, enableGTID bool, meta *config.Meta, cpMinLoc *binlog.Location) RealChecker {
-	return &MetaPositionChecker{db: db, sourceCfg: sourceCfg, enableGTID: enableGTID, meta: meta, cpLoc: cpMinLoc}
+func NewMetaPositionChecker(db *conn.BaseDB, sourceCfg dbconfig.DBConfig, enableGTID bool, meta *config.Meta, cpLoc *binlog.Location) RealChecker {
+	return &MetaPositionChecker{db: db, sourceCfg: sourceCfg, enableGTID: enableGTID, meta: meta, cpLoc: cpLoc}
 }
 
 // Check implements the RealChecker interface.

--- a/dm/worker/server.go
+++ b/dm/worker/server.go
@@ -51,7 +51,7 @@ var (
 	retryGetRelayConfig       = 5
 	retryConnectSleepTime     = time.Second
 	syncMasterEndpointsTime   = 3 * time.Second
-	getMinLocForSubTaskFunc   = getMinLocForSubTask
+	getMinLocForSubTaskFunc   = GetMinLocForSubTask
 )
 
 // Server accepts RPC requests
@@ -932,7 +932,8 @@ func getMinLocInAllSubTasks(ctx context.Context, subTaskCfgs map[string]config.S
 	return minLoc, nil
 }
 
-func getMinLocForSubTask(ctx context.Context, subTaskCfg config.SubTaskConfig) (minLoc *binlog.Location, err error) {
+// GetMinLocForSubTaskFunc get min location for subtask. exported for precheck in master.
+func GetMinLocForSubTask(ctx context.Context, subTaskCfg config.SubTaskConfig) (minLoc *binlog.Location, err error) {
 	if !config.HasSync(subTaskCfg.Mode) {
 		return nil, nil
 	}

--- a/dm/worker/server_test.go
+++ b/dm/worker/server_test.go
@@ -66,7 +66,7 @@ func (t *testServer) SetUpSuite(c *check.C) {
 }
 
 func (t *testServer) TearDownSuite(c *check.C) {
-	getMinLocForSubTaskFunc = getMinLocForSubTask
+	getMinLocForSubTaskFunc = GetMinLocForSubTask
 }
 
 func createMockETCD(dir string, host string) (*embed.Etcd, error) {

--- a/dm/worker/source_worker_test.go
+++ b/dm/worker/source_worker_test.go
@@ -68,7 +68,7 @@ func (t *testServer2) SetUpSuite(c *check.C) {
 }
 
 func (t *testServer2) TearDownSuite(c *check.C) {
-	getMinLocForSubTaskFunc = getMinLocForSubTask
+	getMinLocForSubTaskFunc = GetMinLocForSubTask
 	c.Assert(failpoint.Disable("github.com/pingcap/tiflow/dm/worker/MockGetSourceCfgFromETCD"), check.IsNil)
 	c.Assert(failpoint.Disable("github.com/pingcap/tiflow/dm/worker/SkipRefreshFromETCDInUT"), check.IsNil)
 }
@@ -201,7 +201,7 @@ func (t *testWorkerFunctionalities) TearDownSuite(c *check.C) {
 	NewRelayHolder = NewRealRelayHolder
 	NewSubTask = NewRealSubTask
 	createUnits = createRealUnits
-	getMinLocForSubTaskFunc = getMinLocForSubTask
+	getMinLocForSubTaskFunc = GetMinLocForSubTask
 	c.Assert(failpoint.Disable("github.com/pingcap/tiflow/dm/worker/MockGetSourceCfgFromETCD"), check.IsNil)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11648

### What is changed and how it works?

In MetaPositionChecker (GTID enabled), we used to compare only the GTID from config file with the upstream binlog. However when we restart with the same config, the GTID info from config might be outdated (e.g. old binlogs are purgeded), while the updated one is saved in checkpoint.

Now in MetaPositionChecker stage, we load checkpoint data from downstream db, and replace the GTID from config if it is outdated.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
