### PR TITLE
build: add new task for integration tests of sync_diff_inspector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 	mysql_docker_integration_test mysql_docker_integration_test_with_build \
 	build_mysql_integration_test_images clean_integration_test_images \
 	dm dm-master dm-worker dmctl dm-syncer dm_coverage \
-	sync_diff_inspector \
+	sync-diff-inspector \
 	engine tiflow tiflow-demo tiflow-chaos-case engine_image help \
 	format-makefiles check-makefiles oauth2_server prepare_test_binaries
 
@@ -226,7 +226,7 @@ check_third_party_binary:
 	@which bin/minio
 	@which bin/bin/schema-registry-start
 
-integration_test_build: check_failpoint_ctl storage_consumer kafka_consumer pulsar_consumer oauth2_server sync_diff_inspector
+integration_test_build: check_failpoint_ctl storage_consumer kafka_consumer pulsar_consumer oauth2_server sync-diff-inspector
 	$(FAILPOINT_ENABLE)
 	$(GOTEST) -ldflags '$(LDFLAGS)' -c -cover -covermode=atomic \
 		-coverpkg=github.com/pingcap/tiflow/... \
@@ -253,7 +253,7 @@ build_mysql_integration_test_images: ## Build MySQL integration test images with
 build_mysql_integration_test_images: clean_integration_test_containers
 	docker-compose -f $(TICDC_DOCKER_DEPLOYMENTS_DIR)/docker-compose-mysql-integration.yml build --no-cache
 
-integration_test_kafka: check_third_party_binary sync_diff_inspector
+integration_test_kafka: check_third_party_binary sync-diff-inspector
 	tests/integration_tests/run.sh kafka "$(CASE)" "$(START_AT)"
 
 integration_test_storage:
@@ -385,10 +385,10 @@ clean:
 	rm -rf tools/bin
 	rm -rf tools/include
 
-sync_diff_inspector:
+sync-diff-inspector:
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/sync_diff_inspector ./sync_diff_inspector
 
-sync_diff_inspector-integration_test: failpoint-enable sync_diff_inspector failpoint-disable
+sync-diff-inspector-integration_test: failpoint-enable sync-diff-inspector failpoint-disable
 	@which bin/tidb-server
 	@which bin/tikv-server
 	@which bin/pd-server
@@ -457,7 +457,7 @@ dm_unit_test_in_verify_ci: check_failpoint_ctl tools/bin/gotestsum tools/bin/goc
 	tools/bin/gocov convert "$(DM_TEST_DIR)/cov.unit_test.out" | tools/bin/gocov-xml > dm-coverage.xml
 	$(FAILPOINT_DISABLE)
 
-dm_integration_test_build: check_failpoint_ctl sync_diff_inspector
+dm_integration_test_build: check_failpoint_ctl sync-diff-inspector
 	$(FAILPOINT_ENABLE)
 	$(GOTEST) -ldflags '$(LDFLAGS)' -c -cover -covermode=atomic \
 		-coverpkg=github.com/pingcap/tiflow/dm/... \
@@ -509,7 +509,7 @@ install_test_python_dep:
 	@echo "install python requirments for test"
 	pip install --user -q -r ./dm/tests/requirements.txt
 
-check_third_party_binary_for_dm : sync_diff_inspector
+check_third_party_binary_for_dm : sync-diff-inspector
 	@which bin/tidb-server
 	@which mysql
 	@which bin/minio
@@ -567,7 +567,7 @@ tiflow-chaos-case:
 engine_unit_test: check_failpoint_ctl
 	$(call run_engine_unit_test,$(ENGINE_PACKAGES))
 
-engine_integration_test: check_third_party_binary_for_engine sync_diff_inspector
+engine_integration_test: check_third_party_binary_for_engine sync-diff-inspector
 	mkdir -p /tmp/tiflow_engine_test || true
 	./engine/test/integration_tests/run.sh "$(CASE)" "$(START_AT)" 2>&1 | tee /tmp/tiflow_engine_test/engine_it.log
 	./engine/test/utils/check_log.sh

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 	mysql_docker_integration_test mysql_docker_integration_test_with_build \
 	build_mysql_integration_test_images clean_integration_test_images \
 	dm dm-master dm-worker dmctl dm-syncer dm_coverage \
