### PR TITLE
data_validator: initialize the metrics in Start() instead of constructor

### DIFF
--- a/dm/syncer/data_validator.go
+++ b/dm/syncer/data_validator.go
@@ -230,7 +230,6 @@ func NewContinuousDataValidator(cfg *config.SubTaskConfig, syncerObj *Syncer, st
 		cfg:              cfg,
 		syncer:           syncerObj,
 		startWithSubtask: startWithSubtask,
-		vmetric:          metrics.NewValidatorMetrics(cfg.Name, cfg.SourceID),
 	}
 	v.L = log.With(zap.String("task", cfg.Name), zap.String("unit", "continuous validator"))
 
@@ -268,6 +267,7 @@ func (v *DataValidator) initialize() error {
 	v.ctx, v.cancel = context.WithCancel(context.Background())
 	v.tctx = tcontext.NewContext(v.ctx, v.L)
 	v.reset()
+	v.vmetric = metrics.NewValidatorMetrics(v.cfg.Name, v.cfg.SourceID)
 
 	newCtx, cancelFunc := v.tctx.WithTimeout(unit.DefaultInitTimeout)
 	defer cancelFunc()

--- a/dm/syncer/data_validator_test.go
+++ b/dm/syncer/data_validator_test.go
@@ -104,10 +104,12 @@ func TestValidatorStartStopAndInitialize(t *testing.T) {
 
 	// validator already running
 	validator := NewContinuousDataValidator(cfg, syncerObj, false)
+	require.Nil(t, validator.vmetric)
 	validator.stage = pb.Stage_Running
 	validator.Start(pb.Stage_InvalidStage)
 	// if validator already running, Start will return immediately, so we check validator.ctx which has not initialized.
 	require.Nil(t, validator.ctx)
+	require.Nil(t, validator.vmetric)
 
 	// failed to init
 	cfg.From = dbconfig.DBConfig{
@@ -133,11 +135,20 @@ func TestValidatorStartStopAndInitialize(t *testing.T) {
 
 	// normal start & stop
 	validator = NewContinuousDataValidator(cfg, syncerObj, false)
+	require.Nil(t, validator.vmetric)
 	validator.persistHelper.schemaInitialized.Store(true)
 	validator.Start(pb.Stage_Running)
 	defer validator.Stop() // in case assert failed before Stop
+	require.NotNil(t, validator.vmetric)
+	firstMetric := validator.vmetric
 	require.Equal(t, pb.Stage_Running, validator.Stage())
 	require.True(t, validator.Started())
+	validator.Stop()
+	require.Equal(t, pb.Stage_Stopped, validator.Stage())
+	validator.Start(pb.Stage_Running)
+	require.Equal(t, pb.Stage_Running, validator.Stage())
+	require.NotNil(t, validator.vmetric)
+	require.NotSame(t, firstMetric, validator.vmetric)
 	validator.Stop()
 	require.Equal(t, pb.Stage_Stopped, validator.Stage())
 


### PR DESCRIPTION


### What problem does this PR solve?


Issue Number: close #12601

### What is changed and how it works?

Move the metrics initialization to `Start()` (which calls `initialize()`) rather than in the constructor which is called only once in the entire lifetime.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - [x] Unit test
 - [ ] Integration test
 - [ ] Manual test (add detailed scripts or steps below)
 - [ ] No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Metrics of a restarted DM validator are no longer hidden.
```
