### PR TITLE
mounter(ticdc): fix truncate table cause mounter failed

### DIFF
--- a/cdc/entry/schema/snapshot.go
+++ b/cdc/entry/schema/snapshot.go
@@ -807,7 +807,7 @@ func (s *snapshot) doDropTable(tbInfo *model.TableInfo, currentTs uint64) {
 // truncateTable truncate the table with the given ID, and replace it with a new `tbInfo`.
 // NOTE: after a table is truncated:
 //   - physicalTableByID(id) will return nil;
-//   - IsTruncateTableID(id) should return true.
+//   - IsTruncateTableID(physicalTableID) should return true.
 func (s *snapshot) truncateTable(id int64, tbInfo *model.TableInfo, currentTs uint64) (err error) {
 	old, ok := s.physicalTableByID(id)
 	if !ok {
@@ -815,7 +815,23 @@ func (s *snapshot) truncateTable(id int64, tbInfo *model.TableInfo, currentTs ui
 	}
 	s.doDropTable(old, currentTs)
 	s.doCreateTable(tbInfo, currentTs)
-	s.truncatedTables.ReplaceOrInsert(newVersionedID(id, negative(currentTs)))
+	tag := negative(currentTs)
+	// when the table is a partition table, we have to record all partition ids
+	if tbInfo.IsPartitionTable() {
+		newPi := tbInfo.GetPartitionInfo()
+		oldPi := old.GetPartitionInfo()
+		newPartitionIDMap := make(map[int64]struct{}, len(newPi.NewPartitionIDs))
+		for _, partition := range newPi.Definitions {
+			newPartitionIDMap[partition.ID] = struct{}{}
+		}
+		for _, partition := range oldPi.Definitions {
+			if _, ok := newPartitionIDMap[partition.ID]; !ok {
+				s.truncatedTables.ReplaceOrInsert(newVersionedID(partition.ID, tag))
+			}
+		}
+	} else {
+		s.truncatedTables.ReplaceOrInsert(newVersionedID(id, tag))
+	}
 	s.currentTs = currentTs
 	log.Debug("truncate table success",
 		zap.String("schema", tbInfo.TableName.Schema),

--- a/cdc/entry/schema/snapshot.go
+++ b/cdc/entry/schema/snapshot.go
@@ -817,7 +817,7 @@ func (s *snapshot) truncateTable(id int64, tbInfo *model.TableInfo, currentTs ui
 	s.doCreateTable(tbInfo, currentTs)
 	tag := negative(currentTs)
 	// when the table is a partition table, we have to record all partition ids
-	if tbInfo.IsPartitionTable() {
+	if old.IsPartitionTable() {
 		newPi := tbInfo.GetPartitionInfo()
 		oldPi := old.GetPartitionInfo()
 		newPartitionIDMap := make(map[int64]struct{}, len(newPi.NewPartitionIDs))

--- a/cdc/entry/schema/snapshot_test.go
+++ b/cdc/entry/schema/snapshot_test.go
@@ -173,7 +173,7 @@ func TestTable(t *testing.T) {
 		require.False(t, ok)
 		_, ok = snap.PhysicalTableByID(11 + 65536)
 		require.False(t, ok)
-		require.True(t, snap.IsTruncateTableID(11))
+		require.True(t, snap.IsTruncateTableID(11+65536))
 		_, ok = snap.PhysicalTableByID(12)
 		require.True(t, ok)
 		_, ok = snap.PhysicalTableByID(12 + 65536)
@@ -348,7 +348,7 @@ func TestDrop(t *testing.T) {
 	require.Equal(t, 1, snap.inner.schemaNameToID.Len())
 	require.Equal(t, 1, snap.inner.tableNameToID.Len())
 	require.Equal(t, 1, snap.inner.partitions.Len())
-	require.Equal(t, 0, snap.inner.truncatedTables.Len())
+	require.Equal(t, 1, snap.inner.truncatedTables.Len())
 	require.Equal(t, 2, snap.inner.ineligibleTables.Len())
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12430

### What is changed and how it works?
If the table is a partition table, we have to record the partition table id when executing the truncate table ddl.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 1. create a changefeed
 2. create table t (id INT AUTO_INCREMENT PRIMARY KEY, data VARCHAR(255)) partition by hash(id) partitions 5;
 3. run script
```
function execute_ddls() {
	while true; do
		run_sql "TRUNCATE TABLE test.t;" ${UP_TIDB_HOST} ${UP_TIDB_PORT}
		sleep 1
	done
}

function execute_dml() {
	while true; do
		run_sql "INSERT INTO test.t (data) VALUES ('insert_$(date +%s)_${RANDOM}');"
	done
}

execute_ddls &
execute_dml &
```
Before this PR:
```
[ERROR] [mounter.go:179] ["can not found table schema"] [ts=462616963080781851] [key=7480000000000000865f72800000000000003e] [tableID=134]
```
After this PR:
```
[DEBUG] [mounter.go:176] ["skip the DML of truncated table"] [ts=462617109199585299] [tableID=244]
```

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a bug in truncating the partition table that causes the change feed to fail.
```
