### PR TITLE
feat(ticdc): prevent using the same TiDB cluster as both upstream and downstream

### DIFF
--- a/cdc/api/v1/api.go
+++ b/cdc/api/v1/api.go
@@ -301,14 +301,12 @@ func (h *OpenAPI) CreateChangefeed(c *gin.Context) {
 	notSame, err := check.UpstreamDownstreamNotSame(ctx, up.PDClient, changefeedConfig.SinkURI)
 	if err != nil {
 		_ = c.Error(err)
-		log.Error("same in create", zap.Error(err))
 		return
 	}
 	if !notSame {
 		_ = c.Error(cerror.ErrSameUpstreamDownstream.GenWithStack(
 			"TiCDC does not support creating a changefeed with the same TiDB cluster " +
 				"as both the source and the target for the changefeed."))
-		log.Error("same in create", zap.Error(err))
 		return
 	}
 
@@ -417,14 +415,12 @@ func (h *OpenAPI) ResumeChangefeed(c *gin.Context) {
 	notSame, err := check.UpstreamDownstreamNotSame(ctx, up.PDClient, cfInfo.SinkURI)
 	if err != nil {
 		_ = c.Error(err)
-		log.Error("same in create", zap.Error(err))
 		return
 	}
 	if !notSame {
 		_ = c.Error(cerror.ErrSameUpstreamDownstream.GenWithStack(
 			"TiCDC does not support resuming a changefeed with the same TiDB cluster " +
 				"as both the source and the target for the changefeed."))
-		log.Error("same in create", zap.Error(err))
 		return
 	}
 
@@ -515,14 +511,12 @@ func (h *OpenAPI) UpdateChangefeed(c *gin.Context) {
 	notSame, err := check.UpstreamDownstreamNotSame(ctx, up.PDClient, newInfo.SinkURI)
 	if err != nil {
 		_ = c.Error(err)
-		log.Error("same in create", zap.Error(err))
 		return
 	}
 	if !notSame {
 		_ = c.Error(cerror.ErrSameUpstreamDownstream.GenWithStack(
 			"TiCDC does not support updating a changefeed with the same TiDB cluster " +
 				"as both the source and the target for the changefeed."))
-		log.Error("same in create", zap.Error(err))
 		return
 	}
 

--- a/cdc/api/v1/api.go
+++ b/cdc/api/v1/api.go
@@ -298,13 +298,13 @@ func (h *OpenAPI) CreateChangefeed(c *gin.Context) {
 	}
 
 	// Check whether the upstream and downstream are the different cluster.
-	notSame, err := check.CheckUpstreamDownstreamNotSame(up.PDClient, changefeedConfig.SinkURI, ctx)
+	notSame, err := check.UpstreamDownstreamNotSame(ctx, up.PDClient, changefeedConfig.SinkURI)
 	if err != nil {
 		_ = c.Error(err)
 		log.Error("same in create", zap.Error(err))
 		return
 	}
-	if notSame == false {
+	if !notSame {
 		_ = c.Error(cerror.ErrSameUpstreamDownstream.GenWithStack(
 			"TiCDC does not support creating a changefeed with the same TiDB cluster " +
 				"as both the source and the target for the changefeed."))
@@ -414,13 +414,13 @@ func (h *OpenAPI) ResumeChangefeed(c *gin.Context) {
 		return
 	}
 	// Check whether the upstream and downstream are the different cluster.
-	notSame, err := check.CheckUpstreamDownstreamNotSame(up.PDClient, cfInfo.SinkURI, ctx)
+	notSame, err := check.UpstreamDownstreamNotSame(ctx, up.PDClient, cfInfo.SinkURI)
 	if err != nil {
 		_ = c.Error(err)
 		log.Error("same in create", zap.Error(err))
 		return
 	}
-	if notSame == false {
+	if !notSame {
 		_ = c.Error(cerror.ErrSameUpstreamDownstream.GenWithStack(
 			"TiCDC does not support resuming a changefeed with the same TiDB cluster " +
 				"as both the source and the target for the changefeed."))
@@ -512,13 +512,13 @@ func (h *OpenAPI) UpdateChangefeed(c *gin.Context) {
 		return
 	}
 	// Check whether the upstream and downstream are the different cluster.
-	notSame, err := check.CheckUpstreamDownstreamNotSame(up.PDClient, newInfo.SinkURI, ctx)
+	notSame, err := check.UpstreamDownstreamNotSame(ctx, up.PDClient, newInfo.SinkURI)
 	if err != nil {
 		_ = c.Error(err)
 		log.Error("same in create", zap.Error(err))
 		return
 	}
-	if notSame == false {
+	if !notSame {
 		_ = c.Error(cerror.ErrSameUpstreamDownstream.GenWithStack(
 			"TiCDC does not support updating a changefeed with the same TiDB cluster " +
 				"as both the source and the target for the changefeed."))

--- a/cdc/api/v1/api.go
+++ b/cdc/api/v1/api.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tiflow/cdc/capture"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/owner"
+	"github.com/pingcap/tiflow/pkg/check"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/logutil"
 	"github.com/pingcap/tiflow/pkg/retry"
@@ -295,6 +296,22 @@ func (h *OpenAPI) CreateChangefeed(c *gin.Context) {
 		_ = c.Error(err)
 		return
 	}
+
+	// Check whether the upstream and downstream are the different cluster.
+	notSame, err := check.CheckUpstreamDownstreamNotSame(up.PDClient, changefeedConfig.SinkURI, ctx)
+	if err != nil {
+		_ = c.Error(err)
+		log.Error("same in create", zap.Error(err))
+		return
+	}
+	if notSame == false {
+		_ = c.Error(cerror.ErrSameUpstreamDownstream.GenWithStack(
+			"TiCDC does not support creating a changefeed with the same TiDB cluster " +
+				"as both the source and the target for the changefeed."))
+		log.Error("same in create", zap.Error(err))
+		return
+	}
+
 	upstreamInfo := &model.UpstreamInfo{
 		ID:            up.ID,
 		PDEndpoints:   strings.Join(up.PdEndpoints, ","),
@@ -380,6 +397,37 @@ func (h *OpenAPI) ResumeChangefeed(c *gin.Context) {
 		return
 	}
 
+	cfInfo, err := h.capture.StatusProvider().GetChangeFeedInfo(ctx, changefeedID)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	upManager, err := h.capture.GetUpstreamManager()
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+	up, err := upManager.GetDefaultUpstream()
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+	// Check whether the upstream and downstream are the different cluster.
+	notSame, err := check.CheckUpstreamDownstreamNotSame(up.PDClient, cfInfo.SinkURI, ctx)
+	if err != nil {
+		_ = c.Error(err)
+		log.Error("same in create", zap.Error(err))
+		return
+	}
+	if notSame == false {
+		_ = c.Error(cerror.ErrSameUpstreamDownstream.GenWithStack(
+			"TiCDC does not support resuming a changefeed with the same TiDB cluster " +
+				"as both the source and the target for the changefeed."))
+		log.Error("same in create", zap.Error(err))
+		return
+	}
+
 	job := model.AdminJob{
 		CfID: changefeedID,
 		Type: model.AdminResume,
@@ -450,6 +498,31 @@ func (h *OpenAPI) UpdateChangefeed(c *gin.Context) {
 	newInfo, err := VerifyUpdateChangefeedConfig(ctx, changefeedConfig, info)
 	if err != nil {
 		_ = c.Error(err)
+		return
+	}
+
+	upManager, err := h.capture.GetUpstreamManager()
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+	up, err := upManager.GetDefaultUpstream()
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+	// Check whether the upstream and downstream are the different cluster.
+	notSame, err := check.CheckUpstreamDownstreamNotSame(up.PDClient, newInfo.SinkURI, ctx)
+	if err != nil {
+		_ = c.Error(err)
+		log.Error("same in create", zap.Error(err))
+		return
+	}
+	if notSame == false {
+		_ = c.Error(cerror.ErrSameUpstreamDownstream.GenWithStack(
+			"TiCDC does not support updating a changefeed with the same TiDB cluster " +
+				"as both the source and the target for the changefeed."))
+		log.Error("same in create", zap.Error(err))
 		return
 	}
 

--- a/cdc/api/v1/api_test.go
+++ b/cdc/api/v1/api_test.go
@@ -392,11 +392,11 @@ func TestResumeChangefeed(t *testing.T) {
 	cp.EXPECT().GetUpstreamManager().Return(upstream.NewManager4Test(pdClient), nil).AnyTimes()
 
 	// Mock UpstreamDownstreamNotSame check
-	oldGetClusterID := check.GetClusterIDBySinkURIFn
-	defer func() { check.GetClusterIDBySinkURIFn = oldGetClusterID }()
-	check.GetClusterIDBySinkURIFn = func(_ context.Context, _ string) (uint64, bool, error) {
+	oldGetClusterID := check.GetGetClusterIDBySinkURIFn()
+	defer func() { check.SetGetClusterIDBySinkURIFnForTest(oldGetClusterID) }()
+	check.SetGetClusterIDBySinkURIFnForTest(func(_ context.Context, _ string) (uint64, bool, error) {
 		return 0, false, nil
-	}
+	})
 
 	// test resume changefeed succeeded
 	mo.EXPECT().

--- a/cdc/api/v1/api_test.go
+++ b/cdc/api/v1/api_test.go
@@ -391,7 +391,7 @@ func TestResumeChangefeed(t *testing.T) {
 	pdClient := &gc.MockPDClient{}
 	cp.EXPECT().GetUpstreamManager().Return(upstream.NewManager4Test(pdClient), nil).AnyTimes()
 
-	// Backup and restore global variable
+	// Mock UpstreamDownstreamNotSame check
 	oldGetClusterID := check.GetClusterIDBySinkURIFn
 	defer func() { check.GetClusterIDBySinkURIFn = oldGetClusterID }()
 	check.GetClusterIDBySinkURIFn = func(_ context.Context, _ string) (uint64, bool, error) {

--- a/cdc/api/v1/api_test.go
+++ b/cdc/api/v1/api_test.go
@@ -31,8 +31,11 @@ import (
 	"github.com/pingcap/tiflow/cdc/owner"
 	mock_owner "github.com/pingcap/tiflow/cdc/owner/mock"
 	"github.com/pingcap/tiflow/cdc/scheduler"
+	"github.com/pingcap/tiflow/pkg/check"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	mock_etcd "github.com/pingcap/tiflow/pkg/etcd/mock"
+	"github.com/pingcap/tiflow/pkg/txnutil/gc"
+	"github.com/pingcap/tiflow/pkg/upstream"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -383,6 +386,17 @@ func TestResumeChangefeed(t *testing.T) {
 	router := newRouterWithoutStatusProvider(cp)
 	statusProvider.EXPECT().GetChangeFeedStatus(gomock.Any(), gomock.Any()).
 		Return(&model.ChangeFeedStatusForAPI{CheckpointTs: 1}, nil)
+	statusProvider.EXPECT().GetChangeFeedInfo(gomock.Any(), gomock.Any()).
+		Return(&model.ChangeFeedInfo{SinkURI: "mock"}, nil).AnyTimes()
+	pdClient := &gc.MockPDClient{}
+	cp.EXPECT().GetUpstreamManager().Return(upstream.NewManager4Test(pdClient), nil).AnyTimes()
+
+	// Backup and restore global variable
+	oldGetClusterID := check.GetClusterIDBySinkURIFn
+	defer func() { check.GetClusterIDBySinkURIFn = oldGetClusterID }()
+	check.GetClusterIDBySinkURIFn = func(_ context.Context, _ string) (uint64, bool, error) {
+		return 0, false, nil
+	}
 
 	// test resume changefeed succeeded
 	mo.EXPECT().

--- a/cdc/api/v2/api_helpers.go
+++ b/cdc/api/v2/api_helpers.go
@@ -318,6 +318,7 @@ func (APIV2HelpersImpl) verifyUpdateChangefeedConfig(
 		configUpdated = true
 		newInfo.Config = cfg.ReplicaConfig.ToInternalReplicaConfig()
 	}
+	// If the sinkURI is empty, we keep the old sinkURI.
 	if cfg.SinkURI != "" {
 		sinkURIUpdated = true
 		newInfo.SinkURI = cfg.SinkURI

--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -144,13 +144,13 @@ func (h *OpenAPIV2) createChangefeed(c *gin.Context) {
 	}
 
 	// Check whether the upstream and downstream are the different cluster.
-	notSame, err := check.CheckUpstreamDownstreamNotSame(pdClient, cfg.SinkURI, ctx)
+	notSame, err := check.UpstreamDownstreamNotSame(ctx, pdClient, cfg.SinkURI)
 	if err != nil {
 		_ = c.Error(err)
 		log.Error("same in create", zap.Error(err))
 		return
 	}
-	if notSame == false {
+	if !notSame {
 		_ = c.Error(cerror.ErrSameUpstreamDownstream.GenWithStack(
 			"TiCDC does not support creating a changefeed with the same TiDB cluster " +
 				"as both the source and the target for the changefeed."))
@@ -538,12 +538,12 @@ func (h *OpenAPIV2) updateChangefeed(c *gin.Context) {
 		}
 		defer pdClient.Close()
 	}
-	notSame, err := check.CheckUpstreamDownstreamNotSame(pdClient, newCfInfo.SinkURI, ctx)
+	notSame, err := check.UpstreamDownstreamNotSame(ctx, pdClient, newCfInfo.SinkURI)
 	if err != nil {
 		_ = c.Error(err)
 		return
 	}
-	if notSame == false {
+	if !notSame {
 		_ = c.Error(cerror.ErrSameUpstreamDownstream.GenWithStack(
 			"TiCDC does not support updating a changefeed with the same TiDB cluster " +
 				"as both the source and the target for the changefeed."))
@@ -849,12 +849,12 @@ func (h *OpenAPIV2) resumeChangefeed(c *gin.Context) {
 	}()
 
 	// Check whether the upstream and downstream are the different cluster.
-	notSame, err := check.CheckUpstreamDownstreamNotSame(pdClient, cfInfo.SinkURI, ctx)
+	notSame, err := check.UpstreamDownstreamNotSame(ctx, pdClient, cfInfo.SinkURI)
 	if err != nil {
 		_ = c.Error(err)
 		return
 	}
-	if notSame == false {
+	if !notSame {
 		_ = c.Error(cerror.ErrSameUpstreamDownstream.GenWithStack(
 			"TiCDC does not support resuming a changefeed with the same TiDB cluster " +
 				"as both the source and the target for the changefeed."))

--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -147,14 +147,12 @@ func (h *OpenAPIV2) createChangefeed(c *gin.Context) {
 	notSame, err := check.UpstreamDownstreamNotSame(ctx, pdClient, cfg.SinkURI)
 	if err != nil {
 		_ = c.Error(err)
-		log.Error("same in create", zap.Error(err))
 		return
 	}
 	if !notSame {
 		_ = c.Error(cerror.ErrSameUpstreamDownstream.GenWithStack(
 			"TiCDC does not support creating a changefeed with the same TiDB cluster " +
 				"as both the source and the target for the changefeed."))
-		log.Error("same in create", zap.Error(err))
 		return
 	}
 

--- a/cdc/api/v2/changefeed_test.go
+++ b/cdc/api/v2/changefeed_test.go
@@ -79,11 +79,11 @@ func TestCreateChangefeed(t *testing.T) {
 	cp.EXPECT().StatusProvider().Return(provider).AnyTimes()
 
 	// Mock UpstreamDownstreamNotSame check
-	oldGetClusterID := check.GetClusterIDBySinkURIFn
-	defer func() { check.GetClusterIDBySinkURIFn = oldGetClusterID }()
-	check.GetClusterIDBySinkURIFn = func(_ context.Context, _ string) (uint64, bool, error) {
+	oldGetClusterID := check.GetGetClusterIDBySinkURIFn()
+	defer func() { check.SetGetClusterIDBySinkURIFnForTest(oldGetClusterID) }()
+	check.SetGetClusterIDBySinkURIFnForTest(func(_ context.Context, _ string) (uint64, bool, error) {
 		return 0, false, nil
-	}
+	})
 
 	// case 1: json format mismatches with the spec.
 	errConfig := struct {
@@ -357,11 +357,11 @@ func TestUpdateChangefeed(t *testing.T) {
 	mockCapture.EXPECT().GetOwner().Return(mockOwner, nil).AnyTimes()
 
 	// Mock UpstreamDownstreamNotSame check
-	oldGetClusterID := check.GetClusterIDBySinkURIFn
-	defer func() { check.GetClusterIDBySinkURIFn = oldGetClusterID }()
-	check.GetClusterIDBySinkURIFn = func(_ context.Context, _ string) (uint64, bool, error) {
+	oldGetClusterID := check.GetGetClusterIDBySinkURIFn()
+	defer func() { check.SetGetClusterIDBySinkURIFnForTest(oldGetClusterID) }()
+	check.SetGetClusterIDBySinkURIFnForTest(func(_ context.Context, _ string) (uint64, bool, error) {
 		return 0, false, nil
-	}
+	})
 
 	// case 1 invalid id
 	invalidID := "Invalid_#"
@@ -770,11 +770,11 @@ func TestResumeChangefeed(t *testing.T) {
 		}).AnyTimes()
 
 	// Mock UpstreamDownstreamNotSame check
-	oldGetClusterID := check.GetClusterIDBySinkURIFn
-	defer func() { check.GetClusterIDBySinkURIFn = oldGetClusterID }()
-	check.GetClusterIDBySinkURIFn = func(_ context.Context, _ string) (uint64, bool, error) {
+	oldGetClusterID := check.GetGetClusterIDBySinkURIFn()
+	defer func() { check.SetGetClusterIDBySinkURIFnForTest(oldGetClusterID) }()
+	check.SetGetClusterIDBySinkURIFnForTest(func(_ context.Context, _ string) (uint64, bool, error) {
 		return 0, false, nil
-	}
+	})
 
 	// case 1: invalid changefeed id
 	w := httptest.NewRecorder()

--- a/cdc/api/v2/changefeed_test.go
+++ b/cdc/api/v2/changefeed_test.go
@@ -343,6 +343,8 @@ func TestUpdateChangefeed(t *testing.T) {
 	t.Parallel()
 	update := testCase{url: "/api/v2/changefeeds/%s", method: "PUT"}
 	helpers := NewMockAPIV2Helpers(gomock.NewController(t))
+	helpers.EXPECT().getPDClient(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&mockPDClient{}, nil).AnyTimes()
 	mockOwner := mock_owner.NewMockOwner(gomock.NewController(t))
 	mockCapture := mock_capture.NewMockCapture(gomock.NewController(t))
 	apiV2 := NewOpenAPIV2ForTest(mockCapture, helpers)

--- a/errors.toml
+++ b/errors.toml
@@ -891,6 +891,11 @@ error = '''
 external storage api
 '''
 
+["CDC:ErrSameUpstreamDownstream"]
+error = '''
+upstream and downstream are the same, %s
+'''
+
 ["CDC:ErrSchedulerRequestFailed"]
 error = '''
 scheduler request failed, %s

--- a/pkg/check/cluster.go
+++ b/pkg/check/cluster.go
@@ -1,0 +1,85 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"context"
+	"net/url"
+	"strconv"
+
+	"github.com/pingcap/log"
+	cerror "github.com/pingcap/tiflow/pkg/errors"
+	pmysql "github.com/pingcap/tiflow/pkg/sink/mysql"
+	pd "github.com/tikv/pd/client"
+	"go.uber.org/zap"
+)
+
+// CheckUpstreamDownstreamNotSame checks whether the upstream and downstream are not the same cluster.
+func CheckUpstreamDownstreamNotSame(upPD pd.Client, downSinkURI string, ctx context.Context) (bool, error) {
+	upID := upPD.GetClusterID(ctx)
+
+	downID, isTiDB, err := getClusterIDBySinkURI(downSinkURI, ctx)
+	log.Debug("CheckNotSameUpstreamDownstream",
+		zap.Uint64("upID", upID), zap.Uint64("downID", downID), zap.Bool("isTiDB", isTiDB))
+	if err != nil {
+		log.Error("failed to get cluster ID from sink URI",
+			zap.String("downSinkURI", downSinkURI), zap.Error(err))
+		return false, cerror.Trace(err)
+	}
+
+	if !isTiDB {
+		return true, nil
+	}
+
+	return upID != downID, nil
+}
+
+func getClusterIDBySinkURI(sinkURI string, ctx context.Context) (uint64, bool, error) {
+	// Create a MySQL connection by using the sink URI.
+	url, err := url.Parse(sinkURI)
+	if err != nil {
+		return 0, true, cerror.WrapError(cerror.ErrSinkURIInvalid, err)
+	}
+	dsnStr, err := pmysql.GenerateDSN(ctx, url, pmysql.NewConfig(), pmysql.CreateMySQLDBConn)
+	if err != nil {
+		return 0, true, cerror.Trace(err)
+	}
+	db, err := pmysql.CreateMySQLDBConn(ctx, dsnStr)
+	if err != nil {
+		return 0, true, cerror.Trace(err)
+	}
+	defer db.Close()
+
+	// Check whether the downstream is TiDB.
+	isTiDB := pmysql.CheckIsTiDB(ctx, db)
+	if !isTiDB {
+		return 0, false, nil
+	}
+
+	// Get the cluster ID from the downstream TiDB.
+	row := db.QueryRowContext(ctx, "SELECT VARIABLE_VALUE FROM mysql.tidb WHERE VARIABLE_NAME = 'cluster_id'")
+	if err != nil {
+		return 0, true, cerror.Trace(err)
+	}
+	var clusterIDStr string
+	err = row.Scan(&clusterIDStr)
+	if err != nil {
+		return 0, true, cerror.Trace(err)
+	}
+	clusterID, err := strconv.ParseUint(clusterIDStr, 10, 64)
+	if err != nil {
+		return 0, true, cerror.Trace(err)
+	}
+	return clusterID, true, nil
+}

--- a/pkg/check/cluster.go
+++ b/pkg/check/cluster.go
@@ -27,18 +27,16 @@ import (
 )
 
 var (
-	dbConnImpl  pmysql.IDBConnectionFactory = &pmysql.DBConnectionFactory{}
-	checkIsTiDB                             = pmysql.CheckIsTiDB
-	// GetClusterIDBySinkURIFn is a function to get the cluster ID by the sink URI.
-	// Exported for testing.
-	GetClusterIDBySinkURIFn = getClusterIDBySinkURI
+	dbConnImpl              pmysql.IDBConnectionFactory = &pmysql.DBConnectionFactory{}
+	checkIsTiDB                                         = pmysql.CheckIsTiDB
+	getClusterIDBySinkURIFn                             = getClusterIDBySinkURI
 )
 
 // UpstreamDownstreamNotSame checks whether the upstream and downstream are not the same cluster.
 func UpstreamDownstreamNotSame(ctx context.Context, upPD pd.Client, downSinkURI string) (bool, error) {
 	upID := upPD.GetClusterID(ctx)
 
-	downID, isTiDB, err := GetClusterIDBySinkURIFn(ctx, downSinkURI)
+	downID, isTiDB, err := getClusterIDBySinkURIFn(ctx, downSinkURI)
 	log.Debug("CheckNotSameUpstreamDownstream",
 		zap.Uint64("upID", upID), zap.Uint64("downID", downID), zap.Bool("isTiDB", isTiDB))
 	if err != nil {
@@ -94,4 +92,15 @@ func getClusterIDBySinkURI(ctx context.Context, sinkURI string) (uint64, bool, e
 		return 0, true, cerror.Trace(err)
 	}
 	return clusterID, true, nil
+}
+
+// GetGetClusterIDBySinkURIFn returns the getClusterIDBySinkURIFn function.
+// It is used for testing.
+func GetGetClusterIDBySinkURIFn() func(context.Context, string) (uint64, bool, error) {
+	return getClusterIDBySinkURIFn
+}
+
+// SetGetClusterIDBySinkURIFnForTest sets the getClusterIDBySinkURIFn function for testing.
+func SetGetClusterIDBySinkURIFnForTest(fn func(context.Context, string) (uint64, bool, error)) {
+	getClusterIDBySinkURIFn = fn
 }

--- a/pkg/check/cluster.go
+++ b/pkg/check/cluster.go
@@ -25,11 +25,11 @@ import (
 	"go.uber.org/zap"
 )
 
-// CheckUpstreamDownstreamNotSame checks whether the upstream and downstream are not the same cluster.
-func CheckUpstreamDownstreamNotSame(upPD pd.Client, downSinkURI string, ctx context.Context) (bool, error) {
+// UpstreamDownstreamNotSame checks whether the upstream and downstream are not the same cluster.
+func UpstreamDownstreamNotSame(ctx context.Context, upPD pd.Client, downSinkURI string) (bool, error) {
 	upID := upPD.GetClusterID(ctx)
 
-	downID, isTiDB, err := getClusterIDBySinkURI(downSinkURI, ctx)
+	downID, isTiDB, err := getClusterIDBySinkURI(ctx, downSinkURI)
 	log.Debug("CheckNotSameUpstreamDownstream",
 		zap.Uint64("upID", upID), zap.Uint64("downID", downID), zap.Bool("isTiDB", isTiDB))
 	if err != nil {
@@ -45,7 +45,7 @@ func CheckUpstreamDownstreamNotSame(upPD pd.Client, downSinkURI string, ctx cont
 	return upID != downID, nil
 }
 
-func getClusterIDBySinkURI(sinkURI string, ctx context.Context) (uint64, bool, error) {
+func getClusterIDBySinkURI(ctx context.Context, sinkURI string) (uint64, bool, error) {
 	// Create a MySQL connection by using the sink URI.
 	url, err := url.Parse(sinkURI)
 	if err != nil {

--- a/pkg/check/cluster.go
+++ b/pkg/check/cluster.go
@@ -29,7 +29,8 @@ import (
 var (
 	dbConnImpl  pmysql.IDBConnectionFactory = &pmysql.DBConnectionFactory{}
 	checkIsTiDB                             = pmysql.CheckIsTiDB
-	// Export for testing only.
+	// GetClusterIDBySinkURIFn is a function to get the cluster ID by the sink URI.
+	// Exported for testing.
 	GetClusterIDBySinkURIFn = getClusterIDBySinkURI
 )
 

--- a/pkg/check/cluster.go
+++ b/pkg/check/cluster.go
@@ -69,13 +69,11 @@ func getClusterIDBySinkURI(ctx context.Context, sinkURI string) (uint64, bool, e
 
 	// Get the cluster ID from the downstream TiDB.
 	row := db.QueryRowContext(ctx, "SELECT VARIABLE_VALUE FROM mysql.tidb WHERE VARIABLE_NAME = 'cluster_id'")
-	if err != nil {
-		return 0, true, cerror.Trace(err)
-	}
 	var clusterIDStr string
 	err = row.Scan(&clusterIDStr)
 	if err != nil {
-		return 0, true, cerror.Trace(err)
+		// If the cluster ID is not set, it is a legacy TiDB cluster, these should be compatible with it.
+		return 0, false, nil
 	}
 	clusterID, err := strconv.ParseUint(clusterIDStr, 10, 64)
 	if err != nil {

--- a/pkg/check/cluster_test.go
+++ b/pkg/check/cluster_test.go
@@ -1,0 +1,203 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	cerror "github.com/pingcap/tiflow/pkg/errors"
+	pmysql "github.com/pingcap/tiflow/pkg/sink/mysql"
+	"github.com/stretchr/testify/require"
+	pd "github.com/tikv/pd/client"
+)
+
+// Mock PD Client
+type mockPDClient struct {
+	pd.Client
+	clusterID uint64
+}
+
+func (m *mockPDClient) GetClusterID(ctx context.Context) uint64 {
+	return m.clusterID
+}
+
+// TestGetClusterIDBySinkURI
+func TestGetClusterIDBySinkURI(t *testing.T) {
+	// Backup and restore global variables
+	oldDBConnImpl := dbConnImpl
+	oldCheckIsTiDB := checkIsTiDB
+	defer func() {
+		dbConnImpl = oldDBConnImpl
+		checkIsTiDB = oldCheckIsTiDB
+	}()
+
+	testCases := []struct {
+		name          string
+		sinkURI       string
+		mockDBSetup   func(sqlmock.Sqlmock)
+		mockTiDBCheck bool
+		wantClusterID uint64
+		wantIsTiDB    bool
+		wantErr       error
+	}{
+		{
+			name:       "non mysql scheme",
+			sinkURI:    "kafka://127.0.0.1:9092/topic",
+			wantIsTiDB: false,
+		},
+		{
+			name:    "invalid uri",
+			sinkURI: ":invalid:",
+			wantErr: cerror.ErrSinkURIInvalid.Wrap(errors.New("parse \":invalid:\": missing protocol scheme")),
+		},
+		{
+			name:    "connect error",
+			sinkURI: "mysql://user:pass@127.0.0.1:3306/db",
+			mockDBSetup: func(mock sqlmock.Sqlmock) {
+				dbFactory := pmysql.NewDBConnectionFactoryForTest()
+				dbFactory.SetStandardConnectionFactory(
+					func(ctx context.Context, dsn string) (*sql.DB, error) {
+						return nil, errors.New("connect error")
+					})
+				dbConnImpl = dbFactory
+			},
+			wantErr: errors.New("connect error"),
+		},
+		{
+			name:    "not tidb",
+			sinkURI: "mysql://user:pass@127.0.0.1:3306/db",
+			mockDBSetup: func(mock sqlmock.Sqlmock) {
+				checkIsTiDB = func(ctx context.Context, db *sql.DB) bool { return false }
+			},
+			wantIsTiDB: false,
+		},
+		{
+			name:    "tidb no cluster id",
+			sinkURI: "mysql://user:pass@127.0.0.1:3306/db",
+			mockDBSetup: func(mock sqlmock.Sqlmock) {
+				checkIsTiDB = func(ctx context.Context, db *sql.DB) bool { return true }
+				mock.ExpectQuery("SELECT VARIABLE_VALUE FROM mysql.tidb WHERE VARIABLE_NAME = 'cluster_id'").
+					WillReturnError(sql.ErrNoRows)
+			},
+			wantIsTiDB: false,
+		},
+		{
+			name:    "success",
+			sinkURI: "mysql://user:pass@127.0.0.1:3306/db",
+			mockDBSetup: func(mock sqlmock.Sqlmock) {
+				checkIsTiDB = func(ctx context.Context, db *sql.DB) bool { return true }
+				rows := mock.NewRows([]string{"VARIABLE_VALUE"}).AddRow("12345")
+				mock.ExpectQuery("SELECT VARIABLE_VALUE FROM mysql.tidb WHERE VARIABLE_NAME = 'cluster_id'").
+					WillReturnRows(rows)
+			},
+			wantClusterID: 12345,
+			wantIsTiDB:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup mock database
+			if tc.mockDBSetup != nil {
+				db, mock, err := sqlmock.New()
+				require.NoError(t, err)
+				defer db.Close()
+
+				dbFactory := pmysql.NewDBConnectionFactoryForTest()
+				dbFactory.SetStandardConnectionFactory(func(ctx context.Context, dsn string) (*sql.DB, error) {
+					return db, nil
+				})
+				dbConnImpl = dbFactory
+				tc.mockDBSetup(mock)
+			}
+
+			clusterID, isTiDB, err := getClusterIDBySinkURI(context.Background(), tc.sinkURI)
+
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErr.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantClusterID, clusterID)
+				require.Equal(t, tc.wantIsTiDB, isTiDB)
+			}
+		})
+	}
+}
+
+// TestUpstreamDownstreamNotSame
+func TestUpstreamDownstreamNotSame(t *testing.T) {
+	// Backup and restore global variable
+	oldGetClusterID := GetClusterIDBySinkURIFn
+	defer func() { GetClusterIDBySinkURIFn = oldGetClusterID }()
+
+	testCases := []struct {
+		name         string
+		upClusterID  uint64
+		mockDownFunc func(context.Context, string) (uint64, bool, error)
+		wantResult   bool
+		wantErr      error
+	}{
+		{
+			name:        "same cluster",
+			upClusterID: 123,
+			mockDownFunc: func(_ context.Context, _ string) (uint64, bool, error) {
+				return 123, true, nil
+			},
+			wantResult: false,
+		},
+		{
+			name:        "different cluster",
+			upClusterID: 123,
+			mockDownFunc: func(_ context.Context, _ string) (uint64, bool, error) {
+				return 456, true, nil
+			},
+			wantResult: true,
+		},
+		{
+			name: "not tidb",
+			mockDownFunc: func(_ context.Context, _ string) (uint64, bool, error) {
+				return 0, false, nil
+			},
+			wantResult: true,
+		},
+		{
+			name: "error case",
+			mockDownFunc: func(_ context.Context, _ string) (uint64, bool, error) {
+				return 0, false, errors.New("mock error")
+			},
+			wantErr: errors.New("mock error"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			GetClusterIDBySinkURIFn = tc.mockDownFunc
+			mockPD := &mockPDClient{clusterID: tc.upClusterID}
+
+			result, err := UpstreamDownstreamNotSame(context.Background(), mockPD, "any://uri")
+
+			if tc.wantErr != nil {
+				require.ErrorContains(t, err, tc.wantErr.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantResult, result)
+			}
+		})
+	}
+}

--- a/pkg/check/cluster_test.go
+++ b/pkg/check/cluster_test.go
@@ -143,8 +143,8 @@ func TestGetClusterIDBySinkURI(t *testing.T) {
 // TestUpstreamDownstreamNotSame
 func TestUpstreamDownstreamNotSame(t *testing.T) {
 	// Backup and restore global variable
-	oldGetClusterID := GetClusterIDBySinkURIFn
-	defer func() { GetClusterIDBySinkURIFn = oldGetClusterID }()
+	oldGetClusterID := GetGetClusterIDBySinkURIFn()
+	defer func() { SetGetClusterIDBySinkURIFnForTest(oldGetClusterID) }()
 
 	testCases := []struct {
 		name         string
@@ -187,7 +187,7 @@ func TestUpstreamDownstreamNotSame(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			GetClusterIDBySinkURIFn = tc.mockDownFunc
+			SetGetClusterIDBySinkURIFnForTest(tc.mockDownFunc)
 			mockPD := &mockPDClient{clusterID: tc.upClusterID}
 
 			result, err := UpstreamDownstreamNotSame(context.Background(), mockPD, "any://uri")

--- a/pkg/errors/cdc_errors.go
+++ b/pkg/errors/cdc_errors.go
@@ -959,6 +959,10 @@ var (
 		"internal check failed, %s",
 		errors.RFCCodeText("CDC:ErrInternalCheckFailed"),
 	)
+	ErrSameUpstreamDownstream = errors.Normalize(
+		"upstream and downstream are the same, %s",
+		errors.RFCCodeText("CDC:ErrSameUpstreamDownstream"),
+	)
 
 	ErrHandleDDLFailed = errors.Normalize(
 		"handle ddl failed, query: %s, startTs: %d. "+


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12062, #11767

### What is changed and how it works?

#### Overview  

This PR implements a mechanism to prevent TiCDC from using the same TiDB cluster as both upstream and downstream. The approach relies on retrieving the Cluster ID from `mysql.tidb` in TiDB and comparing it with the upstream Cluster ID obtained from PD.  

#### Changes in This PR  

- Fetch the upstream Cluster ID from PD via gRPC.  
- Query the downstream Cluster ID from TiDB’s `mysql.tidb`.  
- Compare the Cluster IDs during changefeed creating, resuming and updating operation.  
- Reject changefeed operation if the upstream and downstream Cluster IDs match.  
- Add error handling and logging.  

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
1. Create a changefeed using cmd: `cdc cli changefeed create --server=http://127.0.0.1:8300 --sink-uri="mysql://root:@127.0.0.1:8300/" --changefeed-id="create-cmd"`, results:
    ```
    Error: [CDC:ErrSameUpstreamDownstream]TiCDC does not support creating a changefeed with the same TiDB cluster as both the source and the target for the changefeed.
    ```
2. Create a changefeed using Open API V1: `curl -X POST -H "'Content-type':'application/json'" http://127.0.0.1:8300/api/v1/changefeeds -d '{"changefeed_id":"create-v1","sink_uri":"mysql://root:@127.0.0.1:4000/"}'`, results: 
    ```
    {
        "error_msg": "[CDC:ErrSameUpstreamDownstream]TiCDC does not support creating a changefeed with the same TiDB cluster as both the source and the target for the changefeed.",
        "error_code": "CDC:ErrSameUpstreamDownstream"
    }
    ```
3. Create a changefeed using Open API V2: `curl -X POST -H "'Content-type':'application/json'" http://127.0.0.1:8300/api/v2/changefeeds -d '{"changefeed_id":"create-v2","sink_uri":"mysql://root:@127.0.0.1:4000/"}'`, results: 
    ```
    {
        "error_msg": "[CDC:ErrSameUpstreamDownstream]TiCDC does not support creating a changefeed with the same TiDB cluster as both the source and the target for the changefeed.",
        "error_code": "CDC:ErrSameUpstreamDownstream"
    }
    ```
4. Update a changefeed using cmd: `cdc cli changefeed update --changefeed-id update-cmd --sink-uri="mysql://root:@127.0.0.1:4000/"`, results: 
    ```
    Error: [CDC:ErrSameUpstreamDownstream]TiCDC does not support updating a changefeed with the same TiDB cluster as both the source and the target for the changefeed.
    ```
5. Update a changefeed using Open API V1: `curl -X PUT -H "'Content-type':'application/json'" http://127.0.0.1:8300/api/v1/changefeeds/update-v1 -d '{"sink_uri":"mysql://root:@127.0.0.1:4000/"}'`, results: 
    ```
    {
        "error_msg": "[CDC:ErrSameUpstreamDownstream]TiCDC does not support updating a changefeed with the same TiDB cluster as both the source and the target for the changefeed",
        "error_code": "CDC:ErrSameUpstreamDownstream"
    }
    ```
6. Update a changefeed using Open API V2: `curl -X PUT -H "'Content-type':'application/json'" http://127.0.0.1:8300/api/v2/changefeeds/update-v2 -d '{"sink_uri":"mysql://root:@127.0.0.1:4000/"}'`, results: 
    ```
    {
        "error_msg": "[CDC:ErrSameUpstreamDownstream]TiCDC does not support updating a changefeed with the same TiDB cluster as both the source and the target for the changefeed",
        "error_code": "CDC:ErrSameUpstreamDownstream"
    }
    ```
7. Resume a changefeed using cmd: `cdc cli changefeed resume --changefeed-id resume-cmd`, results: 
    ```
    Error: [CDC:ErrSameUpstreamDownstream]TiCDC does not support resuming a changefeed with the same TiDB cluster as both the source and the target for the changefeed.
    ```
8. Resume a changefeed using Open API V1: `curl -X POST http://127.0.0.1:8300/api/v1/changefeeds/resume-v1/resume`, results: 
    ```
    {
        "error_msg": "[CDC:ErrSameUpstreamDownstream]TiCDC does not support resuming a changefeed with the same TiDB cluster as both the source and the target for the changefeed.",
        "error_code": "CDC:ErrSameUpstreamDownstream"
    }
    ```
9. Resume a changefeed using Open API V2: `curl -X POST http://127.0.0.1:8300/api/v2/changefeeds/resume-v2/resume -d '{}'`, results: 
    ```
    {
        "error_msg": "[CDC:ErrSameUpstreamDownstream]TiCDC does not support resuming a changefeed with the same TiDB cluster as both the source and the target for the changefeed.",
        "error_code": "CDC:ErrSameUpstreamDownstream"
    }
    ```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
TiCDC now prevents using the same TiDB cluster as both upstream and downstream, ensuring data consistency and avoiding replication loops.  
```
