### PR TITLE
scheduler: Speed ​​up region scanning before table splitting

### DIFF
--- a/cdc/scheduler/internal/v3/keyspan/mock.go
+++ b/cdc/scheduler/internal/v3/keyspan/mock.go
@@ -15,7 +15,9 @@ package keyspan
 
 import (
 	"bytes"
+	"unsafe"
 
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tiflow/cdc/model"
 	"github.com/pingcap/tiflow/cdc/processor/tablepb"
 	"github.com/pingcap/tiflow/pkg/config"
@@ -26,12 +28,10 @@ import (
 // RegionCache is a simplified interface of tikv.RegionCache.
 // It is useful to restrict RegionCache usage and mocking in tests.
 type RegionCache interface {
-	// ListRegionIDsInKeyRange lists ids of regions in [startKey,endKey].
-	ListRegionIDsInKeyRange(
+	// LoadRegionsInKeyRange loads regions in [startKey,endKey].
+	LoadRegionsInKeyRange(
 		bo *tikv.Backoffer, startKey, endKey []byte,
-	) (regionIDs []uint64, err error)
-	// LocateRegionByID searches for the region with ID.
-	LocateRegionByID(bo *tikv.Backoffer, regionID uint64) (*tikv.KeyLocation, error)
+	) (regions []*tikv.Region, err error)
 }
 
 // mockCache mocks tikv.RegionCache.
@@ -42,34 +42,29 @@ type mockCache struct {
 // NewMockRegionCache returns a new MockCache.
 func NewMockRegionCache() *mockCache { return &mockCache{regions: spanz.NewBtreeMap[uint64]()} }
 
-// ListRegionIDsInKeyRange lists ids of regions in [startKey,endKey].
-func (m *mockCache) ListRegionIDsInKeyRange(
+func (m *mockCache) LoadRegionsInKeyRange(
 	bo *tikv.Backoffer, startKey, endKey []byte,
-) (regionIDs []uint64, err error) {
+) (regions []*tikv.Region, err error) {
 	m.regions.Ascend(func(loc tablepb.Span, id uint64) bool {
 		if bytes.Compare(loc.StartKey, endKey) >= 0 ||
 			bytes.Compare(loc.EndKey, startKey) <= 0 {
 			return true
 		}
-		regionIDs = append(regionIDs, id)
-		return true
-	})
-	return
-}
+		region := &tikv.Region{}
+		meta := &metapb.Region{
+			Id:       id,
+			StartKey: loc.StartKey,
+			EndKey:   loc.EndKey,
+		}
 
-// LocateRegionByID searches for the region with ID.
-func (m *mockCache) LocateRegionByID(
-	bo *tikv.Backoffer, regionID uint64,
-) (loc *tikv.KeyLocation, err error) {
-	m.regions.Ascend(func(span tablepb.Span, id uint64) bool {
-		if id != regionID {
-			return true
-		}
-		loc = &tikv.KeyLocation{
-			StartKey: span.StartKey,
-			EndKey:   span.EndKey,
-		}
-		return false
+		// meta.id is not exported, so we use unsafe to access it more easier for test.
+		regionPtr := (*struct {
+			meta *metapb.Region
+		})(unsafe.Pointer(region))
+		regionPtr.meta = meta
+
+		regions = append(regions, region)
+		return true
 	})
 	return
 }

--- a/cdc/scheduler/internal/v3/keyspan/mock.go
+++ b/cdc/scheduler/internal/v3/keyspan/mock.go
@@ -57,7 +57,7 @@ func (m *mockCache) LoadRegionsInKeyRange(
 			EndKey:   loc.EndKey,
 		}
 
-		// meta.id is not exported, so we use unsafe to access it more easier for test.
+		// region.meta is not exported, so we use unsafe to set it for testing.
 		regionPtr := (*struct {
 			meta *metapb.Region
 		})(unsafe.Pointer(region))

--- a/cdc/scheduler/internal/v3/keyspan/splitter_region_count.go
+++ b/cdc/scheduler/internal/v3/keyspan/splitter_region_count.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/hex"
 	"math"
+	"time"
 
 	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/cdc/model"
@@ -45,6 +46,7 @@ func newRegionCountSplitter(
 func (m *regionCountSplitter) split(
 	ctx context.Context, span tablepb.Span, captureNum int,
 ) []tablepb.Span {
+	startTimestamp := time.Now()
 	bo := tikv.NewBackoffer(ctx, 500)
 	regions, err := m.regionCache.LoadRegionsInKeyRange(bo, span.StartKey, span.EndKey)
 	if err != nil {
@@ -114,7 +116,8 @@ func (m *regionCountSplitter) split(
 		zap.Int("totalCaptures", captureNum),
 		zap.Int("regionCount", len(regions)),
 		zap.Int("regionThreshold", m.regionThreshold),
-		zap.Int("spanRegionLimit", spanRegionLimit))
+		zap.Int("spanRegionLimit", spanRegionLimit),
+		zap.Duration("time", time.Since(startTimestamp)))
 	return spans
 }
 

--- a/cdc/scheduler/internal/v3/keyspan/splitter_region_count.go
+++ b/cdc/scheduler/internal/v3/keyspan/splitter_region_count.go
@@ -16,6 +16,7 @@ package keyspan
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"math"
 
 	"github.com/pingcap/log"
@@ -81,8 +82,8 @@ func (m *regionCountSplitter) split(
 				zap.String("changefeed", m.changefeedID.ID),
 				zap.String("span", span.String()),
 				zap.Stringer("lastSpan", &spans[len(spans)-1]),
-				zap.Any("startKey", startKey),
-				zap.Any("endKey", endKey))
+				zap.String("startKey", hex.EncodeToString(startKey)),
+				zap.String("endKey", hex.EncodeToString(endKey)))
 			return []tablepb.Span{span}
 		}
 		spans = append(spans, tablepb.Span{


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close https://github.com/pingcap/tiflow/issues/12221

### What is changed and how it works?
use `LoadRegionsInKeyRange` instead of `ListRegionIDsInKeyRange` to speed up the region scanning performance

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

We make a tidb cluster with nearly 5w regions(region size is 5MB)
After optimization, the time cost of scanning regions reduce to **450ms** from **10s**.

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
