### PR TITLE
sink(ticdc): fix incorrect encoding default value in Avro protocol

### DIFF
--- a/pkg/sink/codec/avro/avro.go
+++ b/pkg/sink/codec/avro/avro.go
@@ -563,15 +563,7 @@ func (a *BatchEncoder) columns2AvroSchema(tableName model.TableName, input avroE
 				// the string literal "null" must be coerced to a `nil`
 				// see https://github.com/linkedin/goavro/blob/5ec5a5ee7ec82e16e6e2b438d610e1cab2588393/record.go#L109-L114
 				// https://stackoverflow.com/questions/22938124/avro-field-default-values
-				defaultFirst := false
-				if defaultValue == nil {
-					defaultFirst = true
-				} else if s, ok := defaultValue.(string); ok && s == "null" {
-					defaultFirst = true
-				} else if b, ok := defaultValue.([]byte); ok && string(b) == "null" {
-					defaultFirst = true
-				}
-				if defaultFirst {
+				if defaultValue == nil || defaultValue == "null" {
 					field["type"] = []interface{}{"null", avroType}
 				} else {
 					field["type"] = []interface{}{avroType, "null"}

--- a/tests/integration_tests/avro_basic/data/data.sql
+++ b/tests/integration_tests/avro_basic/data/data.sql
@@ -168,7 +168,8 @@ create table t1(
     id int primary key,
     c1 varchar(255) default "null",
     c2 varchar(255) default "NULL",
-    c3 varchar(255) default null
+    c3 varchar(255) default null,
+    c4 varbinary(100) DEFAULT b'01101110011101010110110001101100'
 );
 
 insert into t1(id) values(1);


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #11994

### What is changed and how it works?
related to https://github.com/pingcap/tiflow/pull/11995 
don't treat as a nil when the default value is the byte literal "null"

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
