### PR TITLE
syncer(dm): debounce repeated unhandled-event warnings

### DIFF
--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -261,10 +261,6 @@ type Syncer struct {
 
 	ddlWorker            *DDLWorker
 	unhandledEventLogger *zap.Logger
-	unhandledEvents      struct {
-		sync.Mutex
-		counts map[string]map[string]int
-	}
 }
 
 // NewSyncer creates a new Syncer.
@@ -321,7 +317,6 @@ func NewSyncer(cfg *config.SubTaskConfig, etcdClient *clientv3.Client, relay rel
 		unhandledEventSampleFirst,
 		logFields...,
 	)()
-	syncer.unhandledEvents.counts = make(map[string]map[string]int)
 
 	return syncer
 }
@@ -359,23 +354,7 @@ func (s *Syncer) closeJobChans() {
 }
 
 func (s *Syncer) recordUnhandledEvent(message string, ev interface{}) {
-	eventType := fmt.Sprintf("%T", ev)
-
-	s.unhandledEvents.Lock()
-	eventCounts, ok := s.unhandledEvents.counts[message]
-	if !ok {
-		eventCounts = make(map[string]int)
-		s.unhandledEvents.counts[message] = eventCounts
-	}
-	eventCounts[eventType]++
-
-	snapshot := make(map[string]int, len(eventCounts))
-	for event, count := range eventCounts {
-		snapshot[event] = count
-	}
-	s.unhandledEvents.Unlock()
-
-	s.unhandledEventLogger.Warn(message, zap.Any("events", snapshot))
+	s.unhandledEventLogger.Warn(message, zap.String("type", fmt.Sprintf("%T", ev)))
 }
 
 // Type implements Unit.Type.

--- a/dm/syncer/syncer_test.go
+++ b/dm/syncer/syncer_test.go
@@ -243,28 +243,14 @@ func (s *testSyncerSuite) TestSampleUnhandledEvents(c *check.C) {
 	}
 
 	c.Assert(seen["unhandled event"], check.HasLen, 1)
-	c.Assert(seen["unhandled event"][0]["events"], check.DeepEquals, map[string]int{
-		"*replication.RowsQueryEvent": 1,
-	})
+	c.Assert(seen["unhandled event"][0]["type"], check.Equals, "*replication.RowsQueryEvent")
 	c.Assert(seen["unhandled event from transaction payload"], check.HasLen, 1)
-	c.Assert(seen["unhandled event from transaction payload"][0]["events"], check.DeepEquals, map[string]int{
-		"*replication.QueryEvent": 1,
-	})
+	c.Assert(seen["unhandled event from transaction payload"][0]["type"], check.Equals, "*replication.QueryEvent")
 
 	syncer.recordUnhandledEvent("unhandled event", &replication.RowsQueryEvent{})
 	syncer.recordUnhandledEvent("unhandled event", &replication.QueryEvent{})
 	syncer.recordUnhandledEvent("unhandled event from transaction payload", &replication.QueryEvent{})
 	c.Assert(logs.All(), check.HasLen, 2)
-
-	syncer.unhandledEvents.Lock()
-	defer syncer.unhandledEvents.Unlock()
-	c.Assert(syncer.unhandledEvents.counts["unhandled event"], check.DeepEquals, map[string]int{
-		"*replication.QueryEvent":     2,
-		"*replication.RowsQueryEvent": 3,
-	})
-	c.Assert(syncer.unhandledEvents.counts["unhandled event from transaction payload"], check.DeepEquals, map[string]int{
-		"*replication.QueryEvent": 2,
-	})
 }
 
 func mockGetServerUnixTS(mock sqlmock.Sqlmock) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #12499

### What is changed and how it works?

This change reduces DM syncer log noise from repeated unhandled binlog events.

- use TiDB's sampled logger for the DM syncer unhandled-event warnings
- keep the existing warning messages, but sample repeated logs by message instead of logging every event immediately
- keep the event type in the emitted warning fields
- add a unit test covering the sampling behavior

With the current settings, the sampler allows the first matching warning through once every 5 minutes for the same log message.

### Check List

#### Tests

 - Unit test

#### Questions

##### Will it cause performance regression or break compatibility?

No material compatibility change. This replaces repeated per-event warning logs with sampled warning logs, which reduces log volume in noisy cases.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
Reduce repeated DM syncer "unhandled event" warnings by using sampled logging.
```
