### PR TITLE
sync-diff-inspector: use the tiflow version package to print versions

### DIFF
--- a/sync_diff_inspector/main.go
+++ b/sync_diff_inspector/main.go
@@ -23,8 +23,8 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
-	"github.com/pingcap/tidb/pkg/util"
 	"github.com/pingcap/tidb/pkg/util/collate"
+	"github.com/pingcap/tiflow/pkg/version"
 	"github.com/pingcap/tiflow/sync_diff_inspector/config"
 	"github.com/pingcap/tiflow/sync_diff_inspector/diff"
 	flag "github.com/spf13/pflag"
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	if cfg.PrintVersion {
-		fmt.Print(util.GetRawInfo("sync_diff_inspector"))
+		fmt.Print(version.GetRawInfo())
 		return
 	}
 
@@ -72,7 +72,7 @@ func main() {
 	}
 	log.ReplaceGlobals(lg, p)
 
-	util.PrintInfo("sync_diff_inspector")
+	version.LogVersionInfo("sync_diff_inspector")
 
 	// Initial config
 	err = cfg.Init()


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12567

### What is changed and how it works?

Change sync-diff-inspector to use functions in `github.com/pingcap/tiflow/pkg/version` instead of `github.com/pingcap/tidb/pkg/util`, because the env var are populated to the former.

> Before:
>
> ```
> [2026/04/02 14:15:06.453 +08:00] [INFO] [printer.go:49] ["Welcome to sync_diff_inspector"] ["Release Version"=None] ["Git Commit Hash"=None] ["Git Branch"=None] ["UTC Build Time"=None] ["Go Version"=go1.25.8]
> ```
>
> After:
>
> ```
> [2026/04/02 14:13:43.150 +08:00] [INFO] [version.go:47] ["Welcome to sync_diff_inspector"] [release-version=v9.0.0-beta.2.pre-72-gad3f336bd] [git-hash=ad3f336bd1462634ea31fcc6a6b888f8f8d5bd9a] [git-branch=fix-12567] [utc-build-time="2026-04-02 06:11:47"] [go-version=go1.25.8] [failpoint-build=false]
> ```

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - [ ] Unit test
 - [ ] Integration test
 - [x] Manual test (add detailed scripts or steps below)
     - Run the resulting program with `-V`, and run the program and checking the first line of the log.
 - [ ] No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No

##### Do you need to update user documentation, design documentation or monitoring documentation?

No

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
