### PR TITLE
[DNM] kafka: support GSSAPI auth with custom SPN

### DIFF
--- a/pkg/config/replica_config_test.go
+++ b/pkg/config/replica_config_test.go
@@ -90,6 +90,7 @@ func TestReplicaConfigMarshal(t *testing.T) {
 		SASLGssAPIPassword:           aws.String("password"),
 		SASLGssAPIRealm:              aws.String("realm"),
 		SASLGssAPIDisablePafxfast:    aws.Bool(true),
+		SASLGssAPISpn:                aws.String("kafka1.example.com"),
 		EnableTLS:                    aws.Bool(true),
 		CA:                           aws.String("ca"),
 		Cert:                         aws.String("cert"),

--- a/pkg/config/sink.go
+++ b/pkg/config/sink.go
@@ -333,6 +333,7 @@ type KafkaConfig struct {
 	SASLGssAPIPassword           *string                   `toml:"sasl-gssapi-password" json:"sasl-gssapi-password,omitempty"`
 	SASLGssAPIRealm              *string                   `toml:"sasl-gssapi-realm" json:"sasl-gssapi-realm,omitempty"`
 	SASLGssAPIDisablePafxfast    *bool                     `toml:"sasl-gssapi-disable-pafxfast" json:"sasl-gssapi-disable-pafxfast,omitempty"`
+	SASLGssAPISpn                *string                   `toml:"sasl-gssapi-spn" json:"sasl-gssapi-spn,omitempty"`
 	SASLOAuthClientID            *string                   `toml:"sasl-oauth-client-id" json:"sasl-oauth-client-id,omitempty"`
 	SASLOAuthClientSecret        *string                   `toml:"sasl-oauth-client-secret" json:"sasl-oauth-client-secret,omitempty"`
 	SASLOAuthTokenURL            *string                   `toml:"sasl-oauth-token-url" json:"sasl-oauth-token-url,omitempty"`

--- a/pkg/security/sasl.go
+++ b/pkg/security/sasl.go
@@ -136,4 +136,5 @@ type GSSAPI struct {
 	Password           string         `toml:"sasl-gssapi-password" json:"sasl-gssapi-password"`
 	Realm              string         `toml:"sasl-gssapi-realm" json:"sasl-gssapi-realm"`
 	DisablePAFXFAST    bool           `toml:"sasl-gssapi-disable-pafxfast" json:"sasl-gssapi-disable-pafxfast"`
+	SPN                string         `toml:"sasl-gssapi-spn" json:"sasl-gssapi-spn"`
 }

--- a/pkg/sink/kafka/options.go
+++ b/pkg/sink/kafka/options.go
@@ -127,6 +127,7 @@ type urlConfig struct {
 	SASLGssAPIPassword           *string `form:"sasl-gssapi-password"`
 	SASLGssAPIRealm              *string `form:"sasl-gssapi-realm"`
 	SASLGssAPIDisablePafxfast    *bool   `form:"sasl-gssapi-disable-pafxfast"`
+	SASLGssAPISpn                *string `form:"sasl-gssapi-spn"`
 	EnableTLS                    *bool   `form:"enable-tls"`
 	CA                           *string `form:"ca"`
 	Cert                         *string `form:"cert"`
@@ -341,6 +342,7 @@ func mergeConfig(
 		dest.SASLGssAPIRealm = fileConifg.SASLGssAPIRealm
 		dest.SASLGssAPIUser = fileConifg.SASLGssAPIUser
 		dest.SASLGssAPIPassword = fileConifg.SASLGssAPIPassword
+		dest.SASLGssAPISpn = fileConifg.SASLGssAPISpn
 		dest.EnableTLS = fileConifg.EnableTLS
 		dest.CA = fileConifg.CA
 		dest.Cert = fileConifg.Cert
@@ -452,6 +454,10 @@ func (o *Options) applySASL(urlParameter *urlConfig, replicaConfig *config.Repli
 
 	if urlParameter.SASLGssAPIDisablePafxfast != nil {
 		o.SASL.GSSAPI.DisablePAFXFAST = *urlParameter.SASLGssAPIDisablePafxfast
+	}
+
+	if urlParameter.SASLGssAPISpn != nil && *urlParameter.SASLGssAPISpn != "" {
+		o.SASL.GSSAPI.SPN = *urlParameter.SASLGssAPISpn
 	}
 
 	if replicaConfig.Sink != nil && replicaConfig.Sink.KafkaConfig != nil {

--- a/pkg/sink/kafka/options_test.go
+++ b/pkg/sink/kafka/options_test.go
@@ -654,6 +654,7 @@ func TestMerge(t *testing.T) {
 		SASLGssAPIPassword:        aws.String("pass"),
 		SASLGssAPIRealm:           aws.String("realm"),
 		SASLGssAPIDisablePafxfast: aws.Bool(true),
+		SASLGssAPISpn:             aws.String("kafka1.example.com"),
 		EnableTLS:                 aws.Bool(true),
 		CA:                        aws.String("ca.pem"),
 		Cert:                      aws.String("cert.pem"),
@@ -682,6 +683,7 @@ func TestMerge(t *testing.T) {
 	require.Equal(t, "pass", c.SASL.GSSAPI.Password)
 	require.Equal(t, "realm", c.SASL.GSSAPI.Realm)
 	require.Equal(t, true, c.SASL.GSSAPI.DisablePAFXFAST)
+	require.Equal(t, "kafka1.example.com", c.SASL.GSSAPI.SPN)
 	require.Equal(t, true, c.EnableTLS)
 	require.Equal(t, "ca.pem", c.Credential.CAPath)
 	require.Equal(t, "cert.pem", c.Credential.CertPath)
@@ -708,6 +710,7 @@ func TestMerge(t *testing.T) {
 		"&sasl-gssapi-password=pass" +
 		"&sasl-gssapi-realm=realm" +
 		"&sasl-gssapi-disable-pafxfast=true" +
+		"&sasl-gssapi-spn=kafka3.example.com" +
 		"&enable-tls=true" +
 		"&ca=ca.pem" +
 		"&cert=cert.pem" +
@@ -735,6 +738,7 @@ func TestMerge(t *testing.T) {
 		SASLGssAPIPassword:        aws.String("pass2"),
 		SASLGssAPIRealm:           aws.String("realm2"),
 		SASLGssAPIDisablePafxfast: aws.Bool(false),
+		SASLGssAPISpn:             aws.String("kafka2.example.com"),
 		EnableTLS:                 aws.Bool(false),
 		CA:                        aws.String("ca2.pem"),
 		Cert:                      aws.String("cert2.pem"),
@@ -763,6 +767,7 @@ func TestMerge(t *testing.T) {
 	require.Equal(t, "pass", c.SASL.GSSAPI.Password)
 	require.Equal(t, "realm", c.SASL.GSSAPI.Realm)
 	require.Equal(t, true, c.SASL.GSSAPI.DisablePAFXFAST)
+	require.Equal(t, "kafka3.example.com", c.SASL.GSSAPI.SPN)
 	require.Equal(t, true, c.EnableTLS)
 	require.Equal(t, "ca.pem", c.Credential.CAPath)
 	require.Equal(t, "cert.pem", c.Credential.CertPath)

--- a/pkg/sink/kafka/sarama.go
+++ b/pkg/sink/kafka/sarama.go
@@ -143,6 +143,10 @@ func completeSaramaSASLConfig(ctx context.Context, config *sarama.Config, o *Opt
 				}
 			}
 		case SASLTypeGSSAPI:
+			if len(o.SASL.GSSAPI.SPN) > 0 {
+				return errors.New("custom SPN is not yet supported, requires sarama v1.43 with https://github.com/IBM/sarama/pull/2807")
+			}
+
 			config.Net.SASL.GSSAPI.AuthType = int(o.SASL.GSSAPI.AuthType)
 			config.Net.SASL.GSSAPI.Username = o.SASL.GSSAPI.Username
 			config.Net.SASL.GSSAPI.ServiceName = o.SASL.GSSAPI.ServiceName

--- a/pkg/sink/kafka/v2/factory.go
+++ b/pkg/sink/kafka/v2/factory.go
@@ -151,7 +151,7 @@ func completeSASLConfig(o *pkafka.Options) (sasl.Mechanism, error) {
 				return nil, errors.Trace(err)
 			}
 			return Gokrb5v8(&gokrb5v8ClientImpl{clnt},
-				o.SASL.GSSAPI.ServiceName), nil
+				o.SASL.GSSAPI.ServiceName, o.SASL.GSSAPI.SPN), nil
 
 		case pkafka.SASLTypeOAuth:
 			return nil, errors.ErrKafkaInvalidConfig.GenWithStack(

--- a/pkg/sink/kafka/v2/gssapi.go
+++ b/pkg/sink/kafka/v2/gssapi.go
@@ -78,8 +78,8 @@ func (m mechanism) Name() string {
 //
 // client is a github.com/gokrb5/v8/client *Client instance.
 // kafkaServiceName is the name of the Kafka service in your Kerberos.
-func Gokrb5v8(client Gokrb5v8Client, kafkaServiceName string) sasl.Mechanism {
-	return mechanism{client, kafkaServiceName, ""}
+func Gokrb5v8(client Gokrb5v8Client, kafkaServiceName string, spn string) sasl.Mechanism {
+	return mechanism{client, kafkaServiceName, spn}
 }
 
 // StartWithoutHostError is the error type for when Start is called on
@@ -94,10 +94,12 @@ func (e StartWithoutHostError) Error() string {
 }
 
 func (m mechanism) Start(ctx context.Context) (sasl.StateMachine, []byte, error) {
-	metaData := sasl.MetadataFromContext(ctx)
-	m.host = metaData.Host
-	if m.host == "" {
-		return nil, nil, StartWithoutHostError{}
+	if len(m.host) == 0 {
+		metaData := sasl.MetadataFromContext(ctx)
+		m.host = metaData.Host
+		if m.host == "" {
+			return nil, nil, StartWithoutHostError{}
+		}
 	}
 
 	servicePrincipalName := m.serviceName + "/" + m.host


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?

Issue Number: close #xxx

### What is changed and how it works?

Allow setting a custom SPN (service principal name) of the Kafka servers when using GSSAPI authentication, in case the Kerboros server only recognizes `kafka/<spn>` but not `kafka/<ip>`.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No

##### Do you need to update user documentation, design documentation or monitoring documentation?

Yes

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Support customizing the SPN for GSSAPI
```
