### PR TITLE
sarama: add keep-alive mechanism for sarama connections

### DIFF
--- a/cdc/sink/ddlsink/mq/kafka_ddl_sink.go
+++ b/cdc/sink/ddlsink/mq/kafka_ddl_sink.go
@@ -83,6 +83,7 @@ func NewKafkaDDLSink(
 		topic,
 		options.DeriveTopicConfig(),
 		adminClient,
+		options.KeepConnAliveInterval,
 	)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -112,7 +113,7 @@ func NewKafkaDDLSink(
 	}
 
 	ddlProducer := producerCreator(ctx, changefeedID, syncProducer)
-	s := newDDLSink(changefeedID, ddlProducer, adminClient, topicManager, eventRouter, encoderBuilder.Build(), protocol)
+	s := newDDLSink(changefeedID, ddlProducer, adminClient, topicManager, eventRouter, encoderBuilder.Build(), protocol, syncProducer)
 	log.Info("DDL sink producer client created", zap.Duration("duration", time.Since(start)))
 	return s, nil
 }

--- a/cdc/sink/ddlsink/mq/mq_ddl_sink.go
+++ b/cdc/sink/ddlsink/mq/mq_ddl_sink.go
@@ -87,14 +87,15 @@ func newDDLSink(
 	connRefresherForDDL kafka.SyncProducer,
 ) *DDLSink {
 	return &DDLSink{
-		id:           changefeedID,
-		protocol:     protocol,
-		eventRouter:  eventRouter,
-		topicManager: topicManager,
-		encoder:      encoder,
-		producer:     producer,
-		statistics:   metrics.NewStatistics(changefeedID, sink.RowSink),
-		admin:        adminClient,
+		id:                  changefeedID,
+		protocol:            protocol,
+		eventRouter:         eventRouter,
+		topicManager:        topicManager,
+		encoder:             encoder,
+		producer:            producer,
+		statistics:          metrics.NewStatistics(changefeedID, sink.RowSink),
+		admin:               adminClient,
+		connRefresherForDDL: connRefresherForDDL,
 	}
 }
 

--- a/cdc/sink/ddlsink/mq/mq_ddl_sink_test.go
+++ b/cdc/sink/ddlsink/mq/mq_ddl_sink_test.go
@@ -25,6 +25,12 @@ import (
 	"github.com/pingcap/tiflow/pkg/config"
 	"github.com/pingcap/tiflow/pkg/sink/kafka"
 	"github.com/stretchr/testify/require"
+
+	"sync"
+
+	"github.com/pingcap/tiflow/pkg/errors"
+	"github.com/pingcap/tiflow/pkg/sink/codec"
+	"github.com/pingcap/tiflow/pkg/sink/codec/common"
 )
 
 func TestNewKafkaDDLSinkFailed(t *testing.T) {
@@ -291,4 +297,95 @@ func TestGetDLLDispatchRuleByProtocol(t *testing.T) {
 	require.Equal(t, PartitionAll, getDDLDispatchRule(config.ProtocolCraft))
 	require.Equal(t, PartitionAll, getDDLDispatchRule(config.ProtocolSimple))
 	require.Equal(t, PartitionAll, getDDLDispatchRule(config.ProtocolDebezium))
+}
+
+// mockSyncProducer is used to count the calls to HeartbeatBrokers.
+type mockSyncProducer struct {
+	kafka.MockSaramaSyncProducer
+	heartbeatCount int
+	mu             sync.Mutex
+}
+
+func (m *mockSyncProducer) HeartbeatBrokers() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.heartbeatCount++
+}
+
+func (m *mockSyncProducer) GetHeartbeatCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.heartbeatCount
+}
+
+// mockEncoder is a mock implementation of codec.RowEventEncoder.
+// It is used to prevent the test from needing to set up a real, complex encoder.
+type mockEncoder struct{}
+
+// This line ensures at compile time that mockEncoder correctly implements the interface.
+var _ codec.RowEventEncoder = (*mockEncoder)(nil)
+
+// A predefined error that our mock encoder will return.
+var errMockEncoder = errors.New("mock encoder error")
+
+// EncodeCheckpointEvent returns a specific error to halt the execution
+// of the function under test right after the heartbeat logic.
+func (m *mockEncoder) EncodeCheckpointEvent(ts uint64) (*common.Message, error) {
+	return nil, errMockEncoder
+}
+
+// The following methods are part of the RowEventEncoder interface.
+// They can be left with a minimal implementation as they are not called
+// in the tested code path.
+func (m *mockEncoder) AppendRowChangedEvent(
+	_ context.Context, _ string, _ *model.RowChangedEvent, _ func(),
+) error {
+	return nil
+}
+func (m *mockEncoder) Build() []*common.Message {
+	return nil
+}
+func (m *mockEncoder) EncodeDDLEvent(event *model.DDLEvent) (*common.Message, error) {
+	return nil, nil
+}
+func (m *mockEncoder) SetMaxMessageBytes(bytes int) {}
+
+func TestDDLSinkHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	changefeedID := model.DefaultChangeFeedID("test-ddl-sink")
+	// Protocol is needed by newDDLSink but not used in the tested path.
+	proto := config.ProtocolOpen
+	encoder := &mockEncoder{}
+
+	// Case 1: DDL Sink with a connection refresher.
+	t.Run("DDLSinkWithConnectionRefresher", func(t *testing.T) {
+		t.Parallel()
+		producer := &mockSyncProducer{}
+		// Other dependencies for newDDLSink can be nil as they are not used
+		// before our mock encoder returns an error.
+		ddlSink := newDDLSink(changefeedID, nil, nil, nil, nil, encoder, proto, producer)
+
+		require.Equal(t, 0, producer.GetHeartbeatCount())
+
+		// WriteCheckpointTs should first call HeartbeatBrokers, then fail at the encoder.
+		err := ddlSink.WriteCheckpointTs(ctx, 12345, nil)
+
+		// Assert that the heartbeat was called exactly once.
+		require.Equal(t, 1, producer.GetHeartbeatCount())
+		// Assert that the function failed with the mock encoder's specific error.
+		require.ErrorIs(t, err, errMockEncoder)
+	})
+
+	// Case 2: DDLSink with a nil connection refresher (e.g., for Pulsar).
+	t.Run("DDLSinkWithNilConnectionRefresher", func(t *testing.T) {
+		t.Parallel()
+		// Create the sink with a nil refresher.
+		ddlSinkNilRefresher := newDDLSink(changefeedID, nil, nil, nil, nil, encoder, proto, nil)
+
+		// The call should not panic and should fail with the mock encoder's error.
+		err := ddlSinkNilRefresher.WriteCheckpointTs(ctx, 12347, nil)
+		require.ErrorIs(t, err, errMockEncoder)
+	})
 }

