### PR TITLE
test(ticdc): fix duplicate entry about multi_source test

### DIFF
--- a/tests/integration_tests/multi_source/main.go
+++ b/tests/integration_tests/multi_source/main.go
@@ -210,11 +210,11 @@ func dml(ctx context.Context, db *sql.DB, table string, id int) {
 	var i int
 	var insertSuccess int
 	var deleteSuccess int
-	insertSQL := fmt.Sprintf("insert into test.`%s`(id1, id2) values(?,?)", table)
+	insertSQL := fmt.Sprintf("insert into test.`%s`(id, id1, id2) values(?,?,?)", table)
 	deleteSQL := fmt.Sprintf("delete from test.`%s` where id1 = ? or id2 = ?", table)
 	k := 100000000
 	for i = 0; i < k; i++ {
-		_, err = db.Exec(insertSQL, i+id*k, i+id*k+1)
+		_, err = db.Exec(insertSQL, i+id*k, i+id*k, i+id*k+1)
 		if err == nil {
 			insertSuccess++
 			if insertSuccess%100 == 0 {
@@ -382,7 +382,8 @@ const (
 	createTableSQL    = `
 create table if not exists test.%s
 (
-    id1 int primary key,
+	id int primary key,
+    id1 int unique key not null,
     id2 int unique key not null,
     v1  int default null
 )

--- a/tests/integration_tests/multi_source/main.go
+++ b/tests/integration_tests/multi_source/main.go
@@ -382,7 +382,7 @@ const (
 	createTableSQL    = `
 create table if not exists test.%s
 (
-    id1 int unique key not null,
+    id1 int primary key,
     id2 int unique key not null,
     v1  int default null
 )


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #11879

### What is changed and how it works?
TiDB may set an incorrect auto_increment column when DDL/DML sqls execute concurrently.
related issue: https://github.com/pingcap/tidb/issues/55846
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`.
```
