### PR TITLE
tests(ticdc): stop relying on git root for mq compose paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3
 	github.com/hashicorp/golang-lru v0.5.1
 	github.com/imdario/mergo v0.3.16
-	github.com/integralist/go-findroot v0.0.0-20160518114804-ac90681525dc
 	github.com/jarcoal/httpmock v1.2.0
 	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/jmoiron/sqlx v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -608,8 +608,6 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/tdigest v0.0.1 h1:XpFptwYmnEKUqmkcDjrzffswZ3nvNeevbUSLPP/ZzIY=
 github.com/influxdata/tdigest v0.0.1/go.mod h1:Z0kXnxzbTC2qrx4NaIzYkE1k66+6oEDQTvL95hQFh5Y=
-github.com/integralist/go-findroot v0.0.0-20160518114804-ac90681525dc h1:4IZpk3M4m6ypx0IlRoEyEyY1gAdicWLMQ0NcG/gBnnA=
-github.com/integralist/go-findroot v0.0.0-20160518114804-ac90681525dc/go.mod h1:UlaC6ndby46IJz9m/03cZPKKkR9ykeIVBBDE3UDBdJk=
 github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bwwc=
 github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
 github.com/jawher/mow.cli v1.0.4/go.mod h1:5hQj2V8g+qYmLUVWqu4Wuja1pI57M83EChYLVZ0sMKk=

--- a/tests/mq_protocol_tests/framework/avro/kafka_docker_env.go
+++ b/tests/mq_protocol_tests/framework/avro/kafka_docker_env.go
@@ -17,9 +17,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"path"
 
