### PR TITLE
dm: use nightly tidb instead of latest to fix table not exist error

### DIFF
--- a/dm/tests/mariadb_master_down_and_up/docker-compose.yml
+++ b/dm/tests/mariadb_master_down_and_up/docker-compose.yml
@@ -38,5 +38,5 @@ services:
     hostname: tidb
     ports:
       - "4000:4000"
-    image: pingcap/tidb:latest
+    image: pingcap/tidb:nightly
     restart: always

--- a/dm/tests/upstream_switch/docker-compose.yml
+++ b/dm/tests/upstream_switch/docker-compose.yml
@@ -76,5 +76,5 @@ services:
     networks:
       db-networks:
         ipv4_address: 172.28.128.8
-    image: pingcap/tidb:latest
+    image: pingcap/tidb:nightly
     restart: always


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11811

### What is changed and how it works?
ref https://github.com/pingcap/tidb/issues/58372

concurrent create or replace view will cause tidb report table not exist error in v7.5.1, this is fix in later version, update image version to fix the test

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
