### PR TITLE
kafka(ticdc): close sarama clients on init failures

### DIFF
--- a/pkg/sink/kafka/admin.go
+++ b/pkg/sink/kafka/admin.go
@@ -176,11 +176,21 @@ func (a *saramaAdminClient) CreateTopic(
 }
 
 func (a *saramaAdminClient) Close() {
-	if err := a.admin.Close(); err != nil {
-		log.Warn("close admin client meet error",
-			zap.String("namespace", a.changefeed.Namespace),
-			zap.String("changefeed", a.changefeed.ID),
-			zap.Error(err))
+	if a.admin != nil {
+		if err := a.admin.Close(); err != nil {
+			log.Warn("close admin client meet error",
+				zap.String("namespace", a.changefeed.Namespace),
+				zap.String("changefeed", a.changefeed.ID),
+				zap.Error(err))
+		}
+	}
+	if a.client != nil {
+		if err := a.client.Close(); err != nil && err != sarama.ErrClosedClient {
+			log.Warn("close admin client connection meet error",
+				zap.String("namespace", a.changefeed.Namespace),
+				zap.String("changefeed", a.changefeed.ID),
+				zap.Error(err))
+		}
 	}
 }
 

--- a/pkg/sink/kafka/admin_test.go
+++ b/pkg/sink/kafka/admin_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"testing"
+
+	"github.com/IBM/sarama"
+	"github.com/pingcap/tiflow/cdc/model"
+	"github.com/stretchr/testify/require"
+)
+
+type testSyncProducer struct {
+	sarama.SyncProducer
+	closeCalls int
+	closeErr   error
+	callOrder  *[]string
+	callLabel  string
+}
+
+func (p *testSyncProducer) Close() error {
+	p.closeCalls++
+	if p.callOrder != nil {
+		*p.callOrder = append(*p.callOrder, p.callLabel)
+	}
+	return p.closeErr
+}
+
+// TestSaramaAdminClientCloseClosesAdminThenClient covers the normal admin close
+// path and verifies the wrapper releases both the admin handle and the owned
+// client in a deterministic order.
+func TestSaramaAdminClientCloseClosesAdminThenClient(t *testing.T) {
+	callOrder := make([]string, 0, 2)
+	client := &testSaramaClient{callOrder: &callOrder, callLabel: "client"}
+	admin := &testSaramaClusterAdmin{callOrder: &callOrder, callLabel: "admin"}
+
+	adminClient := &saramaAdminClient{
+		changefeed: model.DefaultChangeFeedID("admin-close-test"),
+		client:     client,
+		admin:      admin,
+	}
+
+	adminClient.Close()
+	require.Equal(t, 1, admin.closeCalls)
+	require.Equal(t, 1, client.closeCalls)
+	require.Equal(t, []string{"admin", "client"}, callOrder)
+}
+
+// TestSaramaAdminClientCloseStillClosesClientWhenAdminCloseFails covers the
+// error path where admin.Close reports an error but the wrapper must still close
+// the owned sarama client.
+func TestSaramaAdminClientCloseStillClosesClientWhenAdminCloseFails(t *testing.T) {
+	client := &testSaramaClient{}
+	admin := &testSaramaClusterAdmin{closeErr: sarama.ErrOutOfBrokers}
+
+	adminClient := &saramaAdminClient{
+		changefeed: model.DefaultChangeFeedID("admin-close-error-test"),
+		client:     client,
+		admin:      admin,
+	}
+
+	adminClient.Close()
+	require.Equal(t, 1, admin.closeCalls)
+	require.Equal(t, 1, client.closeCalls)
+	require.True(t, client.closed)
+}
+
+// TestSaramaSyncProducerCloseClosesProducerAndClient covers the normal cleanup
+// path for sync producers and verifies the wrapper closes the producer before
+// releasing the owned sarama client.
+func TestSaramaSyncProducerCloseClosesProducerAndClient(t *testing.T) {
+	callOrder := make([]string, 0, 2)
+	client := &testSaramaClient{callOrder: &callOrder, callLabel: "client"}
+	producer := &testSyncProducer{callOrder: &callOrder, callLabel: "producer"}
+
+	syncProducer := &saramaSyncProducer{
+		id:       model.DefaultChangeFeedID("sync-close-test"),
+		client:   client,
+		producer: producer,
+	}
+
+	syncProducer.Close()
+	require.Equal(t, 1, producer.closeCalls)
+	require.Equal(t, 1, client.closeCalls)
+	require.Equal(t, []string{"producer", "client"}, callOrder)
+}
+
+// TestSaramaSyncProducerCloseStillClosesClientWhenProducerCloseFails covers the
+// partial-close path and verifies the wrapper still releases the owned client
+// even if producer.Close returns an error.
+func TestSaramaSyncProducerCloseStillClosesClientWhenProducerCloseFails(t *testing.T) {
+	client := &testSaramaClient{}
+	producer := &testSyncProducer{closeErr: sarama.ErrOutOfBrokers}
+
+	syncProducer := &saramaSyncProducer{
+		id:       model.DefaultChangeFeedID("sync-close-error-test"),
+		client:   client,
+		producer: producer,
+	}
+
+	syncProducer.Close()
+	require.Equal(t, 1, producer.closeCalls)
+	require.Equal(t, 1, client.closeCalls)
+	require.True(t, client.closed)
+}

