### PR TITLE
test: fix date_formats test for GET_FORMAT behavior change

### DIFF
--- a/tests/integration_tests/tidb_mysql_test/r/date_formats.result
+++ b/tests/integration_tests/tidb_mysql_test/r/date_formats.result
@@ -317,13 +317,13 @@ a
 %m.%d.%Y
 select get_format(TIME, 'internal') as a;
 a
-
+%H%i%s
 select get_format(DATETIME, 'eur') as a;
 a
-
+%Y-%m-%d %H.%i.%s
 select get_format(TIMESTAMP, 'eur') as a;
 a
-
+%Y-%m-%d %H.%i.%s
 select get_format(DATE, 'TEST') as a;
 a
 


### PR DESCRIPTION
## Summary
Update expected results for GET_FORMAT function after TiDB PR https://github.com/pingcap/tidb/pull/65240 made location parameter case insensitive.

## Changes
The following GET_FORMAT calls now return values instead of empty:
- `GET_FORMAT(TIME, 'internal')` → `%H%i%s`
- `GET_FORMAT(DATETIME, 'eur')` → `%Y-%m-%d %H.%i.%s`
- `GET_FORMAT(TIMESTAMP, 'eur')` → `%Y-%m-%d %H.%i.%s`

## Test plan
- [x] Run `tidb_mysql_test` integration test with `date_formats` case

Fixes #12479

🤖 Generated with [Claude Code](https://claude.com/claude-code)