### PR TITLE
sink(ticdc): fix a bug that may cause data loss while closing Writer failed

### DIFF
--- a/cdc/sink/dmlsink/cloudstorage/dml_worker.go
+++ b/cdc/sink/dmlsink/cloudstorage/dml_worker.go
@@ -283,6 +283,8 @@ func (d *dmlWorker) writeDataFile(ctx context.Context, path string, task *single
 		if _, inErr = writer.Write(ctx, buf.Bytes()); inErr != nil {
 			return 0, 0, inErr
 		}
+		// We have to wait the writer to close to complete the upload
+		// If failed to close writer, some DMLs may not be upload successfully
 		if inErr = writer.Close(ctx); inErr != nil {
 			log.Error("failed to close writer", zap.Error(inErr),
 				zap.Int("workerID", d.id),

--- a/cdc/sink/dmlsink/cloudstorage/dml_worker.go
+++ b/cdc/sink/dmlsink/cloudstorage/dml_worker.go
@@ -280,20 +280,15 @@ func (d *dmlWorker) writeDataFile(ctx context.Context, path string, task *single
 			return 0, 0, inErr
 		}
 
-		defer func() {
-			closeErr := writer.Close(ctx)
-			if inErr != nil {
-				log.Error("failed to close writer", zap.Error(closeErr),
-					zap.Int("workerID", d.id),
-					zap.Any("table", task.tableInfo.TableName),
-					zap.String("namespace", d.changeFeedID.Namespace),
-					zap.String("changefeed", d.changeFeedID.ID))
-				if inErr == nil {
-					inErr = closeErr
-				}
-			}
-		}()
 		if _, inErr = writer.Write(ctx, buf.Bytes()); inErr != nil {
+			return 0, 0, inErr
+		}
+		if inErr = writer.Close(ctx); inErr != nil {
+			log.Error("failed to close writer", zap.Error(inErr),
+				zap.Int("workerID", d.id),
+				zap.Any("table", task.tableInfo.TableName),
+				zap.String("namespace", d.changeFeedID.Namespace),
+				zap.String("changefeed", d.changeFeedID.ID))
 			return 0, 0, inErr
 		}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12436

### What is changed and how it works?
In the previous implementation, the error of `writer.Close` was not handled, and some DMLs may upload failed.
This error should block the advance and cause the changefeed to finally restart.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a bug that may cause DML loss while failing to close the writer of the storage sink
```
