### PR TITLE
sink(ticdc): fix incorrect `default` field

### DIFF
--- a/cdc/entry/mounter_test.go
+++ b/cdc/entry/mounter_test.go
@@ -1629,13 +1629,13 @@ func TestNewDMRowChange(t *testing.T) {
 		cdcTableInfo := model.WrapTableInfo(0, "test", 0, originTI)
 		cols := []*model.Column{
 			{
-				Name: "id", Type: 3, Charset: "binary", Flag: 65, Value: 1, Default: nil,
+				Name: "id", Type: 3, Charset: "binary", Flag: 65, Value: 1,
 			},
 			{
-				Name: "a1", Type: 3, Charset: "binary", Flag: 51, Value: 1, Default: nil,
+				Name: "a1", Type: 3, Charset: "binary", Flag: 51, Value: 1,
 			},
 			{
-				Name: "a3", Type: 3, Charset: "binary", Flag: 51, Value: 2, Default: nil,
+				Name: "a3", Type: 3, Charset: "binary", Flag: 51, Value: 2,
 			},
 		}
 		recoveredTI := model.BuildTiDBTableInfo(cdcTableInfo.TableName.Table, cols, cdcTableInfo.IndexColumnsOffset)

--- a/cdc/model/codec/codec.go
+++ b/cdc/model/codec/codec.go
@@ -223,7 +223,6 @@ func columnFromV1(c *codecv1.Column) *model.Column {
 		Charset:          c.Charset,
 		Flag:             c.Flag,
 		Value:            c.Value,
-		Default:          c.Default,
 		ApproximateBytes: c.ApproximateBytes,
 	}
 }

--- a/cdc/model/schema_storage.go
+++ b/cdc/model/schema_storage.go
@@ -501,9 +501,6 @@ func (ti *TableInfo) GetPrimaryKeyColumnNames() []string {
 // GetColumnDefaultValue returns the default definition of a column.
 func GetColumnDefaultValue(col *model.ColumnInfo) interface{} {
 	defaultValue := col.GetDefaultValue()
-	if defaultValue == nil {
-		defaultValue = col.GetOriginDefaultValue()
-	}
 	defaultDatum := datumTypes.NewDatum(defaultValue)
 	return defaultDatum.GetValue()
 }

--- a/cdc/model/schema_storage.go
+++ b/cdc/model/schema_storage.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/types"
 	"github.com/pingcap/tidb/pkg/table/tables"
-	datumTypes "github.com/pingcap/tidb/pkg/types"
 	"github.com/pingcap/tidb/pkg/util/rowcodec"
 	"go.uber.org/zap"
 )
@@ -496,9 +495,4 @@ func (ti *TableInfo) GetPrimaryKeyColumnNames() []string {
 		}
 	}
 	return result
-}
-
-// GetColumnDefaultValue returns the default definition of a column.
-func GetColumnDefaultValue(col *model.ColumnInfo) interface{} {
-	return col.GetDefaultValue()
 }

--- a/cdc/model/schema_storage.go
+++ b/cdc/model/schema_storage.go
@@ -500,7 +500,5 @@ func (ti *TableInfo) GetPrimaryKeyColumnNames() []string {
 
 // GetColumnDefaultValue returns the default definition of a column.
 func GetColumnDefaultValue(col *model.ColumnInfo) interface{} {
-	defaultValue := col.GetDefaultValue()
-	defaultDatum := datumTypes.NewDatum(defaultValue)
-	return defaultDatum.GetValue()
+	return col.GetDefaultValue()
 }

--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -480,7 +480,6 @@ func columnData2Column(col *ColumnData, tableInfo *TableInfo) *Column {
 		Collation: colInfo.GetCollate(),
 		Flag:      *tableInfo.ColumnsFlag[colID],
 		Value:     col.Value,
-		Default:   colInfo.GetDefaultValue(),
 	}
 }
 
