### PR TITLE
Fix changefeed stuck problem when overwrite resume with a forward checkpointTs

### DIFF
--- a/cdc/owner/changefeed.go
+++ b/cdc/owner/changefeed.go
@@ -719,6 +719,7 @@ func (c *changefeed) releaseResources(ctx cdcContext.Context) {
 	c.barriers = nil
 	c.initialized = false
 	c.isReleased = true
+	c.resolvedTs = 0
 
 	log.Info("changefeed closed",
 		zap.String("namespace", c.id.Namespace),

--- a/tests/integration_tests/overwrite_resume_with_syncpoint/conf/changefeed.toml
+++ b/tests/integration_tests/overwrite_resume_with_syncpoint/conf/changefeed.toml
@@ -1,0 +1,2 @@
+enable-sync-point = true
+sync-point-interval = "30s"

--- a/tests/integration_tests/overwrite_resume_with_syncpoint/run.sh
+++ b/tests/integration_tests/overwrite_resume_with_syncpoint/run.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# the script test when we enable syncpoint, and pause the changefeed, 
+# then resume with a forward checkpoint, to ensure the changefeed can be sync correctly.
+
+set -eux
+
+CUR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source $CUR/../_utils/test_prepare
+WORK_DIR=$OUT_DIR/$TEST_NAME
+CDC_BINARY=cdc.test
+SINK_TYPE=$1
+
+function check_ts_forward() {
+	changefeedid=$1
+	rts1=$(cdc cli changefeed query --changefeed-id=${changefeedid} 2>&1 | jq '.resolved_ts')
+	checkpoint1=$(cdc cli changefeed query --changefeed-id=${changefeedid} 2>&1 | jq '.checkpoint_tso')
+	sleep 1
+	rts2=$(cdc cli changefeed query --changefeed-id=${changefeedid} 2>&1 | jq '.resolved_ts')
+	checkpoint2=$(cdc cli changefeed query --changefeed-id=${changefeedid} 2>&1 | jq '.checkpoint_tso')
+	if [[ "$rts1" != "null" ]] && [[ "$rts1" != "0" ]]; then
+		if [[ "$rts1" -ne "$rts2" ]] || [[ "$checkpoint1" -ne "$checkpoint2" ]]; then
+			echo "changefeed is working normally rts: ${rts1}->${rts2} checkpoint: ${checkpoint1}->${checkpoint2}"
+			return
+		fi
+	fi
+	exit 1
+}
+
+function run() {
+	# No need to test kafka and storage sink.
+	if [ "$SINK_TYPE" != "mysql" ]; then
+		return
+	fi
+
+	rm -rf $WORK_DIR && mkdir -p $WORK_DIR
+
+	start_tidb_cluster --workdir $WORK_DIR 
+
+	cd $WORK_DIR
+
+	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY 
+
+    SINK_URI="mysql://root@127.0.0.1:3306/"
+    run_cdc_cli changefeed create --sink-uri="$SINK_URI" --config=$CUR/conf/changefeed.toml --changefeed-id="test4"
+
+	check_ts_forward "test4"
+
+    run_cdc_cli changefeed pause --changefeed-id="test4"
+
+    sleep 15
+
+    checkpoint1=$(cdc cli changefeed query --changefeed-id="test4" 2>&1 | jq '.checkpoint_tso')
+    # add a large number to avoid the problem of losing precision when jq processing large integers
+    checkpoint1=$((checkpoint1 + 1000000)) 
+
+    # resume a forward checkpointTs
+    run_cdc_cli changefeed resume --changefeed-id="test4" --no-confirm --overwrite-checkpoint-ts=$checkpoint1 
+
+    check_ts_forward "test4"
+
+	cleanup_process $CDC_BINARY
+}
+
+
+trap stop_tidb_cluster EXIT
+run $*
+check_logs $WORK_DIR
+echo "[$(date)] <<<<<< run test case $TEST_NAME success! >>>>>>"


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #https://github.com/pingcap/tiflow/issues/12055

### What is changed and how it works?
release resolvedTs when changefeed is pause

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
