### PR TITLE
redo(ticdc): Fix RedoLogWriter unit test

### DIFF
--- a/cdc/redo/writer/memory/encoding_worker.go
+++ b/cdc/redo/writer/memory/encoding_worker.go
@@ -186,10 +186,9 @@ func (e *encodingWorkerGroup) input(
 		return ctx.Err()
 	case err := <-e.closed:
 		return errors.WrapError(errors.ErrRedoWriterStopped, err, "encoding worker is closed")
-	default:
+	case e.inputChs[idx] <- event:
+		return nil
 	}
-	e.inputChs[idx] <- event
-	return nil
 }
 
 func (e *encodingWorkerGroup) output(
@@ -200,10 +199,9 @@ func (e *encodingWorkerGroup) output(
 		return ctx.Err()
 	case err := <-e.closed:
 		return errors.WrapError(errors.ErrRedoWriterStopped, err, "encoding worker is closed")
-	default:
+	case e.outputCh <- event:
+		return nil
 	}
-	e.outputCh <- event
-	return nil
 }
 
 func (e *encodingWorkerGroup) FlushAll(ctx context.Context) error {
@@ -226,9 +224,8 @@ func (e *encodingWorkerGroup) FlushAll(ctx context.Context) error {
 		return ctx.Err()
 	case err := <-e.closed:
 		return errors.WrapError(errors.ErrRedoWriterStopped, err, "encoding worker is closed")
-	default:
+	case <-flushCh:
 	}
-	<-flushCh
 	return nil
 }
 
@@ -251,9 +248,8 @@ func (e *encodingWorkerGroup) broadcastAndWaitEncoding(ctx context.Context) erro
 			return ctx.Err()
 		case err := <-e.closed:
 			return errors.WrapError(errors.ErrRedoWriterStopped, err, "encoding worker is closed")
-		default:
+		case <-ch:
 		}
-		<-ch
 	}
 	return nil
 }

--- a/cdc/redo/writer/memory/encoding_worker.go
+++ b/cdc/redo/writer/memory/encoding_worker.go
@@ -186,9 +186,10 @@ func (e *encodingWorkerGroup) input(
 		return ctx.Err()
 	case err := <-e.closed:
 		return errors.WrapError(errors.ErrRedoWriterStopped, err, "encoding worker is closed")
-	case e.inputChs[idx] <- event:
-		return nil
+	default:
 	}
+	e.inputChs[idx] <- event
+	return nil
 }
 
 func (e *encodingWorkerGroup) output(
@@ -199,9 +200,10 @@ func (e *encodingWorkerGroup) output(
 		return ctx.Err()
 	case err := <-e.closed:
 		return errors.WrapError(errors.ErrRedoWriterStopped, err, "encoding worker is closed")
-	case e.outputCh <- event:
-		return nil
+	default:
 	}
+	e.outputCh <- event
+	return nil
 }
 
 func (e *encodingWorkerGroup) FlushAll(ctx context.Context) error {
@@ -224,8 +226,9 @@ func (e *encodingWorkerGroup) FlushAll(ctx context.Context) error {
 		return ctx.Err()
 	case err := <-e.closed:
 		return errors.WrapError(errors.ErrRedoWriterStopped, err, "encoding worker is closed")
-	case <-flushCh:
+	default:
 	}
+	<-flushCh
 	return nil
 }
 
@@ -248,8 +251,9 @@ func (e *encodingWorkerGroup) broadcastAndWaitEncoding(ctx context.Context) erro
 			return ctx.Err()
 		case err := <-e.closed:
 			return errors.WrapError(errors.ErrRedoWriterStopped, err, "encoding worker is closed")
-		case <-ch:
+		default:
 		}
+		<-ch
 	}
 	return nil
 }

--- a/cdc/redo/writer/memory/mem_log_writer_test.go
+++ b/cdc/redo/writer/memory/mem_log_writer_test.go
@@ -106,12 +106,30 @@ func testWriteEvents(t *testing.T, events []writer.RedoEvent) {
 
 	functions := map[string]func(error){
 		"WriteEvents": func(expected error) {
-			err := lw.WriteEvents(ctx, events...)
-			require.ErrorIs(t, errors.Cause(err), expected)
+			if expected == nil {
+				err := lw.WriteEvents(ctx, events...)
+				require.ErrorIs(t, errors.Cause(err), expected)
+			} else {
+				require.Eventually(
+					t, func() bool {
+						err := lw.WriteEvents(ctx, events...)
+						return errors.Is(errors.Cause(err), expected)
+					}, time.Second*2, time.Microsecond*10,
+				)
+			}
 		},
 		"FlushLog": func(expected error) {
-			err := lw.FlushLog(ctx)
-			require.ErrorIs(t, errors.Cause(err), expected)
+			if expected == nil {
+				err := lw.FlushLog(ctx)
+				require.ErrorIs(t, errors.Cause(err), expected)
+			} else {
+				require.Eventually(
+					t, func() bool {
+						err := lw.WriteEvents(ctx, events...)
+						return errors.Is(errors.Cause(err), expected)
+					}, time.Second*2, time.Microsecond*10,
+				)
+			}
 		},
 	}
 	firstCall := true

--- a/cdc/redo/writer/memory/mem_log_writer_test.go
+++ b/cdc/redo/writer/memory/mem_log_writer_test.go
@@ -108,7 +108,7 @@ func testWriteEvents(t *testing.T, events []writer.RedoEvent) {
 		"WriteEvents": func(expected error) {
 			if expected == nil {
 				err := lw.WriteEvents(ctx, events...)
-				require.ErrorIs(t, errors.Cause(err), expected)
+				require.Nil(t, err)
 			} else {
 				require.Eventually(
 					t, func() bool {
@@ -121,7 +121,7 @@ func testWriteEvents(t *testing.T, events []writer.RedoEvent) {
 		"FlushLog": func(expected error) {
 			if expected == nil {
 				err := lw.FlushLog(ctx)
-				require.ErrorIs(t, errors.Cause(err), expected)
+				require.Nil(t, err)
 			} else {
 				require.Eventually(
 					t, func() bool {

--- a/cdc/redo/writer/memory/mem_log_writer_test.go
+++ b/cdc/redo/writer/memory/mem_log_writer_test.go
@@ -108,7 +108,7 @@ func testWriteEvents(t *testing.T, events []writer.RedoEvent) {
 		"WriteEvents": func(expected error) {
 			if expected == nil {
 				err := lw.WriteEvents(ctx, events...)
-				require.Nil(t, err)
+				require.NoError(t, err)
 			} else {
 				require.Eventually(
 					t, func() bool {
@@ -121,7 +121,7 @@ func testWriteEvents(t *testing.T, events []writer.RedoEvent) {
 		"FlushLog": func(expected error) {
 			if expected == nil {
 				err := lw.FlushLog(ctx)
-				require.Nil(t, err)
+				require.NoError(t, err)
 			} else {
 				require.Eventually(
 					t, func() bool {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11852 

### What is changed and how it works?
A select blocks until one of its cases can run, then it executes that case. It chooses one at random if multiple are ready.
In these cases, encodingWorkerGroup may run `WriteEvents` or `FlushLog` successfully even if encoding worker is closed. 
```go
select {
case <-ctx.Done():
	return ctx.Err()
case err := <-e.closed:
	return errors.WrapError(errors.ErrRedoWriterStopped, err, "encoding worker is closed")
case e.inputChs[idx] <- event: // executes even if encoding worker is closed
	return nil
}
```


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
