### PR TITLE
sink(ticdc): add parameter to enable watermark events in the Debezium protocol

### DIFF
--- a/pkg/sink/codec/debezium/encoder.go
+++ b/pkg/sink/codec/debezium/encoder.go
@@ -39,7 +39,7 @@ type BatchEncoder struct {
 func (d *BatchEncoder) EncodeCheckpointEvent(ts uint64) (*common.Message, error) {
 	if !d.config.EnableTiDBExtension {
 		return nil, nil
-	}	
+	}
 	keyMap := bytes.Buffer{}
 	valueBuf := bytes.Buffer{}
 	err := d.codec.EncodeCheckpointEvent(ts, &keyMap, &valueBuf)

--- a/pkg/sink/codec/debezium/encoder.go
+++ b/pkg/sink/codec/debezium/encoder.go
@@ -37,6 +37,9 @@ type BatchEncoder struct {
 
 // EncodeCheckpointEvent implements the RowEventEncoder interface
 func (d *BatchEncoder) EncodeCheckpointEvent(ts uint64) (*common.Message, error) {
+	if !d.config.EnableTiDBExtension {
+		return nil, nil
+	}	
 	keyMap := bytes.Buffer{}
 	valueBuf := bytes.Buffer{}
 	err := d.codec.EncodeCheckpointEvent(ts, &keyMap, &valueBuf)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11876 

### What is changed and how it works?
We use `EnableTiDBExtension` to control whether to encode watermark event. After that, it will be up to users to set.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
