### PR TITLE
sink(ticdc): limit encoder-concurrency to avoid crash

### DIFF
--- a/pkg/sink/codec/encoder_group.go
+++ b/pkg/sink/codec/encoder_group.go
@@ -70,7 +70,7 @@ func NewEncoderGroup(
 	if concurrency <= 0 {
 		concurrency = config.DefaultEncoderGroupConcurrency
 	}
-	// limit concurrency to avoid OOM
+	// limit concurrency to avoid crash
 	if concurrency >= cpu.GetCPUCount()*10 {
 		concurrency = cpu.GetCPUCount() * 10
 	}

--- a/pkg/sink/codec/encoder_group.go
+++ b/pkg/sink/codec/encoder_group.go
@@ -70,9 +70,10 @@ func NewEncoderGroup(
 	if concurrency <= 0 {
 		concurrency = config.DefaultEncoderGroupConcurrency
 	}
-	// limit concurrency to avoid crash
-	if concurrency >= cpu.GetCPUCount()*10 {
-		concurrency = cpu.GetCPUCount() * 10
+	limitConcurrency = cpu.GetCPUCount() * 10
+	if concurrency > limitConcurrency {
+		concurrency = limitConcurrency
+		log.Warn("limit concurrency to avoid crash", zap.Int("concurrency", concurrency), zap.Any("limitConcurrency", limitConcurrency))
 	}
 	inputCh := make([]chan *future, concurrency)
 	for i := 0; i < concurrency; i++ {

--- a/pkg/sink/codec/encoder_group.go
+++ b/pkg/sink/codec/encoder_group.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/pkg/util/cpu"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/sink/dmlsink"
 	"github.com/pingcap/tiflow/pkg/config"
@@ -68,6 +69,10 @@ func NewEncoderGroup(
 	concurrency := util.GetOrZero(cfg.EncoderConcurrency)
 	if concurrency <= 0 {
 		concurrency = config.DefaultEncoderGroupConcurrency
+	}
+	// limit concurrency to avoid OOM
+	if concurrency >= cpu.GetCPUCount()*10 {
+		concurrency = cpu.GetCPUCount() * 10
 	}
 	inputCh := make([]chan *future, concurrency)
 	for i := 0; i < concurrency; i++ {

--- a/pkg/sink/codec/encoder_group.go
+++ b/pkg/sink/codec/encoder_group.go
@@ -70,7 +70,7 @@ func NewEncoderGroup(
 	if concurrency <= 0 {
 		concurrency = config.DefaultEncoderGroupConcurrency
 	}
-	limitConcurrency = cpu.GetCPUCount() * 10
+	limitConcurrency := cpu.GetCPUCount() * 10
 	if concurrency > limitConcurrency {
 		concurrency = limitConcurrency
 		log.Warn("limit concurrency to avoid crash", zap.Int("concurrency", concurrency), zap.Any("limitConcurrency", limitConcurrency))

--- a/scripts/download-integration-test-binaries.sh
+++ b/scripts/download-integration-test-binaries.sh
@@ -140,7 +140,7 @@ download_binaries() {
 	local tiflash_sha1=$(echo "$tiflash_branch_sha1" | cut -d':' -f2)
 
 	# Define download URLs
-	local tidb_download_url="${FILE_SERVER_URL}/download/builds/pingcap/tidb/9530fdc2388d025af86eb6fce5e617972c361000/centos7/tidb-server.tar.gz"
+	local tidb_download_url="${FILE_SERVER_URL}/download/builds/pingcap/tidb/5450000d921801751d5677714be7c18129a7fb91/centos7/tidb-server.tar.gz"
 	local tikv_download_url="${FILE_SERVER_URL}/download/builds/pingcap/tikv/${tikv_sha1}/centos7/tikv-server.tar.gz"
 	local pd_download_url="${FILE_SERVER_URL}/download/builds/pingcap/pd/${pd_sha1}/centos7/pd-server.tar.gz"
 	local tiflash_download_url="${FILE_SERVER_URL}/download/builds/pingcap/tiflash/${tiflash_branch}/${tiflash_sha1}/centos7/tiflash.tar.gz"

--- a/scripts/download-integration-test-binaries.sh
+++ b/scripts/download-integration-test-binaries.sh
@@ -140,7 +140,7 @@ download_binaries() {
 	local tiflash_sha1=$(echo "$tiflash_branch_sha1" | cut -d':' -f2)
 
 	# Define download URLs
-	local tidb_download_url="${FILE_SERVER_URL}/download/builds/pingcap/tidb/${tidb_sha1}/centos7/tidb-server.tar.gz"
+	local tidb_download_url="${FILE_SERVER_URL}/download/builds/pingcap/tidb/50b5cd27d41309a9b83d9c6e3529e15dd2cd60f9/centos7/tidb-server.tar.gz"
 	local tikv_download_url="${FILE_SERVER_URL}/download/builds/pingcap/tikv/${tikv_sha1}/centos7/tikv-server.tar.gz"
 	local pd_download_url="${FILE_SERVER_URL}/download/builds/pingcap/pd/${pd_sha1}/centos7/pd-server.tar.gz"
 	local tiflash_download_url="${FILE_SERVER_URL}/download/builds/pingcap/tiflash/${tiflash_branch}/${tiflash_sha1}/centos7/tiflash.tar.gz"

--- a/scripts/download-integration-test-binaries.sh
+++ b/scripts/download-integration-test-binaries.sh
@@ -140,7 +140,7 @@ download_binaries() {
 	local tiflash_sha1=$(echo "$tiflash_branch_sha1" | cut -d':' -f2)
 
 	# Define download URLs
-	local tidb_download_url="${FILE_SERVER_URL}/download/builds/pingcap/tidb/50b5cd27d41309a9b83d9c6e3529e15dd2cd60f9/centos7/tidb-server.tar.gz"
+	local tidb_download_url="${FILE_SERVER_URL}/download/builds/pingcap/tidb/9530fdc2388d025af86eb6fce5e617972c361000/centos7/tidb-server.tar.gz"
 	local tikv_download_url="${FILE_SERVER_URL}/download/builds/pingcap/tikv/${tikv_sha1}/centos7/tikv-server.tar.gz"
 	local pd_download_url="${FILE_SERVER_URL}/download/builds/pingcap/pd/${pd_sha1}/centos7/pd-server.tar.gz"
 	local tiflash_download_url="${FILE_SERVER_URL}/download/builds/pingcap/tiflash/${tiflash_branch}/${tiflash_sha1}/centos7/tiflash.tar.gz"

--- a/scripts/download-integration-test-binaries.sh
+++ b/scripts/download-integration-test-binaries.sh
@@ -140,7 +140,7 @@ download_binaries() {
 	local tiflash_sha1=$(echo "$tiflash_branch_sha1" | cut -d':' -f2)
 
 	# Define download URLs
-	local tidb_download_url="${FILE_SERVER_URL}/download/builds/pingcap/tidb/5450000d921801751d5677714be7c18129a7fb91/centos7/tidb-server.tar.gz"
+	local tidb_download_url="${FILE_SERVER_URL}/download/builds/pingcap/tidb/${tidb_sha1}/centos7/tidb-server.tar.gz"
 	local tikv_download_url="${FILE_SERVER_URL}/download/builds/pingcap/tikv/${tikv_sha1}/centos7/tikv-server.tar.gz"
 	local pd_download_url="${FILE_SERVER_URL}/download/builds/pingcap/pd/${pd_sha1}/centos7/pd-server.tar.gz"
 	local tiflash_download_url="${FILE_SERVER_URL}/download/builds/pingcap/tiflash/${tiflash_branch}/${tiflash_sha1}/centos7/tiflash.tar.gz"


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11773
### What is changed and how it works?
As title. The maximum value is CPU count * 10

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
