### PR TITLE
DM: Support for MySQL 8.4

### DIFF
--- a/dm/pkg/checker/mysql_server.go
+++ b/dm/pkg/checker/mysql_server.go
@@ -35,14 +35,14 @@ func NewMySQLVersionChecker(db *sql.DB, dbinfo *dbutil.DBConfig) RealChecker {
 }
 
 // SupportedVersion defines the MySQL/MariaDB version that DM/syncer supports
-// * 5.6.0 <= MySQL Version < 8.1.0.
+// * 5.6.0 <= MySQL Version < 8.5.0.
 var SupportedVersion = map[string]struct {
 	Min MySQLVersion
 	Max MySQLVersion
 }{
 	"mysql": {
 		MySQLVersion{5, 6, 0},
-		MySQLVersion{8, 1, 0},
+		MySQLVersion{8, 5, 0},
 	},
 }
 

--- a/dm/pkg/checker/utils_test.go
+++ b/dm/pkg/checker/utils_test.go
@@ -14,6 +14,7 @@
 package checker
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pingcap/errors"
@@ -35,7 +36,10 @@ func TestVersionComparison(t *testing.T) {
 		{"5.7.0", true, true, true, true},
 		{"5.8.0", true, true, true, true}, // although it does not exist
 		{"8.0.1", true, true, true, true},
-		{"8.1.0", true, true, false, true},
+		{"8.1.0", true, true, true, true},
+		{"8.4.0", true, true, true, true},
+		{"8.5.0", true, true, false, true},
+		{"9.5.0", true, true, false, false},
 		{"255.255.255", true, true, false, false}, // max version
 	}
 
@@ -46,10 +50,18 @@ func TestVersionComparison(t *testing.T) {
 	for _, cs := range cases {
 		version, err = toMySQLVersion(cs.rawVersion)
 		require.NoError(t, err)
-		require.Equal(t, cs.ge, version.Ge(SupportedVersion["mysql"].Min))
-		require.Equal(t, cs.gt, version.Gt(SupportedVersion["mysql"].Min))
-		require.Equal(t, cs.lt, version.Lt(SupportedVersion["mysql"].Max))
-		require.Equal(t, cs.le, version.Le(SupportedVersion["mysql"].Max))
+		require.Equal(t, cs.ge, version.Ge(SupportedVersion["mysql"].Min),
+			fmt.Sprintf("%s >= min supported version (%s) should be %v", version, SupportedVersion["mysql"].Min, cs.ge),
+		)
+		require.Equal(t, cs.gt, version.Gt(SupportedVersion["mysql"].Min),
+			fmt.Sprintf("%s > min supported version (%s) should be %v", version, SupportedVersion["mysql"].Min, cs.gt),
+		)
+		require.Equal(t, cs.lt, version.Lt(SupportedVersion["mysql"].Max),
+			fmt.Sprintf("%s < max supported version (%s) should be %v", version, SupportedVersion["mysql"].Max, cs.lt),
+		)
+		require.Equal(t, cs.le, version.Le(SupportedVersion["mysql"].Max),
+			fmt.Sprintf("%s <= max suported vesion (%s) should be %v", version, SupportedVersion["mysql"].Max, cs.le),
+		)
 	}
 }
 

--- a/dm/pkg/conn/basedb_test.go
+++ b/dm/pkg/conn/basedb_test.go
@@ -104,3 +104,24 @@ func TestGetBaseConnWontBlock(t *testing.T) {
 	_, err = baseDB.GetBaseConn(ctx)
 	require.Error(t, err)
 }
+
+func TestNeedsModernTerminology(t *testing.T) {
+	var b BaseDB
+
+	cases := []struct {
+		version string
+		modern  bool
+	}{
+		{"5.7.44", false},
+		{"8.0.44", false},
+		{"8.4.7", true},
+		{"9.5.0", true},
+		{"10.4.7-MariaDB", false},
+		{"", false},
+	}
+
+	for _, tc := range cases {
+		b.version = tc.version
+		require.Equal(t, tc.modern, b.needsModernTerminology(), b.version)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11020

### What is changed and how it works?

~~The version is now a string and checking is done with `strings.HasPrefix(...,"8.4")` which obviously isn't very robust but it does work for now. We could change this into a version range check. The result is that for now this only fixes compatibility with 8.4 (which is an LTS release) and not with 9.x or perhaps with 8.3 or earlier (but after 8.0). But for now only 8.0 and 8.4 are LTS releases.~~

~~It is also possible to store the version as 3 ints, but then we can't use this to detect MariaDB, TiDB, etc in the future.~~

~~This might need more unittests and other kinds of testing.~~

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

It improves compatibility for new versions without breaking compatibility with older versions or with MariaDB.

##### Do you need to update user documentation, design documentation or monitoring documentation?

Yes, the version matrix etc.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
MySQL 8.4 is now supported.
```
