### PR TITLE
ddl puller(ticdc): Fix memory retention issue in ddlPullerImpl's PopFrontDDL method

### DIFF
--- a/cdc/puller/ddl_puller.go
+++ b/cdc/puller/ddl_puller.go
@@ -734,6 +734,7 @@ func (h *ddlPullerImpl) PopFrontDDL() (uint64, *timodel.Job) {
 		return atomic.LoadUint64(&h.resolvedTS), nil
 	}
 	job := h.pendingDDLJobs[0]
+	h.pendingDDLJobs[0] = nil
 	h.pendingDDLJobs = h.pendingDDLJobs[1:]
 	return job.BinlogInfo.FinishedTS, job
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11793

### What is changed and how it works?

#### Problem
In the `PopFrontDDL` method of `ddlPullerImpl`, the operation `h.pendingDDLJobs = h.pendingDDLJobs[1:]` creates a new slice by slicing the existing one. However, this leaves the first element (`pendingDDLJobs[0]`) still referenced in the underlying array, potentially causing memory retention issues. 

If the removed element (a `Job` object) occupies significant memory and is no longer needed, this could lead to increased memory usage since it cannot be garbage collected.

#### Solution
The fix ensures that the reference to the removed element is explicitly set to `nil` before updating the slice. This helps the garbage collector to reclaim memory associated with the removed element.

##### Code Changes
- Explicitly set `h.pendingDDLJobs[0] = nil` before updating the slice in `PopFrontDDL`.

Updated code snippet:
```go
func (h *ddlPullerImpl) PopFrontDDL() (uint64, *timodel.Job) {
    h.mu.Lock()
    defer h.mu.Unlock()
    if len(h.pendingDDLJobs) == 0 {
        return atomic.LoadUint64(&h.resolvedTS), nil
    }
    job := h.pendingDDLJobs[0]
    h.pendingDDLJobs[0] = nil // Explicitly clear reference to allow GC
    h.pendingDDLJobs = h.pendingDDLJobs[1:]
    return job.BinlogInfo.FinishedTS, job
}
```

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a memory retention issue in TiCDC’s DDL job processing to enhance memory efficiency in long-running tasks.
```
