### PR TITLE
kvclient(ticdc): fix the resolve last run status gc

### DIFF
--- a/cdc/kv/shared_client.go
+++ b/cdc/kv/shared_client.go
@@ -776,7 +776,7 @@ func (s *SharedClient) handleResolveLockTasks(ctx context.Context) error {
 			now := time.Now()
 			for regionID, lastRun := range resolveLastRun {
 				if now.Sub(lastRun) < resolveLockMinInterval {
-					resolveLastRun[regionID] = lastRun
+					copied[regionID] = lastRun
 				}
 			}
 			resolveLastRun = copied


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12187

### What is changed and how it works?

The current GC actually drop all the resolve status, I doubt that's our purpose.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
