### PR TITLE
codec(ticdc): fix incorrect encoding default "null" in Avro protocol 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d
 	github.com/klauspost/compress v1.17.9
 	github.com/labstack/gommon v0.4.0
-	github.com/linkedin/goavro/v2 v2.11.1
+	github.com/linkedin/goavro/v2 v2.14.0
 	github.com/mailru/easyjson v0.7.7
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/modern-go/reflect2 v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -742,8 +742,8 @@ github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNB
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/linkedin/goavro/v2 v2.11.1 h1:4cuAtbDfqkKnBXp9E+tRkIJGa6W6iAjwonwt8O1f4U0=
-github.com/linkedin/goavro/v2 v2.11.1/go.mod h1:UgQUb2N/pmueQYH9bfqFioWxzYCZXSfF8Jw03O5sjqA=
+github.com/linkedin/goavro/v2 v2.14.0 h1:aNO/js65U+Mwq4yB5f1h01c3wiM458qtRad1DN0CMUI=
+github.com/linkedin/goavro/v2 v2.14.0/go.mod h1:KXx+erlq+RPlGSPmLF7xGo6SAbh8sCQ53x064+ioxhk=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/lufia/plan9stats v0.0.0-20230326075908-cb1d2100619a h1:N9zuLhTvBSRt0gWSiJswwQ2HqDmtX/ZCDJURnKUt1Ik=
 github.com/lufia/plan9stats v0.0.0-20230326075908-cb1d2100619a/go.mod h1:JKx41uQRwqlTZabZc+kILPrO/3jlKnQ2Z8b7YiVw5cE=
@@ -1052,6 +1052,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=

