### PR TITLE
sink(ticdc): fix incorrect table info in delete event

### DIFF
--- a/cmd/pulsar-consumer/main.go
+++ b/cmd/pulsar-consumer/main.go
@@ -524,14 +524,15 @@ func (c *Consumer) HandleMsg(msg pulsar.Message) error {
 				// todo: mark the offset after the DDL is fully synced to the downstream mysql.
 				continue
 			}
-			var partitionID int64
-			if row.TableInfo.IsPartitionTable() {
-				partitionID = row.GetTableID()
-			}
+			tableID := row.GetTableID()
 			// use schema, table and tableID to identify a table
-			tableID := c.fakeTableIDGenerator.
-				generateFakeTableID(row.TableInfo.GetSchemaName(), row.TableInfo.GetTableName(), partitionID)
-			row.TableInfo.TableName.TableID = tableID
+			switch c.option.protocol {
+			case config.ProtocolCanalJSON:
+			default:
+				tableID := c.fakeTableIDGenerator.
+					generateFakeTableID(row.TableInfo.GetSchemaName(), row.TableInfo.GetTableName(), tableID)
+				row.PhysicalTableID = tableID
+			}
 
 			group, ok := c.eventGroups[tableID]
 			if !ok {

--- a/pkg/sink/codec/canal/canal_json_message.go
+++ b/pkg/sink/codec/canal/canal_json_message.go
@@ -222,7 +222,7 @@ func (b *batchDecoder) canalJSONMessage2RowChange() (*model.RowChangedEvent, err
 	mysqlType := msg.getMySQLType()
 	result.TableInfo.TableName.IsPartition = msg.isPartition()
 	result.TableInfo.TableName.TableID = msg.getTableID()
-	
+
 	var err error
 	if msg.eventType() == canal.EventType_DELETE {
 		// for `DELETE` event, `data` contain the old data, set it as the `PreColumns`

--- a/pkg/sink/codec/canal/canal_json_message.go
+++ b/pkg/sink/codec/canal/canal_json_message.go
@@ -220,7 +220,9 @@ func (b *batchDecoder) canalJSONMessage2RowChange() (*model.RowChangedEvent, err
 	result.CommitTs = msg.getCommitTs()
 	result.PhysicalTableID = msg.getPhysicalTableID()
 	mysqlType := msg.getMySQLType()
-
+	result.TableInfo.TableName.IsPartition = msg.isPartition()
+	result.TableInfo.TableName.TableID = msg.getTableID()
+	
 	var err error
 	if msg.eventType() == canal.EventType_DELETE {
 		// for `DELETE` event, `data` contain the old data, set it as the `PreColumns`
@@ -236,8 +238,6 @@ func (b *batchDecoder) canalJSONMessage2RowChange() (*model.RowChangedEvent, err
 	if err != nil {
 		return nil, err
 	}
-	result.TableInfo.TableName.IsPartition = msg.isPartition()
-	result.TableInfo.TableName.TableID = msg.getTableID()
 
 	// for `UPDATE`, `old` contain old data, set it as the `PreColumns`
 	if msg.eventType() == canal.EventType_UPDATE {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #11879

### What is changed and how it works?
The delete event currently does not assign the "table id" and "partition". It leads to DMLs order being incorrect.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
