### PR TITLE
server(ticdc): export ticdc server startup code for public use in new architecture

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -255,6 +255,22 @@ func (o *options) getCredential() *security.Credential {
 	}
 }
 
+// Run a TiCDC server.
+// Exported for the new architecture of TiCDC only.
+func Run(o *options, cmd *cobra.Command) error {
+	err := o.complete(cmd)
+	if err != nil {
+		return err
+	}
+	err = o.validate()
+	if err != nil {
+		return err
+	}
+	err = o.run(cmd)
+	cobra.CheckErr(err)
+	return nil
+}
+
 // NewCmdServer creates the `server` command.
 func NewCmdServer() *cobra.Command {
 	o := newOptions()
@@ -264,17 +280,7 @@ func NewCmdServer() *cobra.Command {
 		Short: "Start a TiCDC capture server",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := o.complete(cmd)
-			if err != nil {
-				return err
-			}
-			err = o.validate()
-			if err != nil {
-				return err
-			}
-			err = o.run(cmd)
-			cobra.CheckErr(err)
-			return nil
+			return Run(o, cmd)
 		},
 	}
 


### PR DESCRIPTION


<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12098

### What is changed and how it works?

This PR refactors and exports the TiCDC server startup code to be publicly accessible. The change enables the new architecture’s cmd to call the TiCDC server startup function dynamically, allowing users to switch between the new and old architectures seamlessly.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
