### PR TITLE
Redact query arguments in dm log

### DIFF
--- a/dm/syncer/dbconn/db.go
+++ b/dm/syncer/dbconn/db.go
@@ -246,7 +246,7 @@ func (conn *DBConn) retryableFn(tctx *tcontext.Context, queries, args any) func(
 			if err != nil {
 				tctx.L().Error("reset connection failed", zap.Int("retry", retryTime),
 					zap.String("queries", utils.TruncateInterface(queries, -1)),
-					zap.String("arguments", utils.TruncateInterface(args, -1)),
+					log.ZapRedactString("arguments", utils.TruncateInterface(args, -1)),
 					log.ShortError(err))
 				return false
 			}
@@ -257,7 +257,7 @@ func (conn *DBConn) retryableFn(tctx *tcontext.Context, queries, args any) func(
 		if dbutil.IsRetryableError(err) {
 			tctx.L().Warn("execute statements", zap.Int("retry", retryTime),
 				zap.String("queries", utils.TruncateInterface(queries, -1)),
-				zap.String("arguments", utils.TruncateInterface(args, -1)),
+				log.ZapRedactString("arguments", utils.TruncateInterface(args, -1)),
 				log.ShortError(err))
 			return true
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11489

### What is changed and how it works?

Redact query arguments in dm log when there is retryable error happen in dm syncer.

Have searched for arguments in dm source code to find if there are any missing part for redacting, this one seems like the last missing piece.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
None
