### PR TITLE
docs(ticdc): update command for downloading test binaries in README

### DIFF
--- a/tests/integration_tests/README.md
+++ b/tests/integration_tests/README.md
@@ -2,7 +2,7 @@
 
 ### Run integration tests locally
 
-1. Run `make prepare_test_binaries` to download TiCDC related binaries for integration test.
+1. Run `make prepare_test_binaries community=true` to download TiCDC related binaries for integration test.
 If you need to specify a version, os or arch, you can use, for example: `make prepare_test_binaries community=true ver=v7.0.0 os=linux arch=amd64`. (The `community=true` option is necessary when you need to specify a version, arch or whatever.)
 
    > Note: Please be aware that if you manually specify the versions of the TiDB-related components during the download process, there is a potential risk of incompatibility if the specified versions do not match the current TiCDC version. For example, see issue #11507 where version mismatches caused incompatibility problems during integration tests.


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12278

### What is changed and how it works?

This PR updates the `README.md` for integration tests to ensure the instructions are correct for community contributors.

**Problem:**

The previous command, `make prepare_test_binaries`, defaults to downloading test dependencies from an internal file server. This server is inaccessible to users outside of the organization, which blocks community members from being able to run integration tests locally.

**Changes:**

This PR modifies the command in `tests/integration_tests/README.md` to `make prepare_test_binaries community=true`.

Using the `community=true` flag directs the build script to download the required binaries from public sources, resolving the accessibility issue for community contributors. The documentation has also been clarified to state that this flag is necessary when specifying other variables like version or architecture.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
