### PR TITLE
dm(encrypt): refine error message for secret key not initialized

### DIFF
--- a/dm/pkg/encrypt/encrypt.go
+++ b/dm/pkg/encrypt/encrypt.go
@@ -59,12 +59,18 @@ func IsInitialized() bool {
 // we use a notInitializedCipher to always return error.
 type notInitializedCipher struct{}
 
+const secretKeyNotInitializedError = `secret key not initialized. To enable encryption:
+1. Create a file containing a 32-byte (64-character) hexadecimal AES-256 secret key.
+2. Set 'secret-key-path' in DM-master's configuration file to point to this key file.
+3. Restart DM-master to apply the configuration.
+For details, see: https://docs.pingcap.com/tidb/stable/dm-customized-secret-key`
+
 func (n *notInitializedCipher) Encrypt([]byte) ([]byte, error) {
-	return nil, errors.New("secret key is not initialized")
+	return nil, errors.New(secretKeyNotInitializedError)
 }
 
 func (n *notInitializedCipher) Decrypt([]byte) ([]byte, error) {
-	return nil, errors.New("secret key is not initialized")
+	return nil, errors.New(secretKeyNotInitializedError)
 }
 
 type aesCipher struct {

--- a/dm/tests/dmctl_basic/run.sh
+++ b/dm/tests/dmctl_basic/run.sh
@@ -503,7 +503,7 @@ function run() {
 	check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT
 	run_dm_ctl_cmd_mode $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"encrypt a" \
-		"secret key is not initialized" 1
+		"secret key not initialized" 1
 }
 
 cleanup_data dmctl


### PR DESCRIPTION
## Summary

Improve the error message when `dmctl encrypt/decrypt` is called without initializing the secret key.

**Before:**
```
Error: secret key is not initialized
```

**After:**
```
Error: secret key not initialized. To enable encryption:
1. Create a file containing a 32-byte (64-character) hexadecimal AES-256 secret key.
2. Set 'secret-key-path' in DM-master's configuration file to point to this key file.
3. Restart DM-master to apply the configuration.
For details, see: https://docs.pingcap.com/tidb/stable/dm-customized-secret-key
```

## Changes

- `dm/pkg/encrypt/encrypt.go`: Updated error message with actionable steps
- `dm/tests/dmctl_basic/run.sh`: Updated test to match new error message

Issue Number: close #12046

## Release Note

```release-note
DM: improve error message for "secret key not initialized" to include actionable resolution steps
```