### PR TITLE
sync-diff-inspector: reduce memory usage of `Chunk`

### DIFF
--- a/sync_diff_inspector/splitter/random.go
+++ b/sync_diff_inspector/splitter/random.go
@@ -38,6 +38,7 @@ type RandomIterator struct {
 	chunkBase    *chunk.Range
 	splitColumns []string
 	randomValues [][]string
+	chunkCount   int
 	nextChunk    uint
 
 	dbConn *sql.DB
@@ -195,9 +196,6 @@ NEXTINDEX:
 			failpoint.Return(nil, nil)
 		}
 		chunkCount -= v.(int)
-		if len(randomValues) >= chunkCount {
-			randomValues = randomValues[:chunkCount-1]
-		}
 	})
 
 	progress.StartTable(progressID, chunkCount, true)
@@ -211,6 +209,7 @@ NEXTINDEX:
 		chunkBase:    chunkRange,
 		splitColumns: splitColumns,
 		randomValues: randomValues,
+		chunkCount:   chunkCount,
 		nextChunk:    0,
 		dbConn:       dbConn,
 	}, nil
@@ -243,7 +242,7 @@ func (s *RandomIterator) Next() (*chunk.Range, error) {
 	if s.chunkBase == nil {
 		return nil, nil
 	}
-	if uint(len(s.randomValues)+1) <= s.nextChunk {
+	if uint(s.chunkCount) <= s.nextChunk {
 		return nil, nil
 	}
 	c := s.buildChunk(int(s.nextChunk))


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref https://github.com/pingcap/tiflow/issues/12492

### What is changed and how it works?

Reduce the memory usage of chunk. I ask codex to generate a result for the memory reduction (just a rough estimation).

**Chunk Reduction Rate Matrix**

Estimate goal:

1. old: size of all `Chunk` (including `Where`/`Args`)
2. new: size of all split bounds (`randomValues`)

Variables:
- `k`: chunk count
- `n`: index column count
- `m`: average split bound width (bytes)

Additional estimates for `Where` and `Args`:

- For random-split middle chunks (dominant when `k` is large), measured from `Range.ToString("")` + wrapping with `((%s) AND (%s))` and `limits="TRUE"`:
  - `where_len(n) ~= 13*n^2 + 15*n + 17`
  - `args_count(n) = n*(n+1)`
  - `args_len(n,m) ~= args_count(n) * m`

Large-`k` per-chunk approximation:

- `old_per_chunk ~= (168 + 64*n + n*m) + where_len(n) + args_len(n,m)`
- `old_per_chunk ~= 13*n^2 + 79*n + 185 + n*(n+2)*m`
- `new_per_chunk ~= 24 + 16*n + n*m`
- `reduction ~= 1 - new_per_chunk/old_per_chunk`

| Index cols `n` \ Avg width `m` (bytes) | 16 | 32 | 48 | 64 | 80 | 96 | 112 | 128 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 82.77% | 80.70% | 79.10% | 77.83% | 76.79% | 75.93% | 75.20% | 74.58% |
| 2 | 83.17% | 81.57% | 80.49% | 79.71% | 79.13% | 78.68% | 78.31% | 78.01% |
| 3 | 84.60% | 83.51% | 82.84% | 82.39% | 82.06% | 81.81% | 81.61% | 81.46% |
| 4 | 86.09% | 85.38% | 84.95% | 84.68% | 84.48% | 84.33% | 84.22% | 84.13% |
| 5 | 87.44% | 86.96% | 86.69% | 86.52% | 86.40% | 86.31% | 86.24% | 86.18% |
| 6 | 88.60% | 88.28% | 88.11% | 88.00% | 87.92% | 87.86% | 87.82% | 87.79% |
| 7 | 89.59% | 89.38% | 89.27% | 89.20% | 89.15% | 89.11% | 89.09% | 89.07% |
| 8 | 90.44% | 90.31% | 90.24% | 90.19% | 90.16% | 90.14% | 90.12% | 90.11% |

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

If you don't think this PR needs a release note then fill it with `None`.
```
