### PR TITLE
sink(ticdc): add logs to detect send checkpoint ts correct

### DIFF
--- a/cdc/owner/ddl_sink.go
+++ b/cdc/owner/ddl_sink.go
@@ -174,13 +174,11 @@ func (s *ddlSinkImpl) retrySinkAction(ctx context.Context, name string, action f
 			zap.Bool("retryable", isRetryable),
 			zap.Error(err))
 
-		start := time.Now()
 		if s.sink != nil {
 			s.sink.Close()
 			s.sink = nil
 			log.Info("close the ddl sink, rebuild it when trying again",
-				zap.String("namespace", s.changefeedID.Namespace), zap.String("changefeed", s.changefeedID.ID),
-				zap.Duration("duration", time.Since(start)))
+				zap.String("namespace", s.changefeedID.Namespace), zap.String("changefeed", s.changefeedID.ID))
 		}
 
 		if isRetryable {

--- a/cdc/owner/ddl_sink.go
+++ b/cdc/owner/ddl_sink.go
@@ -175,11 +175,13 @@ func (s *ddlSinkImpl) retrySinkAction(ctx context.Context, name string, action f
 			zap.Error(err))
 
 		start := time.Now()
-		s.sink.Close()
-		s.sink = nil
-		log.Info("close the ddl sink, rebuild it when trying again",
-			zap.String("namespace", s.changefeedID.Namespace), zap.String("changefeed", s.changefeedID.ID),
-			zap.Duration("duration", time.Since(start)))
+		if s.sink != nil {
+			s.sink.Close()
+			s.sink = nil
+			log.Info("close the ddl sink, rebuild it when trying again",
+				zap.String("namespace", s.changefeedID.Namespace), zap.String("changefeed", s.changefeedID.ID),
+				zap.Duration("duration", time.Since(start)))
+		}
 
 		if isRetryable {
 			s.reportWarning(err)

--- a/cdc/owner/ddl_sink.go
+++ b/cdc/owner/ddl_sink.go
@@ -180,7 +180,7 @@ func (s *ddlSinkImpl) retrySinkAction(ctx context.Context, name string, action f
 		log.Info("close the ddl sink, rebuild it when trying again",
 			zap.String("namespace", s.changefeedID.Namespace), zap.String("changefeed", s.changefeedID.ID),
 			zap.Duration("duration", time.Since(start)))
-		
+
 		if isRetryable {
 			s.reportWarning(err)
 		} else {

--- a/cdc/owner/ddl_sink.go
+++ b/cdc/owner/ddl_sink.go
@@ -174,6 +174,7 @@ func (s *ddlSinkImpl) retrySinkAction(ctx context.Context, name string, action f
 			zap.Bool("retryable", isRetryable),
 			zap.Error(err))
 
+		s.sink.Close()
 		s.sink = nil
 		if isRetryable {
 			s.reportWarning(err)
@@ -200,7 +201,7 @@ func (s *ddlSinkImpl) observedRetrySinkAction(ctx context.Context, name string, 
 	defer ticker.Stop()
 	for {
 		select {
-		case err := <-errCh:
+		case err = <-errCh:
 			return err
 		case <-ticker.C:
 			log.Info("owner ddl sink performs an action too long",

--- a/cdc/owner/ddl_sink.go
+++ b/cdc/owner/ddl_sink.go
@@ -174,8 +174,13 @@ func (s *ddlSinkImpl) retrySinkAction(ctx context.Context, name string, action f
 			zap.Bool("retryable", isRetryable),
 			zap.Error(err))
 
+		start := time.Now()
 		s.sink.Close()
 		s.sink = nil
+		log.Info("close the ddl sink, rebuild it when trying again",
+			zap.String("namespace", s.changefeedID.Namespace), zap.String("changefeed", s.changefeedID.ID),
+			zap.Duration("duration", time.Since(start)))
+		
 		if isRetryable {
 			s.reportWarning(err)
 		} else {

--- a/cdc/sink/ddlsink/factory/factory.go
+++ b/cdc/sink/ddlsink/factory/factory.go
@@ -28,10 +28,8 @@ import (
 	"github.com/pingcap/tiflow/pkg/config"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/sink"
-	"github.com/pingcap/tiflow/pkg/sink/kafka"
 	kafkav2 "github.com/pingcap/tiflow/pkg/sink/kafka/v2"
 	pulsarConfig "github.com/pingcap/tiflow/pkg/sink/pulsar"
-	"github.com/pingcap/tiflow/pkg/util"
 )
 
 // New creates a new ddlsink.Sink by scheme.
@@ -48,10 +46,11 @@ func New(
 	scheme := sink.GetScheme(sinkURI)
 	switch scheme {
 	case sink.KafkaScheme, sink.KafkaSSLScheme:
-		factoryCreator := kafka.NewSaramaFactory
-		if util.GetOrZero(cfg.Sink.EnableKafkaSinkV2) {
-			factoryCreator = kafkav2.NewFactory
-		}
+		//factoryCreator := kafka.NewSaramaFactory
+		//if util.GetOrZero(cfg.Sink.EnableKafkaSinkV2) {
+		//	factoryCreator = kafkav2.NewFactory
+		//}
+		factoryCreator := kafkav2.NewFactory
 		return mq.NewKafkaDDLSink(ctx, changefeedID, sinkURI, cfg,
 			factoryCreator, ddlproducer.NewKafkaDDLProducer)
 	case sink.BlackHoleScheme:

--- a/cdc/sink/ddlsink/factory/factory.go
+++ b/cdc/sink/ddlsink/factory/factory.go
@@ -28,8 +28,10 @@ import (
 	"github.com/pingcap/tiflow/pkg/config"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/sink"
+	"github.com/pingcap/tiflow/pkg/sink/kafka"
 	kafkav2 "github.com/pingcap/tiflow/pkg/sink/kafka/v2"
 	pulsarConfig "github.com/pingcap/tiflow/pkg/sink/pulsar"
+	"github.com/pingcap/tiflow/pkg/util"
 )
 
 // New creates a new ddlsink.Sink by scheme.
@@ -46,11 +48,10 @@ func New(
 	scheme := sink.GetScheme(sinkURI)
 	switch scheme {
 	case sink.KafkaScheme, sink.KafkaSSLScheme:
-		//factoryCreator := kafka.NewSaramaFactory
-		//if util.GetOrZero(cfg.Sink.EnableKafkaSinkV2) {
-		//	factoryCreator = kafkav2.NewFactory
-		//}
-		factoryCreator := kafkav2.NewFactory
+		factoryCreator := kafka.NewSaramaFactory
+		if util.GetOrZero(cfg.Sink.EnableKafkaSinkV2) {
+			factoryCreator = kafkav2.NewFactory
+		}
 		return mq.NewKafkaDDLSink(ctx, changefeedID, sinkURI, cfg,
 			factoryCreator, ddlproducer.NewKafkaDDLProducer)
 	case sink.BlackHoleScheme:

--- a/cdc/sink/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
+++ b/cdc/sink/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
@@ -87,9 +87,7 @@ func (k *kafkaDDLProducer) SyncSendMessage(ctx context.Context, topic string,
 	case <-ctx.Done():
 		return errors.Trace(ctx.Err())
 	default:
-		err := k.syncProducer.SendMessage(ctx, topic,
-			partitionNum, message.Key, message.Value)
-		return cerror.WrapError(cerror.ErrKafkaSendMessage, err)
+		return k.syncProducer.SendMessage(ctx, topic, partitionNum, message.Key, message.Value)
 	}
 }
 

--- a/cdc/sink/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
+++ b/cdc/sink/ddlsink/mq/ddlproducer/kafka_ddl_producer.go
@@ -69,9 +69,7 @@ func (k *kafkaDDLProducer) SyncBroadcastMessage(ctx context.Context, topic strin
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
-		err := k.syncProducer.SendMessages(ctx, topic,
-			totalPartitionsNum, message.Key, message.Value)
-		return cerror.WrapError(cerror.ErrKafkaSendMessage, err)
+		return k.syncProducer.SendMessages(ctx, topic, totalPartitionsNum, message.Key, message.Value)
 	}
 }
 

--- a/cdc/sink/ddlsink/mq/kafka_ddl_sink.go
+++ b/cdc/sink/ddlsink/mq/kafka_ddl_sink.go
@@ -112,7 +112,7 @@ func NewKafkaDDLSink(
 	}
 
 	ddlProducer := producerCreator(ctx, changefeedID, syncProducer)
-	s := newDDLSink(ctx, changefeedID, ddlProducer, adminClient, topicManager, eventRouter, encoderBuilder, protocol)
+	s := newDDLSink(ctx, changefeedID, ddlProducer, adminClient, topicManager, eventRouter, encoderBuilder.Build(), protocol)
 	log.Info("DDL sink producer client created", zap.Duration("duration", time.Since(start)))
 	return s, nil
 }

--- a/cdc/sink/ddlsink/mq/mq_ddl_sink.go
+++ b/cdc/sink/ddlsink/mq/mq_ddl_sink.go
@@ -162,10 +162,13 @@ func (k *DDLSink) WriteCheckpointTs(ctx context.Context,
 		if err != nil {
 			return errors.Trace(err)
 		}
-		log.Debug("Emit checkpointTs to default topic",
-			zap.String("topic", topic), zap.Uint64("checkpointTs", ts))
 		err = k.producer.SyncBroadcastMessage(ctx, topic, partitionNum, msg)
-		return errors.Trace(err)
+		if err != nil {
+			log.Warn("Write checkpointTs to default topic failed", zap.String("topic", topic), zap.Uint64("checkpointTs", ts))
+			return errors.Trace(err)
+		}
+		log.Info("Write checkpointTs to default topic", zap.String("topic", topic), zap.Uint64("checkpointTs", ts))
+		return nil
 	}
 	var tableNames []model.TableName
 	for _, table := range tables {
@@ -179,8 +182,10 @@ func (k *DDLSink) WriteCheckpointTs(ctx context.Context,
 		}
 		err = k.producer.SyncBroadcastMessage(ctx, topic, partitionNum, msg)
 		if err != nil {
+			log.Warn("Write checkpointTs to topic failed", zap.String("topic", topic), zap.Uint64("checkpointTs", ts))
 			return errors.Trace(err)
 		}
+		log.Info("Write checkpointTs to topic", zap.String("topic", topic), zap.Uint64("checkpointTs", ts))
 	}
 	return nil
 }

--- a/cdc/sink/ddlsink/mq/pulsar_ddl_sink.go
+++ b/cdc/sink/ddlsink/mq/pulsar_ddl_sink.go
@@ -100,7 +100,7 @@ func NewPulsarDDLSink(
 		return nil, errors.Trace(err)
 	}
 
-	s := newDDLSink(ctx, changefeedID, p, nil, topicManager, eventRouter, encoderBuilder, protocol)
+	s := newDDLSink(ctx, changefeedID, p, nil, topicManager, eventRouter, encoderBuilder.Build(), protocol)
 
 	return s, nil
 }

--- a/pkg/sink/kafka/factory.go
+++ b/pkg/sink/kafka/factory.go
@@ -104,7 +104,7 @@ func (p *saramaSyncProducer) SendMessage(
 	return cerror.WrapError(cerror.ErrKafkaSendMessage, err)
 }
 
-func (p *saramaSyncProducer) SendMessages(ctx context.Context,
+func (p *saramaSyncProducer) SendMessages(_ context.Context,
 	topic string, partitionNum int32,
 	key []byte, value []byte,
 ) error {
@@ -125,13 +125,13 @@ func (p *saramaSyncProducer) Close() {
 	start := time.Now()
 	err := p.producer.Close()
 	if err != nil {
-		log.Error("Close Kafka DDL producer with error",
+		log.Error("close Kafka DDL producer with error",
 			zap.String("namespace", p.id.Namespace),
 			zap.String("changefeed", p.id.ID),
 			zap.Duration("duration", time.Since(start)),
 			zap.Error(err))
 	} else {
-		log.Info("Kafka DDL producer closed",
+		log.Info("close Kafka DDL producer finished",
 			zap.String("namespace", p.id.Namespace),
 			zap.String("changefeed", p.id.ID),
 			zap.Duration("duration", time.Since(start)))

--- a/pkg/sink/kafka/factory.go
+++ b/pkg/sink/kafka/factory.go
@@ -93,7 +93,7 @@ type saramaSyncProducer struct {
 }
 
 func (p *saramaSyncProducer) SendMessage(
-	ctx context.Context,
+	_ context.Context,
 	topic string, partitionNum int32,
 	key []byte, value []byte,
 ) error {
@@ -103,7 +103,7 @@ func (p *saramaSyncProducer) SendMessage(
 		Value:     sarama.ByteEncoder(value),
 		Partition: partitionNum,
 	})
-	return err
+	return cerror.WrapError(cerror.ErrKafkaSendMessage, err)
 }
 
 func (p *saramaSyncProducer) SendMessages(ctx context.Context,

--- a/pkg/sink/kafka/factory.go
+++ b/pkg/sink/kafka/factory.go
@@ -149,45 +149,44 @@ func (p *saramaSyncProducer) SendMessages(ctx context.Context,
 }
 
 func (p *saramaSyncProducer) Close() {
-	go func() {
-		// We need to close it asynchronously. Otherwise, we might get stuck
-		// with an unhealthy(i.e. Network jitter, isolation) state of Kafka.
-		// Factory has a background thread to fetch and update the metadata.
-		// If we close the client synchronously, we might get stuck.
-		// Safety:
-		// * If the kafka cluster is running well, it will be closed as soon as possible.
-		// * If there is a problem with the kafka cluster,
-		//   no data will be lost because this is a synchronous client.
-		// * There is a risk of goroutine leakage, but it is acceptable and our main
-		//   goal is not to get stuck with the owner tick.
-		start := time.Now()
-		if err := p.client.Close(); err != nil {
-			log.Warn("Close Kafka DDL client with error",
-				zap.String("namespace", p.id.Namespace),
-				zap.String("changefeed", p.id.ID),
-				zap.Duration("duration", time.Since(start)),
-				zap.Error(err))
-		} else {
-			log.Info("Kafka DDL client closed",
-				zap.String("namespace", p.id.Namespace),
-				zap.String("changefeed", p.id.ID),
-				zap.Duration("duration", time.Since(start)))
-		}
-		start = time.Now()
-		err := p.producer.Close()
-		if err != nil {
-			log.Error("Close Kafka DDL producer with error",
-				zap.String("namespace", p.id.Namespace),
-				zap.String("changefeed", p.id.ID),
-				zap.Duration("duration", time.Since(start)),
-				zap.Error(err))
-		} else {
-			log.Info("Kafka DDL producer closed",
-				zap.String("namespace", p.id.Namespace),
-				zap.String("changefeed", p.id.ID),
-				zap.Duration("duration", time.Since(start)))
-		}
-	}()
+	// We need to close it asynchronously. Otherwise, we might get stuck
+	// with an unhealthy(i.e. Network jitter, isolation) state of Kafka.
+	// Factory has a background thread to fetch and update the metadata.
+	// If we close the client synchronously, we might get stuck.
+	// Safety:
+	// * If the kafka cluster is running well, it will be closed as soon as possible.
+	// * If there is a problem with the kafka cluster,
+	//   no data will be lost because this is a synchronous client.
+	// * There is a risk of goroutine leakage, but it is acceptable and our main
+	//   goal is not to get stuck with the owner tick.
+	start := time.Now()
+	if err := p.client.Close(); err != nil {
+		log.Warn("Close Kafka DDL client with error",
+			zap.String("namespace", p.id.Namespace),
+			zap.String("changefeed", p.id.ID),
+			zap.Duration("duration", time.Since(start)),
+			zap.Error(err))
+	} else {
+		log.Info("Kafka DDL client closed",
+			zap.String("namespace", p.id.Namespace),
+			zap.String("changefeed", p.id.ID),
+			zap.Duration("duration", time.Since(start)))
+	}
+
+	start = time.Now()
+	err := p.producer.Close()
+	if err != nil {
+		log.Error("Close Kafka DDL producer with error",
+			zap.String("namespace", p.id.Namespace),
+			zap.String("changefeed", p.id.ID),
+			zap.Duration("duration", time.Since(start)),
+			zap.Error(err))
+	} else {
+		log.Info("Kafka DDL producer closed",
+			zap.String("namespace", p.id.Namespace),
+			zap.String("changefeed", p.id.ID),
+			zap.Duration("duration", time.Since(start)))
+	}
 }
 
 type saramaAsyncProducer struct {

--- a/pkg/sink/kafka/factory.go
+++ b/pkg/sink/kafka/factory.go
@@ -15,7 +15,6 @@ package kafka
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/IBM/sarama"
@@ -118,32 +117,7 @@ func (p *saramaSyncProducer) SendMessages(ctx context.Context,
 			Partition: int32(i),
 		}
 	}
-
-	item := ctx.Value("checkpoint")
-	if item != nil {
-		log.Info("try send checkpoint", zap.String("topic", topic), zap.Uint64("checkpoint", item.(uint64)))
-	}
-
-	start := time.Now()
 	err := p.producer.SendMessages(msgs)
-	if item == nil {
-		return cerror.WrapError(cerror.ErrKafkaSendMessage, err)
-	}
-
-	if err == nil {
-		return nil
-	}
-
-	checkpoint := item.(uint64)
-	fields := make([]zap.Field, 0, len(msgs))
-	fields = append(fields, zap.String("topic", topic))
-	fields = append(fields, zap.Uint64("checkpoint", checkpoint))
-	for i := 0; i < len(msgs); i++ {
-		a := fmt.Sprintf("partition-%d-offset", i)
-		fields = append(fields, zap.Int64(a, msgs[i].Offset))
-	}
-	fields = append(fields, zap.Duration("elapsed", time.Since(start)))
-	log.Warn("send checkpoint failed", fields...)
 	return cerror.WrapError(cerror.ErrKafkaSendMessage, err)
 }
 

--- a/pkg/sink/kafka/sarama_factory.go
+++ b/pkg/sink/kafka/sarama_factory.go
@@ -91,18 +91,13 @@ func (f *saramaFactory) SyncProducer(ctx context.Context) (SyncProducer, error) 
 	}
 	config.MetricRegistry = f.registry
 
-	client, err := sarama.NewClient(f.option.BrokerEndpoints, config)
+	p, err := sarama.NewSyncProducer(f.option.BrokerEndpoints, config)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	p, err := sarama.NewSyncProducerFromClient(client)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	return &saramaSyncProducer{
 		id:       f.changefeedID,
-		client:   client,
 		producer: p,
 	}, nil
 }

--- a/pkg/sink/kafka/v2/factory.go
+++ b/pkg/sink/kafka/v2/factory.go
@@ -278,12 +278,13 @@ func (s *syncWriter) SendMessage(
 	topic string, partitionNum int32,
 	key []byte, value []byte,
 ) error {
-	return s.w.WriteMessages(ctx, kafka.Message{
+	err := s.w.WriteMessages(ctx, kafka.Message{
 		Topic:     topic,
 		Partition: int(partitionNum),
 		Key:       key,
 		Value:     value,
 	})
+	return cerror.WrapError(cerror.ErrKafkaSendMessage, err)
 }
 
 // SendMessages produces a given set of messages, and returns only when all

--- a/pkg/sink/kafka/v2/factory.go
+++ b/pkg/sink/kafka/v2/factory.go
@@ -16,7 +16,6 @@ package v2
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"strings"
 	"time"
 
@@ -305,32 +304,7 @@ func (s *syncWriter) SendMessages(
 			Partition: i,
 		}
 	}
-
-	item := ctx.Value("checkpoint")
-	if item != nil {
-		log.Info("try send checkpoint", zap.String("topic", topic), zap.Uint64("checkpoint", item.(uint64)))
-	}
-
-	start := time.Now()
 	err := s.w.WriteMessages(ctx, msgs...)
-	if item == nil {
-		return cerror.WrapError(cerror.ErrKafkaSendMessage, err)
-	}
-
-	if err == nil {
-		return nil
-	}
-
-	checkpoint := item.(uint64)
-	fields := make([]zap.Field, 0, len(msgs))
-	fields = append(fields, zap.String("topic", topic))
-	fields = append(fields, zap.Uint64("checkpoint", checkpoint))
-	for i := 0; i < len(msgs); i++ {
-		a := fmt.Sprintf("partition-%d-offset", i)
-		fields = append(fields, zap.Int64(a, msgs[i].Offset))
-	}
-	fields = append(fields, zap.Duration("elapsed", time.Since(start)))
-	log.Warn("send checkpoint failed", fields...)
 	return cerror.WrapError(cerror.ErrKafkaSendMessage, err)
 }
 
@@ -340,7 +314,7 @@ func (s *syncWriter) SendMessages(
 func (s *syncWriter) Close() {
 	start := time.Now()
 	if err := s.w.Close(); err != nil {
-		log.Warn("Close kafka sync producer failed",
+		log.Warn("Close kafka sync producer meet error",
 			zap.String("namespace", s.changefeedID.Namespace),
 			zap.String("changefeed", s.changefeedID.ID),
 			zap.Duration("duration", time.Since(start)),


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12096

### What is changed and how it works?

* owner/ddl_sink should close if meet any error, and rebuilt by the retry.
* kafka factory implementations should wrap error immediately, and caller should just return error, no need to trace the error.
* kafka ddl sink use encoder directly, instead of encoderBuilder
* syncProducer no need to close in a goroutine, since it only deliver one message at a time, won't be blocked if the downstream kafka cluster unavailable.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
`None`
```