-	sync-diff-inspector \
+	sync_diff_inspector \
 	engine tiflow tiflow-demo tiflow-chaos-case engine_image help \
 	format-makefiles check-makefiles oauth2_server prepare_test_binaries
 
@@ -226,7 +226,7 @@ check_third_party_binary:
 	@which bin/minio
 	@which bin/bin/schema-registry-start
 
-integration_test_build: check_failpoint_ctl storage_consumer kafka_consumer pulsar_consumer oauth2_server sync-diff-inspector
+integration_test_build: check_failpoint_ctl storage_consumer kafka_consumer pulsar_consumer oauth2_server sync_diff_inspector
 	$(FAILPOINT_ENABLE)
 	$(GOTEST) -ldflags '$(LDFLAGS)' -c -cover -covermode=atomic \
 		-coverpkg=github.com/pingcap/tiflow/... \
@@ -253,7 +253,7 @@ build_mysql_integration_test_images: ## Build MySQL integration test images with
 build_mysql_integration_test_images: clean_integration_test_containers
 	docker-compose -f $(TICDC_DOCKER_DEPLOYMENTS_DIR)/docker-compose-mysql-integration.yml build --no-cache
 
-integration_test_kafka: check_third_party_binary sync-diff-inspector
+integration_test_kafka: check_third_party_binary sync_diff_inspector
 	tests/integration_tests/run.sh kafka "$(CASE)" "$(START_AT)"
 
 integration_test_storage:
@@ -385,10 +385,10 @@ clean:
 	rm -rf tools/bin
 	rm -rf tools/include
 
-sync-diff-inspector:
+sync_diff_inspector:
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/sync_diff_inspector ./sync_diff_inspector
 
-sync-diff-inspector-integration-test: failpoint-enable sync_diff_inspector failpoint-disable
+sync_diff_inspector-integration_test: failpoint-enable sync_diff_inspector failpoint-disable
 	@which bin/tidb-server
 	@which bin/tikv-server
 	@which bin/pd-server
@@ -457,7 +457,7 @@ dm_unit_test_in_verify_ci: check_failpoint_ctl tools/bin/gotestsum tools/bin/goc
 	tools/bin/gocov convert "$(DM_TEST_DIR)/cov.unit_test.out" | tools/bin/gocov-xml > dm-coverage.xml
 	$(FAILPOINT_DISABLE)
 
-dm_integration_test_build: check_failpoint_ctl sync-diff-inspector
+dm_integration_test_build: check_failpoint_ctl sync_diff_inspector
 	$(FAILPOINT_ENABLE)
 	$(GOTEST) -ldflags '$(LDFLAGS)' -c -cover -covermode=atomic \
 		-coverpkg=github.com/pingcap/tiflow/dm/... \
@@ -509,7 +509,7 @@ install_test_python_dep:
 	@echo "install python requirments for test"
 	pip install --user -q -r ./dm/tests/requirements.txt
 
-check_third_party_binary_for_dm : sync-diff-inspector
+check_third_party_binary_for_dm : sync_diff_inspector
 	@which bin/tidb-server
 	@which mysql
 	@which bin/minio
@@ -567,7 +567,7 @@ tiflow-chaos-case:
 engine_unit_test: check_failpoint_ctl
 	$(call run_engine_unit_test,$(ENGINE_PACKAGES))
 
-engine_integration_test: check_third_party_binary_for_engine sync-diff-inspector
+engine_integration_test: check_third_party_binary_for_engine sync_diff_inspector
 	mkdir -p /tmp/tiflow_engine_test || true
 	./engine/test/integration_tests/run.sh "$(CASE)" "$(START_AT)" 2>&1 | tee /tmp/tiflow_engine_test/engine_it.log
 	./engine/test/utils/check_log.sh

--- a/Makefile
+++ b/Makefile
@@ -388,6 +388,17 @@ clean:
 sync-diff-inspector:
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/sync_diff_inspector ./sync_diff_inspector
 
