### PR TITLE
dm: stop the old worker promptly on failover

### DIFF
--- a/dm/pkg/ha/keepalive.go
+++ b/dm/pkg/ha/keepalive.go
@@ -119,11 +119,19 @@ func KeepAlive(ctx context.Context, cli *clientv3.Client, workerName string, kee
 		return err
 	}
 
-	// once we put the key successfully, we should revoke lease before we quit keepalive normally
+	// Revoke the lease on a normal (ctx-cancel) exit so the master rebinds
+	// promptly. On the channel-close path the lease is already gone and, under
+	// a partition, revoke blocks for its full timeout (~3s) — which keeps the
+	// old worker writing while a new one takes over. Skip it there and let the
+	// lease expire by TTL.
+	skipRevokeOnExit := false
 	defer func() {
+		if skipRevokeOnExit {
+			return
+		}
 		_, err2 := revokeLease(cli, leaseID)
 		if err2 != nil {
-			log.L().Warn("fail to revoke lease", zap.Error(err))
+			log.L().Warn("fail to revoke lease", zap.Error(err2))
 		}
 	}()
 
@@ -142,6 +150,7 @@ func KeepAlive(ctx context.Context, cli *clientv3.Client, workerName string, kee
 			})
 			if !ok {
 				log.L().Info("keep alive channel is closed")
+				skipRevokeOnExit = true
 				return nil
 			}
 		case <-ctx.Done():

--- a/dm/syncer/causality.go
+++ b/dm/syncer/causality.go
@@ -68,7 +68,7 @@ func causalityWrap(inCh chan *job, syncer *Syncer) chan *job {
 		logger:        syncer.tctx.Logger.WithFields(zap.String("component", "causality")),
 		inCh:          inCh,
 		outCh:         make(chan *job, syncer.cfg.QueueSize),
-		sessCtx:       syncer.sessCtx,
+		sessCtx:       syncer.causalityCtx,
 		workerCount:   syncer.cfg.WorkerCount,
 	}
 

--- a/dm/syncer/dml.go
+++ b/dm/syncer/dml.go
@@ -15,6 +15,7 @@ package syncer
 
 import (
 	"encoding/binary"
+	"strings"
 
 	"github.com/pingcap/tidb/pkg/expression"
 	"github.com/pingcap/tidb/pkg/meta/model"
@@ -146,6 +147,7 @@ func (s *Syncer) genAndFilterInsertDMLs(tctx *tcontext.Context, param *genDMLPar
 		originalDataSeq = extendData
 	}
 
+	causalityKeySourceTable := s.causalityKeySourceTableNameForRowChange(param.sourceTable)
 RowLoop:
 	for _, data := range originalDataSeq {
 		originalValue, err := adjustValueFromBinlogData(data, ti)
@@ -171,9 +173,10 @@ RowLoop:
 			originalValue,
 			param.sourceTableInfo,
 			downstreamTableInfo.TableInfo,
-			s.sessCtx,
+			s.causalityCtx,
 		)
 		rowChange.SetWhereHandle(downstreamTableInfo.WhereHandle)
+		rowChange.SetCausalityKeySourceTable(causalityKeySourceTable)
 		rowChange.SetForeignKeyRelations(downstreamTableInfo.ForeignKeyRelations)
 		dmls = append(dmls, rowChange)
 	}
@@ -205,6 +208,7 @@ func (s *Syncer) genAndFilterUpdateDMLs(
 		originalData = extendData
 	}
 
+	causalityKeySourceTable := s.causalityKeySourceTableNameForRowChange(param.sourceTable)
 RowLoop:
 	for i := 0; i < len(originalData); i += 2 {
 		oriOldData := originalData[i]
@@ -248,9 +252,10 @@ RowLoop:
 			oriChangedValues,
 			param.sourceTableInfo,
 			downstreamTableInfo.TableInfo,
-			s.sessCtx,
+			s.causalityCtx,
 		)
 		rowChange.SetWhereHandle(downstreamTableInfo.WhereHandle)
+		rowChange.SetCausalityKeySourceTable(causalityKeySourceTable)
 		rowChange.SetForeignKeyRelations(downstreamTableInfo.ForeignKeyRelations)
 		dmls = append(dmls, rowChange)
 	}
@@ -277,6 +282,7 @@ func (s *Syncer) genAndFilterDeleteDMLs(tctx *tcontext.Context, param *genDMLPar
 		dataSeq = extendData
 	}
 
+	causalityKeySourceTable := s.causalityKeySourceTableNameForRowChange(param.sourceTable)
 RowLoop:
 	for _, data := range dataSeq {
 		value, err := adjustValueFromBinlogData(data, ti)
@@ -302,14 +308,25 @@ RowLoop:
 			nil,
 			param.sourceTableInfo,
 			downstreamTableInfo.TableInfo,
-			s.sessCtx,
+			s.causalityCtx,
 		)
 		rowChange.SetWhereHandle(downstreamTableInfo.WhereHandle)
+		rowChange.SetCausalityKeySourceTable(causalityKeySourceTable)
 		rowChange.SetForeignKeyRelations(downstreamTableInfo.ForeignKeyRelations)
 		dmls = append(dmls, rowChange)
 	}
 
 	return dmls, nil
+}
+
+func (s *Syncer) causalityKeySourceTableNameForRowChange(sourceTable *filter.Table) *cdcmodel.TableName {
+	if !s.needForeignKeyCausality() || s.cfg.CaseSensitive {
+		return nil
+	}
+	return &cdcmodel.TableName{
+		Schema: strings.ToLower(sourceTable.Schema),
+		Table:  strings.ToLower(sourceTable.Name),
+	}
 }
 
 func castUnsigned(data interface{}, ft *types.FieldType) interface{} {

--- a/dm/syncer/dml_worker.go
+++ b/dm/syncer/dml_worker.go
@@ -345,6 +345,12 @@ func (w *DMLWorker) executeBatchJobs(queueID int, jobs []*job, disableForeignKey
 			}()
 		}
 	}
+	// Don't start a new batch once the syncer is cancelled, so an unbound
+	// worker can't keep writing while a new owner replays the same source.
+	if w.syncCtx.Ctx.Err() != nil {
+		err = w.syncCtx.Ctx.Err()
+		return
+	}
 	// use background context to execute sqls as much as possible
 	// set timeout to maxDMLConnectionDuration to make sure dmls can be replicated to downstream event if the latency is high
 	// if users need to quit this asap, we can support pause-task/stop-task --force in the future

