### PR TITLE
cloudstorage: fix a bug that may cause storage sink get stuck

### DIFF
--- a/cdc/sink/ddlsink/cloudstorage/cloud_storage_ddl_sink.go
+++ b/cdc/sink/ddlsink/cloudstorage/cloud_storage_ddl_sink.go
@@ -74,7 +74,7 @@ func newDDLSink(ctx context.Context,
 		return nil, errors.Trace(err)
 	}
 
-	storage, err := util.GetExternalStorageFromURI(ctx, sinkURI.String())
+	storage, err := util.GetExternalStorageWithDefaultTimeout(ctx, sinkURI.String())
 	if err != nil {
 		return nil, err
 	}

--- a/cdc/sink/dmlsink/cloudstorage/cloud_storage_dml_sink.go
+++ b/cdc/sink/dmlsink/cloudstorage/cloud_storage_dml_sink.go
@@ -117,7 +117,7 @@ func NewDMLSink(ctx context.Context,
 	}
 
 	// create an external storage.
-	storage, err := putil.GetExternalStorageFromURI(ctx, sinkURI.String())
+	storage, err := putil.GetExternalStorageWithDefaultTimeout(ctx, sinkURI.String())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/external_storage.go
+++ b/pkg/util/external_storage.go
@@ -35,7 +35,9 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const defaultTimeout = 5 * time.Minute
+const (
+	defaultTimeout = 5 * time.Minute
+)
 
 // GetExternalStorageFromURI creates a new storage.ExternalStorage from a uri.
 func GetExternalStorageFromURI(

--- a/pkg/util/external_storage.go
+++ b/pkg/util/external_storage.go
@@ -165,7 +165,11 @@ type extStorageWithTimeout struct {
 func (s *extStorageWithTimeout) WriteFile(ctx context.Context, name string, data []byte) error {
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
-	return s.ExternalStorage.WriteFile(ctx, name, data)
+	err := s.ExternalStorage.WriteFile(ctx, name, data)
+	if err != nil {
+		err = errors.ErrExternalStorageAPI.Wrap(err).GenWithStackByArgs("WriteFile")
+	}
+	return err
 }
 
 // ReadFile reads a complete file from storage, similar to os.ReadFile

--- a/pkg/util/external_storage_test.go
+++ b/pkg/util/external_storage_test.go
@@ -1,0 +1,127 @@
+// Copyright 2025 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tidb/br/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// mockRoundTripper blocks until the context is done.
+type mockRoundTripper struct {
+	blockUntilContextDone bool
+	err                   error
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if m.blockUntilContextDone {
+		select {
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		}
+	}
+	// Return immediately for success case
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, m.err
+}
+
+// mockExternalStorage is a mock implementation for testing timeouts via http client.
+type mockExternalStorage struct {
+	storage.ExternalStorage // Embed the interface to satisfy it easily
+	httpClient              *http.Client
+}
+
+// WriteFile simulates a write operation by making an HTTP request that respects context cancellation.
+func (m *mockExternalStorage) WriteFile(ctx context.Context, name string, data []byte) error {
+	if m.httpClient == nil {
+		panic("httpClient not set in mockExternalStorage") // Should be set in tests
+	}
+	// Create a dummy request. The URL doesn't matter as the RoundTripper is mocked.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, "http://mock/"+name, http.NoBody)
+	if err != nil {
+		return err // Should not happen with valid inputs
+	}
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return err // This will include context errors like DeadlineExceeded
+	}
+	resp.Body.Close() // Important to close the body
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("mock http request failed") // Or handle specific statuses
+	}
+	return nil
+}
+
+func TestExtStorageWithTimeoutWriteFileTimeout(t *testing.T) {
+	testTimeout := 50 * time.Millisecond
+
+	// Create a mock HTTP client that blocks until context is done
+	mockClient := &http.Client{
+		Transport: &mockRoundTripper{blockUntilContextDone: true},
+	}
+
+	mockStore := &mockExternalStorage{
+		httpClient: mockClient,
+	}
+
+	// Wrap the mock store with the timeout logic
+	timedStore := &extStorageWithTimeout{
+		ExternalStorage: mockStore,
+		timeout:         testTimeout,
+	}
+
+	startTime := time.Now()
+	// Use context.Background() as the base context
+	err := timedStore.WriteFile(context.Background(), "testfile", []byte("data"))
+	duration := time.Since(startTime)
+
+	// 1. Assert that an error occurred
+	require.Error(t, err, "Expected an error due to timeout")
+
+	// 2. Assert that the error is context.DeadlineExceeded
+	require.True(t, errors.Is(err, context.DeadlineExceeded), "Expected context.DeadlineExceeded error, got: %v", err)
+
+	// 3. Assert that the function returned quickly (around the timeout duration)
+	require.InDelta(t, testTimeout, duration, float64(testTimeout)*0.5, "Duration (%v) should be close to the timeout (%v)", duration, testTimeout)
+}
+
+func TestExtStorageWithTimeoutWriteFileSuccess(t *testing.T) {
+	testTimeout := 100 * time.Millisecond
+
+	// Create a mock HTTP client that returns success immediately
+	mockClient := &http.Client{
+		Transport: &mockRoundTripper{blockUntilContextDone: false, err: nil},
+	}
+
+	mockStore := &mockExternalStorage{
+		httpClient: mockClient,
+	}
+
+	timedStore := &extStorageWithTimeout{
+		ExternalStorage: mockStore,
+		timeout:         testTimeout,
+	}
+
+	// Use context.Background() as the base context
+	err := timedStore.WriteFile(context.Background(), "testfile", []byte("data"))
+
+	// Assert success
+	require.NoError(t, err, "Expected no error for successful write within timeout")
+}

