### PR TITLE
codec(ticdc): improve error logging for Debezium encoding failures

### DIFF
--- a/pkg/sink/codec/encoder_group.go
+++ b/pkg/sink/codec/encoder_group.go
@@ -167,6 +167,13 @@ func (g *encoderGroup) runEncoder(ctx context.Context, idx int) error {
 			for _, event := range future.events {
 				err := encoder.AppendRowChangedEvent(ctx, future.Key.Topic, event.Event, event.Callback)
 				if err != nil {
+					log.Error("encode row changed event failed",
+						zap.String("namespace", g.changefeedID.Namespace),
+						zap.String("changefeed", g.changefeedID.ID),
+						zap.String("schema", event.Event.TableInfo.GetSchemaName()),
+						zap.String("table", event.Event.TableInfo.GetTableName()),
+						zap.Uint64("commitTs", event.Event.CommitTs),
+						zap.Error(err))
 					return errors.Trace(err)
 				}
 			}


### PR DESCRIPTION
## What problem does this PR solve?
Issue Number: close https://github.com/pingcap/tiflow/issues/12485

## Summary
- Add detailed context to error logs when Debezium encoding fails
- Include schema, table, column name, and value in `writeDebeziumFieldValues` error log
- Include namespace, changefeed ID, schema, table, and commitTs in `runEncoder` error log

This helps debugging encoding issues like invalid enum values where previously only the error message was logged without context about which row/column caused the failure.

The `commitTs` in the log can be used to skip problematic events using `cdc cli changefeed resume --overwrite-checkpoint-ts`.

issue: https://github.com/pingcap/tiflow/issues/12485

## PII Consideration
This change logs the column value (`zap.Any("value", col.Value)`) when encoding fails. This may expose sensitive/PII data in logs. However:
- This is consistent with existing behavior in MySQL sink (`mysql.go:229`, `mysql.go:713`) which already logs values
- The value is only logged at ERROR level when encoding actually fails, not during normal operation
- This information is essential for debugging encoding issues (e.g., identifying what invalid value caused the failure)

Users handling sensitive data should ensure appropriate log access controls are in place.

## Check List
### Tests

Unit Test: https://github.com/takaidohigasi/tiflow/pull/2

### Questions

* Will it cause performance regression or break compatibility?
I changed error log format a bit, but does not be much problem.
changes log is only for error, so it does not cause performance regression

* Do you need to update user documentation, design documentation or monitoring documentation?
no

## Test plan
- [x] Existing tests pass (`go test ./pkg/sink/codec/debezium/...`)
- [ ] Manual test with invalid enum value to verify improved logging

## Release note

```
Add CDC error log contents when debezium sink was errored
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)