### PR TITLE
dm/tests: stabilize G11 on release-7.5 (ha_cases, lightning_mode)

### DIFF
--- a/dm/pkg/election/election.go
+++ b/dm/pkg/election/election.go
@@ -482,10 +482,15 @@ forLoop:
 			}
 		}
 
-		// add more options if needed.
-		// NOTE: I think use the client's context is better than something like `concurrency.WithContext(ctx)`,
-		// so we can close the session when the client is still valid.
-		session, err = concurrency.NewSession(e.cli, concurrency.WithTTL(e.sessionTTL))
+		// Bind the session ctx to the election ctx so Session.Close()'s Revoke
+		// call aborts when the election is closed, instead of waiting out the
+		// lease TTL on a dying etcd cluster. Without this, when all dm-masters
+		// receive SIGHUP together and tear down concurrently (ha_cases
+		// cleanup), quorum vanishes mid-Revoke and each non-leader blocks up
+		// to sessionTTL (60s) in session.Close(), exceeding the cleanup
+		// deadline. On normal session expiry (line ~232), the lease is
+		// already gone on the server side so Revoke returns quickly anyway.
+		session, err = concurrency.NewSession(e.cli, concurrency.WithTTL(e.sessionTTL), concurrency.WithContext(ctx))
 		if err == nil || errors.Cause(err) == e.cli.Ctx().Err() {
 			break forLoop
 		}

--- a/dm/tests/lightning_mode/run.sh
+++ b/dm/tests/lightning_mode/run.sh
@@ -51,6 +51,43 @@ function run() {
 	run_dm_master_info_log $WORK_DIR/master $MASTER_PORT $cur/conf/dm-master.toml
 	check_rpc_alive $cur/../bin/check_master_online 127.0.0.1:$MASTER_PORT
 
+	# Pre-create Lightning's internal metadata tables. Each dm-worker spawns its
+	# own Lightning instance with the physical backend, and they race to
+	# bootstrap `lightning_metadata.task_meta_v2` / `table_meta` concurrently.
+	# TiDB's DDL schema cache can lag between the concurrent `CREATE TABLE IF
+	# NOT EXISTS` and the follow-up `SELECT`, yielding `Error 1146: Table ...
+	# doesn't exist` on one worker. Creating the tables ahead of time removes
+	# the race. The schemas mirror
+	# br/pkg/lightning/importer/import.go:CreateTaskMetaTable / CreateTableMetadataTable.
+	run_sql_tidb "CREATE DATABASE IF NOT EXISTS lightning_metadata;"
+	run_sql_tidb "CREATE TABLE IF NOT EXISTS lightning_metadata.task_meta_v2 (
+		task_id BIGINT(20) UNSIGNED NOT NULL,
+		pd_cfgs VARCHAR(2048) NOT NULL DEFAULT '',
+		status  VARCHAR(32) NOT NULL,
+		state   TINYINT(1) NOT NULL DEFAULT 0 COMMENT '0: normal, 1: exited before finish',
+		tikv_source_bytes BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+		tiflash_source_bytes BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+		tikv_avail BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+		tiflash_avail BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+		PRIMARY KEY (task_id)
+	);"
+	run_sql_tidb "CREATE TABLE IF NOT EXISTS lightning_metadata.table_meta (
+		task_id BIGINT(20) UNSIGNED,
+		table_id BIGINT(64) NOT NULL,
+		table_name VARCHAR(64) NOT NULL,
+		row_id_base BIGINT(20) NOT NULL DEFAULT 0,
+		row_id_max BIGINT(20) NOT NULL DEFAULT 0,
+		total_kvs_base BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+		total_bytes_base BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+		checksum_base BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+		total_kvs BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+		total_bytes BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+		checksum BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+		status VARCHAR(32) NOT NULL,
+		has_duplicates BOOL NOT NULL DEFAULT 0,
+		PRIMARY KEY (table_id, task_id)
+	);"
+
 	# start DM task
 	dmctl_start_task "$cur/conf/dm-task-dup.yaml" "--remove-meta"
 	run_dm_ctl_with_retry $WORK_DIR "127.0.0.1:$MASTER_PORT" \


### PR DESCRIPTION
## Summary

G11 of `pull_dm_integration_test` on release-7.5 has been failing across builds 1022–1042, blocking PR merges. Investigation identifies two pre-existing races exposed by slower runners ~20 days ago. This PR fixes one at source and mitigates the other at the test level.

## Changes

### 1. `dm/pkg/election/election.go` — source fix for the ha_cases hang

`Session.Close()` issues an etcd `Revoke` bounded by lease TTL (60s default). The session was created without `WithContext`, so its ctx defaulted to `e.cli.Ctx()` (client lifetime). When `Server.Close()` runs and `e.cancel()` fires, the Revoke call still can't be cancelled — it must wait out its own 60 s timeout.

In ha_cases cleanup, `pkill -hup dm-master.test` hits all three masters concurrently. Each non-leader proposes its `LeaseRevoke` via raft, but peers race to call `s.etcd.Close()` and quorum dies before the proposal commits. The RPC then burns the full 60 s per process, exceeding the `wait_process_exit` 120 s deadline and failing the whole G11 group (observed on builds 1022, 1033, 1037, 1038 — always a non-leader master2/master3).

Fix: pass `concurrency.WithContext(ctx)` so `e.cancel()` aborts `Revoke` immediately. The lease is abandoned and expires by TTL, which the etcd docs call out as the acceptable shutdown tradeoff. The only other `closeSession` call site (session natural expiry at election.go:232) already has a dead lease on the server, so Revoke returns fast regardless of ctx binding.

### 2. `dm/tests/lightning_mode/run.sh` — pre-create `lightning_metadata` tables

Two dm-workers each spawn a TiDB Lightning instance and concurrently bootstrap `lightning_metadata.task_meta_v2` / `table_meta` via `CREATE TABLE IF NOT EXISTS`. Lightning opens `*sql.DB` without pinning a conn (`br/pkg/lightning/importer/meta_manager.go:40-59` on tidb release-7.5), so one instance's CREATE bumps schemaVersion on node X, the other's CREATE on node Y short-circuits (table already in InfoSchema, no DDL scheduled, no bump), and its follow-up `SELECT` on a pooled conn with stale schema returns `Error 1146: Table 'lightning_metadata.task_meta_v2' doesn't exist`. `SQLWithRetry` doesn't retry 1146 (`br/pkg/lightning/common/retry.go:101-136`), so the task permanently fails. Observed once in build 1039.

The proper fix is in tidb/br (pin a `*sql.Conn` across Init + CheckTaskExist) and should be filed separately. As a DM-side mitigation, pre-creating both tables makes the two CREATEs no-ops that never hit the DDL queue, closing the race window entirely.

## Not fixed here

A separate problem: G11 packs 37 cases under a 50-min stage timeout while other groups finish in ~17 min. Builds 1025/1026/1032/1035/1036/1040/1041 were "Terminated" by the timeout at whichever test happened to be running. Recommend a follow-up PR to split G11 — out of scope for this CI unblock.

## Test plan

- [ ] `/test pull-dm-integration-test` passes
- [ ] Re-run pull_dm_integration_test multiple times to confirm G11 stability (the two races should no longer trigger; the timeout problem remains until G11 is split)