--- a/pkg/util/external_storage_test.go
+++ b/pkg/util/external_storage_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -32,10 +33,8 @@ type mockRoundTripper struct {
 
 func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if m.blockUntilContextDone {
-		select {
-		case <-req.Context().Done():
-			return nil, req.Context().Err()
-		}
+		<-req.Context().Done()
+		return nil, req.Context().Err()
 	}
 	// Return immediately for success case
 	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, m.err
@@ -124,4 +123,58 @@ func TestExtStorageWithTimeoutWriteFileSuccess(t *testing.T) {
 
 	// Assert success
 	require.NoError(t, err, "Expected no error for successful write within timeout")
+}
+
+// TestExtStorageWithTimeoutWriteFileAzureTimeout - Tests WriteFile timeout for Azure.
+// NOTE: This test requires Azure Blob Storage connection details (e.g., via environment variables)
+// and a valid Azure storage URI (e.g., "azure://<container-name>/<path>?account-key=...")
+// Or configure it to use Azurite emulator.
+//
+// You can set the environment variable TiCDC_TEST_AZURE_URI to the Azure storage URI for testing.
+// For example:
+// export TiCDC_TEST_AZURE_URI="azure://testcontainer/timeouttest?account-name=$AZURE_STORAGE_ACCOUNT&account-key=$AZURE_STORAGE_KEY"
+//
+// If you want to use Azurite emulator, you can set the environment variable TiCDC_TEST_AZURE_URI to:
+// export TiCDC_TEST_AZURE_URI="http://127.0.0.1:10000/devstoreaccount1/timeouttest"
+
+func TestExtStorageWithTimeoutWriteFileAzureTimeout(t *testing.T) {
+	// 1. Get Azure URI from environment or skip test
+	azureURI := os.Getenv("TiCDC_TEST_AZURE_URI") // Example: "azure://testcontainer/timeouttest"
+	if azureURI == "" {
+		t.Skip("TiCDC_TEST_AZURE_URI environment variable is not set, skipping Azure timeout test")
+	}
+
+	ctx := context.Background()
+
+	// 2. Create base Azure external storage (without timeout wrapper first)
+	// Ensure necessary Azure credentials (like AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_KEY or AZURE_STORAGE_CONNECTION_STRING)
+	// are available in the environment for storage.New to work.
+	baseStorage, err := GetExternalStorage(ctx, azureURI, nil, DefaultS3Retryer()) // Using DefaultS3Retryer might not be ideal for Azure, but fine for this test structure
+	require.NoError(t, err, "Failed to create base Azure external storage")
+
+	// 3. Create the wrapper with a very short timeout
+	veryShortTimeout := 1 * time.Millisecond // Choose a timeout likely to be exceeded
+	storageWithTimeout := &extStorageWithTimeout{
+		ExternalStorage: baseStorage,
+		timeout:         veryShortTimeout,
+	}
+
+	// 4. Attempt to write a file
+	testFileName := "timeout_test_file.txt"
+	testData := []byte("hello azure timeout")
+
+	startTime := time.Now()
+	err = storageWithTimeout.WriteFile(ctx, testFileName, testData)
+	duration := time.Since(startTime)
+
+	// 5. Assertions
+	require.Error(t, err, "WriteFile should have returned an error due to timeout")
+	require.True(t, errors.Is(err, context.DeadlineExceeded), "Error should be context.DeadlineExceeded, but got: %v", err)
+	require.Less(t, duration, veryShortTimeout+500*time.Millisecond, "Operation took much longer than expected after timeout") // Check it didn't wait indefinitely
+
+	// Optional: Cleanup the file if it somehow got created (unlikely with timeout)
+	// It's better practice to use a unique path/container per test run and clean the container afterwards.
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // Use a reasonable timeout for cleanup
+	defer cancel()
+	baseStorage.DeleteFile(cleanupCtx, testFileName) // Use baseStorage for cleanup
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #9162 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test
 
1. I created a container on Azure.
![image](https://github.com/user-attachments/assets/a4eb8add-9e41-4ebc-9b68-050001505a3f)

2. I modified the `WriteFile` function as follows to make it easier to throw a context timeout error.

```bash
func (s *extStorageWithTimeout) WriteFile(ctx context.Context, name string, data []byte) error {
	timeout := s.timeout
	if counter.Load()%10 == 0 {
		// Make it more likely to timeout
		timeout = 5 * time.Millisecond
	}
	ctx, cancel := context.WithTimeout(ctx, timeout)
	counter.Add(1)
	defer cancel()
	return s.ExternalStorage.WriteFile(ctx, name, data)
}
```

3. I compiled the modified CDC and created a changefeed to synchronize data to Azure Blob Storage.

```bash
./cdc cli changefeed create -c test --sink-uri="azure://dongmen-test/cdc?protocol=canal-json&account-name=${}account-key=${}" 
```

4. I wrote data to TiDB.

```bash
./workload -database-host 127.0.0.1 -database-port 4000 -database-db-name "test" -table-count 4 -workload-type large_row -total-row-count 10000 -action prepare -thread 1
```

5. I observed the following warning message from the changefeed.

```bash
./cdc cli changefeed list
[
  {
    "id": "test",
    "namespace": "default",
    "summary": {
      "state": "warning",
      "tso": 457412143773646869,
      "checkpoint": "2025-04-17 19:20:54.117",
      "error": {
        "time": "2025-04-17T19:21:20.841014+08:00",
        "addr": "127.0.0.1:8300",
        "code": "CDC:ErrProcessorUnknown",
        "message": "Failed to write azure blob file, file info: bucket(container)='dongmen-test', key='cdc/test/large_row_1/457412143747432452/2025-04-17/CDC00000000000000000001.json': context deadline exceeded"
      }
    }
  }
]
```

6. The changefeed retried the operation in the sink module when encountering this error and quickly recovered.

```bash
> ./cdc cli changefeed list
[
  {
    "id": "test",
    "namespace": "default",
    "summary": {
      "state": "normal",
      "tso": 457412177498472454,
      "checkpoint": "2025-04-17 19:23:02.767",
      "error": null
    }
  }
]
```

7. I checked the Azure Blob Storage, and all the data was synchronized correctly.

The above test process verifies that the underlying calls of the `WriteFile` function respect the context with a timeout, which validates the effectiveness of the fix.

Moreover, this test verifies that the changefeed can quickly recover from similar errors. 


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a bug that may cause changefeed with storage sink getting stuck.
```
