### PR TITLE
api(cdc): fix create changefeed after scale-in pd

### DIFF
--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -341,6 +341,7 @@ func (h *OpenAPIV2) verifyTable(c *gin.Context) {
 		kvStore, err = h.helpers.createTiStore(ctx, cfg.PDAddrs, credential)
 		if err != nil {
 			_ = c.Error(errors.Trace(err))
+			return
 		}
 	}
 

--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -1114,12 +1114,3 @@ func getCaptureDefaultUpstream(cp capture.Capture) (*upstream.Upstream, error) {
 	}
 	return up, nil
 }
-
-func getUpstreamPDConfig(up *upstream.Upstream) PDConfig {
-	return PDConfig{
-		PDAddrs:  up.PdEndpoints,
-		KeyPath:  up.SecurityConfig.KeyPath,
-		CAPath:   up.SecurityConfig.CAPath,
-		CertPath: up.SecurityConfig.CertPath,
-	}
-}

--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -939,9 +939,11 @@ func (h *OpenAPIV2) synced(c *gin.Context) {
 		cfg.ReplicaConfig.SyncedStatus.CheckpointInterval = status.CheckpointInterval
 		cfg.ReplicaConfig.SyncedStatus.SyncedCheckInterval = status.SyncedCheckInterval
 	}