--- a/cdc/sink/ddlsink/mq/mq_ddl_sink_test.go
+++ b/cdc/sink/ddlsink/mq/mq_ddl_sink_test.go
@@ -17,20 +17,18 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"sync"
 	"testing"
 
 	mm "github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/sink/ddlsink/mq/ddlproducer"
 	"github.com/pingcap/tiflow/pkg/config"
-	"github.com/pingcap/tiflow/pkg/sink/kafka"
-	"github.com/stretchr/testify/require"
-
-	"sync"
-
 	"github.com/pingcap/tiflow/pkg/errors"
 	"github.com/pingcap/tiflow/pkg/sink/codec"
 	"github.com/pingcap/tiflow/pkg/sink/codec/common"
+	"github.com/pingcap/tiflow/pkg/sink/kafka"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewKafkaDDLSinkFailed(t *testing.T) {

--- a/cdc/sink/ddlsink/mq/mq_ddl_sink_test.go
+++ b/cdc/sink/ddlsink/mq/mq_ddl_sink_test.go
@@ -340,9 +340,11 @@ func (m *mockEncoder) AppendRowChangedEvent(
 ) error {
 	return nil
 }
+
 func (m *mockEncoder) Build() []*common.Message {
 	return nil
 }
+
 func (m *mockEncoder) EncodeDDLEvent(event *model.DDLEvent) (*common.Message, error) {
 	return nil, nil
 }

--- a/cdc/sink/ddlsink/mq/pulsar_ddl_sink.go
+++ b/cdc/sink/ddlsink/mq/pulsar_ddl_sink.go
@@ -100,7 +100,7 @@ func NewPulsarDDLSink(
 		return nil, errors.Trace(err)
 	}
 
-	s := newDDLSink(changefeedID, p, nil, topicManager, eventRouter, encoderBuilder.Build(), protocol)
+	s := newDDLSink(changefeedID, p, nil, topicManager, eventRouter, encoderBuilder.Build(), protocol, nil)
 
 	return s, nil
 }

--- a/cdc/sink/dmlsink/mq/kafka_dml_sink.go
+++ b/cdc/sink/dmlsink/mq/kafka_dml_sink.go
@@ -87,6 +87,7 @@ func NewKafkaDMLSink(
 		topic,
 		options.DeriveTopicConfig(),
 		adminClient,
+		options.KeepConnAliveInterval,
 	)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/cdc/sink/dmlsink/mq/manager/kafka_manager.go
