### PR TITLE
Release-testing: v8.5.6 tiflow repo CI trigger

### DIFF
--- a/.github/release-testing-ci-ft.md
+++ b/.github/release-testing-ci-ft.md
@@ -1,0 +1,8 @@
+<!-- release-testing ci ft placeholder: do not merge -->
+# Release-Testing CI FT Placeholder
+
+- repo: `pingcap/tiflow`
+- version: `v8.5.6`
+- base: `release-8.5`
+- branch: `release-testing-tiflow-v8.5.6-ci-ft`
+- generated_at: `2026-04-01 16:20:40`


### PR DESCRIPTION
Automated release-testing placeholder PR for pingcap/tiflow release-8.5.

This PR exists only to trigger CI FT via `/test` comments.
Do not merge.