### PR TITLE
*: add warning to deprecate config sink.enable-partition-separator in the future

### DIFF
--- a/pkg/cmd/cli/cli_changefeed_create.go
+++ b/pkg/cmd/cli/cli_changefeed_create.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/BurntSushi/toml"
 	"github.com/fatih/color"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
@@ -187,12 +188,27 @@ func (o *createChangefeedOptions) completeReplicaCfg() error {
 // validate checks that the provided attach options are specified.
 func (o *createChangefeedOptions) validate(cmd *cobra.Command) error {
 	if o.timezone != "SYSTEM" {
-		cmd.Printf(color.HiYellowString("[WARN] --tz is deprecated in changefeed settings.\n"))
+		cmd.Println(color.HiYellowString("[WARN] --tz is deprecated in changefeed settings.\n"))
+	}
+
+	if len(o.commonChangefeedOptions.configFile) > 0 {
+		cfg := config.GetDefaultReplicaConfig()
+		metaData, err := toml.DecodeFile(o.commonChangefeedOptions.configFile, cfg)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		if metaData.IsDefined("sink", "enable-partition-separator") {
+			cmd.Println(color.HiYellowString("sink.enable-partition-separator is deprecated and will be removed in future versions. " +
+				"The default value for sink.enable-partition-separator is true. " +
+				"Changing it to false may lead to data inconsistency issues. " +
+				"Please update your configuration as needed."))
+		}
 	}
 
 	// user is not allowed to set sort-dir at changefeed level
 	if o.commonChangefeedOptions.sortDir != "" {
-		cmd.Printf(color.HiYellowString("[WARN] --sort-dir is deprecated in changefeed settings. " +
+		cmd.Println(color.HiYellowString("[WARN] --sort-dir is deprecated in changefeed settings. " +
 			"Please use `cdc server --data-dir` to start the cdc server if possible, sort-dir will be set automatically. " +
 			"The --sort-dir here will be no-op\n"))
 		return errors.New("creating changefeed with `--sort-dir`, it's invalid")

--- a/pkg/cmd/cli/cli_changefeed_create.go
+++ b/pkg/cmd/cli/cli_changefeed_create.go
@@ -200,8 +200,8 @@ func (o *createChangefeedOptions) validate(cmd *cobra.Command) error {
 
 		if metaData.IsDefined("sink", "enable-partition-separator") {
 			cmd.Println(color.HiYellowString("sink.enable-partition-separator is deprecated and will be removed in future versions. " +
-				"The default value for sink.enable-partition-separator is true. " +
-				"Changing it to false may lead to data inconsistency issues. " +
+				"The default value for sink.enable-partition-separator is `true`. " +
+				"Changing it to `false` may lead to data inconsistency issues. " +
 				"Please update your configuration as needed."))
 		}
 	}

--- a/pkg/cmd/util/helper.go
+++ b/pkg/cmd/util/helper.go
@@ -123,13 +123,6 @@ func StrictDecodeFile(path, component string, cfg interface{}, ignoreCheckItems 
 		return errors.Trace(err)
 	}
 
-	if metaData.IsDefined("sink", "enable-partition-separator") {
-		log.Warn("sink.enable-partition-separator is deprecated and will be removed in future versions. " +
-			"The default value for sink.enable-partition-separator is true. " +
-			"Changing it to false may lead to data inconsistency issues. " +
-			"Please update your configuration as needed.")
-	}
-
 	// check if item is a ignoreCheckItem
 	hasIgnoreItem := func(item []string) bool {
 		for _, ignoreCheckItem := range ignoreCheckItems {

--- a/pkg/cmd/util/helper.go
+++ b/pkg/cmd/util/helper.go
@@ -123,6 +123,13 @@ func StrictDecodeFile(path, component string, cfg interface{}, ignoreCheckItems 
 		return errors.Trace(err)
 	}
 
+	if metaData.IsDefined("sink", "enable-partition-separator") {
+		log.Warn("sink.enable-partition-separator is deprecated and will be removed in future versions. " +
+			"The default value for sink.enable-partition-separator is true. " +
+			"Changing it to false may lead to data inconsistency issues. " +
+			"Please update your configuration as needed.")
+	}
+
 	// check if item is a ignoreCheckItem
 	hasIgnoreItem := func(item []string) bool {
 		for _, ignoreCheckItem := range ignoreCheckItems {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11979

### What is changed and how it works?
Report a warning to the user if config sink.enable-partition-separator is set explicitly in the config file.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
1. create a changefeed with sink.enable-partition-separator set in config file.
![image](https://github.com/user-attachments/assets/a6c20a0f-2108-42bb-b493-faa144151f0a)

2. update the changefeed with sink.enable-partition-separator set in config file.
![image](https://github.com/user-attachments/assets/56675cc0-0710-4c8d-b0ce-43aed11921ea)


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
