### PR TITLE
ci(dm): Fix DM `import_v10x` Test Failure Due to TiDB int Type Display Change

### DIFF
--- a/dm/tests/import_v10x/run.sh
+++ b/dm/tests/import_v10x/run.sh
@@ -88,7 +88,7 @@ function run() {
 	run_sql "show create table \`dm_meta\`.\`test_syncer_checkpoint\`" $TIDB_PORT $TIDB_PASSWORD
 	check_contains "\`exit_safe_binlog_name\` varchar(128) DEFAULT ''"
 	# different TiDB will output DEFAULT 0 or DEFAULT '0'
-	check_contains "\`exit_safe_binlog_pos\` int(10) unsigned DEFAULT "
+	check_contains "\`exit_safe_binlog_pos\` int unsigned DEFAULT "
 	check_contains "\`exit_safe_binlog_gtid\` text DEFAULT NULL"
 
 	run_sql_file $cur/data/db1.increment.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1

--- a/dm/tests/import_v10x/run.sh
+++ b/dm/tests/import_v10x/run.sh
@@ -88,7 +88,7 @@ function run() {
 	run_sql "show create table \`dm_meta\`.\`test_syncer_checkpoint\`" $TIDB_PORT $TIDB_PASSWORD
 	check_contains "\`exit_safe_binlog_name\` varchar(128) DEFAULT ''"
 	# different TiDB will output DEFAULT 0 or DEFAULT '0'
-	check_contains "\`exit_safe_binlog_pos\` int unsigned DEFAULT "
+	check_contains "\`exit_safe_binlog_pos\` int"
 	check_contains "\`exit_safe_binlog_gtid\` text DEFAULT NULL"
 
 	run_sql_file $cur/data/db1.increment.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1


### PR DESCRIPTION


<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11680

This PR fixes the import_v10x test case in DM’s CI, which has been failing due to recent changes in TiDB. TiDB modified how the default int type is displayed when using the SHOW CREATE TABLE statement, causing the test to break. ref: https://github.com/pingcap/tidb/pull/56529

### What is changed and how it works?

I have updated the import_v10x test to accommodate the changes made in TiDB’s handling of int types in SHOW CREATE TABLE. This ensures compatibility with the latest version of TiDB and prevents the test from failing in future CI runs.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
