### PR TITLE
snapshot(ticdc): fix ddl puller and ddl manager stuck caused by two dead lock

### DIFF
--- a/cdc/entry/schema/snapshot.go
+++ b/cdc/entry/schema/snapshot.go
@@ -258,7 +258,7 @@ func NewEmptySnapshot(forceReplicate bool) *Snapshot {
 func (s *Snapshot) Copy() *Snapshot {
 	s.rwlock.RLock()
 	defer s.rwlock.RUnlock()
-	return &Snapshot{inner: s.inner, rwlock: &sync.RWMutex{}}
+	return &Snapshot{inner: s.inner, rwlock: s.rwlock}
 }
 
 // PrintStatus prints the schema snapshot.

--- a/cdc/entry/schema/snapshot.go
+++ b/cdc/entry/schema/snapshot.go
@@ -258,7 +258,7 @@ func NewEmptySnapshot(forceReplicate bool) *Snapshot {
 func (s *Snapshot) Copy() *Snapshot {
 	s.rwlock.RLock()
 	defer s.rwlock.RUnlock()
-	return &Snapshot{inner: s.inner, rwlock: s.rwlock}
+	return &Snapshot{inner: s.inner, rwlock: &sync.RWMutex{}}
 }
 
 // PrintStatus prints the schema snapshot.
@@ -570,9 +570,6 @@ func (s *Snapshot) SchemaCount() (count int) {
 
 // DumpToString dumps the snapshot to a string.
 func (s *Snapshot) DumpToString() string {
-	s.rwlock.RLock()
-	defer s.rwlock.RUnlock()
-
 	schemas := make([]string, 0, s.inner.schemas.Len())
 	s.IterSchemas(func(dbInfo *timodel.DBInfo) {
 		schemas = append(schemas, fmt.Sprintf("%v", dbInfo))

--- a/cdc/entry/schema_storage.go
+++ b/cdc/entry/schema_storage.go
@@ -273,8 +273,7 @@ func (s *schemaStorage) AllPhysicalTables(ctx context.Context, ts model.Ts) ([]m
 	log.Debug("get new schema snapshot",
 		zap.Uint64("ts", ts),
 		zap.Uint64("snapTs", snap.CurrentTs()),
-		zap.Any("tables", res),
-		zap.String("snapshot", snap.DumpToString()))
+		zap.Any("tables", res))
 
 	return res, nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11884

### What is changed and how it works?

#### Summary

This PR fixes a deadlock issue in the `Snapshot` implementation:
   
**Deadlock in Recursive Read Locking:** Although Go’s `sync.RWMutex` allows recursive read locks, they can result in deadlocks if a write lock is requested during the recursive read lock execution. This blocks the outer read lock from releasing, preventing the write lock from proceeding.

This PR refactors lock usage patterns to avoid recursive read locking.

---

#### Root Causes of the Deadlocks

##### Recursive Read Lock Issue

Recursive calls involving `RWMutex.RLock()` can result in deadlocks when a write lock is requested during the recursive read lock execution. This behavior arises because Go’s `sync.RWMutex` prioritizes write locks over read locks.

Here is an example that illustrates the problem:

```go
func (s *Snapshot) Operation() {
    s.rwlock.RLock()
    defer s.rwlock.RUnlock()
    s.NestedOperation() // Second RLock
}

func (s *Snapshot) NestedOperation() {
    s.rwlock.RLock()
    defer s.rwlock.RUnlock()
    // Perform some operations
}
```

If a write lock is requested while `NestedOperation` is executing, the following chain of events occurs:
1. The write lock request blocks new readers, including the recursive `RLock` in `NestedOperation`.
2. `NestedOperation` cannot complete until its `RLock` is granted.
3. The first `RLock` in Operation cannot release until `NestedOperation` completes.
4. Deadlock occurs because the first `RLock` and the recursive `RLock` are mutually dependent.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None.
```