--- a/pkg/sink/codec/avro/avro.go
+++ b/pkg/sink/codec/avro/avro.go
@@ -560,10 +560,7 @@ func (a *BatchEncoder) columns2AvroSchema(tableName model.TableName, input avroE
 			}
 		} else {
 			if colx.GetFlag().IsNullable() {
-				// the string literal "null" must be coerced to a `nil`
-				// see https://github.com/linkedin/goavro/blob/5ec5a5ee7ec82e16e6e2b438d610e1cab2588393/record.go#L109-L114
-				// https://stackoverflow.com/questions/22938124/avro-field-default-values
-				if defaultValue == nil || defaultValue == "null" {
+				if defaultValue == nil {
 					field["type"] = []interface{}{"null", avroType}
 				} else {
 					field["type"] = []interface{}{avroType, "null"}
@@ -1043,4 +1040,11 @@ func SetupEncoderAndSchemaRegistry4Testing(
 // TeardownEncoderAndSchemaRegistry4Testing stop the local schema registry for testing.
 func TeardownEncoderAndSchemaRegistry4Testing() {
 	stopHTTPInterceptForTestingRegistry()
+}
+
+// GenCodec generate avro codec.
+// Don't treat string literal "null" as null, because we can distinguish them.
+// See https://github.com/pingcap/tiflow/issues/11994
+func GenCodec(schema string) (*goavro.Codec, error) {
+	return goavro.NewCodecWithOptions(schema, &goavro.CodecOption{EnableStringNull: false})
 }

--- a/pkg/sink/codec/avro/avro_test.go
+++ b/pkg/sink/codec/avro/avro_test.go
@@ -247,14 +247,14 @@ func TestAvroEnvelope(t *testing.T) {
 	t.Parallel()
 	cManager := &confluentSchemaManager{}
 	gManager := &glueSchemaManager{}
-	avroCodec, err := goavro.NewCodecWithOptions(`
+	avroCodec, err := GenCodec(`
        {
          "type": "record",
          "name": "testdb.avroenvelope",
          "fields" : [
            {"name": "id", "type": "int", "default": 0}
          ]
-       }`, &goavro.CodecOption{EnableStringNull: false})
+       }`)
 
 	require.NoError(t, err)
 
@@ -390,4 +390,39 @@ func TestArvoAppendRowChangedEventWithCallback(t *testing.T) {
 		msgs[0].Callback()
 		require.Equal(t, expected, count, "expected one callback be called")
 	}
+}
+
+func TestStringNull(t *testing.T) {
+	_, err := goavro.NewCodecWithOptions(`{
+		"type": "record",
+		"name": "test",
+		"fields":
+		  [
+			{
+			 "type": [
+				 "string",
+				 "null"
+			 ],
+			 "default": "null",
+			 "name": "field"
+			}
+		   ]
+	  }`, &goavro.CodecOption{EnableStringNull: true})
+	require.Error(t, err)
+	_, err = goavro.NewCodecWithOptions(`{
+		"type": "record",
+		"name": "test",
+		"fields":
+		  [
+			{
+			 "type": [
+				 "string",
+				 "null"
+			 ],
+			 "default": "null",
+			 "name": "field"
+			}
+		   ]
+	  }`, &goavro.CodecOption{EnableStringNull: false})
+	require.NoError(t, err)
 }

--- a/pkg/sink/codec/avro/avro_test.go
+++ b/pkg/sink/codec/avro/avro_test.go
@@ -247,14 +247,14 @@ func TestAvroEnvelope(t *testing.T) {
 	t.Parallel()
 	cManager := &confluentSchemaManager{}
 	gManager := &glueSchemaManager{}
-	avroCodec, err := goavro.NewCodec(`
+	avroCodec, err := goavro.NewCodecWithOptions(`
        {
          "type": "record",
          "name": "testdb.avroenvelope",
          "fields" : [
            {"name": "id", "type": "int", "default": 0}
          ]
-       }`)
+       }`, &goavro.CodecOption{EnableStringNull: false})
 
 	require.NoError(t, err)
 

--- a/pkg/sink/codec/avro/confluent_schema_registry.go
+++ b/pkg/sink/codec/avro/confluent_schema_registry.go
@@ -267,7 +267,7 @@ func (m *confluentSchemaManager) Lookup(
 	}
 
 	cacheEntry := new(schemaCacheEntry)
-	cacheEntry.codec, err = goavro.NewCodec(jsonResp.Schema)
+	cacheEntry.codec, err = goavro.NewCodecWithOptions(jsonResp.Schema, &goavro.CodecOption{EnableStringNull: false})
 	if err != nil {
 		log.Error("Creating Avro codec failed", zap.Error(err))
 		return nil, cerror.WrapError(cerror.ErrAvroSchemaAPIError, err)
@@ -314,7 +314,7 @@ func (m *confluentSchemaManager) GetCachedOrRegister(
 		return nil, nil, err
 	}
 
-	codec, err := goavro.NewCodec(schema)
+	codec, err := goavro.NewCodecWithOptions(schema, &goavro.CodecOption{EnableStringNull: false})
 	if err != nil {
 		log.Error("GetCachedOrRegister: Could not make goavro codec", zap.Error(err))
 		return nil, nil, cerror.WrapError(cerror.ErrAvroSchemaAPIError, err)

--- a/pkg/sink/codec/avro/confluent_schema_registry.go
+++ b/pkg/sink/codec/avro/confluent_schema_registry.go
@@ -267,11 +267,12 @@ func (m *confluentSchemaManager) Lookup(
 	}
 
 	cacheEntry := new(schemaCacheEntry)
-	cacheEntry.codec, err = goavro.NewCodecWithOptions(jsonResp.Schema, &goavro.CodecOption{EnableStringNull: false})
+	codec, err := GenCodec(jsonResp.Schema)
 	if err != nil {
 		log.Error("Creating Avro codec failed", zap.Error(err))
 		return nil, cerror.WrapError(cerror.ErrAvroSchemaAPIError, err)
 	}
+	cacheEntry.codec = codec
 	cacheEntry.schemaID.confluentSchemaID = schemaID.confluentSchemaID
 	cacheEntry.header, err = m.getMsgHeader(schemaID.confluentSchemaID)
 	if err != nil {
@@ -314,7 +315,7 @@ func (m *confluentSchemaManager) GetCachedOrRegister(
 		return nil, nil, err
 	}
 
-	codec, err := goavro.NewCodecWithOptions(schema, &goavro.CodecOption{EnableStringNull: false})
+	codec, err := GenCodec(schema)
 	if err != nil {
 		log.Error("GetCachedOrRegister: Could not make goavro codec", zap.Error(err))
 		return nil, nil, cerror.WrapError(cerror.ErrAvroSchemaAPIError, err)

--- a/pkg/sink/codec/avro/confluent_schema_registry_test.go
+++ b/pkg/sink/codec/avro/confluent_schema_registry_test.go
@@ -47,7 +47,7 @@ func TestSchemaRegistry(t *testing.T) {
 	_, err = manager.Lookup(ctx, topic, schemaID{confluentSchemaID: 1})
 	require.Regexp(t, `.*not\sfound.*`, err)
 
-	codec, err := goavro.NewCodecWithOptions(`{
+	codec, err := GenCodec(`{
        "type": "record",
        "name": "test",
        "fields":
@@ -57,7 +57,7 @@ func TestSchemaRegistry(t *testing.T) {
              "name": "field1"
            }
           ]
-     }`, &goavro.CodecOption{EnableStringNull: false})
+     }`)
 	require.NoError(t, err)
 
 	schemaID, err := manager.Register(ctx, topic, codec.Schema())
@@ -67,7 +67,7 @@ func TestSchemaRegistry(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, codec.CanonicalSchema(), codec2.CanonicalSchema())
 
-	codec, err = goavro.NewCodecWithOptions(`{
+	codec, err = GenCodec(`{
        "type": "record",
        "name": "test",
        "fields":
@@ -93,7 +93,7 @@ func TestSchemaRegistry(t *testing.T) {
 			"name": "field3"
 		   }
           ]
-     }`, &goavro.CodecOption{EnableStringNull: false})
+     }`)
 	require.NoError(t, err)
 	schemaID, err = manager.Register(ctx, topic, codec.Schema())
 	require.NoError(t, err)
@@ -101,41 +101,6 @@ func TestSchemaRegistry(t *testing.T) {
 	codec2, err = manager.Lookup(ctx, topic, schemaID)
 	require.NoError(t, err)
 	require.Equal(t, codec.CanonicalSchema(), codec2.CanonicalSchema())
-}
-
-func TestStringNull(t *testing.T) {
-	_, err := goavro.NewCodec(`{
-		"type": "record",
-		"name": "test",
-		"fields":
-		  [
-			{
-			 "type": [
-				 "string",
-				 "null"
-			 ],
-			 "default": "null",
-			 "name": "field"
-			}
-		   ]
-	  }`)
-	require.Error(t, err)
-	_, err = goavro.NewCodecWithOptions(`{
-		"type": "record",
-		"name": "test",
-		"fields":
-		  [
-			{
-			 "type": [
-				 "string",
-				 "null"
-			 ],
-			 "default": "null",
-			 "name": "field"
-			}
-		   ]
-	  }`, &goavro.CodecOption{EnableStringNull: false})
-	require.NoError(t, err)
 }
 
 func TestSchemaRegistryBad(t *testing.T) {

--- a/pkg/sink/codec/avro/glue_schema_registry.go
+++ b/pkg/sink/codec/avro/glue_schema_registry.go
@@ -153,7 +153,7 @@ func (m *glueSchemaManager) Lookup(
 			GenWithStackByArgs("schema not found in registry, name: %s, id: %s", schemaName, schemaID.glueSchemaID)
 	}
 
-	codec, err := goavro.NewCodecWithOptions(schema, &goavro.CodecOption{EnableStringNull: false})
+	codec, err := GenCodec(schema)
 	if err != nil {
 		log.Error("could not make goavro codec", zap.Error(err))
 		return nil, cerror.WrapError(cerror.ErrAvroSchemaAPIError, err)
@@ -206,7 +206,7 @@ func (m *glueSchemaManager) GetCachedOrRegister(
 		return nil, nil, err
 	}
 
-	codec, err := goavro.NewCodecWithOptions(schema, &goavro.CodecOption{EnableStringNull: false})
+	codec, err := GenCodec(schema)
 	if err != nil {
 		log.Error("GetCachedOrRegister: Could not make goavro codec", zap.Error(err))
 		return nil, nil, cerror.WrapError(cerror.ErrAvroSchemaAPIError, err)

--- a/pkg/sink/codec/avro/glue_schema_registry.go
+++ b/pkg/sink/codec/avro/glue_schema_registry.go
@@ -153,7 +153,7 @@ func (m *glueSchemaManager) Lookup(
 			GenWithStackByArgs("schema not found in registry, name: %s, id: %s", schemaName, schemaID.glueSchemaID)
 	}
 
-	codec, err := goavro.NewCodec(schema)
+	codec, err := goavro.NewCodecWithOptions(schema, &goavro.CodecOption{EnableStringNull: false})
 	if err != nil {
 		log.Error("could not make goavro codec", zap.Error(err))
 		return nil, cerror.WrapError(cerror.ErrAvroSchemaAPIError, err)
@@ -206,7 +206,7 @@ func (m *glueSchemaManager) GetCachedOrRegister(
 		return nil, nil, err
 	}
 
-	codec, err := goavro.NewCodec(schema)
+	codec, err := goavro.NewCodecWithOptions(schema, &goavro.CodecOption{EnableStringNull: false})
 	if err != nil {
 		log.Error("GetCachedOrRegister: Could not make goavro codec", zap.Error(err))
 		return nil, nil, cerror.WrapError(cerror.ErrAvroSchemaAPIError, err)

--- a/pkg/sink/codec/simple/marshaller.go
+++ b/pkg/sink/codec/simple/marshaller.go
@@ -105,7 +105,7 @@ type avroMarshaller struct {
 }
 
 func newAvroMarshaller(config *common.Config, schema string) (*avroMarshaller, error) {
-	codec, err := goavro.NewCodec(schema)
+	codec, err := goavro.NewCodecWithOptions(schema, &goavro.CodecOption{EnableStringNull: false})
 	return &avroMarshaller{
 		codec:  codec,
 		config: config,


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11994

### What is changed and how it works?
The `goavro` treats string literal "null" as null in the past. This is a bug of `goavro` and is fixed in v2.14.0. https://github.com/linkedin/goavro/issues/280

This PR upgrades the `goavro` dependency and outputs the correct type.

**Before**
```json
{
		"type": "record",
		"name": "test",
		"fields":
		  [
			{
			 "type": [
				 "null",
				 "string"
			 ],
			 "default": "null",
			 "name": "field"
			}
		   ]
}
```
**After**
```json
{
		"type": "record",
		"name": "test",
		"fields":
		  [
			{
			 "type": [
				 "string",
				 "null"
			 ],
			 "default": "null",
			 "name": "field"
			}
		   ]
}
```
### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
According to the Avro documentation (1.11), when a default value is specified for a record field whose type is a union, the type of the default value must match the first element of the union. 
```