+++ b/cdc/sink/dmlsink/mq/manager/kafka_manager.go
@@ -308,4 +308,5 @@ func (m *kafkaTopicManager) CreateTopicAndWaitUntilVisible(
 // Close exits the background goroutine.
 func (m *kafkaTopicManager) Close() {
 	m.cancel()
+	m.admin.Close()
 }

--- a/cdc/sink/dmlsink/mq/manager/kafka_manager.go
+++ b/cdc/sink/dmlsink/mq/manager/kafka_manager.go
@@ -308,5 +308,4 @@ func (m *kafkaTopicManager) CreateTopicAndWaitUntilVisible(
 // Close exits the background goroutine.
 func (m *kafkaTopicManager) Close() {
 	m.cancel()
-	m.admin.Close()
 }

--- a/cdc/sink/dmlsink/mq/manager/kafka_manager.go
+++ b/cdc/sink/dmlsink/mq/manager/kafka_manager.go
@@ -48,7 +48,8 @@ type kafkaTopicManager struct {
 
 	topics sync.Map
 
-	metaRefreshTicker *time.Ticker
+	metaRefreshTicker   *time.Ticker
+	keepConnAliveTicker *time.Ticker
 
 	// cancel is used to cancel the background goroutine.
 	cancel context.CancelFunc
@@ -61,13 +62,15 @@ func NewKafkaTopicManager(
 	changefeedID model.ChangeFeedID,
 	admin kafka.ClusterAdminClient,
 	cfg *kafka.AutoCreateTopicConfig,
+	keepConnAliveInterval time.Duration,
 ) *kafkaTopicManager {
 	mgr := &kafkaTopicManager{
-		defaultTopic:      defaultTopic,
-		changefeedID:      changefeedID,
-		admin:             admin,
-		cfg:               cfg,
-		metaRefreshTicker: time.NewTicker(metaRefreshInterval),
+		defaultTopic:        defaultTopic,
+		changefeedID:        changefeedID,
+		admin:               admin,
+		cfg:                 cfg,
+		metaRefreshTicker:   time.NewTicker(metaRefreshInterval),
+		keepConnAliveTicker: time.NewTicker(keepConnAliveInterval),
 	}
 
 	ctx, mgr.cancel = context.WithCancel(ctx)
@@ -112,6 +115,10 @@ func (m *kafkaTopicManager) backgroundRefreshMeta(ctx context.Context) {
 			for topic, partitionNum := range topicPartitionNums {
 				m.tryUpdatePartitionsAndLogging(topic, partitionNum)
 			}
+		case <-m.keepConnAliveTicker.C:
+			// This operation is used to keep the kafka connection alive.
+			// For more details, see https://github.com/pingcap/tiflow/pull/12173
+			m.admin.HeartbeatBrokers()
 		}
 	}
 }

--- a/cdc/sink/dmlsink/mq/manager/kafka_manager.go
+++ b/cdc/sink/dmlsink/mq/manager/kafka_manager.go
@@ -100,6 +100,7 @@ func (m *kafkaTopicManager) GetPartitionNum(
 }
 
 func (m *kafkaTopicManager) backgroundRefreshMeta(ctx context.Context) {
+	defer m.keepConnAliveTicker.Stop()
 	for {
 		select {
 		case <-ctx.Done():

--- a/cdc/sink/dmlsink/mq/manager/kafka_manager_test.go
+++ b/cdc/sink/dmlsink/mq/manager/kafka_manager_test.go
@@ -16,6 +16,7 @@ package manager
 import (
 	"context"
 	"math"
+	"sync"
 	"testing"
 	"time"
 
@@ -105,4 +106,54 @@ func TestCreateTopicWithDelay(t *testing.T) {
 	err = manager.waitUntilTopicVisible(ctx, topic)
 	require.NoError(t, err)
 	require.Equal(t, int32(2), partitionNum)
+}
+
+// mockAdminClientForHeartbeat is used to count the calls to HeartbeatBrokers.
+type mockAdminClientForHeartbeat struct {
+	kafka.ClusterAdminClientMockImpl
+	heartbeatCount int
+	mu             sync.Mutex
+}
+
+func (m *mockAdminClientForHeartbeat) HeartbeatBrokers() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.heartbeatCount++
+}
+
+func (m *mockAdminClientForHeartbeat) GetHeartbeatCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.heartbeatCount
+}
+
+func TestKafkaManagerHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	adminClient := &mockAdminClientForHeartbeat{}
+	cfg := &kafka.AutoCreateTopicConfig{AutoCreate: false}
+	changefeedID := model.DefaultChangeFeedID("test-heartbeat")
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Use a short interval for testing.
+	keepAliveInterval := 50 * time.Millisecond
+	manager := NewKafkaTopicManager(ctx, "topic", changefeedID, adminClient, cfg, keepAliveInterval)
+
+	// Ensure the manager is closed and the context is canceled at the end of the test.
+	defer manager.Close()
+	defer cancel()
+
+	// Wait for a sufficient amount of time to ensure the heartbeat ticker triggers several times.
+	// Waiting for 175ms should be enough to trigger 3 times (at 50ms, 100ms, 150ms).
+	// Use Eventually to avoid test flakiness.
+	require.Eventually(t, func() bool {
+		return adminClient.GetHeartbeatCount() >= 2
+	}, 2*time.Second, 50*time.Millisecond, "HeartbeatBrokers should be called periodically")
+
+	// Verify that closing the manager stops the heartbeat.
+	countBeforeClose := adminClient.GetHeartbeatCount()
+	manager.Close()
+	// Wait for a short period to ensure no new heartbeats occur.
+	time.Sleep(keepAliveInterval * 2)
+	require.Equal(t, countBeforeClose, adminClient.GetHeartbeatCount(), "Heartbeat should stop after manager is closed")
 }

--- a/cdc/sink/util/helper.go
+++ b/cdc/sink/util/helper.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/sink/dmlsink/mq/manager"
@@ -104,9 +105,10 @@ func GetTopicManagerAndTryCreateTopic(
 	topic string,
 	topicCfg *kafka.AutoCreateTopicConfig,
 	adminClient kafka.ClusterAdminClient,
+	keepConnAliveInterval time.Duration,
 ) (manager.TopicManager, error) {
 	topicManager := manager.NewKafkaTopicManager(
-		ctx, topic, changefeedID, adminClient, topicCfg,
+		ctx, topic, changefeedID, adminClient, topicCfg, keepConnAliveInterval,
 	)
 
 	if _, err := topicManager.CreateTopicAndWaitUntilVisible(ctx, topic); err != nil {

--- a/cdc/sink/util/helper_test.go
+++ b/cdc/sink/util/helper_test.go
@@ -15,13 +15,18 @@ package util
 
 import (
 	"context"
+	"math"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/pkg/sink/kafka"
 	"github.com/stretchr/testify/require"
 )
+
+// A fake interval to keep the connection alive in kafka topic manager.
+const FOREVER = time.Duration(math.MaxInt64)
 
 func TestPartition(t *testing.T) {
 	t.Parallel()
@@ -38,7 +43,8 @@ func TestPartition(t *testing.T) {
 	changefeedID := model.DefaultChangeFeedID("test")
 	ctx := context.Background()
 
-	manager, err := GetTopicManagerAndTryCreateTopic(ctx, changefeedID, kafka.DefaultMockTopicName, cfg, adminClient)
+	manager, err := GetTopicManagerAndTryCreateTopic(
+		ctx, changefeedID, kafka.DefaultMockTopicName, cfg, adminClient, FOREVER)
 	require.NoError(t, err)
 	defer manager.Close()
 

--- a/pkg/sink/kafka/admin.go
+++ b/pkg/sink/kafka/admin.go
@@ -188,8 +188,13 @@ func (a *saramaAdminClient) Close() {
 }
 
 // keepConnAlive is used to keep the connection alive.
-func (a *saramaAdminClient) keepConnAlive() {
-	ticker := time.NewTicker(5 * time.Second)
+func (a *saramaAdminClient) keepConnAlive(duration time.Duration) {
+	if duration <= 0 {
+		log.Warn("keepConnAlive duration is less than or equal to 0")
+		return
+	}
+	log.Info("keepConnAlive for sarama", zap.Duration("duration", duration))
+	ticker := time.NewTicker(duration)
 	defer ticker.Stop()
 
 	for {

--- a/pkg/sink/kafka/admin.go
+++ b/pkg/sink/kafka/admin.go
@@ -185,13 +185,5 @@ func (a *saramaAdminClient) Close() {
 }
 
 func (a *saramaAdminClient) HeartbeatBrokers() {
-	// We don't care about the response and error here, even the connection
-	// is unestablished, we just need to keep the connection alive WHEN it's established.
-	// The connection will be established when a producer send messages.
-	// This is a workaround for the issue that sarama doesn't keep the connection alive
-	// when the connection is idle for a long time and we have disabled the retry in sarama.
-	brokers := a.client.Brokers()
-	for _, b := range brokers {
-		_, _ = b.Heartbeat(&sarama.HeartbeatRequest{})
-	}
+	KeepConnAlive(a.client)
 }

--- a/pkg/sink/kafka/admin.go
+++ b/pkg/sink/kafka/admin.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/IBM/sarama"
 	"github.com/pingcap/errors"
@@ -184,33 +183,5 @@ func (a *saramaAdminClient) Close() {
 			zap.String("namespace", a.changefeed.Namespace),
 			zap.String("changefeed", a.changefeed.ID),
 			zap.Error(err))
-	}
-}
-
-// keepConnAlive is used to keep the connection alive.
-func (a *saramaAdminClient) keepConnAlive(duration time.Duration) {
-	if duration <= 0 {
-		log.Warn("keepConnAlive duration is less than or equal to 0")
-		return
-	}
-	log.Info("keepConnAlive for sarama", zap.Duration("duration", duration))
-	ticker := time.NewTicker(duration)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			// We don't care about the response and error here, even the connection
-			// is unestablished, we just need to keep the connection alive when it's established.
-			// The connection will be established when a producer send messages.
-			// This is a workaround for the issue that sarama doesn't keep the connection alive
-			// when the connection is idle for a long time and we have disabled the retry in sarama.
-			brokers := a.client.Brokers()
-			for _, b := range brokers {
-				_, _ = b.Heartbeat(&sarama.HeartbeatRequest{})
-			}
-		case <-a.done:
-			return
-		}
 	}
 }

--- a/pkg/sink/kafka/admin.go
+++ b/pkg/sink/kafka/admin.go
@@ -187,6 +187,7 @@ func (a *saramaAdminClient) Close() {
 	}
 }
 
+// keepConnAlive is used to keep the connection alive.
 func (a *saramaAdminClient) keepConnAlive() {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
@@ -194,6 +195,11 @@ func (a *saramaAdminClient) keepConnAlive() {
 	for {
 		select {
 		case <-ticker.C:
+			// We don't care about the response and error here, even the connection
+			// is unestablished, we just need to keep the connection alive when it's established.
+			// The connection will be established when a producer send messages.
+			// This is a workaround for the issue that sarama doesn't keep the connection alive
+			// when the connection is idle for a long time and we have disabled the retry in sarama.
 			brokers := a.client.Brokers()
 			for _, b := range brokers {
 				_, _ = b.Heartbeat(&sarama.HeartbeatRequest{})

--- a/pkg/sink/kafka/cluster_admin_client.go
+++ b/pkg/sink/kafka/cluster_admin_client.go
@@ -52,6 +52,9 @@ type ClusterAdminClient interface {
 	// CreateTopic creates a new topic.
 	CreateTopic(ctx context.Context, detail *TopicDetail, validateOnly bool) error
 
+	// HeartbeatBroker sends a heartbeat to all brokers to keep the kafka connection alive.
+	HeartbeatBrokers()
+
 	// Close shuts down the admin client.
 	Close()
 }

--- a/pkg/sink/kafka/cluster_admin_client_mock_impl.go
+++ b/pkg/sink/kafka/cluster_admin_client_mock_impl.go
@@ -100,6 +100,9 @@ func (c *ClusterAdminClientMockImpl) GetAllBrokers(context.Context) ([]Broker, e
 	return nil, nil
 }
 
+// HeartbeatBrokers implement the ClusterAdminClient interface
+func (c *ClusterAdminClientMockImpl) HeartbeatBrokers() {}
+
 // GetBrokerConfig implement the ClusterAdminClient interface
 func (c *ClusterAdminClientMockImpl) GetBrokerConfig(
 	_ context.Context,

--- a/pkg/sink/kafka/cluster_admin_client_mock_impl.go
+++ b/pkg/sink/kafka/cluster_admin_client_mock_impl.go
@@ -42,6 +42,9 @@ const (
 
 	// defaultMinInsyncReplicas specifies the default `min.insync.replicas` for broker and topic.
 	defaultMinInsyncReplicas = "1"
+
+	// 10 minutes, identical to kafka broker's `connections.max.idle.ms`
+	defaultBrokerConnectionsMaxIdleMs = "600000"
 )
 
 var (
@@ -51,6 +54,8 @@ var (
 	TopicMaxMessageBytes = defaultMaxMessageBytes
 	// MinInSyncReplicas is the `min.insync.replicas`
 	MinInSyncReplicas = defaultMinInsyncReplicas
+	// BrokerConnectionsMaxIdleMs is the broker's `connections.max.idle.ms`
+	BrokerConnectionsMaxIdleMs = defaultBrokerConnectionsMaxIdleMs
 )
 
 type topicDetail struct {
@@ -81,6 +86,7 @@ func NewClusterAdminClientMockImpl() *ClusterAdminClientMockImpl {
 	brokerConfigs := make(map[string]string)
 	brokerConfigs[BrokerMessageMaxBytesConfigName] = BrokerMessageMaxBytes
 	brokerConfigs[MinInsyncReplicasConfigName] = MinInSyncReplicas
+	brokerConfigs[BrokerConnectionsMaxIdleMsConfigName] = BrokerConnectionsMaxIdleMs
 
 	topicConfigs := make(map[string]map[string]string)
 	topicConfigs[DefaultMockTopicName] = make(map[string]string)

--- a/pkg/sink/kafka/factory.go
+++ b/pkg/sink/kafka/factory.go
@@ -160,19 +160,17 @@ func (p *saramaAsyncProducer) Close() {
 		// closed, `asyncProducer.Close()` would waste a mount of time to try flush all messages.
 		// To prevent the scenario mentioned above, close the client first.
 		start := time.Now()
-		if !p.client.Closed() {
-			if err := p.client.Close(); err != nil {
-				log.Warn("Close kafka async producer client error",
-					zap.String("namespace", p.changefeedID.Namespace),
-					zap.String("changefeed", p.changefeedID.ID),
-					zap.Duration("duration", time.Since(start)),
-					zap.Error(err))
-			} else {
-				log.Info("Close kafka async producer client success",
-					zap.String("namespace", p.changefeedID.Namespace),
-					zap.String("changefeed", p.changefeedID.ID),
-					zap.Duration("duration", time.Since(start)))
-			}
+		if err := p.client.Close(); err != nil {
+			log.Warn("Close kafka async producer client error",
+				zap.String("namespace", p.changefeedID.Namespace),
+				zap.String("changefeed", p.changefeedID.ID),
+				zap.Duration("duration", time.Since(start)),
+				zap.Error(err))
+		} else {
+			log.Info("Close kafka async producer client success",
+				zap.String("namespace", p.changefeedID.Namespace),
+				zap.String("changefeed", p.changefeedID.ID),
+				zap.Duration("duration", time.Since(start)))
 		}
 
 		start = time.Now()

--- a/pkg/sink/kafka/factory.go
+++ b/pkg/sink/kafka/factory.go
@@ -126,7 +126,7 @@ func (p *saramaSyncProducer) HeartbeatBrokers() {
 	// older than the keep connection alive interval, to avoid sending heartbeat
 	// too frequently.
 	// This function will be called periodically in DDLSink.WriteCheckpointTs.
-	if time.Now().Sub(p.lastHeartbeatTime) < p.keepConnAliveInterval {
+	if time.Since(p.lastHeartbeatTime) < p.keepConnAliveInterval {
 		return
 	}
 

--- a/pkg/sink/kafka/factory.go
+++ b/pkg/sink/kafka/factory.go
@@ -129,6 +129,7 @@ func (p *saramaSyncProducer) HeartbeatBrokers() {
 	if time.Since(p.lastHeartbeatTime) < p.keepConnAliveInterval {
 		return
 	}
+	p.lastHeartbeatTime = time.Now()
 
 	// We don't care about the response and error here, even the connection
 	// is unestablished, we just need to keep the connection alive WHEN it's established.

--- a/pkg/sink/kafka/factory.go
+++ b/pkg/sink/kafka/factory.go
@@ -160,17 +160,19 @@ func (p *saramaAsyncProducer) Close() {
 		// closed, `asyncProducer.Close()` would waste a mount of time to try flush all messages.
 		// To prevent the scenario mentioned above, close the client first.
 		start := time.Now()
-		if err := p.client.Close(); err != nil {
-			log.Warn("Close kafka async producer client error",
-				zap.String("namespace", p.changefeedID.Namespace),
-				zap.String("changefeed", p.changefeedID.ID),
-				zap.Duration("duration", time.Since(start)),
-				zap.Error(err))
-		} else {
-			log.Info("Close kafka async producer client success",
-				zap.String("namespace", p.changefeedID.Namespace),
-				zap.String("changefeed", p.changefeedID.ID),
-				zap.Duration("duration", time.Since(start)))
+		if !p.client.Closed() {
+			if err := p.client.Close(); err != nil {
+				log.Warn("Close kafka async producer client error",
+					zap.String("namespace", p.changefeedID.Namespace),
+					zap.String("changefeed", p.changefeedID.ID),
+					zap.Duration("duration", time.Since(start)),
+					zap.Error(err))
+			} else {
+				log.Info("Close kafka async producer client success",
+					zap.String("namespace", p.changefeedID.Namespace),
+					zap.String("changefeed", p.changefeedID.ID),
+					zap.Duration("duration", time.Since(start)))
+			}
 		}
 
 		start = time.Now()

--- a/pkg/sink/kafka/factory.go
+++ b/pkg/sink/kafka/factory.go
@@ -130,16 +130,7 @@ func (p *saramaSyncProducer) HeartbeatBrokers() {
 		return
 	}
 	p.lastHeartbeatTime = time.Now()
-
-	// We don't care about the response and error here, even the connection
-	// is unestablished, we just need to keep the connection alive WHEN it's established.
-	// The connection will be established when a producer send messages.
-	// This is a workaround for the issue that sarama doesn't keep the connection alive
-	// when the connection is idle for a long time and we have disabled the retry in sarama.
-	brokers := p.client.Brokers()
-	for _, b := range brokers {
-		_, _ = b.Heartbeat(&sarama.HeartbeatRequest{})
-	}
+	KeepConnAlive(p.client)
 }
 
 func (p *saramaSyncProducer) Close() {
@@ -276,14 +267,7 @@ func (p *saramaAsyncProducer) AsyncSend(ctx context.Context, topic string, parti
 	return nil
 }
 
+// heartbeatBrokers sends heartbeat to all brokers to keep the connection alive.
 func (p *saramaAsyncProducer) heartbeatBrokers() {
-	// We don't care about the response and error here, even the connection
-	// is unestablished, we just need to keep the connection alive WHEN it's established.
-	// The connection will be established when a producer send messages.
-	// This is a workaround for the issue that sarama doesn't keep the connection alive
-	// when the connection is idle for a long time and we have disabled the retry in sarama.
-	brokers := p.client.Brokers()
-	for _, b := range brokers {
-		_, _ = b.Heartbeat(&sarama.HeartbeatRequest{})
-	}
+	KeepConnAlive(p.client)
 }

--- a/pkg/sink/kafka/mock_factory.go
+++ b/pkg/sink/kafka/mock_factory.go
@@ -119,6 +119,9 @@ func (m *MockSaramaSyncProducer) SendMessages(ctx context.Context, topic string,
 	return m.Producer.SendMessages(msgs)
 }
 
+// HeartbeatBrokers implement the SyncProducer interface.
+func (m *MockSaramaSyncProducer) HeartbeatBrokers() {}
+
 // Close implement the SyncProducer interface.
 func (m *MockSaramaSyncProducer) Close() {
 	m.Producer.Close()

--- a/pkg/sink/kafka/options.go
+++ b/pkg/sink/kafka/options.go
@@ -62,6 +62,10 @@ const (
 	// See: https://kafka.apache.org/documentation/#brokerconfigs_min.insync.replicas and
 	// https://kafka.apache.org/documentation/#topicconfigs_min.insync.replicas
 	MinInsyncReplicasConfigName = "min.insync.replicas"
+	// BrokerConnectionsMaxIdleMsConfigName specifies the maximum idle time of a connection to a broker.
+	// Broker will close the connection if it is idle for this long.
+	// See: https://kafka.apache.org/documentation/#brokerconfigs_connections.max.idle.ms
+	BrokerConnectionsMaxIdleMsConfigName = "connections.max.idle.ms"
 )
 
 const (

--- a/pkg/sink/kafka/options_test.go
+++ b/pkg/sink/kafka/options_test.go
@@ -811,6 +811,7 @@ func TestAdjustOptionsKeepAlive(t *testing.T) {
 	// Case 1: Successful adjustment.
 	// The broker returns a valid idle time, KeepConnAliveInterval should be set to 1/3 of it.
 	t.Run("SuccessfulAdjustment", func(t *testing.T) {
+		t.Parallel()
 		o := NewOptions()
 		adminClient := &mockAdminClientForAdjust{
 			ClusterAdminClientMockImpl: *NewClusterAdminClientMockImpl(),
@@ -824,6 +825,7 @@ func TestAdjustOptionsKeepAlive(t *testing.T) {
 
 	// Case 2: Error when getting config from admin client.
 	t.Run("ErrorFromAdminClient", func(t *testing.T) {
+		t.Parallel()
 		o := NewOptions()
 		adminClient := &mockAdminClientForAdjust{
 			ClusterAdminClientMockImpl: *NewClusterAdminClientMockImpl(),
@@ -836,6 +838,7 @@ func TestAdjustOptionsKeepAlive(t *testing.T) {
 
 	// Case 3: Broker returns an invalid (non-integer) config value.
 	t.Run("InvalidNonIntegerConfig", func(t *testing.T) {
+		t.Parallel()
 		o := NewOptions()
 		adminClient := &mockAdminClientForAdjust{
 			ClusterAdminClientMockImpl: *NewClusterAdminClientMockImpl(),
@@ -852,6 +855,7 @@ func TestAdjustOptionsKeepAlive(t *testing.T) {
 	// According to the code in the diff, this case will log a warning and return a nil error,
 	// and the configuration item will not be updated.
 	t.Run("InvalidZeroOrNegativeConfig", func(t *testing.T) {
+		t.Parallel()
 		for _, val := range []string{"0", "-1000"} {
 			o := NewOptions()
 			defaultInterval := o.KeepConnAliveInterval

--- a/pkg/sink/kafka/options_test.go
+++ b/pkg/sink/kafka/options_test.go
@@ -823,20 +823,7 @@ func TestAdjustOptionsKeepAlive(t *testing.T) {
 		require.Equal(t, 100*time.Second, o.KeepConnAliveInterval)
 	})
 
-	// Case 2: Error when getting config from admin client.
-	t.Run("ErrorFromAdminClient", func(t *testing.T) {
-		t.Parallel()
-		o := NewOptions()
-		adminClient := &mockAdminClientForAdjust{
-			ClusterAdminClientMockImpl: *NewClusterAdminClientMockImpl(),
-			shouldError:                true,
-		}
-		err := AdjustOptions(ctx, adminClient, o, adminClient.GetDefaultMockTopicName())
-		require.Error(t, err)
-		require.Regexp(t, "mock error: cannot get broker config", err)
-	})
-
-	// Case 3: Broker returns an invalid (non-integer) config value.
+	// Case 2: Broker returns an invalid (non-integer) config value.
 	t.Run("InvalidNonIntegerConfig", func(t *testing.T) {
 		t.Parallel()
 		o := NewOptions()
@@ -851,7 +838,7 @@ func TestAdjustOptionsKeepAlive(t *testing.T) {
 		require.True(t, ok, "error should be of type strconv.NumError")
 	})
 
-	// Case 4: Broker returns an invalid (zero or negative) config value.
+	// Case 3: Broker returns an invalid (zero or negative) config value.
 	// According to the code in the diff, this case will log a warning and return a nil error,
 	// and the configuration item will not be updated.
 	t.Run("InvalidZeroOrNegativeConfig", func(t *testing.T) {

--- a/pkg/sink/kafka/sarama.go
+++ b/pkg/sink/kafka/sarama.go
@@ -255,3 +255,16 @@ func getKafkaVersionFromBroker(config *sarama.Config, requestVersion int16, addr
 	}
 	return KafkaVersion, nil
 }
+
+// KeepConnAlive sends a heartbeat request to all brokers to keep the connection alive.
+func KeepConnAlive(client sarama.Client) {
+	// We don't care about the response and error here, even the connection
+	// is unestablished, we just need to keep the connection alive WHEN it's established.
+	// The connection will be established when a producer send messages.
+	// This is a workaround for the issue that sarama doesn't keep the connection alive
+	// when the connection is idle for a long time and we have disabled the retry in sarama.
+	brokers := client.Brokers()
+	for _, b := range brokers {
+		_, _ = b.Heartbeat(&sarama.HeartbeatRequest{})
+	}
+}

--- a/pkg/sink/kafka/sarama.go
+++ b/pkg/sink/kafka/sarama.go
@@ -29,8 +29,9 @@ import (
 )
 
 var (
-	defaultKafkaVersion = sarama.V2_0_0_0
-	maxKafkaVersion     = sarama.V2_8_0_0
+	defaultKafkaVersion   = sarama.V2_0_0_0
+	maxKafkaVersion       = sarama.V2_8_0_0
+	keepConnAliveInterval = 5 * time.Minute
 )
 
 // NewSaramaConfig return the default config and set the according version and metrics
@@ -257,17 +258,17 @@ func getKafkaVersionFromBroker(config *sarama.Config, requestVersion int16, addr
 }
 
 // keepConnAlive is used to keep the connection alive.
-func keepConnAlive(client sarama.Client, duration time.Duration, done chan struct{}) {
+func keepConnAlive(client sarama.Client, done chan struct{}) {
 	if client == nil || done == nil {
 		log.Warn("keepConnAlive client or done is nil")
 		return
 	}
-	if duration <= 0 {
+	if keepConnAliveInterval <= 0 {
 		log.Warn("keepConnAlive duration is less than or equal to 0")
 		return
 	}
-	log.Info("keepConnAlive for sarama", zap.Duration("duration", duration))
-	ticker := time.NewTicker(duration)
+	log.Info("keepConnAlive for sarama", zap.Duration("keepConnAliveInterval", keepConnAliveInterval))
+	ticker := time.NewTicker(keepConnAliveInterval)
 	defer ticker.Stop()
 
 	for {

--- a/pkg/sink/kafka/sarama.go
+++ b/pkg/sink/kafka/sarama.go
@@ -29,9 +29,8 @@ import (
 )
 
 var (
-	defaultKafkaVersion   = sarama.V2_0_0_0
-	maxKafkaVersion       = sarama.V2_8_0_0
-	keepConnAliveInterval = 5 * time.Minute
+	defaultKafkaVersion = sarama.V2_0_0_0
+	maxKafkaVersion     = sarama.V2_8_0_0
 )
 
 // NewSaramaConfig return the default config and set the according version and metrics
@@ -255,41 +254,4 @@ func getKafkaVersionFromBroker(config *sarama.Config, requestVersion int16, addr
 		KafkaVersion = sarama.V0_8_2_0
 	}
 	return KafkaVersion, nil
-}
-
-// keepConnAlive is used to keep the connection alive.
-func keepConnAlive(client sarama.Client, done chan struct{}) {
-	if client == nil || done == nil {
-		log.Warn("keepConnAlive client or done is nil")
-		return
-	}
-	if keepConnAliveInterval <= 0 {
-		log.Warn("keepConnAlive duration is less than or equal to 0")
-		return
-	}
-	log.Info("keepConnAlive for sarama", zap.Duration("keepConnAliveInterval", keepConnAliveInterval))
-	ticker := time.NewTicker(keepConnAliveInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			// We don't care about the response and error here, even the connection
-			// is unestablished, we just need to keep the connection alive when it's established.
-			// The connection will be established when a producer send messages.
-			// This is a workaround for the issue that sarama doesn't keep the connection alive
-			// when the connection is idle for a long time and we have disabled the retry in sarama.
-			hearbeatBroker(client)
-		case <-done:
-			log.Info("keepConnAlive done")
-			return
-		}
-	}
-}
-
-func hearbeatBroker(client sarama.Client) {
-	brokers := client.Brokers()
-	for _, b := range brokers {
-		_, _ = b.Heartbeat(&sarama.HeartbeatRequest{})
-	}
 }

--- a/pkg/sink/kafka/sarama_factory.go
+++ b/pkg/sink/kafka/sarama_factory.go
@@ -29,7 +29,14 @@ import (
 type saramaFactory struct {
 	changefeedID model.ChangeFeedID
 	option       *Options
-	client       sarama.Client
+	// This client is shared by all producers and admin clients.
+	// It is created when the first producer or admin client is created.
+	// NOTE: Do not close this client before all producers and admin clients are useless and closed.
+	// Why we need to share the client?
+	// Because we have to keep the connection alive to the kafka cluster. And the best way to do this is to
+	// use the same client for all producers and admin clients, and keep them alive.
+	// The keep-alive mechanism is running in saramaAdminClient.keepConnAlive.
+	client sarama.Client
 
 	registry metrics.Registry
 }

--- a/pkg/sink/kafka/sarama_factory.go
+++ b/pkg/sink/kafka/sarama_factory.go
@@ -92,7 +92,7 @@ func (f *saramaFactory) AdminClient(ctx context.Context) (ClusterAdminClient, er
 			zap.String("configName", BrokerConnectionsMaxIdleMsConfigName), zap.String("configValue", idleMs))
 		return nil, errors.Trace(err)
 	}
-	keepConnAliveInterval = time.Duration(idleMsInt) * time.Millisecond
+	keepConnAliveInterval = time.Duration(idleMsInt/2) * time.Millisecond
 	go keepConnAlive(client, a.done)
 	return &a, nil
 }

--- a/pkg/sink/kafka/sarama_factory.go
+++ b/pkg/sink/kafka/sarama_factory.go
@@ -30,14 +30,6 @@ import (
 type saramaFactory struct {
 	changefeedID model.ChangeFeedID
 	option       *Options
-	// This client is shared by all producers and admin clients.
-	// It is created when the first producer or admin client is created.
-	// NOTE: Do not close this client before all producers and admin clients are useless and closed.
-	// Why we need to share the client?
-	// Because we have to keep the connection alive to the kafka cluster. And the best way to do this is to
-	// use the same client for all producers and admin clients, and keep them alive.
-	// The keep-alive mechanism is running in saramaAdminClient.keepConnAlive.
-	client sarama.Client
 
 	registry metrics.Registry
 }
@@ -55,13 +47,29 @@ func NewSaramaFactory(
 }
 
 func (f *saramaFactory) AdminClient(ctx context.Context) (ClusterAdminClient, error) {
-	client, err := f.getClient(ctx)
+	start := time.Now()
+	config, err := NewSaramaConfig(ctx, f.option)
+	duration := time.Since(start).Seconds()
+	if duration > 2 {
+		log.Warn("new sarama config cost too much time", zap.Any("duration", duration), zap.Stringer("changefeedID", f.changefeedID))
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	start = time.Now()
+	client, err := sarama.NewClient(f.option.BrokerEndpoints, config)
+	duration = time.Since(start).Seconds()
+	if duration > 2 {
+		log.Warn("new sarama client cost too much time", zap.Any("duration", duration), zap.Stringer("changefeedID", f.changefeedID))
+	}
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	start := time.Now()
+
+	start = time.Now()
 	admin, err := sarama.NewClusterAdminFromClient(client)
-	duration := time.Since(start).Seconds()
+	duration = time.Since(start).Seconds()
 	if duration > 2 {
 		log.Warn("new sarama cluster admin cost too much time", zap.Any("duration", duration), zap.Stringer("changefeedID", f.changefeedID))
 	}
@@ -91,15 +99,15 @@ func (f *saramaFactory) AdminClient(ctx context.Context) (ClusterAdminClient, er
 // SyncProducer returns a Sync Producer,
 // it should be the caller's responsibility to close the producer
 func (f *saramaFactory) SyncProducer(ctx context.Context) (SyncProducer, error) {
-	client, err := f.getClient(ctx)
+	config, err := NewSaramaConfig(ctx, f.option)
+	if err != nil {
+		return nil, err
+	}
+	config.MetricRegistry = f.registry
+	p, err := sarama.NewSyncProducer(f.option.BrokerEndpoints, config)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	p, err := sarama.NewSyncProducerFromClient(client)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	return &saramaSyncProducer{
 		id:       f.changefeedID,
 		producer: p,
@@ -112,7 +120,13 @@ func (f *saramaFactory) AsyncProducer(
 	ctx context.Context,
 	failpointCh chan error,
 ) (AsyncProducer, error) {
-	client, err := f.getClient(ctx)
+	config, err := NewSaramaConfig(ctx, f.option)
+	if err != nil {
+		return nil, err
+	}
+	config.MetricRegistry = f.registry
+
+	client, err := sarama.NewClient(f.option.BrokerEndpoints, config)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -134,34 +148,4 @@ func (f *saramaFactory) MetricsCollector(
 ) MetricsCollector {
 	return NewSaramaMetricsCollector(
 		f.changefeedID, role, adminClient, f.registry)
-}
-
-func (f *saramaFactory) getClient(ctx context.Context) (sarama.Client, error) {
-	if f.client != nil {
-		return f.client, nil
-	}
-
-	start := time.Now()
-	config, err := NewSaramaConfig(ctx, f.option)
-	duration := time.Since(start).Seconds()
-	if duration > 2 {
-		log.Warn("new sarama config cost too much time", zap.Any("duration", duration), zap.Stringer("changefeedID", f.changefeedID))
-	}
-	if err != nil {
-		return nil, err
-	}
-	config.MetricRegistry = f.registry
-
-	start = time.Now()
-	client, err := sarama.NewClient(f.option.BrokerEndpoints, config)
-	duration = time.Since(start).Seconds()
-	if duration > 2 {
-		log.Warn("new sarama client cost too much time", zap.Any("duration", duration), zap.Stringer("changefeedID", f.changefeedID))
-	}
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	f.client = client
-
-	return client, nil
 }

--- a/pkg/sink/kafka/sarama_factory.go
+++ b/pkg/sink/kafka/sarama_factory.go
@@ -92,7 +92,6 @@ func (f *saramaFactory) AdminClient(ctx context.Context) (ClusterAdminClient, er
 			zap.String("configName", BrokerConnectionsMaxIdleMsConfigName), zap.String("configValue", idleMs))
 		return nil, errors.Trace(err)
 	}
-	go a.keepConnAlive(time.Duration(idleMsInt/2) * time.Millisecond)
 	return &a, nil
 }
 

--- a/pkg/sink/kafka/sarama_factory.go
+++ b/pkg/sink/kafka/sarama_factory.go
@@ -60,11 +60,14 @@ func (f *saramaFactory) AdminClient(ctx context.Context) (ClusterAdminClient, er
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &saramaAdminClient{
+	a := saramaAdminClient{
 		client:     client,
 		admin:      admin,
 		changefeed: f.changefeedID,
-	}, nil
+		done:       make(chan struct{}),
+	}
+	go a.keepConnAlive()
+	return &a, nil
 }
 
 // SyncProducer returns a Sync Producer,

--- a/pkg/sink/kafka/sarama_factory.go
+++ b/pkg/sink/kafka/sarama_factory.go
@@ -75,13 +75,12 @@ func (f *saramaFactory) AdminClient(ctx context.Context) (ClusterAdminClient, er
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	a := saramaAdminClient{
+
+	return &saramaAdminClient{
 		client:     client,
 		admin:      admin,
 		changefeed: f.changefeedID,
-	}
-
-	return &a, nil
+	}, nil
 }
 
 // SyncProducer returns a Sync Producer,
@@ -101,14 +100,14 @@ func (f *saramaFactory) SyncProducer(ctx context.Context) (SyncProducer, error) 
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	sp := saramaSyncProducer{
+
+	return &saramaSyncProducer{
 		id:                    f.changefeedID,
 		producer:              p,
 		client:                client,
 		keepConnAliveInterval: f.option.KeepConnAliveInterval,
 		lastHeartbeatTime:     time.Now().Add(-f.option.KeepConnAliveInterval),
-	}
-	return &sp, nil
+	}, nil
 }
 
 // AsyncProducer return an Async Producer,

--- a/pkg/sink/kafka/sarama_factory_test.go
+++ b/pkg/sink/kafka/sarama_factory_test.go
@@ -17,13 +17,12 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/IBM/sarama"
 	"github.com/IBM/sarama/mocks"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/stretchr/testify/require"
-
-	"time"
 )
 
 func TestNewSaramaFactory(t *testing.T) {

--- a/pkg/sink/kafka/v2/admin.go
+++ b/pkg/sink/kafka/v2/admin.go
@@ -230,6 +230,10 @@ func (a *admin) CreateTopic(
 	return nil
 }
 
+// HeartbeatBrokers is a no-op for the admin client.
+// Just satisfy the ClusterAdminClient interface.
+func (a *admin) HeartbeatBrokers() {}
+
 func (a *admin) Close() {
 	log.Info("admin client start closing",
 		zap.String("namespace", a.changefeedID.Namespace),

--- a/pkg/sink/kafka/v2/factory.go
+++ b/pkg/sink/kafka/v2/factory.go
@@ -306,6 +306,10 @@ func (s *syncWriter) SendMessages(ctx context.Context, topic string, partitionNu
 	return cerror.WrapError(cerror.ErrKafkaSendMessage, err)
 }
 
+// HeartbeatBrokers is a no-op for the sync producer.
+// Just to satisfy the interface.
+func (s *syncWriter) HeartbeatBrokers() {}
+
 // Close shuts down the producer; you must call this function before a producer
 // object passes out of scope, as it may otherwise leak memory.
 // You must call this before calling Close on the underlying client.


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12171

This PR addresses the issue of frequent broken pipe errors in CDC when connecting to Kafka. The user reported that multiple clusters frequently triggered CDC alerts (cdc changefeed meet error) with the error message `write tcp ...: write: broken pipe`, occurring on average once every dozens of minutes. Although CDC appeared to function normally — with business operations unaffected and checkpoint lag remaining within acceptable limits — the alerts persisted.

The reason is that CDC had recently removed retries in the Sarama Kafka client (used by CDC) — reducing the retry count from 3 to 0 in #11870. This change was originally made to avoid potential message reordering issues. However, disabling retries caused CDC to surface connection-related errors directly, such as broken pipe, leading to changefeed failures instead of silent retries.

### What is changed and how it works?

This PR improves the reliability of Kafka connections in TiCDC by introducing a **keep-alive mechanism** for sarama that periodically sends heartbeats to all known Kafka brokers. This is a workaround for a known issue where Kafka broker silently closes idle connections, especially when sarama retry is disabled. The keep-alive interval will be a third of(for fault tolerance) `connections.max.idle.ms` in Kafka broker configs. In CDC, three types of Kafka connections are established, which are used for admin requests, DDL and watermark, and DML respectively.

* For the Kafka connection used for admin requests, I added periodic heartbeat sending to all Kafka brokers in the `kafkaTopicManager.backgroundRefreshMeta` goroutine to refresh the connections with all brokers.

* For the Kafka connection used for DDL and watermark, I added the heartbeat sending operation in the `DDLSink.WriteCheckpointTs` function, which will be invoked periodically.

* For the Kafka connection used for DML, I added periodic heartbeat sending to all Kafka brokers in the `saramaAsyncProducer.AsyncRunCallback`.

#### UT
The units tests cover the entire lifecycle of the keep-alive logic. We verify that the keep-alive interval is correctly calculated from the broker's settings by testing the AdjustOptions function. For the DML sink, we ensure the kafkaTopicManager's background routine sends heartbeats periodically. For the DDL sink, we confirm that a call to WriteCheckpointTs reliably triggers a heartbeat.

At the producer level, the tests validate the specific logic within both the synchronous and asynchronous Sarama producers. This includes testing the throttling mechanism in the sync producer to avoid sending heartbeats too frequently, and the background ticker in the async producer that drives the periodic calls.

To achieve this test coverage, a couple of specific strategies were used. To test the DDL sink's heartbeat trigger in isolation, a mock encoder is introduced that returns an error immediately after the heartbeat logic, simplifying the test by avoiding the need to set up a full message production pipeline. Furthermore, to test the producer-level heartbeats, we mock the sarama.Client interface itself. This approach allows us to verify that the heartbeat logic is being invoked, working around a limitation in the Sarama library that prevents direct mocking of the *sarama.Broker struct's methods.

With these tests in place, the keep-alive feature is now well-covered.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test
 - Test case PR: https://github.com/PingCAP-QE/test-infra/pull/4094
 - Test plan PR: https://github.com/PingCAP-QE/test-plan/pull/3765, will be run in daily and future patch release.
 - Kafka compatibility test: 0.11.0-0-r0, 0.11.0-1-r0, 1.0.0-r0, 1.0.1-r0, 1.1.0, 1.1.1, 2.0.0, 2.0.1, 2.1.0, 2.2.0, 2.3.0, 2.4.0, 2.5.0, 2.6.0, 2.7.0, 2.8.0, 3.0.0, 3.1.0, 3.2.0. 3.4.0, 3.5.0, 3.6.0, 3.7.0.

A cluster was launched for testing, synchronizing upstream data to the downstream Kafka. The `connections.max.idle.ms` setting on the Kafka broker was configured to 10 seconds. Then, a load was added on the upstream side, randomly writing some data and pausing for a while. This load was run continuously, and it was confirmed that there were no issues.

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Improve Kafka connection reliability by introducing a keep-alive mechanism for sarama. This helps prevent unexpected timeouts caused by idle connections being silently closed by Kafka.
```