+sync-diff-inspector-integration-test: failpoint-enable sync_diff_inspector failpoint-disable
+	@which bin/tidb-server
+	@which bin/tikv-server
+	@which bin/pd-server
+	@which bin/sync_diff_inspector
+	@which bin/dumpling
+	@which bin/loader
+	@which bin/importer
+	cd sync_diff_inspector && ln -sf ../bin .
+	cd sync_diff_inspector && ./tests/run.sh
+
 dm: dm-master dm-worker dmctl dm-syncer
 
 dm-master:

--- a/dm/pkg/shardddl/optimism/lock_test.go
+++ b/dm/pkg/shardddl/optimism/lock_test.go
@@ -2738,7 +2738,7 @@ func (t *testLock) TestTrySyncForOneDDL(c *check.C) {
 	c.Assert(schemaChanged, check.IsTrue)
 	c.Assert(conflictStage, check.Equals, ConflictNone)
 
-	// check create partition, no changed since https://github.com/pingcap/tidb-tools/blob/d671b0840063bc2532941f02e02e12627402844c/pkg/schemacmp/table.go#L251
+	// check create partition, no changed since https://github.com/pingcap/tidb/blob/42075e6ad60ba5d1f860ac845908f0c34ac28253/pkg/util/schemacmp/table.go#L256
 	schemaChanged, conflictStage = l.trySyncForOneDDL(source, schema, table1, t0, t1)
 	c.Assert(schemaChanged, check.IsTrue)
 	c.Assert(conflictStage, check.Equals, ConflictNone)

--- a/dm/syncer/validate_worker.go
+++ b/dm/syncer/validate_worker.go
@@ -476,7 +476,7 @@ type validateCompareContext struct {
 	columns     []*model.ColumnInfo
 }
 
-// a simplified version of CompareData in sync_diff_inspector/utils/utils.go
+// a simplified version of CompareData in https://github.com/pingcap/tiflow/blob/4c38b919659e8506c220d1be9b0fdd7baf609e33/sync_diff_inspector/utils/utils.go#L538
 func (c *validateCompareContext) compareData(key string, sourceData, targetData []*sql.NullString) (bool, error) {
 	for i, column := range c.columns {
 		data1, data2 := sourceData[i], targetData[i]

--- a/dm/syncer/validate_worker.go
+++ b/dm/syncer/validate_worker.go
@@ -476,7 +476,7 @@ type validateCompareContext struct {
 	columns     []*model.ColumnInfo
 }
 
-// a simplified version of https://github.com/pingcap/tidb-tools/blob/d9fdfa2f9040aab3fab7cd11774a82226f467fe7/sync_diff_inspector/utils/utils.go#L487-L606
+// a simplified version of CompareData in sync_diff_inspector/utils/utils.go
 func (c *validateCompareContext) compareData(key string, sourceData, targetData []*sql.NullString) (bool, error) {
 	for i, column := range c.columns {
 		data1, data2 := sourceData[i], targetData[i]

--- a/sync_diff_inspector/tests/README.md
+++ b/sync_diff_inspector/tests/README.md
@@ -21,7 +21,7 @@ This folder contains all tests which relies on external service such as TiDB.
 
 3. The user executing the tests must have permission to create the folder
 
-   `/tmp/tidb_tools_test`. All test artifacts will be written into this folder.
+   `/tmp/sync_diff_inspector_test`. All test artifacts will be written into this folder.
 
 ## Running
 

--- a/sync_diff_inspector/tests/_utils/check_contains
+++ b/sync_diff_inspector/tests/_utils/check_contains
@@ -4,7 +4,7 @@
 # argument 2 is the filename
 
 set -eu
-OUT_DIR=/tmp/tidb_tools_test
+OUT_DIR=/tmp/sync_diff_inspector_test
 
 if ! grep -Fq "$1" "$2"; then
 	echo "TEST FAILED: '$2' DOES NOT CONTAIN '$1'"

--- a/sync_diff_inspector/tests/_utils/check_contains_count
+++ b/sync_diff_inspector/tests/_utils/check_contains_count
@@ -5,7 +5,7 @@
 # argument 3 is the match count
 
 set -eu
-OUT_DIR=/tmp/tidb_tools_test
+OUT_DIR=/tmp/sync_diff_inspector_test
 
 count=$(grep -F "$1" "$2" | wc -l)
 

--- a/sync_diff_inspector/tests/_utils/check_contains_regex
+++ b/sync_diff_inspector/tests/_utils/check_contains_regex
@@ -4,7 +4,7 @@
 # argument 2 is the filename
 
 set -eu
-OUT_DIR=/tmp/tidb_tools_test
+OUT_DIR=/tmp/sync_diff_inspector_test
 
 if ! grep -q "$1" "$2"; then
 	echo "TEST FAILED: '$2' DOES NOT CONTAIN '$1'"

--- a/sync_diff_inspector/tests/run.sh
+++ b/sync_diff_inspector/tests/run.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-OUT_DIR=/tmp/tidb_tools_test
+OUT_DIR=/tmp/sync_diff_inspector_test
 
 # assign default value to mysql config
 if [[ -z ${MYSQL_HOST+x} ]]; then

--- a/sync_diff_inspector/tests/sync_diff_inspector/checkpoint/config_base.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/checkpoint/config_base.toml
@@ -40,7 +40,7 @@ chunk-size = 10
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["mysql1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/checkpoint/config_base_continous.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/checkpoint/config_base_continous.toml
@@ -42,7 +42,7 @@ chunk-size = 50
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["mysql1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/checkpoint/config_base_rand.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/checkpoint/config_base_rand.toml
@@ -41,7 +41,7 @@ chunk-size = 500
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["mysql1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/checkpoint/run.sh
+++ b/sync_diff_inspector/tests/sync_diff_inspector/checkpoint/run.sh
@@ -4,7 +4,7 @@ set -ex
 
 cd "$(dirname "$0")"
 
-OUT_DIR=/tmp/tidb_tools_test/sync_diff_inspector/output
+OUT_DIR=/tmp/sync_diff_inspector_test/sync_diff_inspector/output
 rm -rf $OUT_DIR
 mkdir -p $OUT_DIR
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/checkpoint/run.sh
+++ b/sync_diff_inspector/tests/sync_diff_inspector/checkpoint/run.sh
@@ -16,7 +16,7 @@ echo "================test bucket checkpoint================="
 echo "---------1. chunk is in the last of the bucket---------"
 export GO_FAILPOINTS="github.com/pingcap/tiflow/sync_diff_inspector/splitter/check-one-bucket=return();\
 github.com/pingcap/tiflow/sync_diff_inspector/splitter/print-chunk-info=return();\
-main/wait-for-checkpoint=return()"
+github.com/pingcap/tiflow/sync_diff_inspector/diff/wait-for-checkpoint=return()"
 sync_diff_inspector --config=./config.toml >$OUT_DIR/checkpoint_diff.output
 check_contains "check pass!!!" $OUT_DIR/sync_diff.log
 # Save the last chunk's info,
@@ -58,7 +58,7 @@ mkdir -p $OUT_DIR
 export GO_FAILPOINTS="github.com/pingcap/tiflow/sync_diff_inspector/splitter/check-one-bucket=return();\
 github.com/pingcap/tiflow/sync_diff_inspector/splitter/ignore-last-n-chunk-in-bucket=return(1);\
 github.com/pingcap/tiflow/sync_diff_inspector/splitter/print-chunk-info=return();\
-main/wait-for-checkpoint=return()"
+github.com/pingcap/tiflow/sync_diff_inspector/diff/wait-for-checkpoint=return()"
 sync_diff_inspector --config=./config.toml >$OUT_DIR/checkpoint_diff.output
 check_contains "check pass!!!" $OUT_DIR/sync_diff.log
 # Save the last chunk's info,
@@ -103,7 +103,7 @@ rm -rf $OUT_DIR
 mkdir -p $OUT_DIR
 export GO_FAILPOINTS="github.com/pingcap/tiflow/sync_diff_inspector/splitter/ignore-last-n-chunk-in-bucket=return(1);\
 github.com/pingcap/tiflow/sync_diff_inspector/splitter/print-chunk-info=return();\
-main/wait-for-checkpoint=return()"
+github.com/pingcap/tiflow/sync_diff_inspector/diff/wait-for-checkpoint=return()"
 sync_diff_inspector --config=./config.toml >$OUT_DIR/checkpoint_diff.output
 check_contains "check pass!!!" $OUT_DIR/sync_diff.log
 # Save the last chunk's info,
@@ -142,7 +142,7 @@ echo "================test checkpoint continous================="
 # so data-check will be skipped
 mysql -uroot -h 127.0.0.1 -P 4000 -e "create table IF NOT EXISTS diff_test.ttt(a int, aa int, primary key(a), key(aa));"
 mysql -uroot -h ${MYSQL_HOST} -P ${MYSQL_PORT} -e "create table IF NOT EXISTS diff_test.ttt(a int, b int, primary key(a), key(b));"
-export GO_FAILPOINTS="main/wait-for-checkpoint=return()"
+export GO_FAILPOINTS="github.com/pingcap/tiflow/sync_diff_inspector/diff/wait-for-checkpoint=return()"
 sync_diff_inspector --config=./config.toml >$OUT_DIR/checkpoint_diff.output || true
 grep 'save checkpoint' $OUT_DIR/sync_diff.log | awk 'END {print}' >$OUT_DIR/checkpoint_info
 check_not_contains 'has-upper\":true' $OUT_DIR/checkpoint_info

--- a/sync_diff_inspector/tests/sync_diff_inspector/checkpoint/run.sh
+++ b/sync_diff_inspector/tests/sync_diff_inspector/checkpoint/run.sh
@@ -14,8 +14,8 @@ sed "s/\"127.0.0.1\"#MYSQL_HOST/\"${MYSQL_HOST}\"/g" ./config_base.toml | sed "s
 
 echo "================test bucket checkpoint================="
 echo "---------1. chunk is in the last of the bucket---------"
-export GO_FAILPOINTS="github.com/pingcap/tidb-tools/sync_diff_inspector/splitter/check-one-bucket=return();\
-github.com/pingcap/tidb-tools/sync_diff_inspector/splitter/print-chunk-info=return();\
+export GO_FAILPOINTS="github.com/pingcap/tiflow/sync_diff_inspector/splitter/check-one-bucket=return();\
+github.com/pingcap/tiflow/sync_diff_inspector/splitter/print-chunk-info=return();\
 main/wait-for-checkpoint=return()"
 sync_diff_inspector --config=./config.toml >$OUT_DIR/checkpoint_diff.output
 check_contains "check pass!!!" $OUT_DIR/sync_diff.log
@@ -41,7 +41,7 @@ bucket_index_right=$(($(echo ${last_chunk_index_array[1]} | awk -F '-' '{print $
 echo $bucket_index_right
 
 rm -f $OUT_DIR/sync_diff.log
-export GO_FAILPOINTS="github.com/pingcap/tidb-tools/sync_diff_inspector/splitter/print-chunk-info=return()"
+export GO_FAILPOINTS="github.com/pingcap/tiflow/sync_diff_inspector/splitter/print-chunk-info=return()"
 sync_diff_inspector --config=./config.toml >$OUT_DIR/checkpoint_diff.output
 first_chunk_info=$(grep 'print-chunk-info' $OUT_DIR/sync_diff.log | awk -F 'lowerBounds=' '{print $2}' | sed 's/[]["]//g' | sort -n | awk 'NR==1')
 echo $first_chunk_info | awk -F '=' '{print $1}' >$OUT_DIR/first_chunk_bound
@@ -55,9 +55,9 @@ check_contains_regex ".:${bucket_index_right}-.:0:." $OUT_DIR/first_chunk_index
 echo "--------2. chunk is in the middle of the bucket--------"
 rm -rf $OUT_DIR
 mkdir -p $OUT_DIR
-export GO_FAILPOINTS="github.com/pingcap/tidb-tools/sync_diff_inspector/splitter/check-one-bucket=return();\
-github.com/pingcap/tidb-tools/sync_diff_inspector/splitter/ignore-last-n-chunk-in-bucket=return(1);\
-github.com/pingcap/tidb-tools/sync_diff_inspector/splitter/print-chunk-info=return();\
+export GO_FAILPOINTS="github.com/pingcap/tiflow/sync_diff_inspector/splitter/check-one-bucket=return();\
+github.com/pingcap/tiflow/sync_diff_inspector/splitter/ignore-last-n-chunk-in-bucket=return(1);\
+github.com/pingcap/tiflow/sync_diff_inspector/splitter/print-chunk-info=return();\
 main/wait-for-checkpoint=return()"
 sync_diff_inspector --config=./config.toml >$OUT_DIR/checkpoint_diff.output
 check_contains "check pass!!!" $OUT_DIR/sync_diff.log
@@ -84,7 +84,7 @@ bucket_index_right=$(echo ${last_chunk_index_array[1]} | awk -F '-' '{print $2}'
 echo "${bucket_index_left}-${bucket_index_right}"
 
 rm -f $OUT_DIR/sync_diff.log
-export GO_FAILPOINTS="github.com/pingcap/tidb-tools/sync_diff_inspector/splitter/print-chunk-info=return()"
+export GO_FAILPOINTS="github.com/pingcap/tiflow/sync_diff_inspector/splitter/print-chunk-info=return()"
 sync_diff_inspector --config=./config.toml >$OUT_DIR/checkpoint_diff.output
 first_chunk_info=$(grep 'print-chunk-info' $OUT_DIR/sync_diff.log | awk -F 'lowerBounds=' '{print $2}' | sed 's/[]["]//g' | sort -n | awk 'NR==1')
 echo $first_chunk_info | awk -F '=' '{print $1}' >$OUT_DIR/first_chunk_bound
@@ -101,8 +101,8 @@ echo "================test random checkpoint================="
 echo "--------------1. chunk is in the middle----------------"
 rm -rf $OUT_DIR
 mkdir -p $OUT_DIR
-export GO_FAILPOINTS="github.com/pingcap/tidb-tools/sync_diff_inspector/splitter/ignore-last-n-chunk-in-bucket=return(1);\
-github.com/pingcap/tidb-tools/sync_diff_inspector/splitter/print-chunk-info=return();\
+export GO_FAILPOINTS="github.com/pingcap/tiflow/sync_diff_inspector/splitter/ignore-last-n-chunk-in-bucket=return(1);\
+github.com/pingcap/tiflow/sync_diff_inspector/splitter/print-chunk-info=return();\
 main/wait-for-checkpoint=return()"
 sync_diff_inspector --config=./config.toml >$OUT_DIR/checkpoint_diff.output
 check_contains "check pass!!!" $OUT_DIR/sync_diff.log
@@ -125,7 +125,7 @@ done
 [[ $((${last_chunk_index_array[2]} + 2)) -eq ${last_chunk_index_array[3]} ]] || exit 1
 
 rm -f $OUT_DIR/sync_diff.log
-export GO_FAILPOINTS="github.com/pingcap/tidb-tools/sync_diff_inspector/splitter/print-chunk-info=return()"
+export GO_FAILPOINTS="github.com/pingcap/tiflow/sync_diff_inspector/splitter/print-chunk-info=return()"
 sync_diff_inspector --config=./config.toml >$OUT_DIR/checkpoint_diff.output
 first_chunk_info=$(grep 'print-chunk-info' $OUT_DIR/sync_diff.log | awk -F 'lowerBounds=' '{print $2}' | sed 's/[]["]//g' | sort -n | awk 'NR==1')
 echo $first_chunk_info | awk -F '=' '{print $1}' >$OUT_DIR/first_chunk_bound

--- a/sync_diff_inspector/tests/sync_diff_inspector/config_base_mysql.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/config_base_mysql.toml
@@ -36,7 +36,7 @@ check-struct-only = false
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["mysql1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/config_base_tidb.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/config_base_tidb.toml
@@ -37,7 +37,7 @@ check-struct-only = false
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["tidb1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/expression/config.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/expression/config.toml
@@ -36,7 +36,7 @@ check-struct-only = false
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["tidb1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/expression/run.sh
+++ b/sync_diff_inspector/tests/sync_diff_inspector/expression/run.sh
@@ -3,8 +3,8 @@
 set -ex
 
 cd "$(dirname "$0")"
-OUT_DIR=/tmp/tidb_tools_test/sync_diff_inspector/output
-FIX_DIR=/tmp/tidb_tools_test/sync_diff_inspector/fixsql
+OUT_DIR=/tmp/sync_diff_inspector_test/sync_diff_inspector/output
+FIX_DIR=/tmp/sync_diff_inspector_test/sync_diff_inspector/fixsql
 rm -rf $OUT_DIR
 rm -rf $FIX_DIR
 mkdir -p $OUT_DIR

--- a/sync_diff_inspector/tests/sync_diff_inspector/json/config_base.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/json/config_base.toml
@@ -36,7 +36,7 @@ check-struct-only = false
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["mysql1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/json/run.sh
+++ b/sync_diff_inspector/tests/sync_diff_inspector/json/run.sh
@@ -4,7 +4,7 @@ set -e
 
 cd "$(dirname "$0")"
 
-OUT_DIR=/tmp/tidb_tools_test/sync_diff_inspector/output
+OUT_DIR=/tmp/sync_diff_inspector_test/sync_diff_inspector/output
 rm -rf $OUT_DIR
 mkdir -p $OUT_DIR
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/run.sh
+++ b/sync_diff_inspector/tests/sync_diff_inspector/run.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")"
 # check mysql status
 check_db_status "${MYSQL_HOST}" "${MYSQL_PORT}" mysql "."
 
-BASE_DIR=/tmp/tidb_tools_test/sync_diff_inspector
+BASE_DIR=/tmp/sync_diff_inspector_test/sync_diff_inspector
 OUT_DIR=$BASE_DIR/output
 
 mkdir -p $OUT_DIR || true

--- a/sync_diff_inspector/tests/sync_diff_inspector/shard/config_base.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/shard/config_base.toml
@@ -45,7 +45,7 @@ target-table = "test" # 目标表名
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["mysql1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/shard/config_router_1.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/shard/config_router_1.toml
@@ -45,7 +45,7 @@ target-table = "tbl"
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["mysql1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/shard/config_router_2.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/shard/config_router_2.toml
@@ -43,7 +43,7 @@ target-schema = "router_test_1"
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["mysql1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/shard/config_router_3.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/shard/config_router_3.toml
@@ -45,7 +45,7 @@ target-table = "tbl"
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["mysql1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/shard/config_router_4.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/shard/config_router_4.toml
@@ -39,7 +39,7 @@ check-struct-only = false
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["mysql1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/shard/config_router_5.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/shard/config_router_5.toml
@@ -45,7 +45,7 @@ target-table = "tbl"
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["mysql1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/shard/run.sh
+++ b/sync_diff_inspector/tests/sync_diff_inspector/shard/run.sh
@@ -4,7 +4,7 @@ set -e
 
 cd "$(dirname "$0")"
 
-OUT_DIR=/tmp/tidb_tools_test/sync_diff_inspector/output
+OUT_DIR=/tmp/sync_diff_inspector_test/sync_diff_inspector/output
 rm -rf $OUT_DIR
 mkdir -p $OUT_DIR
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/snapshot/config_base.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/snapshot/config_base.toml
@@ -37,7 +37,7 @@ check-struct-only = false
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["tidb1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/snapshot/run.sh
+++ b/sync_diff_inspector/tests/sync_diff_inspector/snapshot/run.sh
@@ -4,8 +4,8 @@ set -e
 
 cd "$(dirname "$0")"
 
-OUT_DIR=/tmp/tidb_tools_test/sync_diff_inspector/output
-FIX_DIR=/tmp/tidb_tools_test/sync_diff_inspector/fixsql
+OUT_DIR=/tmp/sync_diff_inspector_test/sync_diff_inspector/output
+FIX_DIR=/tmp/sync_diff_inspector_test/sync_diff_inspector/fixsql
 rm -rf $OUT_DIR
 rm -rf $FIX_DIR
 mkdir -p $OUT_DIR

--- a/sync_diff_inspector/tests/sync_diff_inspector/table_config/config.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/table_config/config.toml
@@ -37,7 +37,7 @@ check-struct-only = false
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["tidb1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/table_config/run.sh
+++ b/sync_diff_inspector/tests/sync_diff_inspector/table_config/run.sh
@@ -4,8 +4,8 @@ set -e
 
 cd "$(dirname "$0")"
 
-OUT_DIR=/tmp/tidb_tools_test/sync_diff_inspector/output
-FIX_DIR=/tmp/tidb_tools_test/sync_diff_inspector/fixsql
+OUT_DIR=/tmp/sync_diff_inspector_test/sync_diff_inspector/output
+FIX_DIR=/tmp/sync_diff_inspector_test/sync_diff_inspector/fixsql
 rm -rf $OUT_DIR
 rm -rf $FIX_DIR
 mkdir -p $OUT_DIR

--- a/sync_diff_inspector/tests/sync_diff_inspector/table_skip/config_base.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/table_skip/config_base.toml
@@ -39,7 +39,7 @@ skip-non-existing-table = true
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["mysql1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/table_skip/config_router.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/table_skip/config_router.toml
@@ -51,7 +51,7 @@ target-table = "t5"
 
 ######################### Task config #########################
 [task]
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["mysql1", "mysql2"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/table_skip/run.sh
+++ b/sync_diff_inspector/tests/sync_diff_inspector/table_skip/run.sh
@@ -4,7 +4,7 @@ set -ex
 
 cd "$(dirname "$0")"
 
-OUT_DIR=/tmp/tidb_tools_test/sync_diff_inspector/output
+OUT_DIR=/tmp/sync_diff_inspector_test/sync_diff_inspector/output
 rm -rf $OUT_DIR
 mkdir -p $OUT_DIR
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/time_zone/config.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/time_zone/config.toml
@@ -36,7 +36,7 @@ check-struct-only = false
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["tidb1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/time_zone/run.sh
+++ b/sync_diff_inspector/tests/sync_diff_inspector/time_zone/run.sh
@@ -3,8 +3,8 @@
 set -ex
 
 cd "$(dirname "$0")"
-OUT_DIR=/tmp/tidb_tools_test/sync_diff_inspector/output
-FIX_DIR=/tmp/tidb_tools_test/sync_diff_inspector/fixsql
+OUT_DIR=/tmp/sync_diff_inspector_test/sync_diff_inspector/output
+FIX_DIR=/tmp/sync_diff_inspector_test/sync_diff_inspector/fixsql
 rm -rf $OUT_DIR
 rm -rf $FIX_DIR
 mkdir -p $OUT_DIR

--- a/sync_diff_inspector/tests/sync_diff_inspector/tls/config.toml
+++ b/sync_diff_inspector/tests/sync_diff_inspector/tls/config.toml
@@ -41,7 +41,7 @@ check-struct-only = false
     # 2 log: sync-diff.log
     # 3 summary: summary.txt
     # 4 checkpoint: a dir
-    output-dir = "/tmp/tidb_tools_test/sync_diff_inspector/output"
+    output-dir = "/tmp/sync_diff_inspector_test/sync_diff_inspector/output"
 
     source-instances = ["tidb1"]
 

--- a/sync_diff_inspector/tests/sync_diff_inspector/tls/run.sh
+++ b/sync_diff_inspector/tests/sync_diff_inspector/tls/run.sh
@@ -8,7 +8,7 @@ CONF_PATH=$(cd ../../conf && pwd)
 CA_PATH="$CONF_PATH/root.crt"
 CERT_PATH="$CONF_PATH/client.crt"
 KEY_PATH="$CONF_PATH/client.key"
-OUT_DIR=/tmp/tidb_tools_test/sync_diff_inspector/output
+OUT_DIR=/tmp/sync_diff_inspector_test/sync_diff_inspector/output
 rm -rf $OUT_DIR
 mkdir -p $OUT_DIR
 

--- a/sync_diff_inspector/utils/table.go
+++ b/sync_diff_inspector/utils/table.go
@@ -197,7 +197,6 @@ func GetTableInfo(
 // GetTableInfoBySQL gets the table info from SQL.
 // Here we didn't use dbutiltest.GetTableInfoBySQL because it use buildTableInfoWithCheck internally,
 // and the check itself may cause errors in some integration tests.
-// See https://github.com/pingcap/tidb-tools/blob/37c2dad9218826a114e3389ac1209367715383ea/pkg/dbutil/table.go#L156-L162
 func GetTableInfoBySQL(createTableSQL string, parser2 *parser.Parser) (table *model.TableInfo, err error) {
 	stmt, err := parser2.ParseOneStmt(createTableSQL, "", "")
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #11672

### What is changed and how it works?

- Add new build task `sync-diff-inspector-integration-test`.
  - Related CI change: https://github.com/PingCAP-QE/ci/pull/3387
  - This CI is optional before this PR is merged, and can be tested by  /test pull-syncdiff-integration-test
- Remove `tidb-tools` in scripts and comments.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
