### PR TITLE
test: stabilize sync_diff_inspector checkpoint test

### DIFF
--- a/sync_diff_inspector/tests/sync_diff_inspector/checkpoint/run.sh
+++ b/sync_diff_inspector/tests/sync_diff_inspector/checkpoint/run.sh
@@ -36,10 +36,6 @@ for s in ${last_chunk_index_array[@]}; do
 done
 # chunkIndex should be the last Index
 [[ $((${last_chunk_index_array[2]} + 1)) -eq ${last_chunk_index_array[3]} ]] || exit 1
-# Save bucketIndexRight, which should be equal to bucketIndexLeft of the chunk first created in the next running.
-bucket_index_right=$(($(echo ${last_chunk_index_array[1]} | awk -F '-' '{print $2}') + 1))
-echo $bucket_index_right
-
 rm -f $OUT_DIR/sync_diff.log
 export GO_FAILPOINTS="github.com/pingcap/tiflow/sync_diff_inspector/splitter/print-chunk-info=return()"
 sync_diff_inspector --config=./config.toml >$OUT_DIR/checkpoint_diff.output
@@ -50,7 +46,15 @@ echo $first_chunk_info | awk -F '=' '{print $3}' >$OUT_DIR/first_chunk_index
 cat $OUT_DIR/first_chunk_index
 # Notice: when chunk is created paralleling, the least chunk may not appear in the first line. so we sort it as before.
 check_contains "${last_chunk_bound}" $OUT_DIR/first_chunk_bound
-check_contains_regex ".*:${bucket_index_right}-.*:0:.*" $OUT_DIR/first_chunk_index
+OLD_IFS="$IFS"
+IFS=":"
+first_chunk_index_array=($(cat $OUT_DIR/first_chunk_index))
+IFS="$OLD_IFS"
+for s in ${first_chunk_index_array[@]}; do
+	echo "$s"
+done
+# After resuming from the last chunk in a bucket, the next chunk should start a new bucket.
+[[ ${first_chunk_index_array[2]} -eq 0 ]] || exit 1
 
 echo "--------2. chunk is in the middle of the bucket--------"
 rm -rf $OUT_DIR
@@ -78,11 +82,6 @@ for s in ${last_chunk_index_array[@]}; do
 done
 # chunkIndex should be the last Index
 [[ $((${last_chunk_index_array[2]} + 2)) -eq ${last_chunk_index_array[3]} ]] || exit 1
-# Save bucketIndexRight, which should be equal to bucketIndexLeft of the chunk first created in the next running.
-bucket_index_left=$(echo ${last_chunk_index_array[1]} | awk -F '-' '{print $1}')
-bucket_index_right=$(echo ${last_chunk_index_array[1]} | awk -F '-' '{print $2}')
-echo "${bucket_index_left}-${bucket_index_right}"
-
 rm -f $OUT_DIR/sync_diff.log
 export GO_FAILPOINTS="github.com/pingcap/tiflow/sync_diff_inspector/splitter/print-chunk-info=return()"
 sync_diff_inspector --config=./config.toml >$OUT_DIR/checkpoint_diff.output
@@ -93,7 +92,15 @@ echo $first_chunk_info | awk -F '=' '{print $3}' >$OUT_DIR/first_chunk_index
 cat $OUT_DIR/first_chunk_index
 # Notice: when chunk is created paralleling, the least chunk may not appear in the first line. so we sort it as before.
 check_contains "${last_chunk_bound}" $OUT_DIR/first_chunk_bound
-check_contains_regex ".:${bucket_index_left}-${bucket_index_right}:$((${last_chunk_index_array[2]} + 1)):${last_chunk_index_array[3]}" $OUT_DIR/first_chunk_index
+OLD_IFS="$IFS"
+IFS=":"
+first_chunk_index_array=($(cat $OUT_DIR/first_chunk_index))
+IFS="$OLD_IFS"
+for s in ${first_chunk_index_array[@]}; do
+	echo "$s"
+done
+[[ ${first_chunk_index_array[2]} -eq $((${last_chunk_index_array[2]} + 1)) ]] || exit 1
+[[ ${first_chunk_index_array[3]} -eq ${last_chunk_index_array[3]} ]] || exit 1
 
 sed "s/\"127.0.0.1\"#MYSQL_HOST/\"${MYSQL_HOST}\"/g" ./config_base_rand.toml | sed "s/3306#MYSQL_PORT/${MYSQL_PORT}/g" >./config.toml
 
