### PR TITLE
ddl puller: add UTs for ddl schema version removal

### DIFF
--- a/cdc/puller/ddl_puller_test.go
+++ b/cdc/puller/ddl_puller_test.go
@@ -535,6 +535,81 @@ func TestHandleJob(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, skip)
 	}
+
+	// Test finishedTs less than resolvedTs, the job will be skipped
+	{
+		recordResolvedTs := ddlJobPullerImpl.getResolvedTs()
+		// set a fake resolvedTs for test
+		fakeResolvedTs := uint64(100)
+		ddlJobPullerImpl.setResolvedTs(fakeResolvedTs)
+		// mock a job
+		job := &timodel.Job{
+			Type: timodel.ActionCreateTable,
+			BinlogInfo: &timodel.HistoryInfo{
+				FinishedTS: fakeResolvedTs - 1,
+			},
+		}
+		skip, err := ddlJobPullerImpl.handleJob(job)
+		require.NoError(t, err)
+		require.True(t, skip)
+		// reset resolvedTs
+		ddlJobPullerImpl.setResolvedTs(recordResolvedTs)
+	}
+}
+
+func TestSchemaOutOfOrderSuccess(t *testing.T) {
+	ddlJobPuller, helper := newMockDDLJobPuller(t, true)
+	defer helper.Close()
+	startTs := uint64(10)
+	ddlJobPullerImpl := ddlJobPuller.(*ddlJobPullerImpl)
+	ddlJobPullerImpl.setResolvedTs(startTs)
+
+	// Create database
+	{
+		job := helper.DDL2Job("create database testschema")
+		skip, err := ddlJobPullerImpl.handleJob(job)
+		require.NoError(t, err)
+		require.False(t, skip)
+	}
+
+	// Create table
+	{
+		job := helper.DDL2Job("create table testschema.t1(id int primary key)")
+		skip, err := ddlJobPullerImpl.handleJob(job)
+		require.NoError(t, err)
+		require.False(t, skip)
+
+		job = helper.DDL2Job("create table testschema.t2(id int primary key)")
+		skip, err = ddlJobPullerImpl.handleJob(job)
+		require.NoError(t, err)
+		require.False(t, skip)
+	}
+
+	// Test schema versions out of order
+	{
+		recordResolvedTs := ddlJobPullerImpl.getResolvedTs()
+		// set a fake resolvedTs for test
+		fakeResolvedTs := uint64(100)
+		ddlJobPullerImpl.setResolvedTs(fakeResolvedTs)
+		// mock two jobs
+		job1 := helper.DDL2Job("alter table testschema.t1 add column x int")
+		job2 := helper.DDL2Job("alter table testschema.t1 add column y int")
+		job1.BinlogInfo.SchemaVersion = 1
+		job1.BinlogInfo.FinishedTS = fakeResolvedTs + 2
+		job2.BinlogInfo.SchemaVersion = 2
+		job2.BinlogInfo.FinishedTS = fakeResolvedTs + 1
+
+		skip, err := ddlJobPullerImpl.handleJob(job2)
+		require.NoError(t, err)
+		require.False(t, skip)
+
+		skip, err = ddlJobPullerImpl.handleJob(job1)
+		require.NoError(t, err)
+		require.False(t, skip)
+
+		// reset resolvedTs
+		ddlJobPullerImpl.setResolvedTs(recordResolvedTs)
+	}
 }
 
 func TestDDLPuller(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11820

### What is changed and how it works?

This PR introduces a unit test to validate the handling of schema version disorder in TiCDC’s DDL job processing logic.

**Background**

Previously, TiCDC enforced a schema version check that discarded DDL jobs with schema versions smaller than the current schema version, even if their commit timestamps were valid. This logic was removed in #11733 to allow processing of DDL jobs based on commit timestamps alone, improving robustness in handling schema version disorder.

This ensures TiCDC can robustly handle schema version disorder without discarding valid DDL jobs, aligning with the recent removal of schema version checks.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
