### PR TITLE
sync_diff_inspector: fix flaky test TestMysqlRouter

### DIFF
--- a/sync_diff_inspector/source/source_test.go
+++ b/sync_diff_inspector/source/source_test.go
@@ -437,7 +437,7 @@ func TestMysqlShardSources(t *testing.T) {
 	shard.Close()
 }
 
-func TestMysqlRouter(t *testing.T) {
+func TestMySQLRouter(t *testing.T) {
 	ctx := context.Background()
 
 	conn, mock, err := sqlmock.New()

--- a/sync_diff_inspector/source/source_test.go
+++ b/sync_diff_inspector/source/source_test.go
@@ -221,7 +221,7 @@ func TestTiDBSource(t *testing.T) {
 	rowIter, err := tidb.GetRowsIterator(ctx, tableCase.rangeInfo)
 	require.NoError(t, err)
 
-	testfailpoint.Enable(t, "github.com/pingcap/tiflow/sync_diff_inspector/splitter/getRowCount", "return")
+	testfailpoint.Enable(t, "github.com/pingcap/tiflow/sync_diff_inspector/splitter/getRowCount", "return(0)")
 
 	row := 0
 	var firstRow, secondRow map[string]*dbutil.ColumnData
@@ -502,7 +502,7 @@ func TestMySQLRouter(t *testing.T) {
 	require.NoError(t, err)
 
 	// random splitter
-	testfailpoint.Enable(t, "github.com/pingcap/tiflow/sync_diff_inspector/splitter/getRowCount", "return")
+	testfailpoint.Enable(t, "github.com/pingcap/tiflow/sync_diff_inspector/splitter/getRowCount", "return(0)")
 	rangeIter, err := mysql.GetRangeIterator(ctx, nil, mysql.GetTableAnalyzer(), 3)
 	require.NoError(t, err)
 	_, err = rangeIter.Next(ctx)

--- a/sync_diff_inspector/splitter/limit.go
+++ b/sync_diff_inspector/splitter/limit.go
@@ -123,7 +123,7 @@ func NewLimitIteratorWithCheckpoint(
 
 	chunkSize := table.ChunkSize
 	if chunkSize <= 0 {
-		cnt, err := dbutil.GetRowCount(ctx, dbConn, table.Schema, table.Table, "", nil)
+		cnt, err := getRowCount(ctx, dbConn, table.Schema, table.Table, "", nil)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/sync_diff_inspector/splitter/random.go
+++ b/sync_diff_inspector/splitter/random.go
@@ -41,7 +41,7 @@ type RandomIterator struct {
 	dbConn *sql.DB
 }
 
-// Exported for test
+// MockRowCount is the mock row count used in unit tests
 var MockRowCount int64
 
 // a wrapper for get row count to integrate failpoint.

--- a/sync_diff_inspector/splitter/random.go
+++ b/sync_diff_inspector/splitter/random.go
@@ -41,13 +41,12 @@ type RandomIterator struct {
 	dbConn *sql.DB
 }
 
-// MockRowCount is the mock row count used in unit tests
-var MockRowCount int64
-
 // a wrapper for get row count to integrate failpoint.
 func getRowCount(ctx context.Context, db dbutil.QueryExecutor, schemaName string, tableName string, where string, args []any) (int64, error) {
-	failpoint.Inject("getRowCount", func() {
-		failpoint.Return(MockRowCount, nil)
+	failpoint.Inject("getRowCount", func(val failpoint.Value) {
+		if count, ok := val.(int); ok {
+			failpoint.Return(int64(count), nil)
+		}
 	})
 	return dbutil.GetRowCount(ctx, db, schemaName, tableName, where, args)
 }

--- a/sync_diff_inspector/splitter/random.go
+++ b/sync_diff_inspector/splitter/random.go
@@ -41,6 +41,17 @@ type RandomIterator struct {
 	dbConn *sql.DB
 }
 
+// Exported for test
+var MockRowCount int64
+
+// a wrapper for get row count to integrate failpoint.
+func getRowCount(ctx context.Context, db dbutil.QueryExecutor, schemaName string, tableName string, where string, args []any) (int64, error) {
+	failpoint.Inject("getRowCount", func() {
+		failpoint.Return(MockRowCount, nil)
+	})
+	return dbutil.GetRowCount(ctx, db, schemaName, tableName, where, args)
+}
+
 // NewRandomIterator return a new iterator
 func NewRandomIterator(ctx context.Context, progressID string, table *common.TableDiff, dbConn *sql.DB) (*RandomIterator, error) {
 	return NewRandomIteratorWithCheckpoint(ctx, progressID, table, dbConn, nil)
@@ -96,7 +107,7 @@ func NewRandomIteratorWithCheckpoint(
 		// For chunk splitted by random splitter, the checkpoint chunk records the tableCnt.
 		chunkCnt = bucketChunkCnt - beginIndex
 	} else {
-		cnt, err := dbutil.GetRowCount(ctx, dbConn, table.Schema, table.Table, table.Range, nil)
+		cnt, err := getRowCount(ctx, dbConn, table.Schema, table.Table, table.Range, nil)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/sync_diff_inspector/splitter/splitter_test.go
+++ b/sync_diff_inspector/splitter/splitter_test.go
@@ -689,7 +689,7 @@ func TestBucketSpliter(t *testing.T) {
 	db, mock, err = sqlmock.New()
 	require.NoError(t, err)
 	createFakeResultForBucketSplit(mock, nil, nil)
-	testfailpoint.Enable(t, "github.com/pingcap/tiflow/sync_diff_inspector/splitter/getRowCount", "return(64)")
+	testfailpoint.Enable(t, "github.com/pingcap/tiflow/sync_diff_inspector/splitter/getRowCount", "return")
 	createFakeResultForRandom(mock, testCases[0].aRandomValues[stopJ:], testCases[0].bRandomValues[stopJ:])
 	iter, err = NewBucketIteratorWithCheckpoint(ctx, "", tableDiff, db, rangeInfo, utils.NewWorkerPool(1, "bucketIter"))
 	require.NoError(t, err)

--- a/sync_diff_inspector/splitter/splitter_test.go
+++ b/sync_diff_inspector/splitter/splitter_test.go
@@ -689,7 +689,7 @@ func TestBucketSpliter(t *testing.T) {
 	db, mock, err = sqlmock.New()
 	require.NoError(t, err)
 	createFakeResultForBucketSplit(mock, nil, nil)
-	testfailpoint.Enable(t, "github.com/pingcap/tiflow/sync_diff_inspector/splitter/getRowCount", "return")
+	testfailpoint.Enable(t, "github.com/pingcap/tiflow/sync_diff_inspector/splitter/getRowCount", "return(64)")
 	createFakeResultForRandom(mock, testCases[0].aRandomValues[stopJ:], testCases[0].bRandomValues[stopJ:])
 	iter, err = NewBucketIteratorWithCheckpoint(ctx, "", tableDiff, db, rangeInfo, utils.NewWorkerPool(1, "bucketIter"))
 	require.NoError(t, err)
@@ -726,8 +726,10 @@ func createFakeResultForBucketSplit(mock sqlmock.Sqlmock, aRandomValues, bRandom
 func createFakeResultForCount(t *testing.T, count int) {
 	if count > 0 {
 		// generate fake result for get the row count of this table
-		testfailpoint.Enable(t, "github.com/pingcap/tiflow/sync_diff_inspector/splitter/getRowCount", "return")
-		MockRowCount = int64(count)
+		testfailpoint.Enable(t,
+			"github.com/pingcap/tiflow/sync_diff_inspector/splitter/getRowCount",
+			fmt.Sprintf("return(%d)", count),
+		)
 	}
 }
 

--- a/sync_diff_inspector/splitter/splitter_test.go
+++ b/sync_diff_inspector/splitter/splitter_test.go
@@ -23,6 +23,7 @@ import (
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/pingcap/tidb/pkg/parser"
+	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tiflow/sync_diff_inspector/chunk"
 	"github.com/pingcap/tiflow/sync_diff_inspector/source/common"
 	"github.com/pingcap/tiflow/sync_diff_inspector/utils"
@@ -146,7 +147,7 @@ func TestSplitRangeByRandom(t *testing.T) {
 
 		splitCols, err := GetSplitFields(tableInfo, nil)
 		require.NoError(t, err)
-		createFakeResultForRandomSplit(mock, 0, testCase.randomValues)
+		createFakeResultForRandomSplit(t, mock, 0, testCase.randomValues)
 		chunks, err := splitRangeByRandom(context.Background(), db, testCase.originChunk, testCase.splitCount, "test", "test", splitCols, "", "")
 		require.NoError(t, err)
 		for j, chunk := range chunks {
@@ -335,7 +336,7 @@ func TestRandomSpliter(t *testing.T) {
 			ChunkSize:           5,
 		}
 
-		createFakeResultForRandomSplit(mock, testCase.count, testCase.randomValues)
+		createFakeResultForRandomSplit(t, mock, testCase.count, testCase.randomValues)
 
 		iter, err := NewRandomIterator(ctx, "", tableDiff, db)
 		require.NoError(t, err)
@@ -368,7 +369,7 @@ func TestRandomSpliter(t *testing.T) {
 		ChunkSize: 5,
 	}
 
-	createFakeResultForRandomSplit(mock, testCases[0].count, testCases[0].randomValues)
+	createFakeResultForRandomSplit(t, mock, testCases[0].count, testCases[0].randomValues)
 
 	iter, err := NewRandomIterator(ctx, "", tableDiff, db)
 	require.NoError(t, err)
@@ -386,7 +387,7 @@ func TestRandomSpliter(t *testing.T) {
 		ChunkRange: chunk,
 	}
 
-	createFakeResultForRandomSplit(mock, testCases[0].count, testCases[0].randomValues)
+	createFakeResultForRandomSplit(t, mock, testCases[0].count, testCases[0].randomValues)
 
 	iter, err = NewRandomIteratorWithCheckpoint(ctx, "", tableDiff, db, rangeInfo)
 	require.NoError(t, err)
@@ -402,8 +403,8 @@ func TestRandomSpliter(t *testing.T) {
 	require.Equal(t, chunk.Index.ChunkIndex, chunkID1.ChunkIndex+1)
 }
 
-func createFakeResultForRandomSplit(mock sqlmock.Sqlmock, count int, randomValues [][]string) {
-	createFakeResultForCount(mock, count)
+func createFakeResultForRandomSplit(t *testing.T, mock sqlmock.Sqlmock, count int, randomValues [][]string) {
+	createFakeResultForCount(t, count)
 	if randomValues == nil {
 		return
 	}
@@ -688,7 +689,7 @@ func TestBucketSpliter(t *testing.T) {
 	db, mock, err = sqlmock.New()
 	require.NoError(t, err)
 	createFakeResultForBucketSplit(mock, nil, nil)
-	createFakeResultForCount(mock, 64)
+	testfailpoint.Enable(t, "github.com/pingcap/tiflow/sync_diff_inspector/splitter/getRowCount", "return(64)")
 	createFakeResultForRandom(mock, testCases[0].aRandomValues[stopJ:], testCases[0].bRandomValues[stopJ:])
 	iter, err = NewBucketIteratorWithCheckpoint(ctx, "", tableDiff, db, rangeInfo, utils.NewWorkerPool(1, "bucketIter"))
 	require.NoError(t, err)
@@ -722,11 +723,11 @@ func createFakeResultForBucketSplit(mock sqlmock.Sqlmock, aRandomValues, bRandom
 	createFakeResultForRandom(mock, aRandomValues, bRandomValues)
 }
 
-func createFakeResultForCount(mock sqlmock.Sqlmock, count int) {
+func createFakeResultForCount(t *testing.T, count int) {
 	if count > 0 {
 		// generate fake result for get the row count of this table
-		countRows := sqlmock.NewRows([]string{"cnt"}).AddRow(count)
-		mock.ExpectQuery("SELECT COUNT.*").WillReturnRows(countRows)
+		testfailpoint.Enable(t, "github.com/pingcap/tiflow/sync_diff_inspector/splitter/getRowCount", "return")
+		MockRowCount = int64(count)
 	}
 }
 
@@ -910,12 +911,12 @@ func TestChunkSize(t *testing.T) {
 
 	// test random splitter chunksize
 	// chunkNum is only 1, so don't need randomValues
-	createFakeResultForRandomSplit(mock, 1000, nil)
+	createFakeResultForRandomSplit(t, mock, 1000, nil)
 	randomIter, err := NewRandomIterator(ctx, "", tableDiff, db)
 	require.NoError(t, err)
 	require.Equal(t, randomIter.chunkSize, int64(50000))
 
-	createFakeResultForRandomSplit(mock, 1000000000, [][]string{
+	createFakeResultForRandomSplit(t, mock, 1000000000, [][]string{
 		{"1", "2", "3", "4", "5"},
 		{"a", "b", "c", "d", "e"},
 	})
@@ -934,13 +935,12 @@ func TestChunkSize(t *testing.T) {
 		ChunkSize: 0,
 	}
 	// no index
-	createFakeResultForRandomSplit(mock, 1000, nil)
+	createFakeResultForRandomSplit(t, mock, 1000, nil)
 	randomIter, err = NewRandomIterator(ctx, "", tableDiffNoIndex, db)
 	require.NoError(t, err)
 	require.Equal(t, randomIter.chunkSize, int64(1001))
 
 	// test limit splitter chunksize
-	createFakeResultForCount(mock, 1000)
 	mock.ExpectQuery("SELECT `a`,.*limit 50000.*").WillReturnRows(sqlmock.NewRows([]string{"a", "b"}))
 	_, err = NewLimitIterator(ctx, "", tableDiff, db)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/12141

### What is changed and how it works?

There are two problems solved in this PR

The first is unexpected error(see https://github.com/pingcap/tiflow/issues/12141#issuecomment-2826624187). To fix this, some of the mock queries are replaced with failpoint to make tests more stable.

The second is data race problem(see https://github.com/pingcap/tiflow/issues/12141#issuecomment-2826666728). To fix this, `WaitGroup.Add` and `WaitGroup.Wait` operations are moved into one goroutine.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
   - Test should be more stable after this PR.
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
