### PR TITLE
cdc: fix data race in TestGCAndCleanup by moving global variable modification to TestMain

### DIFF
--- a/cdc/redo/main_test.go
+++ b/cdc/redo/main_test.go
@@ -17,8 +17,14 @@ import (
 	"testing"
 
 	"github.com/pingcap/tiflow/pkg/leakutil"
+	"github.com/pingcap/tiflow/pkg/redo"
 )
 
 func TestMain(m *testing.M) {
+	originValue := redo.DefaultGCIntervalInMs
+	redo.DefaultGCIntervalInMs = 20
+	defer func() {
+		redo.DefaultGCIntervalInMs = originValue
+	}()
 	leakutil.SetUpLeakTest(m)
 }

--- a/cdc/redo/meta_manager_test.go
+++ b/cdc/redo/meta_manager_test.go
@@ -242,12 +242,6 @@ func testWriteMeta(ctx context.Context, t *testing.T, m *metaManager) {
 func TestGCAndCleanup(t *testing.T) {
 	t.Parallel()
 
-	originValue := redo.DefaultGCIntervalInMs
-	redo.DefaultGCIntervalInMs = 20
-	defer func() {
-		redo.DefaultGCIntervalInMs = originValue
-	}()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	captureID := "test-capture"


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12371

### What is changed and how it works?

This PR fixes a data race detected in the `cdc/redo` test suite.

**Changes:**

1.  **`cdc/redo/meta_manager_test.go`:**
    * Removed the code block from `TestGCAndCleanup` that sets `redo.DefaultGCIntervalInMs` to `20` and defers its reset. This stops the global variable from being written to inside a parallel test.

2.  **`cdc/redo/main_test.go`:**
    * Added the `github.com/pingcap/tiflow/pkg/redo` import.
    * Moved the logic to set `redo.DefaultGCIntervalInMs = 20` into the `TestMain` function.
    * A `defer` statement is used in `TestMain` to restore the original value after all tests in the `cdc/redo` package have finished running.

By moving this logic to `TestMain`, the global variable is set *once* at the beginning of the entire package's test run, before any parallel tests are executed. This provides a stable test environment for all tests in the package while completely eliminating the data race.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?
None
##### Do you need to update user documentation, design documentation or monitoring documentation?
None
### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