--- a/pkg/sink/kafka/cluster_admin_client.go
+++ b/pkg/sink/kafka/cluster_admin_client.go
@@ -55,6 +55,6 @@ type ClusterAdminClient interface {
 	// HeartbeatBroker sends a heartbeat to all brokers to keep the kafka connection alive.
 	HeartbeatBrokers()
 
-	// Close shuts down the admin client.
+	// Close shuts down the admin client and releases any owned underlying client connections.
 	Close()
 }

--- a/pkg/sink/kafka/factory.go
+++ b/pkg/sink/kafka/factory.go
@@ -60,19 +60,18 @@ type SyncProducer interface {
 	// HeartbeatBrokers sends heartbeat to all brokers to keep the connection alive.
 	HeartbeatBrokers()
 
-	// Close shuts down the producer; you must call this function before a producer
-	// object passes out of scope, as it may otherwise leak memory.
-	// You must call this before calling Close on the underlying client.
+	// Close shuts down the producer and releases the client owned by this wrapper.
+	// You must call this function before the producer passes out of scope, as it
+	// may otherwise leak memory.
 	Close()
 }
 
 // AsyncProducer is the kafka async producer
 type AsyncProducer interface {
-	// Close shuts down the producer and waits for any buffered messages to be
-	// flushed. You must call this function before a producer object passes out of
+	// Close shuts down the producer and releases the client owned by this
+	// wrapper. You must call this function before the producer passes out of
 	// scope, as it may otherwise leak memory. You must call this before process
-	// shutting down, or you may lose messages. You must call this before calling
-	// Close on the underlying client.
+	// shutting down, or you may lose messages.
 	Close()
 
 	// AsyncSend is the input channel for the user to write messages to that they
@@ -144,6 +143,21 @@ func (p *saramaSyncProducer) Close() {
 			zap.Error(err))
 	} else {
 		log.Info("Kafka DDL producer closed",
+			zap.String("namespace", p.id.Namespace),
+			zap.String("changefeed", p.id.ID),
+			zap.Duration("duration", time.Since(start)))
+	}
+
+	start = time.Now()
+	err = p.client.Close()
+	if err != nil && err != sarama.ErrClosedClient {
+		log.Error("Close Kafka DDL producer client with error",
+			zap.String("namespace", p.id.Namespace),
+			zap.String("changefeed", p.id.ID),
+			zap.Duration("duration", time.Since(start)),
+			zap.Error(err))
+	} else {
+		log.Info("Kafka DDL producer client closed",
 			zap.String("namespace", p.id.Namespace),
 			zap.String("changefeed", p.id.ID),
 			zap.Duration("duration", time.Since(start)))

--- a/pkg/sink/kafka/sarama_factory.go
+++ b/pkg/sink/kafka/sarama_factory.go
@@ -26,6 +26,15 @@ import (
 	"go.uber.org/zap"
 )
 
+var (
+	// These constructor seams let unit tests inject partial-init failures without
+	// spinning up a real Kafka cluster.
+	newSaramaClientImpl                  = sarama.NewClient
+	newSaramaClusterAdminFromClientImpl  = sarama.NewClusterAdminFromClient
+	newSaramaSyncProducerFromClientImpl  = sarama.NewSyncProducerFromClient
+	newSaramaAsyncProducerFromClientImpl = sarama.NewAsyncProducerFromClient
+)
+
 type saramaFactory struct {
 	changefeedID model.ChangeFeedID
 	option       *Options
@@ -45,6 +54,14 @@ func NewSaramaFactory(
 	}, nil
 }
 
+func closeSaramaClientOnFailure(changefeedID model.ChangeFeedID, client sarama.Client, reason string) {
+	if closeErr := client.Close(); closeErr != nil && closeErr != sarama.ErrClosedClient {
+		log.Warn(reason,
+			zap.Stringer("changefeedID", changefeedID),
+			zap.Error(closeErr))
+	}
+}
+
 func (f *saramaFactory) AdminClient(ctx context.Context) (ClusterAdminClient, error) {
 	start := time.Now()
 	config, err := NewSaramaConfig(ctx, f.option)
@@ -57,7 +74,7 @@ func (f *saramaFactory) AdminClient(ctx context.Context) (ClusterAdminClient, er
 	}
 
 	start = time.Now()
-	client, err := sarama.NewClient(f.option.BrokerEndpoints, config)
+	client, err := newSaramaClientImpl(f.option.BrokerEndpoints, config)
 	duration = time.Since(start).Seconds()
 	if duration > 2 {
 		log.Warn("new sarama client cost too much time", zap.Any("duration", duration), zap.Stringer("changefeedID", f.changefeedID))
@@ -67,12 +84,13 @@ func (f *saramaFactory) AdminClient(ctx context.Context) (ClusterAdminClient, er
 	}
 
 	start = time.Now()
-	admin, err := sarama.NewClusterAdminFromClient(client)
+	admin, err := newSaramaClusterAdminFromClientImpl(client)
 	duration = time.Since(start).Seconds()
 	if duration > 2 {
 		log.Warn("new sarama cluster admin cost too much time", zap.Any("duration", duration), zap.Stringer("changefeedID", f.changefeedID))
 	}
 	if err != nil {
+		closeSaramaClientOnFailure(f.changefeedID, client, "close sarama client after admin init failed")
 		return nil, errors.Trace(err)
 	}
 
@@ -92,12 +110,13 @@ func (f *saramaFactory) SyncProducer(ctx context.Context) (SyncProducer, error) 
 	}
 	config.MetricRegistry = f.registry
 
-	client, err := sarama.NewClient(f.option.BrokerEndpoints, config)
+	client, err := newSaramaClientImpl(f.option.BrokerEndpoints, config)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	p, err := sarama.NewSyncProducerFromClient(client)
+	p, err := newSaramaSyncProducerFromClientImpl(client)
 	if err != nil {
+		closeSaramaClientOnFailure(f.changefeedID, client, "close sarama client after sync producer init failed")
 		return nil, errors.Trace(err)
 	}
 
@@ -122,12 +141,13 @@ func (f *saramaFactory) AsyncProducer(
 	}
 	config.MetricRegistry = f.registry
 
-	client, err := sarama.NewClient(f.option.BrokerEndpoints, config)
+	client, err := newSaramaClientImpl(f.option.BrokerEndpoints, config)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	p, err := sarama.NewAsyncProducerFromClient(client)
+	p, err := newSaramaAsyncProducerFromClientImpl(client)
 	if err != nil {
+		closeSaramaClientOnFailure(f.changefeedID, client, "close sarama client after async producer init failed")
 		return nil, errors.Trace(err)
 	}
 	return &saramaAsyncProducer{

--- a/pkg/sink/kafka/sarama_factory_test.go
+++ b/pkg/sink/kafka/sarama_factory_test.go
@@ -15,6 +15,7 @@ package kafka
 
 import (
 	"context"
+	stdErrors "errors"
 	"sync"
 	"testing"
 	"time"
@@ -245,4 +246,145 @@ func TestSaramaAsyncProducerHeartbeat(t *testing.T) {
 		}
 	}()
 	drainWg.Wait()
+}
+
+type testSaramaClient struct {
+	sarama.Client
+	closeCalls int
+	closed     bool
+	closeErr   error
+	callOrder  *[]string
+	callLabel  string
+}
+
+func (c *testSaramaClient) Close() error {
+	c.closeCalls++
+	c.closed = true
+	if c.callOrder != nil {
+		*c.callOrder = append(*c.callOrder, c.callLabel)
+	}
+	return c.closeErr
+}
+
+func (c *testSaramaClient) Closed() bool {
+	return c.closed
+}
+
+type testSaramaClusterAdmin struct {
+	sarama.ClusterAdmin
+	closeCalls int
+	closeErr   error
+	callOrder  *[]string
+	callLabel  string
+}
+
+func (a *testSaramaClusterAdmin) Close() error {
+	a.closeCalls++
+	if a.callOrder != nil {
+		*a.callOrder = append(*a.callOrder, a.callLabel)
+	}
+	return a.closeErr
+}
+
+// TestSaramaFactoryAdminClientClosesClientOnAdminInitFailure verifies the
+// factory closes the raw sarama client when admin construction fails before any
+// wrapper takes ownership.
+func TestSaramaFactoryAdminClientClosesClientOnAdminInitFailure(t *testing.T) {
+	o := NewOptions()
+	o.Version = "2.0.0"
+	o.IsAssignedVersion = true
+	o.BrokerEndpoints = []string{"127.0.0.1:9092"}
+	o.ClientID = "sarama-test"
+
+	factory, err := NewSaramaFactory(o, model.DefaultChangeFeedID("sarama-test"))
+	require.NoError(t, err)
+	saramaFactory, ok := factory.(*saramaFactory)
+	require.True(t, ok)
+
+	client := &testSaramaClient{}
+	oldClientCreator := newSaramaClientImpl
+	oldAdminCreator := newSaramaClusterAdminFromClientImpl
+	newSaramaClientImpl = func([]string, *sarama.Config) (sarama.Client, error) {
+		return client, nil
+	}
+	newSaramaClusterAdminFromClientImpl = func(sarama.Client) (sarama.ClusterAdmin, error) {
+		return nil, stdErrors.New("injected admin init failure")
+	}
+	defer func() {
+		newSaramaClientImpl = oldClientCreator
+		newSaramaClusterAdminFromClientImpl = oldAdminCreator
+	}()
+
+	_, err = saramaFactory.AdminClient(context.Background())
+	require.Error(t, err)
+	require.Equal(t, 1, client.closeCalls)
+	require.True(t, client.closed)
+}
+
+// TestSaramaFactorySyncProducerClosesClientOnInitFailure verifies the factory
+// releases the shared sarama client when sync producer construction fails.
+func TestSaramaFactorySyncProducerClosesClientOnInitFailure(t *testing.T) {
+	o := NewOptions()
+	o.Version = "2.0.0"
+	o.IsAssignedVersion = true
+	o.BrokerEndpoints = []string{"127.0.0.1:9092"}
+	o.ClientID = "sarama-test"
+
+	factory, err := NewSaramaFactory(o, model.DefaultChangeFeedID("sarama-test"))
+	require.NoError(t, err)
+	saramaFactory, ok := factory.(*saramaFactory)
+	require.True(t, ok)
+
+	client := &testSaramaClient{}
+	oldClientCreator := newSaramaClientImpl
+	oldSyncCreator := newSaramaSyncProducerFromClientImpl
+	newSaramaClientImpl = func([]string, *sarama.Config) (sarama.Client, error) {
+		return client, nil
+	}
+	newSaramaSyncProducerFromClientImpl = func(sarama.Client) (sarama.SyncProducer, error) {
+		return nil, stdErrors.New("injected sync producer init failure")
+	}
+	defer func() {
+		newSaramaClientImpl = oldClientCreator
+		newSaramaSyncProducerFromClientImpl = oldSyncCreator
+	}()
+
+	_, err = saramaFactory.SyncProducer(context.Background())
+	require.Error(t, err)
+	require.Equal(t, 1, client.closeCalls)
+	require.True(t, client.closed)
+}
+
+// TestSaramaFactoryAsyncProducerClosesClientOnInitFailure verifies the factory
+// releases the shared sarama client when async producer construction fails.
+func TestSaramaFactoryAsyncProducerClosesClientOnInitFailure(t *testing.T) {
+	o := NewOptions()
+	o.Version = "2.0.0"
+	o.IsAssignedVersion = true
+	o.BrokerEndpoints = []string{"127.0.0.1:9092"}
+	o.ClientID = "sarama-test"
+
+	factory, err := NewSaramaFactory(o, model.DefaultChangeFeedID("sarama-test"))
+	require.NoError(t, err)
+	saramaFactory, ok := factory.(*saramaFactory)
+	require.True(t, ok)
+
+	client := &testSaramaClient{}
+	oldClientCreator := newSaramaClientImpl
+	oldAsyncCreator := newSaramaAsyncProducerFromClientImpl
+	newSaramaClientImpl = func([]string, *sarama.Config) (sarama.Client, error) {
+		return client, nil
+	}
+	newSaramaAsyncProducerFromClientImpl = func(sarama.Client) (sarama.AsyncProducer, error) {
+		return nil, stdErrors.New("injected async producer init failure")
+	}
+	defer func() {
+		newSaramaClientImpl = oldClientCreator
+		newSaramaAsyncProducerFromClientImpl = oldAsyncCreator
+	}()
+
+	_, err = saramaFactory.AsyncProducer(context.Background(), make(chan error, 1))
+	require.Error(t, err)
+	require.Equal(t, 1, client.closeCalls)
+	require.True(t, client.closed)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #12572

Kafka admin / producer initialization paths in `pkg/sink/kafka` can return while still leaving the raw Sarama client alive. Repeated retry / rebuild loops may accumulate background metadata updaters, broker connections, and related resources.

The normal wrapper close paths also do not always release the owned client:

- `saramaAdminClient.Close` only closes the admin handle
- `saramaSyncProducer.Close` only closes the producer

### What is changed and how it works?

- close the raw `sarama.Client` when admin creation from client fails
- close the raw `sarama.Client` when sync producer creation from client fails
- close the raw `sarama.Client` when async producer creation from client fails
- explicitly close the owned client in `saramaAdminClient.Close`
- explicitly close the owned client in `saramaSyncProducer.Close`
- add focused regression tests for admin/sync/async init-failure cleanup and for wrapper close behavior

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

Unit test:
- `go test ./pkg/sink/kafka -count=1`

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No. The change only tightens resource cleanup on Kafka init / close paths and does not change normal successful send semantics.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Release leaked Kafka Sarama clients on init-failure and wrapper-close paths.
```