@@ -652,7 +651,6 @@ type Column struct {
 	Collation string         `msg:"collation"`
 	Flag      ColumnFlagType `msg:"-"`
 	Value     interface{}    `msg:"-"`
-	Default   interface{}    `msg:"-"`
 
 	// ApproximateBytes is approximate bytes consumed by the column.
 	ApproximateBytes int `msg:"-"`
@@ -1388,7 +1386,6 @@ func Columns2ColumnDataForTest(columns []*Column) ([]*ColumnData, *TableInfo) {
 		info.Columns[i].SetType(column.Type)
 		info.Columns[i].SetCharset(column.Charset)
 		info.Columns[i].SetCollate(column.Collation)
-		info.Columns[i].DefaultValue = column.Default
 
 		info.ColumnsFlag[columnID] = new(ColumnFlagType)
 		*info.ColumnsFlag[columnID] = column.Flag

--- a/cdc/model/sink.go
+++ b/cdc/model/sink.go
@@ -480,7 +480,7 @@ func columnData2Column(col *ColumnData, tableInfo *TableInfo) *Column {
 		Collation: colInfo.GetCollate(),
 		Flag:      *tableInfo.ColumnsFlag[colID],
 		Value:     col.Value,
-		Default:   GetColumnDefaultValue(colInfo),
+		Default:   colInfo.GetDefaultValue(),
 	}
 }
 
@@ -1360,7 +1360,7 @@ func (x ColumnDataX) GetFlag() ColumnFlagType {
 
 // GetDefaultValue return default value.
 func (x ColumnDataX) GetDefaultValue() interface{} {
-	return GetColumnDefaultValue(x.info)
+	return x.info.GetDefaultValue()
 }
 
 // GetColumnInfo returns column info.

--- a/pkg/sink/cloudstorage/table_definition.go
+++ b/pkg/sink/cloudstorage/table_definition.go
@@ -77,7 +77,7 @@ func (t *TableCol) FromTiColumnInfo(col *timodel.ColumnInfo, outputColumnID bool
 	if mysql.HasNotNullFlag(col.GetFlag()) {
 		t.Nullable = "false"
 	}
-	t.Default = model.GetColumnDefaultValue(col)
+	t.Default = col.GetDefaultValue()
 
 	switch col.GetType() {
 	case mysql.TypeTimestamp, mysql.TypeDatetime, mysql.TypeDuration:

--- a/pkg/sink/codec/debezium/codec.go
+++ b/pkg/sink/codec/debezium/codec.go
@@ -505,7 +505,7 @@ func (c *dbzCodec) writeDebeziumFieldValue(
 	col model.ColumnDataX,
 	ft *types.FieldType,
 ) error {
-	value := getValue(col)
+	value := col.Value
 	if value == nil {
 		writer.WriteNullField(col.GetName())
 		return nil

--- a/pkg/sink/codec/debezium/codec.go
+++ b/pkg/sink/codec/debezium/codec.go
@@ -507,6 +507,9 @@ func (c *dbzCodec) writeDebeziumFieldValue(
 ) error {
 	value := col.Value
 	if value == nil {
+		value = col.GetDefaultValue()
+	}
+	if value == nil {
 		writer.WriteNullField(col.GetName())
 		return nil
 	}

--- a/pkg/sink/codec/debezium/helper.go
+++ b/pkg/sink/codec/debezium/helper.go
@@ -243,13 +243,6 @@ func getBitFromUint64(n int, v uint64) []byte {
 	return buf[:numBytes]
 }
 
-func getValue(col model.ColumnDataX) any {
-	if col.Value == nil {
-		return col.GetDefaultValue()
-	}
-	return col.Value
-}
-
 func getDBTableName(e *model.DDLEvent) (string, string) {
 	if e.TableInfo == nil {
 		return "", ""

--- a/pkg/sink/codec/debezium/helper_test.go
+++ b/pkg/sink/codec/debezium/helper_test.go
@@ -65,7 +65,7 @@ func TestGetValue(t *testing.T) {
 	}
 	data := model.Column2ColumnDataXForTest(column)
 	v := getValue(data)
-	require.Equal(t, v, int64(1))
+	require.Equal(t, v, 1)
 	data.Value = 2
 	v = getValue(data)
 	require.Equal(t, v, 2)

--- a/pkg/sink/codec/debezium/helper_test.go
+++ b/pkg/sink/codec/debezium/helper_test.go
@@ -20,7 +20,6 @@ import (
 	pmodel "github.com/pingcap/tidb/pkg/parser/model"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/types"
-	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,18 +56,6 @@ func TestGetColumns(t *testing.T) {
 	require.Equal(t, columnInfos[4].GetFlen(), 4)
 	require.Equal(t, columnInfos[4].GetDefaultValue(), "1970")
 	require.Equal(t, columnInfos[4].Comment, "")
-}
-
-func TestGetValue(t *testing.T) {
-	column := &model.Column{
-		Default: 1,
-	}
-	data := model.Column2ColumnDataXForTest(column)
-	v := getValue(data)
-	require.Equal(t, v, 1)
-	data.Value = 2
-	v = getValue(data)
-	require.Equal(t, v, 2)
 }
 
 func TestGetSchemaTopicName(t *testing.T) {

--- a/pkg/sink/codec/simple/avro.go
+++ b/pkg/sink/codec/simple/avro.go
@@ -109,7 +109,7 @@ func newTableSchemaMap(tableInfo *model.TableInfo) interface{} {
 			"nullable": !mysql.HasNotNullFlag(col.GetFlag()),
 			"default":  nil,
 		}
-		defaultValue := model.GetColumnDefaultValue(col)
+		defaultValue := col.GetDefaultValue()
 		if defaultValue != nil {
 			// according to TiDB source code, the default value is converted to string if not nil.
 			column["default"] = map[string]interface{}{

--- a/pkg/sink/codec/simple/encoder_test.go
+++ b/pkg/sink/codec/simple/encoder_test.go
@@ -1487,7 +1487,7 @@ func TestEncodeLargeEventsNormal(t *testing.T) {
 
 			obtainedDefaultValues := make(map[string]interface{}, len(obtainedDDL.TableInfo.Columns))
 			for _, col := range obtainedDDL.TableInfo.Columns {
-				obtainedDefaultValues[col.Name.O] = model.GetColumnDefaultValue(col)
+				obtainedDefaultValues[col.Name.O] = col.GetDefaultValue()
 				switch col.GetType() {
 				case mysql.TypeFloat, mysql.TypeDouble:
 					require.Equal(t, 0, col.GetDecimal())
@@ -1495,7 +1495,7 @@ func TestEncodeLargeEventsNormal(t *testing.T) {
 				}
 			}
 			for _, col := range ddlEvent.TableInfo.Columns {
-				expected := model.GetColumnDefaultValue(col)
+				expected := col.GetDefaultValue()
 				obtained := obtainedDefaultValues[col.Name.O]
 				require.Equal(t, expected, obtained)
 			}

--- a/pkg/sink/codec/simple/message.go
+++ b/pkg/sink/codec/simple/message.go
@@ -145,7 +145,7 @@ func newColumnSchema(col *timodel.ColumnInfo) *columnSchema {
 		tp.Decimal = col.GetDecimal()
 	}
 
-	defaultValue := model.GetColumnDefaultValue(col)
+	defaultValue := col.GetDefaultValue()
 	if defaultValue != nil && col.GetType() == mysql.TypeBit {
 		defaultValue = common.MustBinaryLiteralToInt([]byte(defaultValue.(string)))
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12037

### What is changed and how it works?
`OriginDefaultValue` is used as the column value when the default value is invisible. 
It should not be used as the `default` field.

**Affected protocol**
- Cloud Storage
- Simple
- Avro
- Debezium

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
fix incorrect `default` field.
```
