### PR TITLE
etcd(ticdc): update etcd cluster member correctly

### DIFF
--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -519,7 +519,7 @@ func (checker *healthyChecker) patrol(ctx context.Context) []string {
 }
 
 func (checker *healthyChecker) update(eps []string) {
-	updateEps := make(map[string]struct{})
+	updateEps := make(map[string]struct{}, len(eps))
 	for _, ep := range eps {
 		updateEps[ep] = struct{}{}
 		// check if client exists, if not, create one, if exists, check if it's offline or disconnected.

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -519,20 +519,22 @@ func (checker *healthyChecker) patrol(ctx context.Context) []string {
 }
 
 func (checker *healthyChecker) update(eps []string) {
-	updateEps := make(map[string]struct{}, len(eps))
+	updateEps := make(map[string]struct{})
 	for _, ep := range eps {
 		updateEps[ep] = struct{}{}
 		// check if client exists, if not, create one, if exists, check if it's offline or disconnected.
-		if client, ok := checker.Load(ep); ok {
-			lastHealthy := client.(*healthyClient).lastHealth
+		if value, ok := checker.Load(ep); ok {
+			client := value.(*healthyClient)
+			lastHealthy := client.lastHealth
 			if time.Since(lastHealthy) > etcdServerOfflineTimeout {
 				log.Info("some etcd server maybe offline", zap.String("endpoint", ep))
+				client.Close()
 				checker.Delete(ep)
 			}
 			if time.Since(lastHealthy) > etcdServerDisconnectedTimeout {
 				// try to reset client endpoint to trigger reconnect
-				client.(*healthyClient).Client.SetEndpoints([]string{}...)
-				client.(*healthyClient).Client.SetEndpoints(ep)
+				client.Client.SetEndpoints([]string{}...)
+				client.Client.SetEndpoints(ep)
 			}
 			continue
 		}
@@ -541,6 +543,9 @@ func (checker *healthyChecker) update(eps []string) {
 	checker.Range(func(key, value interface{}) bool {
 		ep := key.(string)
 		if _, exist := updateEps[ep]; !exist {
+			if client, ok := value.(*healthyClient); ok {
+				client.Close()
+			}
 			checker.Delete(key)
 		}
 		return true

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -519,7 +519,9 @@ func (checker *healthyChecker) patrol(ctx context.Context) []string {
 }
 
 func (checker *healthyChecker) update(eps []string) {
+	updateEps := make(map[string]struct{})
 	for _, ep := range eps {
+		updateEps[ep] = struct{}{}
 		// check if client exists, if not, create one, if exists, check if it's offline or disconnected.
 		if client, ok := checker.Load(ep); ok {
 			lastHealthy := client.(*healthyClient).lastHealth
@@ -536,6 +538,13 @@ func (checker *healthyChecker) update(eps []string) {
 		}
 		checker.addClient(ep, time.Now())
 	}
+	checker.Range(func(key, value interface{}) bool {
+		ep := key.(string)
+		if _, exist := updateEps[ep]; !exist {
+			checker.Delete(key)
+		}
+		return true
+	})
 }
 
 func (checker *healthyChecker) addClient(ep string, lastHealth time.Time) {

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tiflow/pkg/security"
 	"github.com/pingcap/tiflow/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/tikv/pd/client/errs"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	v3rpc "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/client/pkg/v3/logutil"
@@ -331,8 +332,6 @@ func isRetryableError(rpcName string) retry.IsRetryable {
 const (
 	// defaultEtcdClientTimeout is the default timeout for etcd client.
 	defaultEtcdClientTimeout = 5 * time.Second
-	// defaultAutoSyncInterval is the interval to update endpoints with its latest members.
-	defaultAutoSyncInterval = 30 * time.Second
 	// defaultDialKeepAliveTime is the time after which client pings the server to see if transport is alive.
 	defaultDialKeepAliveTime = 10 * time.Second
 	// defaultDialKeepAliveTimeout is the time that the client waits for a response for the
@@ -360,7 +359,6 @@ func newClient(tlsConfig *tls.Config, grpcDialOption grpc.DialOption, endpoints 
 		TLS:                  tlsConfig,
 		LogConfig:            &logConfig,
 		DialTimeout:          defaultEtcdClientTimeout,
-		AutoSyncInterval:     defaultAutoSyncInterval,
 		DialKeepAliveTime:    defaultDialKeepAliveTime,
 		DialKeepAliveTimeout: defaultDialKeepAliveTimeout,
 		DialOptions: []grpc.DialOption{
@@ -402,16 +400,18 @@ func CreateRawEtcdClient(securityConf *security.Credential, grpcDialOption grpc.
 		return nil, err
 	}
 
+	tickerInterval := defaultDialKeepAliveTime
+
 	checker := &healthyChecker{
 		tlsConfig:      tlsConfig,
 		grpcDialOption: grpcDialOption,
 	}
-	eps := client.Endpoints()
+	eps := syncUrls(client)
 	checker.update(eps)
 
 	// Create a goroutine to check the health of etcd endpoints periodically.
 	go func(client *clientv3.Client) {
-		ticker := time.NewTicker(defaultDialKeepAliveTime)
+		ticker := time.NewTicker(tickerInterval)
 		defer ticker.Stop()
 		lastAvailable := time.Now()
 		for {
@@ -454,7 +454,7 @@ func CreateRawEtcdClient(securityConf *security.Credential, grpcDialOption grpc.
 
 	// Notes: use another goroutine to update endpoints to avoid blocking health check in the first goroutine.
 	go func(client *clientv3.Client) {
-		ticker := time.NewTicker(defaultAutoSyncInterval)
+		ticker := time.NewTicker(tickerInterval)
 		defer ticker.Stop()
 		for {
 			select {
@@ -462,8 +462,7 @@ func CreateRawEtcdClient(securityConf *security.Credential, grpcDialOption grpc.
 				log.Info("etcd client is closed, exit update endpoint goroutine")
 				return
 			case <-ticker.C:
-				// the client will auto sync endpoints
-				eps := client.Endpoints()
+				eps := syncUrls(client)
 				checker.update(eps)
 			}
 		}
@@ -499,7 +498,7 @@ func (checker *healthyChecker) patrol(ctx context.Context) []string {
 			defer wg.Done()
 			ep := key.(string)
 			client := value.(*healthyClient)
-			if IsHealthy(ctx, client.Client) {
+			if isHealthy(ctx, client.Client) {
 				hch <- ep
 				checker.Store(ep, &healthyClient{
 					Client:     client.Client,
@@ -564,8 +563,27 @@ func (checker *healthyChecker) addClient(ep string, lastHealth time.Time) {
 	})
 }
 
-// IsHealthy checks if the etcd is healthy.
-func IsHealthy(ctx context.Context, client *clientv3.Client) bool {
+func syncUrls(client *clientv3.Client) []string {
+	// See https://github.com/etcd-io/etcd/blob/85b640cee793e25f3837c47200089d14a8392dc7/clientv3/client.go#L170-L183
+	ctx, cancel := context.WithTimeout(clientv3.WithRequireLeader(client.Ctx()),
+		etcdClientTimeoutDuration)
+	defer cancel()
+	mresp, err := client.MemberList(ctx)
+	if err != nil {
+		log.Error("failed to list members", errs.ZapError(err))
+		return []string{}
+	}
+	var eps []string
+	for _, m := range mresp.Members {
+		if len(m.Name) != 0 && !m.IsLearner {
+			eps = append(eps, m.ClientURLs...)
+		}
+	}
+	return eps
+}
+
+// isHealthy checks if the etcd is healthy.
+func isHealthy(ctx context.Context, client *clientv3.Client) bool {
 	timeout := etcdClientTimeoutDuration
 	ctx, cancel := context.WithTimeout(clientv3.WithRequireLeader(ctx), timeout)
 	defer cancel()

--- a/pkg/etcd/client.go
+++ b/pkg/etcd/client.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pingcap/tiflow/pkg/security"
 	"github.com/pingcap/tiflow/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/tikv/pd/pkg/errs"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	v3rpc "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/client/pkg/v3/logutil"
@@ -332,6 +331,8 @@ func isRetryableError(rpcName string) retry.IsRetryable {
 const (
 	// defaultEtcdClientTimeout is the default timeout for etcd client.
 	defaultEtcdClientTimeout = 5 * time.Second
+	// defaultAutoSyncInterval is the interval to update endpoints with its latest members.
+	defaultAutoSyncInterval = 30 * time.Second
 	// defaultDialKeepAliveTime is the time after which client pings the server to see if transport is alive.
 	defaultDialKeepAliveTime = 10 * time.Second
 	// defaultDialKeepAliveTimeout is the time that the client waits for a response for the
@@ -359,7 +360,7 @@ func newClient(tlsConfig *tls.Config, grpcDialOption grpc.DialOption, endpoints 
 		TLS:                  tlsConfig,
 		LogConfig:            &logConfig,
 		DialTimeout:          defaultEtcdClientTimeout,
-		AutoSyncInterval:     30 * time.Second,
+		AutoSyncInterval:     defaultAutoSyncInterval,
 		DialKeepAliveTime:    defaultDialKeepAliveTime,
 		DialKeepAliveTimeout: defaultDialKeepAliveTimeout,
 		DialOptions: []grpc.DialOption{
@@ -401,18 +402,16 @@ func CreateRawEtcdClient(securityConf *security.Credential, grpcDialOption grpc.
 		return nil, err
 	}
 
-	tickerInterval := defaultDialKeepAliveTime
-
 	checker := &healthyChecker{
 		tlsConfig:      tlsConfig,
 		grpcDialOption: grpcDialOption,
 	}
-	eps := syncUrls(client)
+	eps := client.Endpoints()
 	checker.update(eps)
 
 	// Create a goroutine to check the health of etcd endpoints periodically.
 	go func(client *clientv3.Client) {
-		ticker := time.NewTicker(tickerInterval)
+		ticker := time.NewTicker(defaultDialKeepAliveTime)
 		defer ticker.Stop()
 		lastAvailable := time.Now()
 		for {
@@ -455,7 +454,7 @@ func CreateRawEtcdClient(securityConf *security.Credential, grpcDialOption grpc.
 
 	// Notes: use another goroutine to update endpoints to avoid blocking health check in the first goroutine.
 	go func(client *clientv3.Client) {
-		ticker := time.NewTicker(tickerInterval)
+		ticker := time.NewTicker(defaultAutoSyncInterval)
 		defer ticker.Stop()
 		for {
 			select {
@@ -463,7 +462,8 @@ func CreateRawEtcdClient(securityConf *security.Credential, grpcDialOption grpc.
 				log.Info("etcd client is closed, exit update endpoint goroutine")
 				return
 			case <-ticker.C:
-				eps := syncUrls(client)
+				// the client will auto sync endpoints
+				eps := client.Endpoints()
 				checker.update(eps)
 			}
 		}
@@ -562,25 +562,6 @@ func (checker *healthyChecker) addClient(ep string, lastHealth time.Time) {
 		Client:     client,
 		lastHealth: lastHealth,
 	})
-}
-
-func syncUrls(client *clientv3.Client) []string {
-	// See https://github.com/etcd-io/etcd/blob/85b640cee793e25f3837c47200089d14a8392dc7/clientv3/client.go#L170-L183
-	ctx, cancel := context.WithTimeout(clientv3.WithRequireLeader(client.Ctx()),
-		etcdClientTimeoutDuration)
-	defer cancel()
-	mresp, err := client.MemberList(ctx)
-	if err != nil {
-		log.Error("failed to list members", errs.ZapError(err))
-		return []string{}
-	}
-	var eps []string
-	for _, m := range mresp.Members {
-		if len(m.Name) != 0 && !m.IsLearner {
-			eps = append(eps, m.ClientURLs...)
-		}
-	}
-	return eps
 }
 
 // IsHealthy checks if the etcd is healthy.


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12368

### What is changed and how it works?
When updating etcd client URLs, remove the client that is not a member of the etcd cluster.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
```
tiup playground $VERSION --db 1 --kv 1 --pd 3 --ticdc 1 --tiflash 0 --without-monitor
tiup cdc:$VERSION cli changefeed create --sink-uri 'blackhole://'
tiup playground scale-out --pd 1
tiup playground display
tiup playground scale-in --pid 153389 # pick any one from the display
```
Print only once
```
[2026/05/21 10:03:39.588 +00:00] [INFO] [client.go:447] ["update endpoints"] [numChange=3->4] [lastEndpoints="[http://127.0.0.1:2382,http://127.0.0.1:2379,http://127.0.0.1:2384]"] [endpoints="[http://127.0.0.1:44765,http://127.0.0.1:2382,http://127.0.0.1:2384,http://127.0.0.1:2379]"]
```
#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fixed the bug of using an incorrect etcd client when scaling PD nodes
```
