### PR TITLE
dm: ignore ghost/trash table DDL without gh-ost comment when online-ddl is enabled

### DIFF
--- a/dm/syncer/ddl.go
+++ b/dm/syncer/ddl.go
@@ -15,6 +15,7 @@ package syncer
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -51,6 +52,10 @@ import (
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 )
+
+// ghostCommentRegexp matches the /* gh-ost */ or /* gh-ost ... */ marker that
+// gh-ost embeds in its atomic RENAME TABLE cutover statement.
+var ghostCommentRegexp = regexp.MustCompile(`/\*\s*gh-ost[^*]*\*/`)
 
 type shardDDLStrategy interface {
 	// when preFilter returns true, it means we should skip this DDL
@@ -1269,6 +1274,23 @@ func (ddl *DDLWorker) processOneDDL(qec *queryEventContext, sql string) ([]strin
 	if ddl.onlineDDL == nil {
 		return []string{ddlInfo.originDDL}, nil
 	}
+
+	// Ghost/trash tables (_gho, _ghc, _del) never exist in the downstream
+	// because DM never replicates their creation. All genuine gh-ost statements
+	// carry a /* gh-ost */ comment; any DDL on these tables without it is a
+	// manual operation (e.g. operator cleanup) and must be silently ignored so
+	// that replication is not blocked.
+	if len(ddlInfo.sourceTables) > 0 && !ghostCommentRegexp.MatchString(qec.originSQL) {
+		if tp := ddl.onlineDDL.TableType(ddlInfo.sourceTables[0].Name); tp == onlineddl.GhostTable || tp == onlineddl.TrashTable {
+			ddl.logger.Info("ignoring DDL on ghost/trash table without gh-ost comment: table does not exist in downstream, likely a manual operation",
+				zap.String("table", ddlInfo.sourceTables[0].Name),
+				zap.String("tableType", string(tp)),
+				zap.String("statement", sql),
+			)
+			return nil, nil
+		}
+	}
+
 	// filter and save ghost table ddl
 	sqls, err := ddl.onlineDDL.Apply(qec.tctx, ddlInfo.sourceTables, ddlInfo.originDDL, ddlInfo.stmtCache, qec.p)
 	if err != nil {

--- a/dm/syncer/ddl_test.go
+++ b/dm/syncer/ddl_test.go
@@ -636,6 +636,100 @@ func (s *testDDLSuite) TestMistakeOnlineDDLRegex(c *check.C) {
 	cluster.Stop()
 }
 
+func (s *testDDLSuite) TestGhostTableDDLWithoutGhostComment(c *check.C) {
+	tctx := tcontext.Background().WithLogger(log.With(zap.String("test", "TestGhostTableDDLWithoutGhostComment")))
+	p := parser.New()
+	testEC := &eventContext{tctx: tctx}
+
+	cluster, err := conn.NewCluster()
+	c.Assert(err, check.IsNil)
+	c.Assert(cluster.Start(), check.IsNil)
+	defer cluster.Stop()
+	dbCfg := config.GetDBConfigForTest()
+	dbCfg.Port = cluster.Port
+	dbCfg.Password = ""
+	cfg := s.newSubTaskCfg(dbCfg)
+
+	// Sub-case A: gh-ost cutover RENAME WITH /* gh-ost */ comment — stored ALTER
+	// must be applied to the real table (existing behavior preserved).
+	{
+		plugin, err := onlineddl.NewRealOnlinePlugin(tctx, cfg, nil)
+		c.Assert(err, check.IsNil)
+		syncer := NewSyncer(cfg, nil, nil)
+		syncer.tctx = tctx
+		syncer.onlineDDL = plugin
+		c.Assert(plugin.Clear(tctx), check.IsNil)
+		c.Assert(syncer.genRouter(), check.IsNil)
+		ddlWorker := NewDDLWorker(&tctx.Logger, syncer)
+
+		// First accumulate an ALTER on the ghost table.
+		// originSQL carries the /* gh-ost */ comment as gh-ost does in practice.
+		alterSQL := "ALTER TABLE `test`.`_t1_gho` ADD COLUMN `n` INT"
+		alterOriginSQL := "alter /* gh-ost */ table `test`.`_t1_gho` ADD COLUMN `n` INT"
+		qec := &queryEventContext{
+			eventContext: testEC,
+			ddlSchema:    "test",
+			originSQL:    alterOriginSQL,
+			p:            p,
+		}
+		sqls, err := ddlWorker.processOneDDL(qec, alterSQL)
+		c.Assert(err, check.IsNil)
+		c.Assert(sqls, check.HasLen, 0) // stored, not emitted yet
+
+		// Now run the cutover RENAME with the gh-ost comment in originSQL.
+		renameOrigin := "RENAME /* gh-ost */ TABLE `test`.`t1` TO `test`.`_t1_del`, `test`.`_t1_gho` TO `test`.`t1`"
+		renameSplit := "RENAME TABLE `test`.`_t1_gho` TO `test`.`t1`"
+		qec = &queryEventContext{
+			eventContext: testEC,
+			ddlSchema:    "test",
+			originSQL:    renameOrigin,
+			p:            p,
+		}
+		sqls, err = ddlWorker.processOneDDL(qec, renameSplit)
+		c.Assert(err, check.IsNil)
+		c.Assert(sqls, check.HasLen, 1)
+		c.Assert(sqls[0], check.Equals, "ALTER TABLE `test`.`t1` ADD COLUMN `n` INT")
+	}
+
+	// Sub-case B: manual RENAME WITHOUT gh-ost comment — must return nil (no
+	// error, no DDL emitted).
+	{
+		plugin, err := onlineddl.NewRealOnlinePlugin(tctx, cfg, nil)
+		c.Assert(err, check.IsNil)
+		syncer := NewSyncer(cfg, nil, nil)
+		syncer.tctx = tctx
+		syncer.onlineDDL = plugin
+		c.Assert(plugin.Clear(tctx), check.IsNil)
+		c.Assert(syncer.genRouter(), check.IsNil)
+		ddlWorker := NewDDLWorker(&tctx.Logger, syncer)
+
+		// Accumulate an ALTER on the ghost table.
+		alterSQL := "ALTER TABLE `test`.`_t1_gho` ADD COLUMN `n` INT"
+		qec := &queryEventContext{
+			eventContext: testEC,
+			ddlSchema:    "test",
+			originSQL:    alterSQL,
+			p:            p,
+		}
+		sqls, err := ddlWorker.processOneDDL(qec, alterSQL)
+		c.Assert(err, check.IsNil)
+		c.Assert(sqls, check.HasLen, 0)
+
+		// Manual cleanup rename — no gh-ost comment. Since ghost tables never
+		// exist in TiDB, the event must be silently ignored (nil returned).
+		renameSQL := "RENAME TABLE `test`.`_t1_gho` TO `test`.`will_be_deleted`"
+		qec = &queryEventContext{
+			eventContext: testEC,
+			ddlSchema:    "test",
+			originSQL:    renameSQL,
+			p:            p,
+		}
+		sqls, err = ddlWorker.processOneDDL(qec, renameSQL)
+		c.Assert(err, check.IsNil)
+		c.Assert(sqls, check.HasLen, 0)
+	}
+}
+
 func (s *testDDLSuite) TestDropSchemaInSharding(c *check.C) {
 	var (
 		targetTable = &filter.Table{


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #12564

When a gh-ost migration leaves behind a ghost table (e.g. `_t_gho`), an operator may manually rename it for cleanup:

```sql
RENAME TABLE _t_gho TO will_be_deleted_t_gho;
```

Because DM identifies gh-ost tables purely by table-name regex, it treats any `GhostTable → RealTable` rename as a gh-ost cutover and tries to replay stored `ALTER TABLE` statements against the destination. Since that table doesn't exist in TiDB, the apply fails and blocks replication.

### What is changed and how it works?

gh-ost embeds a `/* gh-ost */` comment in **all** SQL statements it issues — `CREATE TABLE`, `ALTER TABLE`, `RENAME TABLE`, `DROP TABLE`, etc.:

```sql
create /* gh-ost */ table `schema`.`_t_gho` like `schema`.`t`
alter /* gh-ost */ table `schema`.`_t_gho` add column `n` int
rename /* gh-ost */ table `schema`.`t` to `schema`.`_t_del`, `schema`.`_t_gho` to `schema`.`t`
```

This comment is preserved verbatim in the MySQL binlog QUERY event.

Since ghost/trash tables (`_gho`, `_ghc`, `_del`) **never exist in TiDB** (DM does not replicate their creation downstream), any DDL on these tables that lacks the `/* gh-ost */` comment is a manual operation and must be silently ignored. In `processOneDDL`, before calling `Apply()`, we now check the first source table type and the presence of the comment. Without the comment on a ghost/trash table, the event returns `nil` and replication continues unblocked.

**Why not pass the statement through?**
The initial approach returned the statement as-is for manual renames. But since ghost tables never exist in TiDB, executing `RENAME TABLE _t_gho TO will_be_deleted` downstream would also fail. Returning `nil` (ignore) is the correct behaviour.

### Check List

#### Tests

- [x] Unit test (`TestGhostTableDDLWithoutGhostComment`)
  - Sub-case A: gh-ost ALTER (with `/* gh-ost */` comment) is stored; cutover RENAME (with comment) replays the stored ALTER — existing behaviour preserved
  - Sub-case B: manual RENAME without comment — silently ignored, no DDL emitted, no error

#### Questions

##### Will it cause performance regression or break compatibility?

No. The added check only runs when `onlineDDL` is enabled (`online-ddl: true`). The regexp match is O(n) on the raw SQL string and is negligible compared to the rest of DDL processing.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
Fixed DM incorrectly replaying stored gh-ost ALTER TABLE DDLs when a ghost/trash table is manually operated on without the gh-ost comment. Such events are now silently ignored since ghost tables never exist in the downstream.
```