### PR TITLE
sync-diff-inspectpr: fix checkpoint resume with TLS configuration

### DIFF
--- a/sync_diff_inspector/config/config.go
+++ b/sync_diff_inspector/config/config.go
@@ -98,7 +98,7 @@ func (t *TableConfig) Valid() bool {
 
 // Security is the wrapper for TLS Security
 type Security struct {
-	TLSName string `json:"tls-name"`
+	TLSName string `toml:"-" json:"-"`
 
 	CAPath   string `toml:"ca-path" json:"ca-path"`
 	CertPath string `toml:"cert-path" json:"cert-path"`


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12491

### What is changed and how it works?

Introduced in https://github.com/pingcap/tidb-tools/pull/675

`TLSName` is a random UUID generated on each run, which is only an in-process key for the MySQL driver’s TLS config registry. But it's included in the calculation of hash in ComputeConfigHash`.

https://github.com/pingcap/tiflow/blob/b1c5679ac1bb0bfdc02f650894c66890dd97625d/sync_diff_inspector/config/config.go#L100-L102

https://github.com/pingcap/tiflow/blob/b1c5679ac1bb0bfdc02f650894c66890dd97625d/sync_diff_inspector/config/config.go#L177-L180

There is no need to store `TLSName` in checkpoint.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
