### PR TITLE
syncer(dm): prevent checkpoint flush after BeginTx error

### DIFF
--- a/dm/syncer/checkpoint_flush_worker.go
+++ b/dm/syncer/checkpoint_flush_worker.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/pkg/util/filter"
 	tcontext "github.com/pingcap/tiflow/dm/pkg/context"
-	"github.com/pingcap/tiflow/dm/pkg/terror"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 )
@@ -77,7 +76,7 @@ func (w *checkpointFlushWorker) Run(ctx *tcontext.Context) {
 		// optimistic shard info, DM-master may resolved the optimistic lock and let other worker execute DDL. So after this
 		// worker resume, it can not execute the DML/DDL in old binlog because of downstream table structure mismatching.
 		// We should find a way to (compensating) implement a transaction containing interaction with both etcd and SQL.
-		if err != nil && (terror.ErrDBExecuteFailed.Equal(err) || terror.ErrDBUnExpect.Equal(err)) {
+		if isDownstreamExecutionError(err) {
 			ctx.L().Warn(fmt.Sprintf("error detected when executing SQL job, skip %s checkpoint and shutdown checkpointFlushWorker", flushLogMsg),
 				zap.Stringer("globalPos", task.snapshotInfo.globalPos),
 				zap.Error(err))

--- a/dm/syncer/checkpoint_flush_worker_test.go
+++ b/dm/syncer/checkpoint_flush_worker_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncer
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/util/filter"
+	"github.com/pingcap/tiflow/dm/pkg/binlog"
+	tcontext "github.com/pingcap/tiflow/dm/pkg/context"
+	"github.com/pingcap/tiflow/dm/pkg/schema"
+	"github.com/pingcap/tiflow/dm/pkg/terror"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func TestCheckpointFlushWorkerSkipsCheckpointOnBeginError(t *testing.T) {
+	t.Parallel()
+
+	cp := &checkpointFlushWorkerTestCheckpoint{}
+	var execError atomic.Error
+	execError.Store(terror.ErrDBExecuteFailedBegin.Delegate(sql.ErrConnDone))
+
+	worker := &checkpointFlushWorker{
+		input:              make(chan *checkpointFlushTask, 1),
+		cp:                 cp,
+		execError:          &execError,
+		afterFlushFn:       func(*checkpointFlushTask) error { return nil },
+		updateJobMetricsFn: func(bool, string, *job) {},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		worker.Run(tcontext.Background())
+		close(done)
+	}()
+
+	errCh := make(chan error, 1)
+	worker.Add(&checkpointFlushTask{
+		snapshotInfo:   &SnapshotInfo{id: 1},
+		syncFlushErrCh: errCh,
+	})
+	require.NoError(t, <-errCh)
+
+	worker.Close()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("checkpoint flush worker did not stop")
+	}
+	require.Zero(t, cp.flushCount, "checkpoint flush must be skipped after downstream BeginTx failure; flushing here can persist a checkpoint past non-durable DML")
+}
+
+type checkpointFlushWorkerTestCheckpoint struct {
+	flushCount int
+}
+
+func (c *checkpointFlushWorkerTestCheckpoint) Init(*tcontext.Context) error { return nil }
+
+func (c *checkpointFlushWorkerTestCheckpoint) Close() {}
+
+func (c *checkpointFlushWorkerTestCheckpoint) ResetConn(*tcontext.Context) error { return nil }
+
+func (c *checkpointFlushWorkerTestCheckpoint) Clear(*tcontext.Context) error { return nil }
+
+func (c *checkpointFlushWorkerTestCheckpoint) Load(*tcontext.Context) error { return nil }
+
+func (c *checkpointFlushWorkerTestCheckpoint) LoadMeta(context.Context) error { return nil }
+
+func (c *checkpointFlushWorkerTestCheckpoint) SaveTablePoint(*filter.Table, binlog.Location, *model.TableInfo) {
+}
+
+func (c *checkpointFlushWorkerTestCheckpoint) DeleteTablePoint(*tcontext.Context, *filter.Table) error {
+	return nil
+}
+
+func (c *checkpointFlushWorkerTestCheckpoint) DeleteAllTablePoint(*tcontext.Context) error {
+	return nil
+}
+
+func (c *checkpointFlushWorkerTestCheckpoint) DeleteSchemaPoint(*tcontext.Context, string) error {
+	return nil
+}
+
+func (c *checkpointFlushWorkerTestCheckpoint) IsOlderThanTablePoint(*filter.Table, binlog.Location) bool {
+	return false
+}
+
+func (c *checkpointFlushWorkerTestCheckpoint) SaveGlobalPoint(binlog.Location) {}
+
+func (c *checkpointFlushWorkerTestCheckpoint) SaveGlobalPointForcibly(binlog.Location) {}
+
+func (c *checkpointFlushWorkerTestCheckpoint) Snapshot(bool) *SnapshotInfo { return nil }
+
+func (c *checkpointFlushWorkerTestCheckpoint) DiscardPendingSnapshots() {}
+
+func (c *checkpointFlushWorkerTestCheckpoint) FlushPointsExcept(
+	*tcontext.Context,
+	int,
+	[]*filter.Table,
+	[]string,
+	[][]interface{},
+) error {
+	c.flushCount++
+	return nil
+}
+
+func (c *checkpointFlushWorkerTestCheckpoint) FlushPointsWithTableInfos(
+	*tcontext.Context,
+	[]*filter.Table,
+	[]*model.TableInfo,
+) error {
+	return nil
+}
+
+func (c *checkpointFlushWorkerTestCheckpoint) FlushSafeModeExitPoint(*tcontext.Context) error {
+	return nil
+}
+
+func (c *checkpointFlushWorkerTestCheckpoint) GlobalPoint() binlog.Location { return binlog.Location{} }
+
+func (c *checkpointFlushWorkerTestCheckpoint) GlobalPointSaveTime() time.Time { return time.Time{} }
+
+func (c *checkpointFlushWorkerTestCheckpoint) SaveSafeModeExitPoint(*binlog.Location) {}
+
+func (c *checkpointFlushWorkerTestCheckpoint) SafeModeExitPoint() *binlog.Location { return nil }
+
+func (c *checkpointFlushWorkerTestCheckpoint) TablePoint() map[string]map[string]binlog.Location {
+	return nil
+}
+
+func (c *checkpointFlushWorkerTestCheckpoint) GetTableInfo(string, string) *model.TableInfo {
+	return nil
+}
+
+func (c *checkpointFlushWorkerTestCheckpoint) FlushedGlobalPoint() binlog.Location {
+	return binlog.Location{}
+}
+
+func (c *checkpointFlushWorkerTestCheckpoint) LastFlushOutdated() bool { return false }
+
+func (c *checkpointFlushWorkerTestCheckpoint) Rollback() {}
+
+func (c *checkpointFlushWorkerTestCheckpoint) String() string { return "" }
+
+func (c *checkpointFlushWorkerTestCheckpoint) LoadIntoSchemaTracker(context.Context, *schema.Tracker) error {
+	return nil
+}
+
+func (c *checkpointFlushWorkerTestCheckpoint) CheckAndUpdate(
+	context.Context,
+	map[string]string,
+	map[string]map[string]string,
+) error {
+	return nil
+}

--- a/dm/syncer/dml_worker.go
+++ b/dm/syncer/dml_worker.go
@@ -365,7 +365,7 @@ func (w *DMLWorker) executeBatchJobs(queueID int, jobs []*job, disableForeignKey
 		}
 	})
 
