### PR TITLE
codec(ticdc): Revert "codec(ticdc): canal-json encode table id (#11875)"

### DIFF
--- a/pkg/sink/codec/canal/canal_json_message.go
+++ b/pkg/sink/codec/canal/canal_json_message.go
@@ -227,11 +227,16 @@ func (b *batchDecoder) setPhysicalTableID(event *model.RowChangedEvent, physical
 			}
 		}
 		for _, partition := range event.TableInfo.Partition.Definitions {
-			if partition.LessThan[0] == "MAXVALUE" {
+			lessThan := partition.LessThan[0]
+			if lessThan == "MAXVALUE" {
 				event.PhysicalTableID = partition.ID
 				return nil
 			}
-			if strings.Compare(columnValue, partition.LessThan[0]) == -1 {
+			if len(columnValue) < len(lessThan) {
+				event.PhysicalTableID = partition.ID
+				return nil
+			}
+			if strings.Compare(columnValue, lessThan) == -1 {
 				event.PhysicalTableID = partition.ID
 				return nil
 			}

--- a/pkg/sink/codec/canal/canal_json_message.go
+++ b/pkg/sink/codec/canal/canal_json_message.go
@@ -38,6 +38,8 @@ type canalJSONMessageInterface interface {
 	getSchema() *string
 	getTable() *string
 	getCommitTs() uint64
+	getPhysicalTableID() int64
+	getTableID() int64
 	getQuery() string
 	getOld() map[string]interface{}
 	getData() map[string]interface{}
@@ -82,6 +84,14 @@ func (c *JSONMessage) getTable() *string {
 
 // for JSONMessage, we lost the commitTs.
 func (c *JSONMessage) getCommitTs() uint64 {
+	return 0
+}
+
+func (c *JSONMessage) getTableID() int64 {
+	return 0
+}
+
+func (c *JSONMessage) getPhysicalTableID() int64 {
 	return 0
 }
 

--- a/pkg/sink/codec/canal/canal_json_row_event_encoder.go
+++ b/pkg/sink/codec/canal/canal_json_row_event_encoder.go
@@ -255,18 +255,6 @@ func newJSONMessageForDML(
 		out.RawByte('{')
 		out.RawString("\"commitTs\":")
 		out.Uint64(e.CommitTs)
-		out.RawByte(',')
-
-		// the logical table id
-		out.RawString("\"tableId\":")
-		out.Int64(e.TableInfo.ID)
-
-		// the physical table id
-		if e.TableInfo.IsPartitionTable() {
-			out.RawByte(',')
-			out.RawString("\"partitionId\":")
-			out.Int64(e.GetTableID())
-		}
 
 		// only send handle key may happen in 2 cases:
 		// 1. delete event, and set only handle key config. no need to encode `onlyHandleKey` field

--- a/pkg/sink/codec/canal/canal_json_row_event_encoder_test.go
+++ b/pkg/sink/codec/canal/canal_json_row_event_encoder_test.go
@@ -90,12 +90,9 @@ func TestDMLE2E(t *testing.T) {
 
 		require.True(t, decodedEvent.IsInsert())
 		if enableTiDBExtension {
-			require.Equal(t, insertEvent.CommitTs, decodedEvent.CommitTs)
-			require.Equal(t, insertEvent.GetTableID(), decodedEvent.GetTableID())
-		} else {
-			require.NotZero(t, decodedEvent.GetTableID())
-			require.Equal(t, decodedEvent.GetTableID(), decodedEvent.TableInfo.ID)
+			require.Equal(t, insertEvent.GetCommitTs(), decodedEvent.GetCommitTs())
 		}
+		require.NotZero(t, decodedEvent.GetTableID())
 		require.Equal(t, insertEvent.TableInfo.GetSchemaName(), decodedEvent.TableInfo.GetSchemaName())
 		require.Equal(t, insertEvent.TableInfo.GetTableName(), decodedEvent.TableInfo.GetTableName())
 
@@ -793,13 +790,8 @@ func TestE2EPartitionTable(t *testing.T) {
 
 		decodedEvent, err := decoder.NextRowChangedEvent()
 		require.NoError(t, err)
-
-		if enableTiDBExtension {
-			require.Equal(t, decodedEvent.GetTableID(), insertEvent.GetTableID())
-		} else {
-			require.NotZero(t, decodedEvent.GetTableID())
-			require.Equal(t, decodedEvent.GetTableID(), decodedEvent.TableInfo.GetPartitionInfo().Definitions[0].ID)
-		}
+		require.NotZero(t, decodedEvent.GetTableID())
+		require.Equal(t, decodedEvent.GetTableID(), decodedEvent.TableInfo.GetPartitionInfo().Definitions[0].ID)
 
 		err = encoder.AppendRowChangedEvent(ctx, "", insertEvent1, nil)
 		require.NoError(t, err)
@@ -815,12 +807,8 @@ func TestE2EPartitionTable(t *testing.T) {
 		decodedEvent, err = decoder.NextRowChangedEvent()
 		require.NoError(t, err)
 
-		if enableTiDBExtension {
-			require.Equal(t, decodedEvent.GetTableID(), insertEvent1.GetTableID())
-		} else {
-			require.NotZero(t, decodedEvent.GetTableID())
-			require.Equal(t, decodedEvent.GetTableID(), decodedEvent.TableInfo.GetPartitionInfo().Definitions[1].ID)
-		}
+		require.NotZero(t, decodedEvent.GetTableID())
+		require.Equal(t, decodedEvent.GetTableID(), decodedEvent.TableInfo.GetPartitionInfo().Definitions[1].ID)
 
 		err = encoder.AppendRowChangedEvent(ctx, "", insertEvent2, nil)
 		require.NoError(t, err)
@@ -836,11 +824,7 @@ func TestE2EPartitionTable(t *testing.T) {
 		decodedEvent, err = decoder.NextRowChangedEvent()
 		require.NoError(t, err)
 
-		if enableTiDBExtension {
-			require.Equal(t, decodedEvent.GetTableID(), insertEvent2.GetTableID())
-		} else {
-			require.NotZero(t, decodedEvent.GetTableID())
-			require.Equal(t, decodedEvent.GetTableID(), decodedEvent.TableInfo.GetPartitionInfo().Definitions[2].ID)
-		}
+		require.NotZero(t, decodedEvent.GetTableID())
+		require.Equal(t, decodedEvent.GetTableID(), decodedEvent.TableInfo.GetPartitionInfo().Definitions[2].ID)
 	}
 }

--- a/pkg/sink/codec/canal/canal_json_row_event_encoder_test.go
+++ b/pkg/sink/codec/canal/canal_json_row_event_encoder_test.go
@@ -729,6 +729,59 @@ func TestCanalJSONContentCompatibleE2E(t *testing.T) {
 	}
 }
 
+func TestE2EPartitionTableByHash(t *testing.T) {
+	helper := entry.NewSchemaTestHelper(t)
+	defer helper.Close()
+
+	helper.Tk().MustExec("use test")
+
+	createTableDDLEvent := helper.DDL2Event(`CREATE TABLE t (a INT,PRIMARY KEY(a)) PARTITION BY HASH (a) PARTITIONS 5`)
+	require.NotNil(t, createTableDDLEvent)
+	insertEvent := helper.DML2Event(`insert into t values (5)`, "test", "t", "p0")
+	require.NotNil(t, insertEvent)
+
+	ctx := context.Background()
+	codecConfig := common.NewConfig(config.ProtocolCanalJSON)
+
+	builder, err := NewJSONRowEventEncoderBuilder(ctx, codecConfig)
+	require.NoError(t, err)
+	encoder := builder.Build()
+
+	decoder, err := NewBatchDecoder(ctx, codecConfig, nil)
+	require.NoError(t, err)
+
+	message, err := encoder.EncodeDDLEvent(createTableDDLEvent)
+	require.NoError(t, err)
+
+	err = decoder.AddKeyValue(message.Key, message.Value)
+	require.NoError(t, err)
+
+	tp, hasNext, err := decoder.HasNext()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+	require.Equal(t, model.MessageTypeDDL, tp)
+
+	decodedDDL, err := decoder.NextDDLEvent()
+	require.NoError(t, err)
+	require.NotNil(t, decodedDDL)
+
+	err = encoder.AppendRowChangedEvent(ctx, "", insertEvent, nil)
+	require.NoError(t, err)
+	message = encoder.Build()[0]
+
+	err = decoder.AddKeyValue(message.Key, message.Value)
+	require.NoError(t, err)
+	tp, hasNext, err = decoder.HasNext()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+	require.Equal(t, model.MessageTypeRow, tp)
+
+	decodedEvent, err := decoder.NextRowChangedEvent()
+	require.NoError(t, err)
+	require.NotZero(t, decodedEvent.GetTableID())
+	require.Equal(t, decodedEvent.GetTableID(), decodedEvent.TableInfo.GetPartitionInfo().Definitions[0].ID)
+}
+
 func TestE2EPartitionTableByRange(t *testing.T) {
 	helper := entry.NewSchemaTestHelper(t)
 	defer helper.Close()

--- a/pkg/sink/codec/canal/canal_json_txn_event_decoder.go
+++ b/pkg/sink/codec/canal/canal_json_txn_event_decoder.go
@@ -115,7 +115,6 @@ func (d *canalJSONTxnEventDecoder) canalJSONMessage2RowChange() (*model.RowChang
 	result := new(model.RowChangedEvent)
 	result.TableInfo = newTableInfo(msg, nil)
 	result.CommitTs = msg.getCommitTs()
-	result.PhysicalTableID = msg.getPhysicalTableID()
 
 	mysqlType := msg.getMySQLType()
 	var err error

--- a/pkg/sink/codec/canal/canal_json_txn_event_decoder_test.go
+++ b/pkg/sink/codec/canal/canal_json_txn_event_decoder_test.go
@@ -29,7 +29,7 @@ func TestNewCanalJSONBatchDecoder4RowMessage(t *testing.T) {
 	_, insertEvent, _, _ := utils.NewLargeEvent4Test(t, config.GetDefaultReplicaConfig())
 	ctx := context.Background()
 
-	for _, encodeEnable := range []bool{true, false} {
+	for _, encodeEnable := range []bool{false, true} {
 		encodeConfig := common.NewConfig(config.ProtocolCanalJSON)
 		encodeConfig.EnableTiDBExtension = encodeEnable
 		encodeConfig.Terminator = config.CRLF
@@ -45,7 +45,7 @@ func TestNewCanalJSONBatchDecoder4RowMessage(t *testing.T) {
 		require.Equal(t, 1, len(messages))
 		msg := messages[0]
 
-		for _, decodeEnable := range []bool{true, false} {
+		for _, decodeEnable := range []bool{false, true} {
 			decodeConfig := common.NewConfig(config.ProtocolCanalJSON)
 			decodeConfig.EnableTiDBExtension = decodeEnable
 
@@ -63,8 +63,6 @@ func TestNewCanalJSONBatchDecoder4RowMessage(t *testing.T) {
 
 			if encodeEnable && decodeEnable {
 				require.Equal(t, insertEvent.CommitTs, decodedEvent.CommitTs)
-				require.Equal(t, insertEvent.GetTableID(), decodedEvent.GetTableID())
-				require.Equal(t, insertEvent.TableInfo.IsPartitionTable(), decodedEvent.TableInfo.IsPartitionTable())
 			}
 			require.Equal(t, insertEvent.TableInfo.GetSchemaName(), decodedEvent.TableInfo.GetSchemaName())
 			require.Equal(t, insertEvent.TableInfo.GetTableName(), decodedEvent.TableInfo.GetTableName())


### PR DESCRIPTION
This reverts commit 44a46bf23fe31995f120454b29de6feb839d1bc6.

<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11993 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
