### PR TITLE
dm: make binlog event cache configurable

### DIFF
--- a/dm/config/subtask.go
+++ b/dm/config/subtask.go
@@ -388,6 +388,9 @@ func (c *SubTaskConfig) Adjust(verifyDecryptPassword bool) error {
 	if c.SyncerConfig.QueueSize == 0 {
 		c.SyncerConfig.QueueSize = defaultQueueSize
 	}
+	if c.SyncerConfig.EventCacheCount == 0 {
+		c.SyncerConfig.EventCacheCount = defaultEventCacheCount
+	}
 	if c.SyncerConfig.CheckpointFlushInterval == 0 {
 		c.SyncerConfig.CheckpointFlushInterval = defaultCheckpointFlushInterval
 	}

--- a/dm/syncer/data_validator.go
+++ b/dm/syncer/data_validator.go
@@ -314,7 +314,7 @@ func (v *DataValidator) initialize() error {
 		return err
 	}
 
-	v.syncCfg, err = subtaskCfg2BinlogSyncerCfg(v.cfg, v.timezone, v.syncer.baList)
+	v.syncCfg, err = subtaskCfg2BinlogSyncerCfg(v.cfg, v.timezone, v.syncer.baList, v.cfg.ValidatorCfg.EventCacheCount)
 	if err != nil {
 		return err
 	}

--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -386,7 +386,7 @@ func (s *Syncer) Init(ctx context.Context) (err error) {
 		return terror.ErrSyncerUnitGenBAList.Delegate(err)
 	}
 
-	s.syncCfg, err = subtaskCfg2BinlogSyncerCfg(s.cfg, s.timezone, s.baList)
+	s.syncCfg, err = subtaskCfg2BinlogSyncerCfg(s.cfg, s.timezone, s.baList, s.cfg.SyncerConfig.EventCacheCount)
 	if err != nil {
 		return err
 	}

--- a/dm/syncer/util.go
+++ b/dm/syncer/util.go
@@ -139,7 +139,7 @@ func str2TimezoneOrFromDB(tctx *tcontext.Context, tzStr string, dbCfg conn.Scope
 	return loc, tzStr, nil
 }
 
-func subtaskCfg2BinlogSyncerCfg(cfg *config.SubTaskConfig, timezone *time.Location, baList *filter.Filter) (replication.BinlogSyncerConfig, error) {
+func subtaskCfg2BinlogSyncerCfg(cfg *config.SubTaskConfig, timezone *time.Location, baList *filter.Filter, eventCacheCount int) (replication.BinlogSyncerConfig, error) {
 	var tlsConfig *tls.Config
 	var err error
 	if cfg.From.Security != nil {
@@ -213,6 +213,7 @@ func subtaskCfg2BinlogSyncerCfg(cfg *config.SubTaskConfig, timezone *time.Locati
 		TLSConfig:               tlsConfig,
 		RowsEventDecodeFunc:     rowsEventDecodeFunc,
 		Localhost:               h,
+		EventCacheCount:         eventCacheCount,
 	}
 	// when retry count > 1, go-mysql will retry sync from the previous GTID set in GTID mode,
 	// which may get duplicate binlog event after retry success. so just set retry count = 1, and task

--- a/dm/syncer/util_test.go
+++ b/dm/syncer/util_test.go
@@ -19,10 +19,12 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	_ "github.com/pingcap/tidb/pkg/types/parser_driver"
 	"github.com/pingcap/tidb/pkg/util/filter"
+	"github.com/pingcap/tiflow/dm/config"
 	"github.com/pingcap/tiflow/dm/pkg/conn"
 	tcontext "github.com/pingcap/tiflow/dm/pkg/context"
 	"github.com/pingcap/tiflow/dm/syncer/dbconn"
@@ -126,6 +128,19 @@ func TestRecordSourceTbls(t *testing.T) {
 
 	recordSourceTbls(sourceTbls, &ast.DropDatabaseStmt{}, &filter.Table{Schema: "a", Name: ""})
 	require.Len(t, sourceTbls, 0)
+}
+
+func TestSubtaskCfg2BinlogSyncerCfgEventCacheCount(t *testing.T) {
+	cfg := &config.SubTaskConfig{
+		ServerID:   1234,
+		Flavor:     mysql.MySQLFlavor,
+		WorkerName: "worker-01",
+		From:       config.GetDBConfigForTest(),
+	}
+
+	syncCfg, err := subtaskCfg2BinlogSyncerCfg(cfg, time.UTC, nil, 2048)
+	require.NoError(t, err)
+	require.Equal(t, 2048, syncCfg.EventCacheCount)
 }
 
 func TestGetDDLStatusFromTiDB(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref https://github.com/pingcap/tiflow/issues/12410

### What is changed and how it works?

Introduces a new configuration option, event-cache-count, for both the Syncer and Validator components. It allows users to control the number of events cached during binlog sync and decoding.

By lowering event-cache-count, users can reduce memory usage in scenarios where binlog processing consumes a significant amount of memory, helping prevent potential OOM issues on the worker.

Default value for both behave the same as before.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - [x] Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