-	if w.judgeKeyNotFound(affect, jobs) {
+	if err == nil && w.judgeKeyNotFound(affect, jobs) {
 		// throw an error if needed in the future.
 		// err = terror.ErrDBExecuteFailed.Delegate(errors.New("key not found"), "mock")
 		w.logger.Warn("no matching record is found to update/delete, ER_KEY_NOT_FOUND", zap.Int("affect", affect), zap.Int("jobs", len(jobs)), zap.Stringer("start from", jobs[0].startLocation), zap.Stringer("end at", jobs[len(jobs)-1].currentLocation))

--- a/dm/syncer/execution_error.go
+++ b/dm/syncer/execution_error.go
@@ -1,0 +1,24 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncer
+
+import "github.com/pingcap/tiflow/dm/pkg/terror"
+
+func isDownstreamExecutionError(err error) bool {
+	return err != nil &&
+		(terror.ErrDBExecuteFailed.Equal(err) ||
+			terror.ErrDBExecuteFailedBegin.Equal(err) ||
+			terror.ErrDBUnExpect.Equal(err))
+}

--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -1291,7 +1291,7 @@ func (s *Syncer) flushCheckPoints() error {
 	// optimistic shard info, DM-master may resolved the optimistic lock and let other worker execute DDL. So after this
 	// worker resume, it can not execute the DML/DDL in old binlog because of downstream table structure mismatching.
 	// We should find a way to (compensating) implement a transaction containing interaction with both etcd and SQL.
-	if err != nil && (terror.ErrDBExecuteFailed.Equal(err) || terror.ErrDBUnExpect.Equal(err)) {
+	if isDownstreamExecutionError(err) {
 		s.tctx.L().Warn("error detected when executing SQL job, skip sync flush checkpoints",
 			zap.Stringer("checkpoint", s.checkpoint),
 			zap.Error(err))
@@ -1327,7 +1327,7 @@ func (s *Syncer) flushCheckPointsAsync(asyncFlushJob *job) {
 	// optimistic shard info, DM-master may resolved the optimistic lock and let other worker execute DDL. So after this
 	// worker resume, it can not execute the DML/DDL in old binlog because of downstream table structure mismatching.
 	// We should find a way to (compensating) implement a transaction containing interaction with both etcd and SQL.
-	if err != nil && (terror.ErrDBExecuteFailed.Equal(err) || terror.ErrDBUnExpect.Equal(err)) {
+	if isDownstreamExecutionError(err) {
 		s.tctx.L().Warn("error detected when executing SQL job, skip async flush checkpoints",
 			zap.Stringer("checkpoint", s.checkpoint),
 			zap.Error(err))
@@ -1974,7 +1974,7 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 		}
 
 		// if any execute error, flush safemode exit point
-		if err2 = s.execError.Load(); err2 != nil && (terror.ErrDBExecuteFailed.Equal(err2) || terror.ErrDBUnExpect.Equal(err2)) {
+		if err2 = s.execError.Load(); isDownstreamExecutionError(err2) {
 			if err2 = s.checkpoint.FlushSafeModeExitPoint(s.tctx); err2 != nil {
 				s.tctx.L().Warn("failed to flush safe mode checkpoints when exit task", zap.Error(err2))
 			}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #12626

### What is changed and how it works?

This PR fixes a DM correctness issue where checkpoint flush could still advance after a downstream transaction `BeginTx` failure.

Changes:

- Introduce a shared downstream execution error predicate that includes `ErrDBExecuteFailedBegin` together with existing `ErrDBExecuteFailed` and `ErrDBUnExpect`.
- Use the predicate in sync, async, and checkpoint flush worker guards so checkpoint flush is skipped after downstream begin failures.
- Treat begin failures as downstream execution errors when flushing the safe-mode exit point on task exit.
- Avoid running key-not-found diagnostics after `ExecuteSQL` already returned an execution error.
- Add a regression test for `ErrDBExecuteFailedBegin(sql.ErrConnDone)` to ensure checkpoint flush is skipped.

### Check List

#### Tests

 - Unit test

```bash
go test ./dm/syncer -run TestCheckpointFlushWorkerSkipsCheckpointOnBeginError -count=1
go test ./dm/syncer -run 'Test(CheckpointFlushWorkerSkipsCheckpointOnBeginError|JudgeKeyNotFound|EnableSafeModeInitializationPhase)$' -count=1
```

Also ran:

```bash
make fmt
git diff --check
```

#### Questions

##### Will it cause performance regression or break compatibility?

No. The change only broadens existing checkpoint-blocking error classification to include downstream transaction begin failures and suppresses a misleading diagnostic after failed execution.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
Fix a DM correctness issue that could flush checkpoints after downstream transaction begin failures.
```