-	if err := c.BindJSON(cfg); err != nil {
-		_ = c.Error(cerror.WrapError(cerror.ErrAPIInvalidParam, err))
-		return
+	if c.Request.Body != nil && c.Request.ContentLength > 0 {
+		if err := c.BindJSON(cfg); err != nil {
+			_ = c.Error(cerror.WrapError(cerror.ErrAPIInvalidParam, err))
+			return
+		}
 	}
 
 	// try to get pd client to get pd time, and determine synced status based on the pd time

--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -935,6 +935,10 @@ func (h *OpenAPIV2) synced(c *gin.Context) {
 		cfg.ReplicaConfig.SyncedStatus.CheckpointInterval = status.CheckpointInterval
 		cfg.ReplicaConfig.SyncedStatus.SyncedCheckInterval = status.SyncedCheckInterval
 	}
+	if err := c.BindJSON(cfg); err != nil {
+		_ = c.Error(cerror.WrapError(cerror.ErrAPIInvalidParam, err))
+		return
+	}
 
 	// try to get pd client to get pd time, and determine synced status based on the pd time
 	var pdClient pd.Client
@@ -950,7 +954,7 @@ func (h *OpenAPIV2) synced(c *gin.Context) {
 		timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 
-		pdClient, err := h.helpers.getPDClient(timeoutCtx, cfg.PDAddrs, credential)
+		pdClient, err = h.helpers.getPDClient(timeoutCtx, cfg.PDAddrs, credential)
 		if err != nil {
 			// case 1. we can't get pd client, pd may be unavailable.
 			//         if pullerResolvedTs - checkpointTs > checkpointInterval, data is not synced

--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/pkg/kv"
 	tidbkv "github.com/pingcap/tidb/pkg/kv"
 	"github.com/pingcap/tiflow/cdc/api"
 	"github.com/pingcap/tiflow/cdc/capture"
@@ -66,30 +67,47 @@ func (h *OpenAPIV2) createChangefeed(c *gin.Context) {
 		_ = c.Error(cerror.WrapError(cerror.ErrAPIInvalidParam, err))
 		return
 	}
+	var pdClient pd.Client
+	var kvStorage kv.Storage
+	var etcdCli *clientv3.Client
+	// if PDAddrs is empty, use the default pdClient
 	if len(cfg.PDAddrs) == 0 {
 		up, err := getCaptureDefaultUpstream(h.capture)
 		if err != nil {
 			_ = c.Error(err)
 			return
 		}
-		cfg.PDConfig = getUpstreamPDConfig(up)
-	}
-	credential := cfg.PDConfig.toCredential()
-
-	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-	pdClient, err := h.helpers.getPDClient(timeoutCtx, cfg.PDAddrs, credential)
-	if err != nil {
-		_ = c.Error(cerror.WrapError(cerror.ErrAPIGetPDClientFailed, err))
-		return
-	}
-	defer pdClient.Close()
-
-	// verify tables todo: del kvstore
-	kvStorage, err := h.helpers.createTiStore(ctx, cfg.PDAddrs, credential)
-	if err != nil {
-		_ = c.Error(cerror.WrapError(cerror.ErrNewStore, err))
-		return
+		pdClient = up.PDClient
+		kvStorage = up.KVStorage
+		etcdCli = h.capture.GetEtcdClient().GetEtcdClient().Unwrap()
+	} else {
+		credential := cfg.PDConfig.toCredential()
+		timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		var err error
+		pdClient, err = h.helpers.getPDClient(timeoutCtx, cfg.PDAddrs, credential)
+		if err != nil {
+			_ = c.Error(cerror.WrapError(cerror.ErrAPIInvalidParam, err))
+			return
+		}
+		defer pdClient.Close()
+		// verify tables todo: del kvstore
+		kvStorage, err = h.helpers.createTiStore(ctx, cfg.PDAddrs, credential)
+		if err != nil {
+			_ = c.Error(cerror.WrapError(cerror.ErrNewStore, err))
+			return
+		}
+		// cannot create changefeed if there are running lightning/restore tasks
+		tlsCfg, err := credential.ToTLSConfig()
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+		etcdCli, err = h.helpers.getEtcdClient(ctx, cfg.PDAddrs, tlsCfg)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
 	}
 	provider := h.capture.StatusProvider()
 	owner, err := h.capture.GetOwner()
@@ -136,19 +154,7 @@ func (h *OpenAPIV2) createChangefeed(c *gin.Context) {
 		CertAllowedCN: cfg.CertAllowedCN,
 	}
 
-	// cannot create changefeed if there are running lightning/restore tasks
-	tlsCfg, err := credential.ToTLSConfig()
-	if err != nil {
-		_ = c.Error(err)
-		return
-	}
-
-	cli, err := h.helpers.getEtcdClient(ctx, cfg.PDAddrs, tlsCfg)
-	if err != nil {
-		_ = c.Error(err)
-		return
-	}
-	err = hasRunningImport(ctx, cli)
+	err = hasRunningImport(ctx, etcdCli)
 	if err != nil {
 		log.Error("failed to create changefeed", zap.Error(err))
 		_ = c.Error(
@@ -319,21 +325,25 @@ func (h *OpenAPIV2) verifyTable(c *gin.Context) {
 		_ = c.Error(cerror.WrapError(cerror.ErrAPIInvalidParam, err))
 		return
 	}
+	ctx := c.Request.Context()
+	var kvStore tidbkv.Storage
+	// if PDAddrs is empty, use the default upstream
 	if len(cfg.PDAddrs) == 0 {
 		up, err := getCaptureDefaultUpstream(h.capture)
 		if err != nil {
 			_ = c.Error(err)
 			return
 		}
-		cfg.PDConfig = getUpstreamPDConfig(up)
+		kvStore = up.KVStorage
+	} else {
+		credential := cfg.PDConfig.toCredential()
+		var err error
+		kvStore, err = h.helpers.createTiStore(ctx, cfg.PDAddrs, credential)
+		if err != nil {
+			_ = c.Error(errors.Trace(err))
+		}
 	}
-	credential := cfg.PDConfig.toCredential()
-	ctx := c.Request.Context()
-	kvStore, err := h.helpers.createTiStore(ctx, cfg.PDAddrs, credential)
-	if err != nil {
-		_ = c.Error(err)
-		return
-	}
+
 	uri, err := url.Parse(cfg.SinkURI)
 	if err != nil {
 		_ = c.Error(err)
@@ -926,46 +936,47 @@ func (h *OpenAPIV2) synced(c *gin.Context) {
 	}
 
 	// try to get pd client to get pd time, and determine synced status based on the pd time
+	var pdClient pd.Client
 	if len(cfg.PDAddrs) == 0 {
 		up, err := getCaptureDefaultUpstream(h.capture)
 		if err != nil {
 			_ = c.Error(err)
 			return
 		}
-		cfg.PDConfig = getUpstreamPDConfig(up)
-	}
-	credential := cfg.PDConfig.toCredential()
+		pdClient = up.PDClient
+	} else {
+		credential := cfg.PDConfig.toCredential()
+		timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	pdClient, err := h.helpers.getPDClient(timeoutCtx, cfg.PDAddrs, credential)
-	if err != nil {
-		// case 1. we can't get pd client, pd may be unavailable.
-		//         if pullerResolvedTs - checkpointTs > checkpointInterval, data is not synced
-		//         otherwise, if pd is unavailable, we decide data whether is synced based on
-		//         the time difference between current time and lastSyncedTs.
-		var message string
-		if (oracle.ExtractPhysical(status.PullerResolvedTs) - oracle.ExtractPhysical(status.CheckpointTs)) >
-			cfg.ReplicaConfig.SyncedStatus.CheckpointInterval*1000 {
-			message = fmt.Sprintf("%s. Besides the data is not finish syncing", err.Error())
-		} else {
-			message = fmt.Sprintf("%s. You should check the pd status first. If pd status is normal, means we don't finish sync data. "+
-				"If pd is offline, please check whether we satisfy the condition that "+
-				"the time difference from lastSyncedTs to the current time from the time zone of pd is greater than %v secs. "+
-				"If it's satisfied, means the data syncing is totally finished", err, cfg.ReplicaConfig.SyncedStatus.SyncedCheckInterval)
+		pdClient, err := h.helpers.getPDClient(timeoutCtx, cfg.PDAddrs, credential)
+		if err != nil {
+			// case 1. we can't get pd client, pd may be unavailable.
+			//         if pullerResolvedTs - checkpointTs > checkpointInterval, data is not synced
+			//         otherwise, if pd is unavailable, we decide data whether is synced based on
+			//         the time difference between current time and lastSyncedTs.
+			var message string
+			if (oracle.ExtractPhysical(status.PullerResolvedTs) - oracle.ExtractPhysical(status.CheckpointTs)) >
+				cfg.ReplicaConfig.SyncedStatus.CheckpointInterval*1000 {
+				message = fmt.Sprintf("%s. Besides the data is not finish syncing", err.Error())
+			} else {
+				message = fmt.Sprintf("%s. You should check the pd status first. If pd status is normal, means we don't finish sync data. "+
+					"If pd is offline, please check whether we satisfy the condition that "+
+					"the time difference from lastSyncedTs to the current time from the time zone of pd is greater than %v secs. "+
+					"If it's satisfied, means the data syncing is totally finished", err, cfg.ReplicaConfig.SyncedStatus.SyncedCheckInterval)
+			}
+			c.JSON(http.StatusOK, SyncedStatus{
+				Synced:           false,
+				SinkCheckpointTs: model.JSONTime(oracle.GetTimeFromTS(status.CheckpointTs)),
+				PullerResolvedTs: model.JSONTime(oracle.GetTimeFromTS(status.PullerResolvedTs)),
+				LastSyncedTs:     model.JSONTime(oracle.GetTimeFromTS(status.LastSyncedTs)),
+				NowTs:            model.JSONTime(time.Unix(0, 0)),
+				Info:             message,
+			})
+			return
 		}
-		c.JSON(http.StatusOK, SyncedStatus{
-			Synced:           false,
-			SinkCheckpointTs: model.JSONTime(oracle.GetTimeFromTS(status.CheckpointTs)),
-			PullerResolvedTs: model.JSONTime(oracle.GetTimeFromTS(status.PullerResolvedTs)),
-			LastSyncedTs:     model.JSONTime(oracle.GetTimeFromTS(status.LastSyncedTs)),
-			NowTs:            model.JSONTime(time.Unix(0, 0)),
-			Info:             message,
-		})
-		return
+		defer pdClient.Close()
 	}
-	defer pdClient.Close()
 	// get time from pd
 	physicalNow, _, _ := pdClient.GetTS(ctx)
 

--- a/cdc/api/v2/changefeed_test.go
+++ b/cdc/api/v2/changefeed_test.go
@@ -1040,8 +1040,7 @@ func TestChangefeedSynced(t *testing.T) {
 		cfg := getDefaultVerifyTableConfig()
 		// arbitrary pd address to trigger create new pd client
 		cfg.PDAddrs = []string{"http://127.0.0.1:2379"}
-		body, err := json.Marshal(&cfg)
-		require.Nil(t, err)
+		body, _ := json.Marshal(&cfg)
 		helpers.EXPECT().getPDClient(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, cerrors.ErrAPIGetPDClientFailed).Times(1)
 		// case3: pd is offline，resolvedTs - checkpointTs > 15s
 		statusProvider.changeFeedSyncedStatus = &model.ChangeFeedSyncedStatusForAPI{
@@ -1059,7 +1058,7 @@ func TestChangefeedSynced(t *testing.T) {
 		router.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code)
 		resp := SyncedStatus{}
-		err = json.NewDecoder(w.Body).Decode(&resp)
+		err := json.NewDecoder(w.Body).Decode(&resp)
 		require.Nil(t, err)
 		require.Equal(t, false, resp.Synced)
 		require.Equal(t, "[CDC:ErrAPIGetPDClientFailed]failed to get PDClient to connect PD, "+
@@ -1070,7 +1069,7 @@ func TestChangefeedSynced(t *testing.T) {
 		cfg := getDefaultVerifyTableConfig()
 		// arbitrary pd address to trigger create new pd client
 		cfg.PDAddrs = []string{"http://127.0.0.1:2379"}
-		body, err := json.Marshal(&cfg)
+		body, _ := json.Marshal(&cfg)
 		helpers.EXPECT().getPDClient(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, cerrors.ErrAPIGetPDClientFailed).Times(1)
 		// case4: pd is offline，resolvedTs - checkpointTs < 15s
 		statusProvider.changeFeedSyncedStatus = &model.ChangeFeedSyncedStatusForAPI{
@@ -1088,7 +1087,7 @@ func TestChangefeedSynced(t *testing.T) {
 		router.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code)
 		resp := SyncedStatus{}
-		err = json.NewDecoder(w.Body).Decode(&resp)
+		err := json.NewDecoder(w.Body).Decode(&resp)
 		require.Nil(t, err)
 		require.Equal(t, false, resp.Synced)
 		require.Equal(t, "[CDC:ErrAPIGetPDClientFailed]failed to get PDClient to connect PD, please recheck. "+
@@ -1105,7 +1104,7 @@ func TestChangefeedSynced(t *testing.T) {
 		cfg := getDefaultVerifyTableConfig()
 		// arbitrary pd address to trigger create new pd client
 		cfg.PDAddrs = []string{"http://127.0.0.1:2379"}
-		body, err := json.Marshal(&cfg)
+		body, _ := json.Marshal(&cfg)
 		// case5: pdTs - lastSyncedTs > 5min, pdTs - checkpointTs < 15s
 		statusProvider.changeFeedSyncedStatus = &model.ChangeFeedSyncedStatusForAPI{
 			CheckpointTs:     1701153217209 << 18,
@@ -1122,7 +1121,7 @@ func TestChangefeedSynced(t *testing.T) {
 		router.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code)
 		resp := SyncedStatus{}
-		err = json.NewDecoder(w.Body).Decode(&resp)
+		err := json.NewDecoder(w.Body).Decode(&resp)
 		require.Nil(t, err)
 		require.Equal(t, true, resp.Synced)
 		require.Equal(t, "Data syncing is finished", resp.Info)
@@ -1132,7 +1131,7 @@ func TestChangefeedSynced(t *testing.T) {
 		cfg := getDefaultVerifyTableConfig()
 		// arbitrary pd address to trigger create new pd client
 		cfg.PDAddrs = []string{"http://127.0.0.1:2379"}
-		body, err := json.Marshal(&cfg)
+		body, _ := json.Marshal(&cfg)
 		// case6: pdTs - lastSyncedTs > 5min, pdTs - checkpointTs > 15s, resolvedTs - checkpointTs < 15s
 		statusProvider.changeFeedSyncedStatus = &model.ChangeFeedSyncedStatusForAPI{
 			CheckpointTs:     1701153201279 << 18,
@@ -1149,7 +1148,7 @@ func TestChangefeedSynced(t *testing.T) {
 		router.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code)
 		resp := SyncedStatus{}
-		err = json.NewDecoder(w.Body).Decode(&resp)
+		err := json.NewDecoder(w.Body).Decode(&resp)
 		require.Nil(t, err)
 		require.Equal(t, false, resp.Synced)
 		require.Equal(t, "Please check whether PD is online and TiKV Regions are all available. "+
@@ -1164,7 +1163,7 @@ func TestChangefeedSynced(t *testing.T) {
 		cfg := getDefaultVerifyTableConfig()
 		// arbitrary pd address to trigger create new pd client
 		cfg.PDAddrs = []string{"http://127.0.0.1:2379"}
-		body, err := json.Marshal(&cfg)
+		body, _ := json.Marshal(&cfg)
 		// case7: pdTs - lastSyncedTs > 5min, pdTs - checkpointTs > 15s, resolvedTs - checkpointTs > 15s
 		statusProvider.changeFeedSyncedStatus = &model.ChangeFeedSyncedStatusForAPI{
 			CheckpointTs:     1701153201279 << 18,
@@ -1181,7 +1180,7 @@ func TestChangefeedSynced(t *testing.T) {
 		router.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code)
 		resp := SyncedStatus{}
-		err = json.NewDecoder(w.Body).Decode(&resp)
+		err := json.NewDecoder(w.Body).Decode(&resp)
 		require.Nil(t, err)
 		require.Equal(t, false, resp.Synced)
 		require.Equal(t, "The data syncing is not finished, please wait", resp.Info)
@@ -1191,7 +1190,7 @@ func TestChangefeedSynced(t *testing.T) {
 		cfg := getDefaultVerifyTableConfig()
 		// arbitrary pd address to trigger create new pd client
 		cfg.PDAddrs = []string{"http://127.0.0.1:2379"}
-		body, err := json.Marshal(&cfg)
+		body, _ := json.Marshal(&cfg)
 		// case8: pdTs - lastSyncedTs < 5min
 		statusProvider.changeFeedSyncedStatus = &model.ChangeFeedSyncedStatusForAPI{
 			CheckpointTs:     1701153217279 << 18,
@@ -1208,7 +1207,7 @@ func TestChangefeedSynced(t *testing.T) {
 		router.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code)
 		resp := SyncedStatus{}
-		err = json.NewDecoder(w.Body).Decode(&resp)
+		err := json.NewDecoder(w.Body).Decode(&resp)
 		require.Nil(t, err)
 		require.Equal(t, false, resp.Synced)
 		require.Equal(t, "The data syncing is not finished, please wait", resp.Info)

--- a/cdc/api/v2/changefeed_test.go
+++ b/cdc/api/v2/changefeed_test.go
@@ -647,6 +647,8 @@ func TestVerifyTable(t *testing.T) {
 
 	// case 2: kv create failed
 	updateCfg := getDefaultVerifyTableConfig()
+	// arbitrary pd address to trigger create new pd client
+	updateCfg.PDAddrs = []string{"http://127.0.0.1:2379"}
 	body, err := json.Marshal(&updateCfg)
 	require.Nil(t, err)
 	helpers.EXPECT().

--- a/cdc/api/v2/changefeed_test.go
+++ b/cdc/api/v2/changefeed_test.go
@@ -77,7 +77,7 @@ func TestCreateChangefeed(t *testing.T) {
 	cp.EXPECT().GetOwner().Return(mo, nil).AnyTimes()
 	cp.EXPECT().StatusProvider().Return(provider).AnyTimes()
 
-	// case 1: json format mismatches with the spec.
+	case 1: json format mismatches with the spec.
 	errConfig := struct {
 		ID        string `json:"changefeed_id"`
 		Namespace string `json:"namespace"`
@@ -110,7 +110,7 @@ func TestCreateChangefeed(t *testing.T) {
 		ID:        changeFeedID.ID,
 		Namespace: changeFeedID.Namespace,
 		SinkURI:   blackholeSink,
-		PDAddrs:   []string{},
+		PDAddrs:   []string{"http://127.0.0.1:2379"}, // arbitrary pd address to trigger create new pd client
 	}
 	body, err := json.Marshal(&cfConfig)
 	require.Nil(t, err)

--- a/cdc/api/v2/changefeed_test.go
+++ b/cdc/api/v2/changefeed_test.go
@@ -77,7 +77,7 @@ func TestCreateChangefeed(t *testing.T) {
 	cp.EXPECT().GetOwner().Return(mo, nil).AnyTimes()
 	cp.EXPECT().StatusProvider().Return(provider).AnyTimes()
 
-	case 1: json format mismatches with the spec.
+	// case 1: json format mismatches with the spec.
 	errConfig := struct {
 		ID        string `json:"changefeed_id"`
 		Namespace string `json:"namespace"`

--- a/tests/integration_tests/synced_status_with_redo/run.sh
+++ b/tests/integration_tests/synced_status_with_redo/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-## test the same logic as `sync_status``, but with redo mode
+## test the same logic as `sync_status`, but with redo mode
 
 #!/bin/bash
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12004

### What is changed and how it works?
When the api request doesn't contain any pd address, we previously use the old pd address to create a new pd client.
If the old pd address are all scaled-in, the newly created pd client cannot connect to the upstream.
To fix this problem, in this case we should use pd client in the default upstream of the capture which can manage pd scale-in/scale-out internally.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
1. Deploy a cluster with 3 pds;
2. Scale out 3 new pds;
3. Transfer pd leader;
4. Scale in 3 old pds;
5. Create changefeed;

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix create changefeed after scale in pds in some scenarios.
```