--- a/dm/syncer/dml_worker_test.go
+++ b/dm/syncer/dml_worker_test.go
@@ -373,3 +373,47 @@ func TestExecuteBatchJobsWithForeignKey(t *testing.T) {
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+func TestExecuteBatchJobsReturnsWhenSyncContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	sqlConn, err := db.Conn(context.Background())
+	require.NoError(t, err)
+	defer sqlConn.Close()
+
+	baseConn := connpkg.NewBaseConnForTest(sqlConn, nil)
+	cfg := &config.SubTaskConfig{Name: "test"}
+	dbConn := dbconn.NewDBConn(cfg, baseConn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var fatalErr error
+	successCalled := false
+	worker := &DMLWorker{
+		toDBConns: []*dbconn.DBConn{dbConn},
+		syncCtx:   tcontext.NewContext(ctx, log.L()),
+		successFunc: func(int, int, []*job) {
+			successCalled = true
+		},
+		fatalFunc: func(_ *job, err error) {
+			fatalErr = err
+		},
+		logger: log.L(),
+	}
+
+	source := &cdcmodel.TableName{Schema: "db", Table: "tb"}
+	target := &cdcmodel.TableName{Schema: "targetSchema", Table: "targetTable"}
+	tableInfo := mockTableInfo(t, "create table db.tb(id int primary key, name varchar(24))")
+	change := sqlmodel.NewRowChange(source, target, nil, []interface{}{1, "canceled"}, tableInfo, nil, nil)
+
+	worker.executeBatchJobs(0, []*job{newDMLJob(change, ec)}, false)
+
+	require.False(t, successCalled)
+	require.ErrorIs(t, fatalErr, context.Canceled)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -169,6 +169,7 @@ type Syncer struct {
 	baList          *filter.Filter
 	exprFilterGroup *ExprFilterGroup
 	sessCtx         sessionctx.Context
+	causalityCtx    sessionctx.Context
 
 	running atomic.Bool
 	closed  atomic.Bool
@@ -440,6 +441,18 @@ func (s *Syncer) Init(ctx context.Context) (err error) {
 	}
 	s.sessCtx = utils.NewSessionCtx(vars)
 	s.exprFilterGroup = NewExprFilterGroup(s.tctx, s.sessCtx, s.cfg.ExprFilter)
+
+	causalityVars := map[string]string{
+		"time_zone": s.timezone.String(),
+	}
+	// Expression-index causality uses the downstream apply SQL mode.
+	for k, v := range s.cfg.To.Session {
+		if strings.EqualFold(k, "sql_mode") {
+			causalityVars["sql_mode"] = v
+			break
+		}
+	}
+	s.causalityCtx = utils.NewSessionCtx(causalityVars)
 	// create an empty Tracker and will be initialized in `Run`
 	s.schemaTracker = schema.NewTracker()
 

--- a/dm/tests/all_mode/data/db1.increment.sql
+++ b/dm/tests/all_mode/data/db1.increment.sql
@@ -24,6 +24,40 @@ update t1 set name = 'gentestxxxxxx', dt = '2021-05-11 12:03:05', ts = '2021-05-
 -- delete with unique key
 delete from t1 where gen_id > 124;
 
+-- test unique index on a stored generated column
+create table t_stored_gen_unique (
+    id int primary key,
+    name varchar(64),
+    lower_name varchar(64) generated always as (lower(name)) stored,
+    unique key uk_lower_name (lower_name)
+);
+replace into t_stored_gen_unique (id, name) values (10, 'Carol');
+replace into t_stored_gen_unique (id, name) values (20, 'Carol');
+replace into t_stored_gen_unique (id, name) values (30, 'Dave');
+replace into t_stored_gen_unique (id, name) values (40, 'DAVE');
+
+-- test unique functional index backed by a hidden generated column
+create table t_expr_unique (
+    id int primary key,
+    name varchar(64)
+);
+/*!80013 alter table t_expr_unique add unique key uk_lower_name ((lower(name))) */;
+replace into t_expr_unique values (10, 'Alice');
+replace into t_expr_unique values (20, 'Alice');
+replace into t_expr_unique values (30, 'Bob');
+replace into t_expr_unique values (40, 'BOB');
+
+-- test unique functional index inside table definition
+/*!80013 create table t_expr_unique_inline (
+    id int primary key,
+    name varchar(64),
+    unique key uk_lower_name ((lower(name)))
+) */;
+/*!80013 replace into t_expr_unique_inline values (10, 'Eve') */;
+/*!80013 replace into t_expr_unique_inline values (20, 'Eve') */;
+/*!80013 replace into t_expr_unique_inline values (30, 'Frank') */;
+/*!80013 replace into t_expr_unique_inline values (40, 'FRANK') */;
+
 -- test alter database
 -- tidb doesn't support alter character set from latin1 to utf8m64 so we comment this now
 -- alter database all_mode CHARACTER SET = utf8mb4;

--- a/dm/tests/all_mode/run.sh
+++ b/dm/tests/all_mode/run.sh
@@ -8,6 +8,17 @@ WORK_DIR=$TEST_DIR/$TEST_NAME
 API_VERSION="v1alpha1"
 ILLEGAL_CHAR_NAME='t-Ë!s`t'
 
+function check_expression_index_case_enabled() {
+	run_sql_source1 "select count(*) as expression_index_table_count from information_schema.tables where table_schema = 'all_mode' and table_name = 't_expr_unique_inline';"
+	if grep -Fq "expression_index_table_count: 0" "$TEST_DIR/sql_res.$TEST_NAME.txt"; then
+		echo "unique functional index case is skipped because upstream does not support /*!80013 */ syntax"
+		return
+	fi
+
+	run_sql_source1 "select count(*) as expression_index_count from information_schema.statistics where table_schema = 'all_mode' and table_name in ('t_expr_unique', 't_expr_unique_inline') and index_name = 'uk_lower_name';"
+	check_contains "expression_index_count: 2"
+}
+
 function test_session_config() {
 	echo "[$(date)] <<<<<< start test_session_config >>>>>>"
 	run_sql_file $cur/data/db1.prepare.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1
@@ -502,6 +513,7 @@ function run() {
 		"\"result\": true" 2
 	# we used failpoint to imitate an upstream switching, which purged whole relay dir
 	run_sql_file $cur/data/db1.increment.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1
+	check_expression_index_case_enabled
 	run_sql_file $cur/data/db2.increment.sql $MYSQL_HOST2 $MYSQL_PORT2 $MYSQL_PASSWORD2
 	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
 		"resume-relay -s mysql-replica-01" \

--- a/dm/worker/source_worker.go
+++ b/dm/worker/source_worker.go
@@ -236,6 +236,14 @@ func (w *SourceWorker) stopWithCause(graceful bool, cause error) {
 
 	// cancel status output ticker and wait for return
 	w.cancel()
+
+	// On failover, cancel subtasks before waiting: the syncer context is not
+	// reached by w.cancel(), so otherwise the wait blocks until in-flight SQL
+	// times out, leaving the unbound worker writing downstream.
+	if !graceful {
+		w.subTaskHolder.killAllSubTasksWithCause(cause)
+	}
+
 	w.wg.Wait()
 	w.relayWg.Wait()
 	w.subTaskWg.Wait()
@@ -246,8 +254,6 @@ func (w *SourceWorker) stopWithCause(graceful bool, cause error) {
 	// close or kill all subtasks
 	if graceful {
 		w.subTaskHolder.closeAllSubTasksWithCause(cause)
-	} else {
-		w.subTaskHolder.killAllSubTasksWithCause(cause)
 	}
 
 	if w.relayHolder != nil {

--- a/pkg/sqlmodel/causality.go
+++ b/pkg/sqlmodel/causality.go
@@ -22,6 +22,8 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/tablecodec"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/pingcap/tidb/pkg/util/chunk"
 	"github.com/pingcap/tiflow/dm/pkg/log"
 	"github.com/pingcap/tiflow/dm/pkg/utils"
 	"go.uber.org/zap"
@@ -201,24 +203,41 @@ func (r *RowChange) getForeignKeyCausalityString(values []interface{}) []string 
 }
 
 func (r *RowChange) getCausalityString(values []interface{}) []string {
-	pkAndUks := r.whereHandle.UniqueIdxs
-	if len(pkAndUks) == 0 {
-		// the table has no PK/UK, all values of the row consists the causality key
-		return []string{genKeyString(r.sourceTable.String(), r.sourceTableInfo.Columns, values)}
+	sourceTable := r.sourceTable
+	if r.causalityKeySourceTable != nil {
+		// Only causality keys use this table name; r.sourceTable keeps the original source table.
+		sourceTable = r.causalityKeySourceTable
+	}
+	causalityIndexes := r.whereHandle.causalityIdxs
+	if len(causalityIndexes) == 0 {
+		// No causality index: use the whole row.
+		columns := r.whereHandle.rowMapper.columnsForValues(values)
+		return []string{genKeyString(sourceTable.String(), columns, values)}
 	}
 
-	ret := make([]string, 0, len(pkAndUks))
+	ret := make([]string, 0, len(causalityIndexes))
 
-	for _, indexCols := range pkAndUks {
+	values, fullValuesOK := r.fillVirtualGeneratedValues(values)
+
+	for _, indexCols := range causalityIndexes {
 		// TODO: should not support multi value index and generate the value
 		// TODO: also fix https://github.com/pingcap/tiflow/issues/3286#issuecomment-971264282
 		if indexCols.MVIndex {
 			continue
 		}
-		cols, vals := getColsAndValuesOfIdx(r.sourceTableInfo.Columns, indexCols, values)
+
+		// Only hidden-column indexes require materialized values.
+		if indexHasHiddenColumn(indexCols, r.sourceTableInfo) && !fullValuesOK {
+			continue
+		}
+
+		cols, vals := r.whereHandle.rowMapper.columnsAndValuesByIndex(
+			indexCols,
+			values,
+		)
 		// handle prefix index
 		truncVals := truncateIndexValues(r.tiSessionCtx, r.sourceTableInfo, indexCols, cols, vals)
-		key := genKeyString(r.sourceTable.String(), cols, truncVals)
+		key := genKeyString(sourceTable.String(), cols, truncVals)
 		if len(key) > 0 { // ignore `null` value.
 			ret = append(ret, key)
 		} else {
@@ -227,10 +246,87 @@ func (r *RowChange) getCausalityString(values []interface{}) []string {
 	}
 
 	if len(ret) == 0 {
-		// the table has no PK/UK, or all UK are NULL. all values of the row
-		// consists the causality key
-		return []string{genKeyString(r.sourceTable.String(), r.sourceTableInfo.Columns, values)}
+		// No index key was generated; fall back to the whole row.
+		columns := r.whereHandle.rowMapper.columnsForValues(values)
+		return []string{genKeyString(sourceTable.String(), columns, values)}
 	}
 
 	return ret
+}
+
+// fillVirtualGeneratedValues returns a copy of values extended to the full
+// source column list, with hidden/virtual generated columns evaluated. The bool
+// reports whether full values are available.
+func (r *RowChange) fillVirtualGeneratedValues(values []any) ([]any, bool) {
+	if r.whereHandle.hiddenGeneratedColumnExprCache == nil {
+		return values, false
+	}
+
+	cols := r.sourceTableInfo.Columns
+	if r.whereHandle.rowMapper.isFullValues(values) {
+		return values, true
+	}
+
+	exprs, exprCtx, ok := r.whereHandle.hiddenGeneratedColumnExprCache.getOrBuildExprs(r.tiSessionCtx)
+	if !ok {
+		return values, false
+	}
+
+	visibleCols := r.whereHandle.rowMapper.visibleColumns
+	if len(values) != len(visibleCols) {
+		return values, false
+	}
+
+	datums, err := utils.AdjustBinaryProtocolForDatum(r.tiSessionCtx, values, visibleCols)
+	if err != nil {
+		log.L().Debug("cannot adjust row for generated column evaluation",
+			zap.String("table", r.sourceTable.String()), zap.Error(err))
+		return values, false
+	}
+
+	full := make([]any, len(cols))
+	fullDatums := make([]types.Datum, len(cols))
+	fieldTypes := make([]*types.FieldType, len(cols))
+	for i, col := range cols {
+		fieldTypes[i] = &col.FieldType
+	}
+	mutRow := chunk.MutRowFromTypes(fieldTypes)
+	for i, col := range visibleCols {
+		full[col.Offset] = values[i]
+		fullDatums[col.Offset] = datums[i]
+		mutRow.SetDatum(col.Offset, datums[i])
+	}
+
+	for _, col := range r.whereHandle.hiddenGeneratedColumnExprCache.columns {
+		expr, ok := exprs[col.Offset]
+		if !ok {
+			return values, false
+		}
+		d, err := expr.Eval(exprCtx.GetEvalCtx(), mutRow.ToRow())
+		if err != nil {
+			log.L().Debug("cannot evaluate generated column expression",
+				zap.String("table", r.sourceTable.String()),
+				zap.String("column", col.Name.O), zap.Error(err))
+			return values, false
+		}
+		full[col.Offset] = datumValue(d)
+		fullDatums[col.Offset] = d
+		mutRow.SetDatum(col.Offset, d)
+	}
+	return full, true
+}
+
+func datumValue(d types.Datum) any {
+	if d.IsNull() {
+		return nil
+	}
+	if s, err := d.ToString(); err == nil {
+		return s
+	}
+	value := d.GetValue()
+	// Keep byte values comparable for identityUpdated's != check.
+	if bs, ok := value.([]byte); ok {
+		return string(bs)
+	}
+	return value
 }

--- a/pkg/sqlmodel/causality_test.go
+++ b/pkg/sqlmodel/causality_test.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"testing"
 
+	timodel "github.com/pingcap/tidb/pkg/meta/model"
 	cdcmodel "github.com/pingcap/tiflow/cdc/model"
 	"github.com/stretchr/testify/require"
 )
@@ -212,5 +213,226 @@ func TestGetCausalityString(t *testing.T) {
 		change := NewRowChange(source, nil, nil, ca.values, ti, nil, nil)
 		change.lazyInitWhereHandle()
 		require.Equal(t, ca.keys, change.getCausalityString(ca.values))
+	}
+}
+
+func TestCausalityKeysExpressionIndex(t *testing.T) {
+	t.Parallel()
+
+	source := &cdcmodel.TableName{Schema: "db", Table: "tb1"}
+	// A functional UNIQUE index is backed by a hidden generated column (#12696).
+	// The binlog row image carries only the two stored columns (id, name). The
+	// hidden column's value must be materialized from its expression so the
+	// expression index still participates in conflict detection, instead of
+	// panicking with "index out of range".
+	ti := mockTableInfo(t, "CREATE TABLE tb1 (id BIGINT PRIMARY KEY, name VARCHAR(255), "+
+		"UNIQUE KEY only_one_alice ((CASE name WHEN 'Alice' THEN 1 ELSE NULL END)))")
+
+	// name = 'Alice' -> the expression evaluates to 1, so the expression index
+	// produces a key; the PK produces another. Two different rows that collide on
+	// the expression value will share the expression key and be serialized.
+	change := NewRowChange(source, nil, nil, []any{1, "Alice"}, ti, nil, nil)
+	change.lazyInitWhereHandle()
+	var keys []string
+	require.NotPanics(t, func() {
+		keys = change.getCausalityString([]any{1, "Alice"})
+	})
+	require.Contains(t, keys, "1.id.db.tb1") // PK key
+	require.Len(t, keys, 2)                  // PK key + expression-index key
+
+	// A second, different row that also evaluates to 'Alice' collides on the
+	// expression value. The two rows must share the expression-index key so that
+	// they are serialized (skipping the index would lose this and could replicate
+	// them out of order, hitting a transient unique-key violation downstream).
+	other := NewRowChange(source, nil, nil, []any{9, "Alice"}, ti, nil, nil)
+	other.lazyInitWhereHandle()
+	otherKeys := other.getCausalityString([]any{9, "Alice"})
+	exprKey := func(ks []string) string {
+		for _, k := range ks {
+			if k != "1.id.db.tb1" && k != "9.id.db.tb1" {
+				return k
+			}
+		}
+		return ""
+	}
+	require.NotEmpty(t, exprKey(keys))
+	require.Equal(t, exprKey(keys), exprKey(otherKeys),
+		"rows colliding on the expression value must share the expression-index key")
+
+	// name = 'Bob' -> the expression evaluates to NULL, so the expression index
+	// contributes no key and only the PK key remains.
+	change = NewRowChange(source, nil, nil, []any{2, "Bob"}, ti, nil, nil)
+	change.lazyInitWhereHandle()
+	require.NotPanics(t, func() {
+		keys = change.getCausalityString([]any{2, "Bob"})
+	})
+	require.Equal(t, []string{"2.id.db.tb1"}, keys)
+}
+
+func TestCausalityKeysInterleavedHiddenColumn(t *testing.T) {
+	t.Parallel()
+
+	source := &cdcmodel.TableName{Schema: "db", Table: "tb1"}
+	ti := mockTableInfo(t, "CREATE TABLE tb1 ("+
+		"id INT PRIMARY KEY, "+
+		"a VARCHAR(32), "+
+		"b VARCHAR(32), "+
+		"UNIQUE KEY uk_a ((lower(a))), "+
+		"UNIQUE KEY uk_b ((lower(b))))")
+
+	hiddenA := expressionIndexColumnName(t, ti, "uk_a")
+	hiddenB := expressionIndexColumnName(t, ti, "uk_b")
+	reorderColumnsByName(t, ti, "id", "a", hiddenA, "b", hiddenB)
+
+	change := NewRowChange(source, nil, nil, []any{1, "Alice", "Bob"}, ti, nil, nil)
+	require.ElementsMatch(t, []string{
+		"alice." + hiddenA + ".db.tb1",
+		"bob." + hiddenB + ".db.tb1",
+		"1.id.db.tb1",
+	}, change.CausalityKeys())
+}
+
+func TestCausalityKeysStoredGeneratedUniqueIndex(t *testing.T) {
+	t.Parallel()
+
+	source := &cdcmodel.TableName{Schema: "db", Table: "tb1"}
+	ti := mockTableInfo(t, "CREATE TABLE tb1 ("+
+		"id BIGINT PRIMARY KEY, name VARCHAR(255), "+
+		"lower_name VARCHAR(255) GENERATED ALWAYS AS (lower(name)) STORED, "+
+		"UNIQUE KEY uk_lower_name (lower_name))")
+
+	// MySQL row binlog includes visible stored generated columns, so they are
+	// handled as ordinary visible unique-key columns.
+	change := NewRowChange(source, nil, nil, []any{1, "Alice", "alice"}, ti, nil, nil)
+	require.Equal(t, []string{"alice.lower_name.db.tb1", "1.id.db.tb1"}, change.CausalityKeys())
+}
+
+func TestCausalityKeysExpressionIndexMaterializeFailure(t *testing.T) {
+	t.Parallel()
+
+	source := &cdcmodel.TableName{Schema: "db", Table: "tb1"}
+	ti := mockTableInfo(t, "CREATE TABLE tb1 (id BIGINT PRIMARY KEY, name VARCHAR(255), "+
+		"UNIQUE KEY only_one_alice ((CASE name WHEN 'Alice' THEN 1 ELSE NULL END)))")
+	corruptHiddenGeneratedExpr(t, ti)
+
+	change := NewRowChange(source, nil, nil, []any{1, "Alice"}, ti, nil, nil)
+
+	var keys []string
+	require.NotPanics(t, func() {
+		keys = change.CausalityKeys()
+	})
+	require.Equal(t, []string{"1.id.db.tb1"}, keys)
+}
+
+func TestCausalityKeysMaterializeFailureFallback(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		createSQL   string
+		columnOrder []string
+		postValues  []any
+		keys        []string
+	}{
+		{
+			name: "visible unique after hidden column",
+			createSQL: "CREATE TABLE tb1 (" +
+				"a VARCHAR(32), " +
+				"b INT UNIQUE, " +
+				"c VARCHAR(32), " +
+				"UNIQUE KEY uk_a ((lower(a))))",
+			columnOrder: []string{"a", "uk_a", "b", "c"},
+			postValues:  []any{"Alice", 7, "tail"},
+			keys:        []string{"7.b.db.tb1"},
+		},
+		{
+			name: "whole row fallback with hidden column",
+			createSQL: "CREATE TABLE tb1 (" +
+				"a VARCHAR(32), " +
+				"c VARCHAR(32), " +
+				"UNIQUE KEY uk_a ((lower(a))))",
+			columnOrder: []string{"a", "uk_a", "c"},
+			postValues:  []any{"Alice", "tail"},
+			keys:        []string{"Alice.a.tail.c.db.tb1"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			source := &cdcmodel.TableName{Schema: "db", Table: "tb1"}
+			ti := mockTableInfo(t, tc.createSQL)
+
+			hiddenA := expressionIndexColumnName(t, ti, "uk_a")
+			columnNames := make([]string, 0, len(tc.columnOrder))
+			for _, name := range tc.columnOrder {
+				if name == "uk_a" {
+					name = hiddenA
+				}
+				columnNames = append(columnNames, name)
+			}
+			reorderColumnsByName(t, ti, columnNames...)
+			corruptHiddenGeneratedExpr(t, ti)
+
+			change := NewRowChange(source, nil, nil, tc.postValues, ti, nil, nil)
+
+			var keys []string
+			require.NotPanics(t, func() {
+				keys = change.CausalityKeys()
+			})
+			require.Equal(t, tc.keys, keys)
+		})
+	}
+}
+
+func corruptHiddenGeneratedExpr(t *testing.T, ti *timodel.TableInfo) {
+	t.Helper()
+
+	found := false
+	for _, col := range ti.Columns {
+		if col.Hidden && col.IsGenerated() {
+			col.GeneratedExprString = "not a valid expression +"
+			found = true
+		}
+	}
+	require.True(t, found, "expression index should create a hidden generated column")
+}
+
+func expressionIndexColumnName(t *testing.T, ti *timodel.TableInfo, indexName string) string {
+	t.Helper()
+
+	for _, idx := range ti.Indices {
+		if idx.Name.L == indexName {
+			require.Len(t, idx.Columns, 1)
+			return idx.Columns[0].Name.L
+		}
+	}
+	require.FailNowf(t, "index not found", "index %q not found", indexName)
+	return ""
+}
+
+func reorderColumnsByName(t *testing.T, ti *timodel.TableInfo, names ...string) {
+	t.Helper()
+	require.Len(t, names, len(ti.Columns))
+
+	colsByName := make(map[string]*timodel.ColumnInfo, len(ti.Columns))
+	for _, col := range ti.Columns {
+		colsByName[col.Name.L] = col
+	}
+
+	for i, name := range names {
+		col := colsByName[name]
+		require.NotNilf(t, col, "column %q not found", name)
+		ti.Columns[i] = col
+		col.Offset = i
+	}
+
+	for _, idx := range ti.Indices {
+		for _, idxCol := range idx.Columns {
+			col := colsByName[idxCol.Name.L]
+			require.NotNilf(t, col, "index column %q not found", idxCol.Name.L)
+			idxCol.Offset = col.Offset
+		}
 	}
 }

--- a/pkg/sqlmodel/reduce.go
+++ b/pkg/sqlmodel/reduce.go
@@ -41,7 +41,7 @@ func (r *RowChange) IdentityValues() ([]interface{}, []interface{}) {
 		return r.preValues, r.postValues
 	}
 
-	return r.identityValuesByIndex(indexInfo)
+	return r.identityValuesByIndex(indexInfo, r.preValues, r.postValues)
 }
 
 // RowIdentity returns the identity of this row change, caller should
@@ -62,11 +62,7 @@ func (r *RowChange) RowIdentity() []interface{} {
 		return targetVals
 	}
 
-	identityVals := make([]interface{}, 0, len(indexInfo.Columns))
-	for _, column := range indexInfo.Columns {
-		identityVals = append(identityVals, targetVals[column.Offset])
-	}
-	return identityVals
+	return r.whereHandle.rowMapper.valuesByIndex(indexInfo, targetVals)
 }
 
 // RowStrIdentity returns the identity of the row change as string slice
@@ -106,7 +102,7 @@ func (r *RowChange) IsPrimaryOrUniqueKeyUpdated() bool {
 	}
 
 	r.lazyInitWhereHandle()
-	identityUpdated := func(pre, post []interface{}) bool {
+	identityUpdated := func(pre, post []any) bool {
 		if len(pre) != len(post) {
 			// should not happen
 			return true
@@ -120,7 +116,7 @@ func (r *RowChange) IsPrimaryOrUniqueKeyUpdated() bool {
 	}
 
 	if idx := r.whereHandle.UniqueNotNullIdx; idx != nil {
-		pre, post := r.identityValuesByIndex(idx)
+		pre, post := r.identityValuesByIndex(idx, r.preValues, r.postValues)
 		if identityUpdated(pre, post) {
 			return true
 		}
@@ -130,11 +126,27 @@ func (r *RowChange) IsPrimaryOrUniqueKeyUpdated() bool {
 		}
 	}
 
-	for _, idx := range r.whereHandle.UniqueIdxs {
+	var (
+		preValues     = r.preValues
+		postValues    = r.postValues
+		checkIndexes  = r.whereHandle.UniqueIdxs
+		preOK, postOK bool
+	)
+
+	if r.whereHandle.hiddenGeneratedColumnExprCache != nil {
+		// Use expression indexes only when both row images are fully materialized.
+		// Otherwise fall back to visible-column unique indexes.
+		preValues, preOK = r.fillVirtualGeneratedValues(r.preValues)
+		postValues, postOK = r.fillVirtualGeneratedValues(r.postValues)
+		if preOK && postOK {
+			checkIndexes = r.whereHandle.causalityIdxs
+		}
+	}
+	for _, idx := range checkIndexes {
 		if idx == nil || idx == r.whereHandle.UniqueNotNullIdx {
 			continue
 		}
-		pre, post := r.identityValuesByIndex(idx)
+		pre, post := r.identityValuesByIndex(idx, preValues, postValues)
 		if identityUpdated(pre, post) {
 			return true
 		}
@@ -143,20 +155,14 @@ func (r *RowChange) IsPrimaryOrUniqueKeyUpdated() bool {
 	return false
 }
 
-// identityValuesByIndex extra pre and post column values of given index
-func (r *RowChange) identityValuesByIndex(indexInfo *timodel.IndexInfo) ([]interface{}, []interface{}) {
-	pre := make([]interface{}, 0, len(indexInfo.Columns))
-	post := make([]interface{}, 0, len(indexInfo.Columns))
-
-	for _, column := range indexInfo.Columns {
-		if r.preValues != nil {
-			pre = append(pre, r.preValues[column.Offset])
-		}
-		if r.postValues != nil {
-			post = append(post, r.postValues[column.Offset])
-		}
-	}
-	return pre, post
+// identityValuesByIndex extracts pre and post column values of given index
+func (r *RowChange) identityValuesByIndex(
+	indexInfo *timodel.IndexInfo,
+	preValues []any,
+	postValues []any,
+) ([]any, []any) {
+	return r.whereHandle.rowMapper.valuesByIndex(indexInfo, preValues),
+		r.whereHandle.rowMapper.valuesByIndex(indexInfo, postValues)
 }
 
 // genKey gens key by values e.g. "a.1.b".

--- a/pkg/sqlmodel/reduce_test.go
+++ b/pkg/sqlmodel/reduce_test.go
@@ -71,6 +71,207 @@ func TestIdentityUpdatedWithUniqueKeys(t *testing.T) {
 	require.True(t, change.IsPrimaryOrUniqueKeyUpdated())
 }
 
+func TestPrimaryOrUniqueKeyUpdatedWithExpressionIndex(t *testing.T) {
+	t.Parallel()
+
+	source := &cdcmodel.TableName{Schema: "db", Table: "tb1"}
+	cases := []struct {
+		name       string
+		createSQL  string
+		preValues  []any
+		postValues []any
+		updated    bool
+	}{
+		{
+			name: "expression unchanged",
+			createSQL: "CREATE TABLE tb1 (id INT PRIMARY KEY, name VARCHAR(255), " +
+				"UNIQUE KEY only_one_alice ((CASE name WHEN 'Alice' THEN 1 ELSE NULL END)))",
+			preValues:  []any{1, "Bob"},
+			postValues: []any{1, "Charlie"},
+		},
+		{
+			name: "expression changed",
+			createSQL: "CREATE TABLE tb1 (id INT PRIMARY KEY, name VARCHAR(255), " +
+				"UNIQUE KEY only_one_alice ((CASE name WHEN 'Alice' THEN 1 ELSE NULL END)))",
+			preValues:  []any{1, "Bob"},
+			postValues: []any{1, "Alice"},
+			updated:    true,
+		},
+		{
+			name: "ordinary unique changed with lower expression index",
+			createSQL: "CREATE TABLE tb1 (id INT PRIMARY KEY, email VARCHAR(255) UNIQUE, name VARCHAR(255), " +
+				"UNIQUE KEY lower_name ((lower(name))))",
+			preValues:  []any{1, "a@example.com", "Bob"},
+			postValues: []any{1, "b@example.com", "Bob"},
+			updated:    true,
+		},
+		{
+			name: "arithmetic expression index unchanged",
+			createSQL: "CREATE TABLE tb1 (id INT PRIMARY KEY, code INT, name VARCHAR(255), " +
+				"UNIQUE KEY next_code ((code + 1)))",
+			preValues:  []any{1, 10, "Bob"},
+			postValues: []any{1, 10, "Alice"},
+		},
+		{
+			name: "composite expression index changed by visible column",
+			createSQL: "CREATE TABLE tb1 (id INT PRIMARY KEY, score INT, code INT, " +
+				"UNIQUE KEY next_score_code ((score + 1), code))",
+			preValues:  []any{1, -7, 10},
+			postValues: []any{1, -7, 20},
+			updated:    true,
+		},
+		{
+			name: "binary expression index changed",
+			createSQL: "CREATE TABLE tb1 (id INT PRIMARY KEY, payload VARBINARY(16), " +
+				"UNIQUE KEY uk_payload_expr ((CAST(payload AS BINARY(16)))))",
+			preValues:  []any{1, "alice"},
+			postValues: []any{1, "bob"},
+			updated:    true,
+		},
+		{
+			name: "binary expression index unchanged",
+			createSQL: "CREATE TABLE tb1 (id INT PRIMARY KEY, payload VARBINARY(16), note VARCHAR(16), " +
+				"UNIQUE KEY uk_payload_expr ((CAST(payload AS BINARY(16)))))",
+			preValues:  []any{1, "alice", "old"},
+			postValues: []any{1, "alice", "new"},
+		},
+		{
+			name: "decimal expression index unchanged",
+			createSQL: "CREATE TABLE tb1 (id INT PRIMARY KEY, price DECIMAL(10, 2), note VARCHAR(16), " +
+				"UNIQUE KEY uk_price_expr ((price + 0)))",
+			preValues:  []any{1, "12.30", "old"},
+			postValues: []any{1, "12.30", "new"},
+		},
+		{
+			name: "bit expression index unchanged",
+			createSQL: "CREATE TABLE tb1 (id INT PRIMARY KEY, flag BIT(8), note VARCHAR(16), " +
+				"UNIQUE KEY uk_flag_expr ((flag | b'00000000')))",
+			preValues:  []any{1, uint64(1), "old"},
+			postValues: []any{1, uint64(1), "new"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sourceTI := mockTableInfo(t, tc.createSQL)
+			change := NewRowChange(source, nil, tc.preValues, tc.postValues, sourceTI, nil, nil)
+			require.False(t, change.IsIdentityUpdated())
+			require.Equal(t, tc.updated, change.IsPrimaryOrUniqueKeyUpdated())
+		})
+	}
+}
+
+func TestPrimaryOrUniqueKeyUpdatedInterleavedHiddenColumn(t *testing.T) {
+	t.Parallel()
+
+	source := &cdcmodel.TableName{Schema: "db", Table: "tb1"}
+	sourceTI := mockTableInfo(t, "CREATE TABLE tb1 ("+
+		"id INT PRIMARY KEY, "+
+		"a VARCHAR(32), "+
+		"b VARCHAR(32), "+
+		"UNIQUE KEY uk_a ((lower(a))), "+
+		"UNIQUE KEY uk_b ((lower(b))))")
+
+	hiddenA := expressionIndexColumnName(t, sourceTI, "uk_a")
+	hiddenB := expressionIndexColumnName(t, sourceTI, "uk_b")
+	reorderColumnsByName(t, sourceTI, "id", "a", hiddenA, "b", hiddenB)
+
+	change := NewRowChange(source, nil,
+		[]any{1, "Alice", "Bob"},
+		[]any{1, "Alice", "Carol"},
+		sourceTI, nil, nil)
+	require.False(t, change.IsIdentityUpdated())
+	require.True(t, change.IsPrimaryOrUniqueKeyUpdated())
+}
+
+func TestPrimaryOrUniqueKeyUpdatedUniqueAfterHiddenColumn(t *testing.T) {
+	t.Parallel()
+
+	source := &cdcmodel.TableName{Schema: "db", Table: "tb1"}
+	sourceTI := mockTableInfo(t, "CREATE TABLE tb1 ("+
+		"a VARCHAR(32), "+
+		"b INT NOT NULL UNIQUE, "+
+		"c VARCHAR(32), "+
+		"UNIQUE KEY uk_a ((lower(a))))")
+
+	hiddenA := expressionIndexColumnName(t, sourceTI, "uk_a")
+	reorderColumnsByName(t, sourceTI, "a", hiddenA, "b", "c")
+
+	change := NewRowChange(source, nil,
+		[]any{"Alice", 1, "old"},
+		[]any{"Alice", 2, "old"},
+		sourceTI, nil, nil)
+	require.NotPanics(t, func() {
+		require.True(t, change.IsIdentityUpdated())
+	})
+	require.NotPanics(t, func() {
+		require.True(t, change.IsPrimaryOrUniqueKeyUpdated())
+	})
+
+	change = NewRowChange(source, nil,
+		[]any{"Alice", 1, "old"},
+		[]any{"Alice", 1, "new"},
+		sourceTI, nil, nil)
+	require.NotPanics(t, func() {
+		require.False(t, change.IsIdentityUpdated())
+	})
+	require.NotPanics(t, func() {
+		require.Equal(t, []any{1}, change.RowIdentity())
+	})
+	require.NotPanics(t, func() {
+		require.False(t, change.IsPrimaryOrUniqueKeyUpdated())
+	})
+}
+
+func TestPrimaryOrUniqueKeyUpdatedExpressionIndexMaterializeFailure(t *testing.T) {
+	t.Parallel()
+
+	source := &cdcmodel.TableName{Schema: "db", Table: "tb1"}
+	sourceTI := mockTableInfo(t, "CREATE TABLE tb1 (id INT PRIMARY KEY, email VARCHAR(255) UNIQUE, name VARCHAR(255), "+
+		"UNIQUE KEY lower_name ((lower(name))))")
+	corruptHiddenGeneratedExpr(t, sourceTI)
+
+	change := NewRowChange(source, nil,
+		[]any{1, "a@example.com", "Bob"},
+		[]any{1, "b@example.com", "Alice"},
+		sourceTI, nil, nil)
+	require.False(t, change.IsIdentityUpdated())
+	require.True(t, change.IsPrimaryOrUniqueKeyUpdated())
+
+	change = NewRowChange(source, nil,
+		[]any{1, "a@example.com", "Bob"},
+		[]any{1, "a@example.com", "Alice"},
+		sourceTI, nil, nil)
+	require.False(t, change.IsIdentityUpdated())
+	require.False(t, change.IsPrimaryOrUniqueKeyUpdated())
+}
+
+func TestPrimaryOrUniqueKeyUpdatedWithStoredGeneratedUniqueIndex(t *testing.T) {
+	t.Parallel()
+
+	source := &cdcmodel.TableName{Schema: "db", Table: "tb1"}
+	sourceTI := mockTableInfo(t, "CREATE TABLE tb1 ("+
+		"id BIGINT PRIMARY KEY, name VARCHAR(255), "+
+		"lower_name VARCHAR(255) GENERATED ALWAYS AS (lower(name)) STORED, "+
+		"UNIQUE KEY uk_lower_name (lower_name))")
+
+	change := NewRowChange(source, nil,
+		[]any{1, "Alice", "alice"},
+		[]any{1, "ALICE", "alice"},
+		sourceTI, nil, nil)
+	require.False(t, change.IsIdentityUpdated())
+	require.False(t, change.IsPrimaryOrUniqueKeyUpdated())
+
+	change = NewRowChange(source, nil,
+		[]any{1, "Alice", "alice"},
+		[]any{1, "Bob", "bob"},
+		sourceTI, nil, nil)
+	require.False(t, change.IsIdentityUpdated())
+	require.True(t, change.IsPrimaryOrUniqueKeyUpdated())
+}
+
 func TestSplit(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/sqlmodel/row_change.go
+++ b/pkg/sqlmodel/row_change.go
@@ -58,6 +58,8 @@ func (t RowChangeType) String() string {
 type RowChange struct {
 	sourceTable *cdcmodel.TableName
 	targetTable *cdcmodel.TableName
+	// Optional source table name used only by CausalityKeys.
+	causalityKeySourceTable *cdcmodel.TableName
 
 	preValues  []interface{}
 	postValues []interface{}
@@ -213,6 +215,11 @@ func (r *RowChange) SetForeignKeyRelations(relations []ForeignKeyCausalityRelati
 	r.foreignKeyRelations = relations
 }
 
+// SetCausalityKeySourceTable sets the source table name used by CausalityKeys.
+func (r *RowChange) SetCausalityKeySourceTable(table *cdcmodel.TableName) {
+	r.causalityKeySourceTable = table
+}
+
 // GetApproximateDataSize returns internal approximateDataSize, it could be zero
 // if this value is not set.
 func (r *RowChange) GetApproximateDataSize() int64 {
@@ -237,11 +244,14 @@ func (r *RowChange) lazyInitWhereHandle() {
 func (r *RowChange) whereColumnsAndValues() ([]string, []interface{}) {
 	r.lazyInitWhereHandle()
 
-	columns, values := r.sourceTableInfo.Columns, r.preValues
-
+	columns := r.whereHandle.rowMapper.visibleColumns
+	values := r.preValues
 	uniqueIndex := r.whereHandle.getWhereIdxByData(r.preValues)
 	if uniqueIndex != nil {
-		columns, values = getColsAndValuesOfIdx(r.sourceTableInfo.Columns, uniqueIndex, values)
+		columns, values = r.whereHandle.rowMapper.columnsAndValuesByIndex(
+			uniqueIndex,
+			values,
+		)
 	}
 
 	columnNames := make([]string, 0, len(columns))

--- a/pkg/sqlmodel/row_change_test.go
+++ b/pkg/sqlmodel/row_change_test.go
@@ -155,6 +155,14 @@ func (s *dpanicSuite) TestGenDelete() {
 			"DELETE FROM `db`.`tb2` WHERE `c` = ? AND `c2` IS ? LIMIT 1",
 			[]interface{}{1, nil},
 		},
+		{
+			"CREATE TABLE tb1 (name VARCHAR(64), UNIQUE KEY uk_lower_name ((lower(name))))",
+			"CREATE TABLE tb2 (name VARCHAR(64), UNIQUE KEY uk_lower_name ((lower(name))))",
+			[]interface{}{"Alice"},
+
+			"DELETE FROM `db`.`tb2` WHERE `name` = ? LIMIT 1",
+			[]interface{}{"Alice"},
+		},
 		// next 2 cases test using downstream table to generate WHERE
 		{
 			"CREATE TABLE tb1 (id INT PRIMARY KEY, user_id INT NOT NULL UNIQUE)",
@@ -190,6 +198,30 @@ func (s *dpanicSuite) TestGenDelete() {
 	s.Equal("DELETE FROM `db`.`tb1` WHERE `id` = ? LIMIT 1", sql)
 	s.Equal([]interface{}{1}, args)
 
+	sourceTI = mockTableInfo(s.T(), "CREATE TABLE tb1 ("+
+		"a VARCHAR(32), "+
+		"b INT UNIQUE, "+
+		"c INT, "+
+		"UNIQUE KEY uk_a ((lower(a))))")
+	hiddenA := expressionIndexColumnName(s.T(), sourceTI, "uk_a")
+	reorderColumnsByName(s.T(), sourceTI, "a", hiddenA, "b", "c")
+	change = NewRowChange(source, nil, []interface{}{"Alice", 1, 9}, nil, sourceTI, nil, nil)
+	sql, args = change.GenSQL(DMLDelete)
+	s.Equal("DELETE FROM `db`.`tb1` WHERE `b` = ? LIMIT 1", sql)
+	s.Equal([]interface{}{1}, args)
+
+	sourceTI = mockTableInfo(s.T(), "CREATE TABLE tb1 ("+
+		"a VARCHAR(32), "+
+		"c INT, "+
+		"UNIQUE KEY uk_a ((lower(a))))")
+	hiddenA = expressionIndexColumnName(s.T(), sourceTI, "uk_a")
+	reorderColumnsByName(s.T(), sourceTI, "a", hiddenA, "c")
+	change = NewRowChange(source, nil, []interface{}{"Alice", 9}, nil, sourceTI, nil, nil)
+	sql, args = change.GenSQL(DMLDelete)
+	s.Equal("DELETE FROM `db`.`tb1` WHERE `a` = ? AND `c` = ? LIMIT 1", sql)
+	s.Equal([]interface{}{"Alice", 9}, args)
+
+	sourceTI = mockTableInfo(s.T(), "CREATE TABLE tb1 (id INT PRIMARY KEY, name INT)")
 	change = NewRowChange(source, nil, nil, []interface{}{3, 4}, sourceTI, nil, nil)
 	s.Panics(func() {
 		change.GenSQL(DMLDelete)
@@ -235,6 +267,15 @@ func (s *dpanicSuite) TestGenUpdate() {
 
 			"UPDATE `db`.`tb2` SET `c` = ?, `c2` = ? WHERE `c` = ? AND `c2` = ? LIMIT 1",
 			[]interface{}{3, 4, 1, 2},
+		},
+		{
+			"CREATE TABLE tb1 (name VARCHAR(64), UNIQUE KEY uk_lower_name ((lower(name))))",
+			"CREATE TABLE tb2 (name VARCHAR(64), UNIQUE KEY uk_lower_name ((lower(name))))",
+			[]interface{}{"Alice"},
+			[]interface{}{"Bob"},
+
+			"UPDATE `db`.`tb2` SET `name` = ? WHERE `name` = ? LIMIT 1",
+			[]interface{}{"Bob", "Alice"},
 		},
 		// next 2 cases test generated column
 		{

--- a/pkg/sqlmodel/utils.go
+++ b/pkg/sqlmodel/utils.go
@@ -20,21 +20,6 @@ import (
 	timodel "github.com/pingcap/tidb/pkg/meta/model"
 )
 
-func getColsAndValuesOfIdx(
-	columns []*timodel.ColumnInfo,
-	indexColumns *timodel.IndexInfo,
-	data []interface{},
-) ([]*timodel.ColumnInfo, []interface{}) {
-	cols := make([]*timodel.ColumnInfo, 0, len(indexColumns.Columns))
-	values := make([]interface{}, 0, len(indexColumns.Columns))
-	for _, col := range indexColumns.Columns {
-		cols = append(cols, columns[col.Offset])
-		values = append(values, data[col.Offset])
-	}
-
-	return cols, values
-}
-
 // valuesHolder gens values holder like (?,?,?).
 func valuesHolder(n int) string {
 	var builder strings.Builder

--- a/pkg/sqlmodel/where_handle.go
+++ b/pkg/sqlmodel/where_handle.go
@@ -14,27 +14,185 @@
 package sqlmodel
 
 import (
+	"slices"
+	"sync"
+
 	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/pkg/expression"
+	"github.com/pingcap/tidb/pkg/expression/exprstatic"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	pmodel "github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/sessionctx"
 	"github.com/pingcap/tidb/pkg/types"
+	contextutil "github.com/pingcap/tidb/pkg/util/context"
+	"go.uber.org/zap"
 )
 
-// WhereHandle is used to generate a WHERE clause in SQL.
+// WhereHandle is used to generate a WHERE clause in SQL and select causality
+// keys. It also caches generated-column expressions needed to materialize
+// hidden columns backing unique expression indexes.
 type WhereHandle struct {
 	UniqueNotNullIdx *model.IndexInfo
-	// If the index and columns have no NOT NULL constraint, but all data is NOT
-	// NULL, we can still use it.
-	// every index that is UNIQUE should be added to UniqueIdxs, even for
-	// PK and NOT NULL.
+	// UniqueIdxs contains WHERE-eligible unique indexes. Expression indexes
+	// backed by hidden generated columns are tracked in causalityIdxs instead.
 	UniqueIdxs []*model.IndexInfo
+
+	// causalityIdxs is a superset of UniqueIdxs and also includes expression indexes.
+	causalityIdxs                  []*model.IndexInfo
+	hiddenGeneratedColumnExprCache *generatedColumnExprCache
+	rowMapper                      rowValueMapper
+}
+
+type rowValueMapper struct {
+	columns                     []*model.ColumnInfo
+	visibleColumns              []*model.ColumnInfo
+	visibleOffsetByColumnOffset []int
+}
+
+func newRowValueMapper(columns []*model.ColumnInfo) rowValueMapper {
+	visibleColumns := make([]*model.ColumnInfo, 0, len(columns))
+	visibleOffsetByColumnOffset := make([]int, len(columns))
+	for i := range visibleOffsetByColumnOffset {
+		visibleOffsetByColumnOffset[i] = -1
+	}
+	for _, column := range columns {
+		if column.Hidden {
+			continue
+		}
+		visibleOffsetByColumnOffset[column.Offset] = len(visibleColumns)
+		visibleColumns = append(visibleColumns, column)
+	}
+	return rowValueMapper{
+		columns:                     columns,
+		visibleColumns:              visibleColumns,
+		visibleOffsetByColumnOffset: visibleOffsetByColumnOffset,
+	}
+}
+
+func (m rowValueMapper) isFullValues(values []any) bool {
+	return len(values) == len(m.visibleOffsetByColumnOffset)
+}
+
+func (m rowValueMapper) columnsForValues(values []any) []*model.ColumnInfo {
+	if m.isFullValues(values) {
+		return m.columns
+	}
+	return m.visibleColumns
+}
+
+func (m rowValueMapper) columnsAndValuesByIndex(
+	indexInfo *model.IndexInfo,
+	values []any,
+) ([]*model.ColumnInfo, []any) {
+	cols := make([]*model.ColumnInfo, 0, len(indexInfo.Columns))
+	vals := make([]any, 0, len(indexInfo.Columns))
+	for _, column := range indexInfo.Columns {
+		offset := m.valueOffset(column.Offset, values)
+		cols = append(cols, m.columns[column.Offset])
+		vals = append(vals, values[offset])
+	}
+	return cols, vals
+}
+
+func (m rowValueMapper) valuesByIndex(indexInfo *model.IndexInfo, values []any) []any {
+	ret := make([]any, 0, len(indexInfo.Columns))
+	if values == nil {
+		return ret
+	}
+	for _, column := range indexInfo.Columns {
+		offset := m.valueOffset(column.Offset, values)
+		ret = append(ret, values[offset])
+	}
+	return ret
+}
+
+func (m rowValueMapper) valueOffset(columnOffset int, values []any) int {
+	if m.isFullValues(values) {
+		return columnOffset
+	}
+	return m.visibleOffsetByColumnOffset[columnOffset]
+}
+
+type generatedColumnExprCache struct {
+	sourceTableInfo *model.TableInfo
+	columns         []*model.ColumnInfo
+	once            sync.Once
+	// ExprContext is cached with the per-table WhereHandle. The handle is rebuilt
+	// after DDL invalidates the schema cache. Within one Syncer lifetime, DM uses
+	// a fixed downstream apply SQL mode/timezone for expression-index evaluation.
+	exprCtx *exprstatic.ExprContext
+	exprs   map[int]expression.Expression
+	ok      bool
+}
+
+func newGeneratedColumnExprCache(source *model.TableInfo) *generatedColumnExprCache {
+	cols := make([]*model.ColumnInfo, 0)
+	for _, col := range source.Columns {
+		if col.Hidden && col.IsGenerated() {
+			cols = append(cols, col)
+		}
+	}
+	return &generatedColumnExprCache{
+		sourceTableInfo: source,
+		columns:         cols,
+	}
+}
+
+// getOrBuildExprs uses tiSessionCtx only on the first cache build.
+func (c *generatedColumnExprCache) getOrBuildExprs(
+	tiSessionCtx sessionctx.Context,
+) (map[int]expression.Expression, *exprstatic.ExprContext, bool) {
+	c.once.Do(func() {
+		c.exprCtx = generatedColumnExprContext(tiSessionCtx)
+		exprs := make(map[int]expression.Expression)
+		for _, col := range c.columns {
+			e, err := expression.ParseSimpleExprWithTableInfo(c.exprCtx, col.GeneratedExprString, c.sourceTableInfo)
+			if err != nil {
+				// Current causality callers cannot surface this error to the
+				// scheduler, so keep the existing degraded behavior: skip the
+				// table's hidden-column indexes. This can reduce causality, but
+				// after DM has tracked the DDL, a build failure usually means a
+				// schema/session mismatch that may also fail downstream DML.
+				log.Warn("cannot build generated column expression, hidden-column indexes will be skipped for causality",
+					zap.String("column", col.Name.O), zap.Error(err))
+				return
+			}
+			exprs[col.Offset] = e
+		}
+		c.exprs = exprs
+		c.ok = true
+	})
+	return c.exprs, c.exprCtx, c.ok
+}
+
+func generatedColumnExprContext(tiSessionCtx sessionctx.Context) *exprstatic.ExprContext {
+	vars := tiSessionCtx.GetSessionVars()
+	charset, collation := vars.GetCharsetInfo()
+	// TODO(joechenrh): Carry downstream charset/collation for collation-sensitive
+	// expression indexes. Until then, causality keys use the current session
+	// charset/collation and may not exactly match downstream unique-index
+	// comparison semantics. Remove this once DM initializes these session
+	// settings from downstream.
+	evalCtx := exprstatic.NewEvalContext(
+		exprstatic.WithLocation(vars.Location()),
+		exprstatic.WithSQLMode(vars.SQLMode),
+		exprstatic.WithWarnHandler(contextutil.IgnoreWarn),
+	)
+	planCacheTracker := contextutil.NewPlanCacheTracker(contextutil.IgnoreWarn)
+	return exprstatic.NewExprContext(
+		exprstatic.WithCharset(charset, collation),
+		exprstatic.WithEvalCtx(evalCtx),
+		exprstatic.WithPlanCacheTracker(&planCacheTracker),
+	)
 }
 
 // GetWhereHandle calculates a WhereHandle by source/target TableInfo's indices,
 // columns and state. Other component can cache the result.
 func GetWhereHandle(source, target *model.TableInfo) *WhereHandle {
-	ret := WhereHandle{}
+	ret := WhereHandle{
+		rowMapper: newRowValueMapper(source.Columns),
+	}
 	indices := make([]*model.IndexInfo, 0, len(target.Indices)+1)
 	indices = append(indices, target.Indices...)
 	if idx := getPKIsHandleIdx(target); target.PKIsHandle && idx != nil {
@@ -55,6 +213,14 @@ func GetWhereHandle(source, target *model.TableInfo) *WhereHandle {
 		if rewritten == nil {
 			continue
 		}
+
+		ret.causalityIdxs = append(ret.causalityIdxs, rewritten)
+		if indexHasHiddenColumn(rewritten, source) {
+			if ret.hiddenGeneratedColumnExprCache == nil {
+				ret.hiddenGeneratedColumnExprCache = newGeneratedColumnExprCache(source)
+			}
+			continue
+		}
 		ret.UniqueIdxs = append(ret.UniqueIdxs, rewritten)
 
 		if rewritten.Primary {
@@ -69,6 +235,15 @@ func GetWhereHandle(source, target *model.TableInfo) *WhereHandle {
 		}
 	}
 	return &ret
+}
+
+func indexHasHiddenColumn(index *model.IndexInfo, source *model.TableInfo) bool {
+	return slices.ContainsFunc(
+		[]*model.IndexColumn(index.Columns),
+		func(key *model.IndexColumn) bool {
+			return key.Offset < len(source.Columns) && source.Columns[key.Offset].Hidden
+		},
+	)
 }
 
 // rewriteColsOffset rewrites index columns offset to those from source table.
@@ -140,8 +315,9 @@ func (h *WhereHandle) getWhereIdxByData(data []interface{}) *model.IndexInfo {
 	}
 	for i, idx := range h.UniqueIdxs {
 		ok := true
-		for _, idxCol := range idx.Columns {
-			if data[idxCol.Offset] == nil {
+		values := h.rowMapper.valuesByIndex(idx, data)
+		for _, value := range values {
+			if value == nil {
 				ok = false
 				break
 			}

--- a/pkg/sqlmodel/where_handle_test.go
+++ b/pkg/sqlmodel/where_handle_test.go
@@ -14,10 +14,12 @@
 package sqlmodel
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/pingcap/tidb/pkg/ddl"
 	"github.com/pingcap/tidb/pkg/meta/metabuild"
+	timodel "github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/stretchr/testify/require"
@@ -214,4 +216,65 @@ CREATE TABLE t (
 	// no index available
 	idx = handle.getWhereIdxByData([]interface{}{1, nil, 3, nil})
 	require.Nil(t, idx)
+}
+
+func TestGetWhereIdxByDataUniqueAfterHiddenColumn(t *testing.T) {
+	t.Parallel()
+
+	ti := mockTableInfo(t, "CREATE TABLE t ("+
+		"a VARCHAR(32), "+
+		"b INT UNIQUE, "+
+		"c INT, "+
+		"UNIQUE KEY uk_a ((lower(a))))")
+
+	hiddenA := expressionIndexColumnName(t, ti, "uk_a")
+	reorderColumnsByName(t, ti, "a", hiddenA, "b", "c")
+
+	handle := GetWhereHandle(ti, ti)
+	idx := handle.getWhereIdxByData([]interface{}{"Alice", 1, nil})
+	require.NotNil(t, idx)
+	require.Equal(t, "b", idx.Columns[0].Name.L)
+
+	idx = handle.getWhereIdxByData([]interface{}{"Alice", nil, 1})
+	require.Nil(t, idx)
+}
+
+func TestGetWhereHandleExpressionIndex(t *testing.T) {
+	t.Parallel()
+
+	// A functional/expression UNIQUE index is backed by a hidden virtual
+	// generated column that is never present in the binlog row image. It must be
+	// kept for causality (so the constraint is still enforced for conflict
+	// detection) but excluded from the WHERE candidate set, because a hidden
+	// column has no addressable name.
+	ti := mockTableInfo(t, "CREATE TABLE t (id BIGINT PRIMARY KEY, name VARCHAR(255), "+
+		"UNIQUE KEY only_one_alice ((CASE name WHEN 'Alice' THEN 1 ELSE NULL END)))")
+
+	hasHidden := slices.ContainsFunc(ti.Columns, func(c *timodel.ColumnInfo) bool {
+		return c.Hidden
+	})
+	require.True(t, hasHidden, "expression index should create a hidden generated column")
+
+	handle := GetWhereHandle(ti, ti)
+
+	// the expression index is a causality candidate.
+	inCausality := false
+	for _, idx := range handle.causalityIdxs {
+		if idx.Name.L == "only_one_alice" {
+			inCausality = true
+			require.True(t, indexHasHiddenColumn(idx, ti),
+				"expression index needs a full row with its hidden generated column materialized")
+		} else {
+			require.False(t, indexHasHiddenColumn(idx, ti))
+		}
+	}
+	require.True(t, inCausality, "expression index must be a causality candidate")
+
+	// ... but never a WHERE candidate (hidden column is not addressable).
+	for _, idx := range handle.UniqueIdxs {
+		require.NotEqual(t, "only_one_alice", idx.Name.L,
+			"expression index must not be a WHERE candidate")
+	}
+	require.NotNil(t, handle.UniqueNotNullIdx)
+	require.False(t, indexHasHiddenColumn(handle.UniqueNotNullIdx, ti))
 }


### PR DESCRIPTION
> **Draft / WIP** — proposal for review. See caveats at the bottom.

### What problem does this PR solve?

Under a `network-partition-dm-worker-master` event, DM can leave the downstream with **stale/phantom rows**. On the partition the master rebinds the source to a new worker, but the old worker keeps writing for ~3s, so **two workers commit the same source's rows concurrently** to one downstream that shares **one source-id-keyed checkpoint**. A stale out-of-order write can then be frozen by the checkpoint (a resuming worker never re-replays past it), leaving a durable mismatch.

### What is changed and how it works?

Make the old worker stop writing in ~ms instead of ~3s, shrinking the two-writer overlap:

- `pkg/ha/keepalive.go`: on the keepalive-channel-close path, skip the deferred `revokeLease()` — under partition that `Revoke` RPC blocks until its ~3s timeout, which is the whole overlap window. The lease is already gone there; let it expire by TTL. (The graceful `ctx.Done()` path still revokes, for prompt planned failover.)
- `worker/source_worker.go`: on failover (non-graceful) stop, kill subtasks **before** `subTaskWg.Wait()`, so the syncer's cancel fires immediately and in-flight `db.ExecuteSQL` returns at once instead of running to `maxDMLConnectionDuration`.
- `syncer/dml_worker.go`: refuse to issue a new DML batch once `syncCtx` is cancelled.

### Check List

Tests:
- [x] Unit test (`dm/syncer/dml_worker_test.go`)
- [ ] Integration / chaos test showing no overlapping same-source commits. **Pending.**

Side effects:
- [x] On a transient channel-close where the lease is still alive and etcd is reachable, skipping the revoke can delay the master's rebind by up to one lease TTL (a replication gap, not data loss). Rare; see caveats.

### Release note

```release-note
fix(dm): shrink the split-brain write window after a worker-master partition by stopping the old worker promptly on failover.
```

---

### Caveats (why this is a draft)

1. This shrinks the overlap but is **not a complete fix** on its own. Follow-ups: a **master rebind margin** (don't bind the new worker until the old one is provably stopped) and/or **per-bind epoch fencing** (reject writes/checkpoint-advances from a stale-epoch worker — the timing-independent guarantee).
2. The keepalive change is a hard skip; a **short-timeout revoke** (revoke with ~1s instead of skipping) would also cover the rare transient-channel-close case in the side-effect note above. Open question.
