### PR TITLE
*: replace BenMeadowcroft with likidu in OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,10 +3,10 @@
 aliases:
   sig-critical-approvers-cdc:
     - yudongusa
-    - BenMeadowcroft
+    - likidu
   sig-critical-approvers-dm:
     - yudongusa
-    - BenMeadowcroft
+    - likidu
   sig-approvers-dm:
     - Benjamin2037
     - D3Hunter


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?

Issue Number: ref #12623

### What is changed and how it works?

- Replace `BenMeadowcroft` with `likidu` in `OWNERS_ALIASES` for `sig-critical-approvers-*`.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
