### PR TITLE
cloudstorage: fix a bug causing context cancelled errors and stuck sink

### DIFF
--- a/pkg/util/external_storage.go
+++ b/pkg/util/external_storage.go
@@ -197,9 +197,28 @@ func (s *extStorageWithTimeout) DeleteFile(ctx context.Context, name string) err
 func (s *extStorageWithTimeout) Open(
 	ctx context.Context, path string, _ *storage.ReaderOption,
 ) (storage.ExternalFileReader, error) {
+	// Unlike other methods, Open method cannot call cancel() in defer.
+	// This is because the reader's lifetime is bound to the context provided at Open().
+	// Subsequent Read() calls on reader will observe context cancellation.
+	// Instead, we wrap the reader in a struct and cancel it's context in Close().
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
-	defer cancel()
-	return s.ExternalStorage.Open(ctx, path, nil)
+	r, err := s.ExternalStorage.Open(ctx, path, nil)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	return &readerWithCancel{ExternalFileReader: r, cancel: cancel}, nil
+}
+
+type readerWithCancel struct {
+	storage.ExternalFileReader
+	cancel context.CancelFunc
+}
+
+// Close the reader and cancel the context.
+func (r *readerWithCancel) Close() error {
+	r.cancel()
+	return r.ExternalFileReader.Close()
 }
 
 // WalkDir traverse all the files in a dir.

--- a/pkg/util/external_storage.go
+++ b/pkg/util/external_storage.go
@@ -217,7 +217,7 @@ type readerWithCancel struct {
 
 // Close the reader and cancel the context.
 func (r *readerWithCancel) Close() error {
-	r.cancel()
+	defer r.cancel()
 	return r.ExternalFileReader.Close()
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:  close https://github.com/pingcap/tiflow/issues/12277

Fixes TiCDC cloud storage sink flapping (start/stop spam) on Azure Blob caused by premature context cancellation during reads.

Symptoms included:
- “Failed to read data from azure blob, data info: pos='0', count='1': context canceled”
- “failed to generate data file path”
- “dead dmlSink”

The regression seems to be introduced by https://github.com/pingcap/tiflow/commit/0e6782b71. Switching to GetExternalStorageWithDefaultTimeout wrapped `Open` with a timeout and canceled it immediately, breaking subsequent Read() calls that reuse the Open() context.

### What is changed and how it works?

Before: Open wrapped the passed context with `context.WithTimeout` and deferred `cancel()`. Since many backends bind the reader’s lifetime to the Open context, the deferred cancel immediately invalidated the reader’s future Read() calls, causing “context canceled” errors.

Now: Open passes the caller's context through without wrapping or canceling it. This prevents premature cancellation while keeping existing timeouts for other APIs. `extStorageWithTimeout.Open` returns a `readerWithCancel` wrapper struct which calls `cancel()` on `Close()` 

#### Tests <!-- At least one of them must be included. -->

 - Unit tests

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
