### PR TITLE
ticdc:bug fix - added pulsar+http and pulsar+https protocols in IsMQScheme to honor MQ fields in changefeed

### DIFF
--- a/pkg/sink/sink_type.go
+++ b/pkg/sink/sink_type.go
@@ -81,7 +81,7 @@ const (
 // IsMQScheme returns true if the scheme belong to mq scheme.
 func IsMQScheme(scheme string) bool {
 	return scheme == KafkaScheme || scheme == KafkaSSLScheme ||
-		scheme == PulsarScheme || scheme == PulsarSSLScheme
+		scheme == PulsarScheme || scheme == PulsarSSLScheme || scheme == PulsarHTTPScheme || scheme ==PulsarHTTPSScheme
 }
 
 // IsMySQLCompatibleScheme returns true if the scheme is compatible with MySQL.

--- a/pkg/sink/sink_type.go
+++ b/pkg/sink/sink_type.go
@@ -81,7 +81,7 @@ const (
 // IsMQScheme returns true if the scheme belong to mq scheme.
 func IsMQScheme(scheme string) bool {
 	return scheme == KafkaScheme || scheme == KafkaSSLScheme ||
-		scheme == PulsarScheme || scheme == PulsarSSLScheme || scheme == PulsarHTTPScheme || scheme ==PulsarHTTPSScheme
+		scheme == PulsarScheme || scheme == PulsarSSLScheme || scheme == PulsarHTTPScheme || scheme == PulsarHTTPSScheme
 }
 
 // IsMySQLCompatibleScheme returns true if the scheme is compatible with MySQL.


### PR DESCRIPTION
### What problem does this PR solve?
MQ fields like DispatchRules not getting honor in pulsar+http protocol for pulsar changefeeds because pulsar+http and pulsar+https protocols were not added iin IsMQScheme function. It is bug fix for the same. The bug was introduced in below PR:https://github.com/pingcap/tiflow/pull/11338

Issue Number: ref #12068 

### What is changed and how it works?
-> pulsar+http and pulsar+https protocols are added in IsMQScheme function so that MQ related fields will get picked up for these protocols


#### Tests 
1. Unit test
2. Feature test by deploying the image on  k8s environment and creating multiple changefeeds.


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
-> It should not cause any performance regression or break compatibility. It only addition schema addition for pulsar client creation.



```release-note
Bug fix for  pulsar+http and pulsar+https schema  pulsar protocols to honor MQ fields. 
```