@@ -133,8 +140,8 @@ cat $OUT_DIR/first_chunk_bound
 echo $first_chunk_info | awk -F '=' '{print $3}' >$OUT_DIR/first_chunk_index
 cat $OUT_DIR/first_chunk_index
 # Notice: when chunk is created paralleling, the least chunk may not appear in the first line. so we sort it as before.
+# The random splitter may re-split the remaining range after resuming, so its indexCode is not stable across runs.
 check_contains "${last_chunk_bound}" $OUT_DIR/first_chunk_bound
-check_contains_regex ".:0-0:$((${last_chunk_index_array[2]} + 1)):${last_chunk_index_array[3]}" $OUT_DIR/first_chunk_index
 
 sed "s/\"127.0.0.1\"#MYSQL_HOST/\"${MYSQL_HOST}\"/g" ./config_base_continous.toml | sed "s/3306#MYSQL_PORT/${MYSQL_PORT}/g" >./config.toml
 echo "================test checkpoint continous================="

--- a/sync_diff_inspector/tests/sync_diff_inspector/checkpoint/run.sh
+++ b/sync_diff_inspector/tests/sync_diff_inspector/checkpoint/run.sh
@@ -46,13 +46,7 @@ echo $first_chunk_info | awk -F '=' '{print $3}' >$OUT_DIR/first_chunk_index
 cat $OUT_DIR/first_chunk_index
 # Notice: when chunk is created paralleling, the least chunk may not appear in the first line. so we sort it as before.
 check_contains "${last_chunk_bound}" $OUT_DIR/first_chunk_bound
-OLD_IFS="$IFS"
-IFS=":"
-first_chunk_index_array=($(cat $OUT_DIR/first_chunk_index))
-IFS="$OLD_IFS"
-for s in ${first_chunk_index_array[@]}; do
-	echo "$s"
-done
+IFS=: read -r -a first_chunk_index_array < "$OUT_DIR/first_chunk_index"
 # After resuming from the last chunk in a bucket, the next chunk should start a new bucket.
 [[ ${first_chunk_index_array[2]} -eq 0 ]] || exit 1
 
@@ -92,13 +86,7 @@ echo $first_chunk_info | awk -F '=' '{print $3}' >$OUT_DIR/first_chunk_index
 cat $OUT_DIR/first_chunk_index
 # Notice: when chunk is created paralleling, the least chunk may not appear in the first line. so we sort it as before.
 check_contains "${last_chunk_bound}" $OUT_DIR/first_chunk_bound
-OLD_IFS="$IFS"
-IFS=":"
-first_chunk_index_array=($(cat $OUT_DIR/first_chunk_index))
-IFS="$OLD_IFS"
-for s in ${first_chunk_index_array[@]}; do
-	echo "$s"
-done
+IFS=: read -r -a first_chunk_index_array < "$OUT_DIR/first_chunk_index"
 [[ ${first_chunk_index_array[2]} -eq $((${last_chunk_index_array[2]} + 1)) ]] || exit 1
 [[ ${first_chunk_index_array[3]} -eq ${last_chunk_index_array[3]} ]] || exit 1
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12553

### What is changed and how it works?

The checkpoint integration test (`checkpoint/run.sh`) was flaky because it pre-computed a `bucket_index_right` (or `bucket_index_left-bucket_index_right`) from the *last* run and then used `check_contains_regex` to match a full `indexCode` pattern in the *resumed* run's first chunk. When chunks are created in parallel, multiple resumed chunks can share the same lower bound, so the selected first chunk may carry a different—but equally valid—`indexCode`, causing the regex match to fail nondeterministically.

**Changes (bucket splitter, cases 1 & 2):**
- Removed the pre-computed `bucket_index_right`/`bucket_index_left` variables that were derived from the previous run's index.
- Instead of matching the entire `indexCode` string with a regex, we now parse the resumed first chunk's `indexCode` into an array and assert only the structurally stable fields:
  - **Case 1 (last chunk in bucket):** after resuming, the next chunk must start a new bucket, so we assert `chunkIndex == 0`.
  - **Case 2 (middle of bucket):** the next chunk must be the immediate successor within the same bucket, so we assert `chunkIndex == lastChunkIndex + 1` and `chunkCount == lastChunkCount`.

**Changes (random splitter, case 1):**
- Removed the `check_contains_regex` assertion on `indexCode` entirely, because the random splitter may re-split the remaining range after resuming, making the `indexCode` unstable across runs.
- We still assert that the resumed chunk's *bound* matches the last chunk's upper bound, which is the meaningful invariant.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No. This is a test-only change.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```