### PR TITLE
codec(ticdc): simple protocol set table id by using the physical table id

### DIFF
--- a/cdc/entry/schema_test_helper.go
+++ b/cdc/entry/schema_test_helper.go
@@ -173,7 +173,11 @@ func (s *SchemaTestHelper) DML2Event(dml string, schema, table string, partition
 	require.True(s.t, ok)
 
 	tableID := tableInfo.ID
-	partitionTableID := tableInfo.TableInfo.GetPartitionInfo().GetPartitionIDByName(partitionID[0])
+
+	var partitionTableID int64 = -1
+	if len(partitionID) == 1 {
+		partitionTableID = tableInfo.TableInfo.GetPartitionInfo().GetPartitionIDByName(partitionID[0])
+	}
 	if partitionTableID != -1 {
 		tableID = partitionTableID
 	}

--- a/cdc/entry/schema_test_helper.go
+++ b/cdc/entry/schema_test_helper.go
@@ -166,13 +166,19 @@ func (s *SchemaTestHelper) DDL2Jobs(ddl string, jobCnt int) []*timodel.Job {
 // DML2Event execute the dml and return the corresponding row changed event.
 // caution: it does not support `delete` since the key value cannot be found
 // after the query executed.
-func (s *SchemaTestHelper) DML2Event(dml string, schema, table string) *model.RowChangedEvent {
+func (s *SchemaTestHelper) DML2Event(dml string, schema, table string, partitionID ...string) *model.RowChangedEvent {
 	s.tk.MustExec(dml)
 
 	tableInfo, ok := s.schemaStorage.GetLastSnapshot().TableByName(schema, table)
 	require.True(s.t, ok)
 
-	key, value := s.getLastKeyValue(tableInfo.ID)
+	tableID := tableInfo.ID
+	partitionTableID := tableInfo.TableInfo.GetPartitionInfo().GetPartitionIDByName(partitionID[0])
+	if partitionTableID != -1 {
+		tableID = partitionTableID
+	}
+
+	key, value := s.getLastKeyValue(tableID)
 	ts := s.schemaStorage.GetLastSnapshot().CurrentTs()
 	rawKV := &model.RawKVEntry{
 		OpType:   model.OpTypePut,

--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -714,13 +714,6 @@ type NameBasedColumnIDAllocator struct {
 	nameToIDMap map[string]int64
 }
 
-// NewNameBasedColumnIDAllocator creates a new NameBasedColumnIDAllocator
-func NewNameBasedColumnIDAllocator(nameToIDMap map[string]int64) *NameBasedColumnIDAllocator {
-	return &NameBasedColumnIDAllocator{
-		nameToIDMap: nameToIDMap,
-	}
-}
-
 // GetColumnID return the column id of the name
 func (n *NameBasedColumnIDAllocator) GetColumnID(name string) int64 {
 	colID, ok := n.nameToIDMap[name]

--- a/pkg/sink/codec/avro/avro_test.go
+++ b/pkg/sink/codec/avro/avro_test.go
@@ -76,6 +76,7 @@ func TestDMLEventE2E(t *testing.T) {
 			decodedEvent, err := decoder.NextRowChangedEvent()
 			require.NoError(t, err)
 			require.NotNil(t, decodedEvent)
+			require.Equal(t, decodedEvent.GetTableID(), int64(0))
 
 			TeardownEncoderAndSchemaRegistry4Testing()
 		}

--- a/pkg/sink/codec/canal/canal_json_row_event_encoder_test.go
+++ b/pkg/sink/codec/canal/canal_json_row_event_encoder_test.go
@@ -687,6 +687,58 @@ func TestCanalJSONContentCompatibleE2E(t *testing.T) {
 	}
 }
 
+func TestE2EPartitionTable(t *testing.T) {
+	helper := entry.NewSchemaTestHelper(t)
+	defer helper.Close()
+
+	ctx := context.Background()
+	codecConfig := common.NewConfig(config.ProtocolCanalJSON)
+
+	builder, err := NewJSONRowEventEncoderBuilder(ctx, codecConfig)
+	require.NoError(t, err)
+	encoder := builder.Build()
+
+	decoder, err := NewBatchDecoder(ctx, codecConfig, nil)
+	require.NoError(t, err)
+
+	helper.Tk().MustExec("use test")
+
+	createPartitionTableDDL := helper.DDL2Event(`create table test.t(a int primary key, b int) partition by range (a) (
+		partition p0 values less than (10),
+		partition p1 values less than (20),
+		partition p2 values less than MAXVALUE)`)
+	require.NotNil(t, createPartitionTableDDL)
+
+	insertEvent := helper.DML2Event(`insert into test.t values (1, 1)`, "test", "t", "p0")
+	require.NotNil(t, insertEvent)
+
+	insertEvent1 := helper.DML2Event(`insert into test.t values (11, 11)`, "test", "t", "p1")
+	require.NotNil(t, insertEvent1)
+
+	insertEvent2 := helper.DML2Event(`insert into test.t values (21, 21)`, "test", "t", "p2")
+	require.NotNil(t, insertEvent2)
+
+	events := []*model.RowChangedEvent{insertEvent, insertEvent1, insertEvent2}
+
+	for _, event := range events {
+		err = encoder.AppendRowChangedEvent(ctx, "", event, nil)
+		require.NoError(t, err)
+		message := encoder.Build()[0]
+
+		err = decoder.AddKeyValue(message.Key, message.Value)
+		require.NoError(t, err)
+		tp, hasNext, err := decoder.HasNext()
+		require.NoError(t, err)
+		require.True(t, hasNext)
+		require.Equal(t, model.MessageTypeRow, tp)
+
+		decodedEvent, err := decoder.NextRowChangedEvent()
+		require.NoError(t, err)
+		// table id should be set to the partition table id, the PhysicalTableID
+		require.Equal(t, decodedEvent.GetTableID(), int64(0))
+	}
+}
+
 func TestNewCanalJSONBatchDecoder4RowMessage(t *testing.T) {
 	_, insertEvent, _, _ := utils.NewLargeEvent4Test(t, config.GetDefaultReplicaConfig())
 	ctx := context.Background()

--- a/pkg/sink/codec/canal/canal_json_row_event_encoder_test.go
+++ b/pkg/sink/codec/canal/canal_json_row_event_encoder_test.go
@@ -734,7 +734,7 @@ func TestE2EPartitionTable(t *testing.T) {
 
 		decodedEvent, err := decoder.NextRowChangedEvent()
 		require.NoError(t, err)
-		// table id should be set to the partition table id, the PhysicalTableID
+		// canal-json does not support encode the table id, so it's 0
 		require.Equal(t, decodedEvent.GetTableID(), int64(0))
 	}
 }

--- a/pkg/sink/codec/simple/avro.go
+++ b/pkg/sink/codec/simple/avro.go
@@ -252,7 +252,7 @@ func (a *avroMarshaller) newDMLMessageMap(
 	dmlMessagePayload["version"] = defaultVersion
 	dmlMessagePayload["database"] = event.TableInfo.GetSchemaName()
 	dmlMessagePayload["table"] = event.TableInfo.GetTableName()
-	dmlMessagePayload["tableID"] = event.TableInfo.ID
+	dmlMessagePayload["tableID"] = event.GetTableID()
 	dmlMessagePayload["commitTs"] = int64(event.CommitTs)
 	dmlMessagePayload["buildTs"] = time.Now().UnixMilli()
 	dmlMessagePayload["schemaVersion"] = int64(event.TableInfo.UpdateTS)

--- a/pkg/sink/codec/simple/encoder_test.go
+++ b/pkg/sink/codec/simple/encoder_test.go
@@ -203,6 +203,28 @@ func TestEncodeDMLEnableChecksum(t *testing.T) {
 	require.Nil(t, decodedRow)
 }
 
+func TestEncodePartitionTables(t *testing.T) {
+	helper := entry.NewSchemaTestHelper(t)
+	defer helper.Close()
+
+	helper.Tk().MustExec("use test")
+
+	createPartitionTableDDL := helper.DDL2Event(`create table test.t(a int primary key, b int) partition by range (a) (
+		partition p0 values less than (10),
+		partition p1 values less than (20),
+		partition p2 values less than MAXVALUE)`)
+	require.NotNil(t, createPartitionTableDDL)
+
+	insertEvent := helper.DML2Event(`insert into test.t values (1, 1)`, "test", "t")
+	require.NotNil(t, insertEvent)
+
+	insertEvent = helper.DML2Event(`insert into test.t values (11, 11)`, "test", "t")
+	require.NotNil(t, insertEvent)
+
+	insertEvent = helper.DML2Event(`insert into test.t values (21, 21)`, "test", "t")
+	require.NotNil(t, insertEvent)
+}
+
 func TestEncodeDDLSequence(t *testing.T) {
 	helper := entry.NewSchemaTestHelper(t)
 	defer helper.Close()

--- a/pkg/sink/codec/simple/encoder_test.go
+++ b/pkg/sink/codec/simple/encoder_test.go
@@ -229,18 +229,17 @@ func TestE2EPartitionTable(t *testing.T) {
 	ctx := context.Background()
 	codecConfig := common.NewConfig(config.ProtocolSimple)
 
-	builder, err := NewBuilder(ctx, codecConfig)
-	require.NoError(t, err)
-	enc := builder.Build()
-
-	decoder, err := NewDecoder(ctx, codecConfig, nil)
-	require.NoError(t, err)
-
 	for _, format := range []common.EncodingFormatType{
 		common.EncodingFormatAvro,
 		common.EncodingFormatJSON,
 	} {
 		codecConfig.EncodingFormat = format
+		builder, err := NewBuilder(ctx, codecConfig)
+		require.NoError(t, err)
+		enc := builder.Build()
+
+		decoder, err := NewDecoder(ctx, codecConfig, nil)
+		require.NoError(t, err)
 
 		message, err := enc.EncodeDDLEvent(createPartitionTableDDL)
 		require.NoError(t, err)
@@ -1214,6 +1213,86 @@ func TestEncoderOtherTypes(t *testing.T) {
 			decoded, ok := decodedColumns[colName]
 			require.True(t, ok)
 			require.EqualValues(t, expected.Value, decoded.Value)
+		}
+	}
+}
+
+func TestE2EPartitionTableDMLBeforeDDL(t *testing.T) {
+	helper := entry.NewSchemaTestHelper(t)
+	defer helper.Close()
+
+	helper.Tk().MustExec("use test")
+
+	createPartitionTableDDL := helper.DDL2Event(`create table test.t(a int primary key, b int) partition by range (a) (
+		partition p0 values less than (10),
+		partition p1 values less than (20),
+		partition p2 values less than MAXVALUE)`)
+	require.NotNil(t, createPartitionTableDDL)
+
+	insertEvent := helper.DML2Event(`insert into test.t values (1, 1)`, "test", "t", "p0")
+	require.NotNil(t, insertEvent)
+
+	insertEvent1 := helper.DML2Event(`insert into test.t values (11, 11)`, "test", "t", "p1")
+	require.NotNil(t, insertEvent1)
+
+	insertEvent2 := helper.DML2Event(`insert into test.t values (21, 21)`, "test", "t", "p2")
+	require.NotNil(t, insertEvent2)
+
+	events := []*model.RowChangedEvent{insertEvent, insertEvent1, insertEvent2}
+
+	ctx := context.Background()
+	codecConfig := common.NewConfig(config.ProtocolSimple)
+
+	for _, format := range []common.EncodingFormatType{
+		common.EncodingFormatAvro,
+		common.EncodingFormatJSON,
+	} {
+		codecConfig.EncodingFormat = format
+		builder, err := NewBuilder(ctx, codecConfig)
+		require.NoError(t, err)
+
+		enc := builder.Build()
+
+		decoder, err := NewDecoder(ctx, codecConfig, nil)
+		require.NoError(t, err)
+
+		codecConfig.EncodingFormat = format
+		for _, event := range events {
+			err = enc.AppendRowChangedEvent(ctx, "", event, nil)
+			require.NoError(t, err)
+			message := enc.Build()[0]
+
+			err = decoder.AddKeyValue(message.Key, message.Value)
+			require.NoError(t, err)
+			tp, hasNext, err := decoder.HasNext()
+			require.NoError(t, err)
+			require.True(t, hasNext)
+			require.Equal(t, model.MessageTypeRow, tp)
+
+			decodedEvent, err := decoder.NextRowChangedEvent()
+			require.NoError(t, err)
+			require.Nil(t, decodedEvent)
+		}
+
+		message, err := enc.EncodeDDLEvent(createPartitionTableDDL)
+		require.NoError(t, err)
+
+		err = decoder.AddKeyValue(message.Key, message.Value)
+		require.NoError(t, err)
+		tp, hasNext, err := decoder.HasNext()
+		require.NoError(t, err)
+		require.True(t, hasNext)
+		require.Equal(t, model.MessageTypeDDL, tp)
+
+		decodedDDL, err := decoder.NextDDLEvent()
+		require.NoError(t, err)
+		require.NotNil(t, decodedDDL)
+
+		cachedEvents := decoder.GetCachedEvents()
+		for idx, decodedRow := range cachedEvents {
+			require.NotNil(t, decodedRow)
+			require.NotNil(t, decodedRow.TableInfo)
+			require.Equal(t, decodedRow.GetTableID(), events[idx].GetTableID())
 		}
 	}
 }

--- a/pkg/sink/codec/simple/message.go
+++ b/pkg/sink/codec/simple/message.go
@@ -554,7 +554,7 @@ func (a *jsonMarshaller) newDMLMessage(
 		Version:            defaultVersion,
 		Schema:             event.TableInfo.GetSchemaName(),
 		Table:              event.TableInfo.GetTableName(),
-		TableID:            event.TableInfo.ID,
+		TableID:            event.GetTableID(),
 		CommitTs:           event.CommitTs,
 		BuildTs:            time.Now().UnixMilli(),
 		SchemaVersion:      event.TableInfo.UpdateTS,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11846 

### What is changed and how it works?

* when the simple protocol encode row events, set the table id by using the physical table id, instead of the logic id.
https://github.com/pingcap/tiflow/pull/11845/files#diff-7503164863112a4d454976ac5347d75a046c600a1ab3d5914a741eec262bba79R255
https://github.com/pingcap/tiflow/pull/11845/files#diff-ab57979355b5c3e268e38318362ab236cb5c8a3a27662d4aa79eeadb865da617R557

* add more unit test to cover that `open-protocol` table id is is set correctly.
* add unit test to cover that `canal-json` does not set the table id.


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
fix the row message table id not set by the physical table id cause the consumer don't known the table partition the row belongs to.
```
