### PR TITLE
dm: fix start task check when both shard-mode and TLS are configured

### DIFF
--- a/dm/ctl/master/start_task.go
+++ b/dm/ctl/master/start_task.go
@@ -60,13 +60,6 @@ func startTaskFunc(cmd *cobra.Command, _ []string) error {
 	if yamlErr != nil {
 		return yamlErr
 	}
-	if task.TargetDB != nil && task.TargetDB.Security != nil {
-		loadErr := task.TargetDB.Security.LoadTLSContent()
-		if loadErr != nil {
-			log.L().Warn("load tls content failed", zap.Error(terror.ErrCtlLoadTLSCfg.Generate(loadErr)))
-		}
-		content = []byte(task.String())
-	}
 
 	lines := bytes.Split(content, []byte("\n"))
 	// we check if `is-sharding` is explicitly set, to distinguish between `false` from default value
@@ -93,6 +86,14 @@ func startTaskFunc(cmd *cobra.Command, _ []string) error {
 	if shardModeSet && task.ShardMode == "" && task.IsSharding {
 		common.PrintLinesf("The behaviour of `is-sharding` and `shard-mode` is conflicting. `is-sharding` is deprecated, please use `shard-mode` only.")
 		return errors.New("please check output to see error")
+	}
+
+	if task.TargetDB != nil && task.TargetDB.Security != nil {
+		loadErr := task.TargetDB.Security.LoadTLSContent()
+		if loadErr != nil {
+			log.L().Warn("load tls content failed", zap.Error(terror.ErrCtlLoadTLSCfg.Generate(loadErr)))
+		}
+		content = []byte(task.String())
 	}
 
 	sources, err := common.GetSourceArgs(cmd)

--- a/dm/tests/tls/conf/dm-task-3.yaml
+++ b/dm/tests/tls/conf/dm-task-3.yaml
@@ -1,0 +1,49 @@
+---
+name: test3
+task-mode: all
+shard-mode: "pessimistic"
+meta-schema: "dm_meta"
+
+target-database:
+  host: "127.0.0.1"
+  port: 4400
+  user: "root"
+  password: ""
+  security:
+    ssl-ca: "dir-placeholer/task-ca.pem"
+    ssl-cert: "dir-placeholer/dm.pem"
+    ssl-key: "dir-placeholer/dm.key"
+
+mysql-instances:
+  - source-id: "mysql-replica-01"
+    black-white-list: "instance"
+    route-rules: ["route-rule-1"]
+    mydumper-config-name: "global"
+    loader-config-name: "global"
+    syncer-config-name: "global"
+
+black-white-list:
+  instance:
+    do-dbs: ["tls"]
+
+routes:
+  route-rule-1:
+    schema-pattern: "tls"
+    target-schema: "tls3"
+
+mydumpers:
+  global:
+    threads: 4
+    chunk-filesize: 0
+    skip-tz-utc: true
+    extra-args: "--statement-size=100"
+
+loaders:
+  global:
+    pool-size: 16
+    dir: "./dumped_data"
+
+syncers:
+  global:
+    worker-count: 16
+    batch: 100

--- a/dm/tests/tls/run.sh
+++ b/dm/tests/tls/run.sh
@@ -108,6 +108,7 @@ function test_worker_handle_multi_tls_tasks() {
 	cp $cur/conf/dm-worker2.toml $WORK_DIR/
 	cp $cur/conf/dm-task.yaml $WORK_DIR/
 	cp $cur/conf/dm-task-2.yaml $WORK_DIR/
+	cp $cur/conf/dm-task-3.yaml $WORK_DIR/
 
 	sed -i "s%dir-placeholer%$cur\/conf%g" $WORK_DIR/dm-master1.toml
 	sed -i "s%dir-placeholer%$cur\/conf%g" $WORK_DIR/dm-master2.toml
@@ -116,6 +117,7 @@ function test_worker_handle_multi_tls_tasks() {
 	sed -i "s%dir-placeholer%$cur\/conf%g" $WORK_DIR/dm-worker2.toml
 	sed -i "s%dir-placeholer%$cur\/conf%g" $WORK_DIR/dm-task.yaml
 	sed -i "s%dir-placeholer%$cur\/conf%g" $WORK_DIR/dm-task-2.yaml
+	sed -i "s%dir-placeholer%$cur\/conf%g" $WORK_DIR/dm-task-3.yaml
 
 	run_dm_master $WORK_DIR/master1 $MASTER_PORT1 $WORK_DIR/dm-master1.toml
 	run_dm_master $WORK_DIR/master2 $MASTER_PORT2 $WORK_DIR/dm-master2.toml
@@ -138,6 +140,8 @@ function test_worker_handle_multi_tls_tasks() {
 		"start-task $WORK_DIR/dm-task.yaml --remove-meta=true"
 	run_dm_ctl_with_tls_and_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" $cur/conf/ca.pem $cur/conf/dm.pem $cur/conf/dm.key \
 		"start-task $WORK_DIR/dm-task-2.yaml --remove-meta=true"
+	run_dm_ctl_with_tls_and_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" $cur/conf/ca.pem $cur/conf/dm.pem $cur/conf/dm.key \
+		"start-task $WORK_DIR/dm-task-3.yaml --remove-meta=true"
 
 	run_dm_ctl_with_tls_and_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" $cur/conf/ca.pem $cur/conf/dm.pem $cur/conf/dm.key \
 		"query-status test" \
@@ -145,6 +149,10 @@ function test_worker_handle_multi_tls_tasks() {
 		"\"unit\": \"Sync\"" 1
 	run_dm_ctl_with_tls_and_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" $cur/conf/ca.pem $cur/conf/dm.pem $cur/conf/dm.key \
 		"query-status test2" \
+		"\"result\": true" 2 \
+		"\"unit\": \"Sync\"" 1
+	run_dm_ctl_with_tls_and_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" $cur/conf/ca.pem $cur/conf/dm.pem $cur/conf/dm.key \
+		"query-status test3" \
 		"\"result\": true" 2 \
 		"\"unit\": \"Sync\"" 1
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->
When task configuration contains both shard-mode and TLS configuration, start task fails

![Image](https://github.com/user-attachments/assets/e46714dc-0913-4dd6-8ac6-bdfadbc51fe6)

Issue Number: close #11842

### What is changed and how it works?
The content of the task configuration file is replaced with the TLS context populated when TLS configuration exists. The changed configuration file content generates false positives in the pre-checking logic. Reordering the pre-checking and loading of the TLS context can make it work in such cases.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
