### PR TITLE
sink(ticdc): Treat column and index names as case insensitive

### DIFF
--- a/cdc/model/schema_storage.go
+++ b/cdc/model/schema_storage.go
@@ -444,7 +444,7 @@ func (ti *TableInfo) GetIndex(name string) *model.IndexInfo {
 }
 
 // IndexByName returns the index columns and offsets of the corresponding index by name
-// Column is not case-sensitive on any platform, nor are column aliases.
+// Index is not case-sensitive on any platform.
 // So we always match in lowercase.
 // See also: https://dev.mysql.com/doc/refman/5.7/en/identifier-case-sensitivity.html
 func (ti *TableInfo) IndexByName(name string) ([]string, []int, bool) {

--- a/cdc/model/schema_storage_test.go
+++ b/cdc/model/schema_storage_test.go
@@ -315,6 +315,16 @@ func TestIndexByName(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, []string{"col1"}, names)
 	require.Equal(t, []int{0}, offsets)
+
+	names, offsets, ok = tableInfo.IndexByName("IDX1")
+	require.True(t, ok)
+	require.Equal(t, []string{"col1"}, names)
+	require.Equal(t, []int{0}, offsets)
+
+	names, offsets, ok = tableInfo.IndexByName("Idx1")
+	require.True(t, ok)
+	require.Equal(t, []string{"col1"}, names)
+	require.Equal(t, []int{0}, offsets)
 }
 
 func TestColumnsByNames(t *testing.T) {
@@ -349,6 +359,11 @@ func TestColumnsByNames(t *testing.T) {
 	offsets, ok = tableInfo.OffsetsByNames(names)
 	require.False(t, ok)
 	require.Nil(t, offsets)
+
+	names = []string{"Col1", "COL2", "CoL3"}
+	offsets, ok = tableInfo.OffsetsByNames(names)
+	require.True(t, ok)
+	require.Equal(t, []int{1, 0, 2}, offsets)
 }
 
 func TestBuildTiDBTableInfoWithIntPrimaryKey(t *testing.T) {

--- a/cdc/model/schema_storage_test.go
+++ b/cdc/model/schema_storage_test.go
@@ -318,34 +318,32 @@ func TestIndexByName(t *testing.T) {
 }
 
 func TestColumnsByNames(t *testing.T) {
-	tableInfo := &TableInfo{
-		TableInfo: &timodel.TableInfo{
-			Columns: []*timodel.ColumnInfo{
-				{
-					Name:   pmodel.NewCIStr("col2"),
-					Offset: 1,
-				},
-				{
-					Name:   pmodel.NewCIStr("col1"),
-					Offset: 0,
-				},
-				{
-					Name:   pmodel.NewCIStr("col3"),
-					Offset: 2,
-				},
+	tableInfo := WrapTableInfo(100, "test", 100, &timodel.TableInfo{
+		Columns: []*timodel.ColumnInfo{
+			{
+				Name: pmodel.NewCIStr("col2"),
+				ID:   1,
+			},
+			{
+				Name: pmodel.NewCIStr("col1"),
+				ID:   0,
+			},
+			{
+				Name: pmodel.NewCIStr("col3"),
+				ID:   2,
 			},
 		},
-	}
+	})
 
 	names := []string{"col1", "col2", "col3"}
 	offsets, ok := tableInfo.OffsetsByNames(names)
 	require.True(t, ok)
-	require.Equal(t, []int{0, 1, 2}, offsets)
+	require.Equal(t, []int{1, 0, 2}, offsets)
 
 	names = []string{"col2"}
 	offsets, ok = tableInfo.OffsetsByNames(names)
 	require.True(t, ok)
-	require.Equal(t, []int{1}, offsets)
+	require.Equal(t, []int{0}, offsets)
 
 	names = []string{"col1", "col-not-found"}
 	offsets, ok = tableInfo.OffsetsByNames(names)

--- a/cdc/model/schema_storage_test.go
+++ b/cdc/model/schema_storage_test.go
@@ -295,14 +295,10 @@ func TestIndexByName(t *testing.T) {
 		TableInfo: &timodel.TableInfo{
 			Indices: []*timodel.IndexInfo{
 				{
-					Name: pmodel.CIStr{
-						O: "idx1",
-					},
+					Name: pmodel.NewCIStr("idx1"),
 					Columns: []*timodel.IndexColumn{
 						{
-							Name: pmodel.CIStr{
-								O: "col1",
-							},
+							Name: pmodel.NewCIStr("col1"),
 						},
 					},
 				},
@@ -326,21 +322,15 @@ func TestColumnsByNames(t *testing.T) {
 		TableInfo: &timodel.TableInfo{
 			Columns: []*timodel.ColumnInfo{
 				{
-					Name: pmodel.CIStr{
-						O: "col2",
-					},
+					Name:   pmodel.NewCIStr("col2"),
 					Offset: 1,
 				},
 				{
-					Name: pmodel.CIStr{
-						O: "col1",
-					},
+					Name:   pmodel.NewCIStr("col1"),
 					Offset: 0,
 				},
 				{
-					Name: pmodel.CIStr{
-						O: "col3",
-					},
+					Name:   pmodel.NewCIStr("col3"),
 					Offset: 2,
 				},
 			},

--- a/cdc/sink/dmlsink/mq/dispatcher/partition/columns.go
+++ b/cdc/sink/dmlsink/mq/dispatcher/partition/columns.go
@@ -15,6 +15,7 @@ package partition
 
 import (
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/pingcap/log"
@@ -69,7 +70,7 @@ func (r *ColumnsDispatcher) DispatchRowChangedEvent(row *model.RowChangedEvent, 
 		if col == nil {
 			continue
 		}
-		r.hasher.Write([]byte(r.Columns[idx]), []byte(model.ColumnValueString(col.Value)))
+		r.hasher.Write([]byte(strings.ToLower(r.Columns[idx])), []byte(model.ColumnValueString(col.Value)))
 	}
 
 	sum32 := r.hasher.Sum32()

--- a/cdc/sink/dmlsink/mq/dispatcher/partition/columns_test.go
+++ b/cdc/sink/dmlsink/mq/dispatcher/partition/columns_test.go
@@ -55,4 +55,9 @@ func TestColumnsDispatcher(t *testing.T) {
 	index, _, err := p.DispatchRowChangedEvent(event, 16)
 	require.NoError(t, err)
 	require.Equal(t, int32(15), index)
+
+	p = NewColumnsDispatcher([]string{"COL2", "Col1"})
+	index, _, err = p.DispatchRowChangedEvent(event, 16)
+	require.NoError(t, err)
+	require.Equal(t, int32(15), index)
 }

--- a/cdc/sink/dmlsink/mq/dispatcher/partition/index_value.go
+++ b/cdc/sink/dmlsink/mq/dispatcher/partition/index_value.go
@@ -15,6 +15,7 @@ package partition
 
 import (
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/pingcap/log"
@@ -61,7 +62,7 @@ func (r *IndexValueDispatcher) DispatchRowChangedEvent(row *model.RowChangedEven
 				continue
 			}
 			if tableInfo.ForceGetColumnFlagType(col.ColumnID).IsHandleKey() {
-				r.hasher.Write([]byte(tableInfo.ForceGetColumnName(col.ColumnID)), []byte(model.ColumnValueString(col.Value)))
+				r.hasher.Write([]byte(strings.ToLower(tableInfo.ForceGetColumnName(col.ColumnID))), []byte(model.ColumnValueString(col.Value)))
 			}
 		}
 	} else {

--- a/cdc/sink/dmlsink/mq/dispatcher/partition/index_value_test.go
+++ b/cdc/sink/dmlsink/mq/dispatcher/partition/index_value_test.go
@@ -180,4 +180,9 @@ func TestIndexValueDispatcherWithIndexName(t *testing.T) {
 	index, _, err := p.DispatchRowChangedEvent(event, 16)
 	require.NoError(t, err)
 	require.Equal(t, int32(2), index)
+
+	p = NewIndexValueDispatcher("INDEX1")
+	index, _, err = p.DispatchRowChangedEvent(event, 16)
+	require.NoError(t, err)
+	require.Equal(t, int32(2), index)
 }

--- a/cdc/sink/dmlsink/mq/dispatcher/partition/index_value_test.go
+++ b/cdc/sink/dmlsink/mq/dispatcher/partition/index_value_test.go
@@ -154,14 +154,10 @@ func TestIndexValueDispatcherWithIndexName(t *testing.T) {
 		},
 		Indices: []*timodel.IndexInfo{
 			{
-				Name: pmodel.CIStr{
-					O: "index1",
-				},
+				Name: pmodel.NewCIStr("index1"),
 				Columns: []*timodel.IndexColumn{
 					{
-						Name: pmodel.CIStr{
-							O: "a",
-						},
+						Name: pmodel.NewCIStr("a"),
 					},
 				},
 			},

--- a/cdc/sink/dmlsink/mq/dispatcher/partition/index_value_test.go
+++ b/cdc/sink/dmlsink/mq/dispatcher/partition/index_value_test.go
@@ -147,17 +147,19 @@ func TestIndexValueDispatcherWithIndexName(t *testing.T) {
 	t.Parallel()
 
 	tidbTableInfo := &timodel.TableInfo{
-		ID:   100,
-		Name: pmodel.NewCIStr("t1"),
+		ID:         100,
+		Name:       pmodel.NewCIStr("t1"),
+		PKIsHandle: true,
 		Columns: []*timodel.ColumnInfo{
-			{ID: 1, Name: pmodel.NewCIStr("a"), FieldType: *types.NewFieldType(mysql.TypeLong)},
+			{ID: 1, Name: pmodel.NewCIStr("A"), FieldType: *types.NewFieldType(mysql.TypeLong)},
 		},
 		Indices: []*timodel.IndexInfo{
 			{
-				Name: pmodel.NewCIStr("index1"),
+				Primary: true,
+				Name:    pmodel.NewCIStr("index1"),
 				Columns: []*timodel.IndexColumn{
 					{
-						Name: pmodel.NewCIStr("a"),
+						Name: pmodel.NewCIStr("A"),
 					},
 				},
 			},
@@ -185,4 +187,9 @@ func TestIndexValueDispatcherWithIndexName(t *testing.T) {
 	index, _, err = p.DispatchRowChangedEvent(event, 16)
 	require.NoError(t, err)
 	require.Equal(t, int32(2), index)
+
+	p = NewIndexValueDispatcher("")
+	index, _, err = p.DispatchRowChangedEvent(event, 3)
+	require.NoError(t, err)
+	require.Equal(t, int32(0), index)
 }

--- a/tests/integration_tests/mq_sink_dispatcher/conf/changefeed.toml
+++ b/tests/integration_tests/mq_sink_dispatcher/conf/changefeed.toml
@@ -1,5 +1,6 @@
 [sink]
 dispatchers = [
     {matcher = ['verify.t'], partition = "index-value"},
-    {matcher = ['dispatcher.index'], partition = "index-value", index = "idx_a"}
+    {matcher = ['dispatcher.index'], partition = "index-value", index = "idx_a"},
+    {matcher = ['dispatcher.columns'], partition = "columns", columns = ['id', 'col1']}
 ]

--- a/tests/integration_tests/mq_sink_dispatcher/conf/diff_config.toml
+++ b/tests/integration_tests/mq_sink_dispatcher/conf/diff_config.toml
@@ -7,7 +7,7 @@ export-fix-sql = true
 check-struct-only = false
 
 [task]
-output-dir = "/tmp/tidb_cdc_test/dispatcher/output"
+output-dir = "/tmp/tidb_cdc_test/mq_sink_dispatcher/output"
 
 source-instances = ["tidb0"]
 

--- a/tests/integration_tests/mq_sink_dispatcher/conf/new_changefeed.toml
+++ b/tests/integration_tests/mq_sink_dispatcher/conf/new_changefeed.toml
@@ -1,4 +1,5 @@
 [sink]
 dispatchers = [
-    {matcher = ['dispatcher.index'], partition = "index-value", index = ""}
+    {matcher = ['dispatcher.index'], partition = "index-value", index = ""},
+    {matcher = ['dispatcher.columns'], partition = "columns", columns = ['ID', 'CoL1']}
 ]

--- a/tests/integration_tests/mq_sink_dispatcher/run.sh
+++ b/tests/integration_tests/mq_sink_dispatcher/run.sh
@@ -42,8 +42,10 @@ function run() {
 	run_sql "DROP DATABASE if exists dispatcher;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "CREATE DATABASE dispatcher;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "CREATE TABLE dispatcher.index (a int primary key, b int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "CREATE TABLE dispatcher.columns (id int primary key, col1 int);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 
 	run_sql "INSERT INTO dispatcher.index values (1, 2);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "INSERT INTO dispatcher.columns values (1, 2);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 
 	ensure $MAX_RETRIES check_changefeed_state http://${UP_PD_HOST_1}:${UP_PD_PORT_1} $changefeed_id "failed" "ErrDispatcherFailed"
 
@@ -61,6 +63,13 @@ function run() {
 	run_sql "UPDATE dispatcher.index set b = 5 where a = 1;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "UPDATE dispatcher.index set b = 6 where a = 2;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "DELETE FROM dispatcher.index where a = 3;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+
+	run_sql "INSERT INTO dispatcher.columns values (2, 3);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "INSERT INTO dispatcher.columns values (3, 4);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "INSERT INTO dispatcher.columns values (4, 5);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "UPDATE dispatcher.columns set col1 = 5 where id = 1;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "UPDATE dispatcher.columns set CoL1 = 6 where ID = 2;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "DELETE FROM dispatcher.columns where Id = 3;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 
 	run_sql "CREATE TABLE test.finish_mark (a int primary key);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 

--- a/tests/integration_tests/mq_sink_dispatcher/run.sh
+++ b/tests/integration_tests/mq_sink_dispatcher/run.sh
@@ -21,7 +21,7 @@ function run() {
 
 	cd $WORK_DIR
 
-	TOPIC_NAME="dispatcher-test"
+	TOPIC_NAME="dispatcher-test-$RANDOM"
 
 	run_cdc_server --workdir $WORK_DIR --binary $CDC_BINARY --loglevel "info"
 
@@ -55,7 +55,7 @@ function run() {
 
 	ensure $MAX_RETRIES check_changefeed_state http://${UP_PD_HOST_1}:${UP_PD_PORT_1} $changefeed_id "normal" "null" ""
 
-	cdc_kafka_consumer --upstream-uri $SINK_URI --downstream-uri="mysql://root@127.0.0.1:3306/?safe-mode=true&batch-dml-enable=false" --upstream-tidb-dsn="root@tcp(${UP_TIDB_HOST}:${UP_TIDB_PORT})/?" --config="$CUR/conf/new_changefeed.toml" 2>&1 &
+	cdc_kafka_consumer --log-level="debug" --upstream-uri $SINK_URI --downstream-uri="mysql://root@127.0.0.1:3306/?safe-mode=true&batch-dml-enable=false" --upstream-tidb-dsn="root@tcp(${UP_TIDB_HOST}:${UP_TIDB_PORT})/?" --config="$CUR/conf/new_changefeed.toml" 2>&1 &
 
 	run_sql "INSERT INTO dispatcher.index values (2, 3);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "INSERT INTO dispatcher.index values (3, 4);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
@@ -64,12 +64,12 @@ function run() {
 	run_sql "UPDATE dispatcher.index set b = 6 where a = 2;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "DELETE FROM dispatcher.index where a = 3;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 
+	# make sure send rows into same partition
 	run_sql "INSERT INTO dispatcher.columns values (2, 3);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-	run_sql "INSERT INTO dispatcher.columns values (3, 4);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 	run_sql "INSERT INTO dispatcher.columns values (4, 5);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-	run_sql "UPDATE dispatcher.columns set col1 = 5 where id = 1;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-	run_sql "UPDATE dispatcher.columns set CoL1 = 6 where ID = 2;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
-	run_sql "DELETE FROM dispatcher.columns where Id = 3;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "UPDATE dispatcher.columns set col1 = 3 where id = 1;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "UPDATE dispatcher.columns set CoL1 = 4 where ID = 2;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
+	run_sql "DELETE FROM dispatcher.columns where Id = 4;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 
 	run_sql "CREATE TABLE test.finish_mark (a int primary key);" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12103

### What is changed and how it works?
According to [MySQL doc](https://dev.mysql.com/doc/refman/5.7/en/identifier-case-sensitivity.html), column and index names are not case-sensitive on any platform. 

Make cdc compatible with it.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Treat column and index names as case-insensitive in dispatchers configuration.
```
