### PR TITLE
grafana: render stacked nulls as zero

### DIFF
--- a/metrics/grafana/ticdc.json
+++ b/metrics/grafana/ticdc.json
@@ -19503,7 +19503,7 @@
           "linewidth": 1,
           "links": [],
           "maxPerRow": 3,
-          "nullPointMode": "null",
+          "nullPointMode": "null as zero",
           "percentage": false,
           "pluginVersion": "6.1.6",
           "pointradius": 5,


### PR DESCRIPTION
## Summary
- set stacked Grafana graph panels to render null points as zero
- avoid misleading stacked visualizations when a series has data gaps

## Test
- parsed dashboard JSON files
- verified every `stack: true` graph panel has `nullPointMode: "null as zero"`