-	"github.com/integralist/go-findroot/find"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/tests/mq_protocol_tests/framework"
@@ -75,11 +73,11 @@ func NewKafkaDockerEnv(dockerComposeFile string) *KafkaDockerEnv {
 
 	var file string
 	if dockerComposeFile == "" {
-		st, err := find.Repo()
+		resolvedFile, err := framework.ResolveRepoPath(dockerComposeFilePath)
 		if err != nil {
-			log.Fatal("Could not find git repo root", zap.Error(err))
+			log.Fatal("Could not find repo-local docker-compose file", zap.Error(err))
 		}
-		file = path.Join(st.Path, dockerComposeFilePath)
+		file = resolvedFile
 	} else {
 		file = dockerComposeFile
 	}

--- a/tests/mq_protocol_tests/framework/canal/kafka_docker_env.go
+++ b/tests/mq_protocol_tests/framework/canal/kafka_docker_env.go
@@ -18,7 +18,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/integralist/go-findroot/find"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/tests/mq_protocol_tests/framework"
@@ -51,11 +50,11 @@ func NewKafkaDockerEnv(dockerComposeFile string) *KafkaDockerEnv {
 	}
 	var file string
 	if dockerComposeFile == "" {
-		st, err := find.Repo()
+		resolvedFile, err := framework.ResolveRepoPath(dockerComposeFilePath)
 		if err != nil {
-			log.Fatal("Could not find git repo root", zap.Error(err))
+			log.Fatal("Could not find repo-local docker-compose file", zap.Error(err))
 		}
-		file = st.Path + dockerComposeFilePath
+		file = resolvedFile
 	} else {
 		file = dockerComposeFile
 	}

--- a/tests/mq_protocol_tests/framework/docker_compose_op.go
+++ b/tests/mq_protocol_tests/framework/docker_compose_op.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/integralist/go-findroot/find"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	cerrors "github.com/pingcap/tiflow/pkg/errors"
@@ -143,11 +142,11 @@ func execInController(controller, shellCmd string) ([]byte, error) {
 func (d *DockerComposeOperator) DumpStdout() error {
 	log.Info("Dumping container logs")
 	cmd := exec.Command("docker-compose", "-f", d.FileName, "logs", "-t")
-	st, err := find.Repo()
+	stdoutPath, err := ResolveRepoPath("/deployments/ticdc/docker-compose/logs/stdout.log")
 	if err != nil {
-		log.Fatal("Could not find git repo root", zap.Error(err))
+		log.Fatal("Could not find repo-local docker-compose logs directory", zap.Error(err))
 	}
-	f, err := os.Create(st.Path + "/deployments/ticdc/docker-compose/logs/stdout.log")
+	f, err := os.Create(stdoutPath)
 	if err != nil {
 		return errors.AddStack(err)
 	}

--- a/tests/mq_protocol_tests/framework/mysql/docker_env.go
+++ b/tests/mq_protocol_tests/framework/mysql/docker_env.go
@@ -16,7 +16,6 @@ package mysql
 import (
 	"database/sql"
 
-	"github.com/integralist/go-findroot/find"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/tests/mq_protocol_tests/framework"
@@ -46,11 +45,11 @@ func NewDockerEnv(dockerComposeFile string) *DockerEnv {
 	}
 	var file string
 	if dockerComposeFile == "" {
-		st, err := find.Repo()
+		resolvedFile, err := framework.ResolveRepoPath(dockerComposeFilePath)
 		if err != nil {
-			log.Fatal("Could not find git repo root", zap.Error(err))
+			log.Fatal("Could not find repo-local docker-compose file", zap.Error(err))
 		}
-		file = st.Path + dockerComposeFilePath
+		file = resolvedFile
 	} else {
 		file = dockerComposeFile
 	}

--- a/tests/mq_protocol_tests/framework/repo_path.go
+++ b/tests/mq_protocol_tests/framework/repo_path.go
@@ -1,0 +1,68 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// ResolveRepoPath returns an absolute path under the tiflow repository
+// without relying on git metadata. This keeps repo-local test assets
+// discoverable from symlinked checkouts and git worktrees.
+func ResolveRepoPath(rel string) (string, error) {
+	normalizedRel := filepath.FromSlash(strings.TrimPrefix(rel, "/"))
+	for _, base := range repoPathCandidates() {
+		dir := base
+		for dir != "." && dir != string(filepath.Separator) {
+			if isRepoRoot(dir) {
+				return filepath.Join(dir, normalizedRel), nil
+			}
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+			dir = parent
+		}
+	}
+
+	return "", fmt.Errorf("cannot resolve repo path for %q", rel)
+}
+
+func repoPathCandidates() []string {
+	var candidates []string
+	if _, file, _, ok := runtime.Caller(0); ok {
+		candidates = append(candidates, filepath.Dir(file))
+	}
+	if wd, err := os.Getwd(); err == nil {
+		candidates = append(candidates, wd)
+	}
+	return candidates
+}
+
+func isRepoRoot(dir string) bool {
+	for _, marker := range []string{
+		filepath.Join(dir, "go.mod"),
+		filepath.Join(dir, "deployments", "ticdc", "docker-compose"),
+		filepath.Join(dir, "tests", "mq_protocol_tests", "framework"),
+	} {
+		if _, err := os.Stat(marker); err != nil {
+			return false
+		}
+	}
+	return true
+}

--- a/tests/mq_protocol_tests/framework/repo_path_test.go
+++ b/tests/mq_protocol_tests/framework/repo_path_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 PingCAP, Inc.
+// Copyright 2026 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,21 +14,19 @@
 package framework
 
 import (
+	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestDockerComposeOperator_SetupTearDown(t *testing.T) {
-	// This integration-style test verifies the operator can boot and tear down
-	// the avro compose stack after resolving its compose file from the repo tree.
-	fileName, err := ResolveRepoPath(DockerComposeFilePathPrefix + "docker-compose-avro.yml")
-	assert.NoError(t, err)
+func TestResolveRepoPath(t *testing.T) {
+	// This regression test verifies repo-local compose assets can be found
+	// without invoking git, so worktree and symlinked checkouts stay stable.
+	composePath, err := ResolveRepoPath(DockerComposeFilePathPrefix + "docker-compose-avro.yml")
+	require.NoError(t, err)
 
-	d := &DockerComposeOperator{
-		FileName:   fileName,
-		Controller: "controller0",
-	}
-	d.Setup()
-	d.TearDown()
+	info, statErr := os.Stat(composePath)
+	require.NoError(t, statErr)
+	require.False(t, info.IsDir())
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #12606

### What is changed and how it works?

This removes the mq protocol test framework dependency on git metadata when it resolves repo-local docker-compose assets.

- add `framework.ResolveRepoPath`, which searches upward from the framework source tree and current working directory
- use the helper in the avro/canal/mysql docker envs, compose log dumping, and the compose operator test
- add a regression test for compose path resolution and drop the unused `go-findroot` dependency

### Check List

#### Tests

 - Unit test
 - Manual test

Manual test:
- `go test ./tests/mq_protocol_tests/framework/... -run TestResolveRepoPath -count=1`

#### Questions

##### Will it cause performance regression or break compatibility?

No. This is a test-only path resolution change.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```
