### PR TITLE
sink(ticdc): fix incorrect encoding default value in Avro protocol

### DIFF
--- a/pkg/sink/codec/avro/avro.go
+++ b/pkg/sink/codec/avro/avro.go
@@ -560,8 +560,18 @@ func (a *BatchEncoder) columns2AvroSchema(tableName model.TableName, input avroE
 			}
 		} else {
 			if colx.GetFlag().IsNullable() {
+				// the string literal "null" must be coerced to a `nil`
+				// see https://github.com/linkedin/goavro/blob/5ec5a5ee7ec82e16e6e2b438d610e1cab2588393/record.go#L109-L114
 				// https://stackoverflow.com/questions/22938124/avro-field-default-values
+				defaultFirst := false
 				if defaultValue == nil {
+					defaultFirst = true
+				} else if s, ok := defaultValue.(string); ok && s == "null" {
+					defaultFirst = true
+				} else if b, ok := defaultValue.([]byte); ok && string(b) == "null" {
+					defaultFirst = true
+				}
+				if defaultFirst {
 					field["type"] = []interface{}{"null", avroType}
 				} else {
 					field["type"] = []interface{}{avroType, "null"}

--- a/tests/integration_tests/avro_basic/data/data.sql
+++ b/tests/integration_tests/avro_basic/data/data.sql
@@ -164,6 +164,15 @@ insert into t(c_tinyint, c_mediumint, c_int, c_bigint, a) values (4, 5, 6, 7, 8)
 alter table t modify c_mediumint varchar(10) null;
 insert into t(c_tinyint, c_mediumint, c_int, c_bigint, a) values (5, "234", 6, 7, 8);
 
+create table t1(
+    id int primary key,
+    c1 varchar(255) DEFAULT "null",
+    c2 varchar(255) DEFAULT "NULL",
+    c3 varchar(255) DEFAULT NULL
+);
+
+insert into t1(id) values(1);
+
 create table finish_mark
 (
     id int PRIMARY KEY

--- a/tests/integration_tests/avro_basic/data/data.sql
+++ b/tests/integration_tests/avro_basic/data/data.sql
@@ -166,13 +166,16 @@ insert into t(c_tinyint, c_mediumint, c_int, c_bigint, a) values (5, "234", 6, 7
 
 create table t1(
     id int primary key,
-    c1 varchar(255) DEFAULT "null",
-    c2 varchar(255) DEFAULT "NULL",
-    c3 varchar(255) DEFAULT NULL
+    c1 varchar(255) default "null",
+    c2 varchar(255) default "NULL",
+    c3 varchar(255) default null
 );
 
 insert into t1(id) values(1);
-update t1 set c1 = "null", c2 = "NULL", c3 = NULL where id = 1;
+update t1 set c1 = "null", c2 = "NULL", c3 = null where id = 1;
+alter table t1 add column col json not null;
+alter table t1 modify column col json default null;
+insert into t1(id) values(2);
 
 create table finish_mark
 (

--- a/tests/integration_tests/avro_basic/data/data.sql
+++ b/tests/integration_tests/avro_basic/data/data.sql
@@ -172,6 +172,7 @@ create table t1(
 );
 
 insert into t1(id) values(1);
+update t1 set c1 = "null", c2 = "NULL", c3 = NULL where id = 1;
 
 create table finish_mark
 (

--- a/tests/integration_tests/avro_basic/run.sh
+++ b/tests/integration_tests/avro_basic/run.sh
@@ -47,7 +47,7 @@ function run() {
 	SINK_URI="kafka://127.0.0.1:9092/$TOPIC_NAME?protocol=avro&enable-tidb-extension=true&avro-enable-watermark=true&avro-decimal-handling-mode=string&avro-bigint-unsigned-handling-mode=string"
 
 	run_cdc_cli changefeed create --start-ts=$start_ts --sink-uri="$SINK_URI" --config="$CUR/conf/changefeed.toml" --schema-registry=http://127.0.0.1:8088
-	cdc_kafka_consumer --upstream-uri $SINK_URI --downstream-uri="mysql://root@127.0.0.1:3306/?safe-mode=true&batch-dml-enable=false" --upstream-tidb-dsn="root@tcp(${UP_TIDB_HOST}:${UP_TIDB_PORT})/?" --schema-registry-uri=http://127.0.0.1:8088 --config="$CUR/conf/changefeed.toml" 2>&1 &
+	run_kafka_consumer $WORK_DIR $SINK_URI "$CUR/conf/changefeed.toml" http://127.0.0.1:8088
 
 	run_sql_file $CUR/data/data.sql ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11994

### What is changed and how it works?
treat as a `nil` when the default value is the string literal "null" 

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
 Fix incorrect encoding default value in Avro protocol.
```
