### PR TITLE
[DNM]: test

### DIFF
--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -609,22 +609,23 @@ func (tr *Tracker) buildForeignKeyRelations(
 	cache map[string][]sqlmodel.ForeignKeyCausalityRelation,
 	visiting map[string]struct{},
 ) ([]sqlmodel.ForeignKeyCausalityRelation, error) {
-	if relations, ok := cache[tableID]; ok {
-		return relations, nil
-	}
-
-	if _, ok := visiting[tableID]; ok {
-		return nil, nil
-	}
-	visiting[tableID] = struct{}{}
-	defer delete(visiting, tableID)
-
 	if sourceTable == nil {
 		sourceTable = utils.UnpackTableID(tableID)
 	}
 	if targetTable == nil {
 		targetTable = utils.UnpackTableID(tableID)
 	}
+
+	sourceTableID := utils.GenTableID(sourceTable)
+	if relations, ok := cache[sourceTableID]; ok {
+		return relations, nil
+	}
+
+	if _, ok := visiting[sourceTableID]; ok {
+		return nil, nil
+	}
+	visiting[sourceTableID] = struct{}{}
+	defer delete(visiting, sourceTableID)
 
 	routedSourceTable := resolveTableRoute(routeResolver, sourceTable)
 	if len(downstreamTI.ForeignKeys) > 0 && !sameTableIdentity(routedSourceTable, targetTable) {
@@ -814,7 +815,7 @@ func (tr *Tracker) buildForeignKeyRelations(
 		}
 	}
 
-	cache[tableID] = relations
+	cache[sourceTableID] = relations
 	return relations, nil
 }
 

--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -91,6 +91,10 @@ type DownstreamTableInfo struct {
 	foreignKeyInitErr   error
 }
 
+// TableRouteResolver resolves a source table to its downstream routed table.
+// A nil resolver means identity route.
+type TableRouteResolver func(*filter.Table) *filter.Table
+
 type executorContext struct {
 	sessionctx.Context
 }
@@ -406,7 +410,7 @@ func (tr *Tracker) GetDownStreamTableInfo(tctx *tcontext.Context, tableID string
 		return nil, err
 	}
 
-	if err := dti.initForeignKeyRelations(tr, tctx, tableID, targetTable, targetTable, originTI); err != nil {
+	if err := dti.initForeignKeyRelations(tr, tctx, tableID, targetTable, targetTable, originTI, nil); err != nil {
 		return nil, err
 	}
 
@@ -424,6 +428,7 @@ func (tr *Tracker) InitDownStreamForeignKeyRelations(
 	sourceTable *filter.Table,
 	targetTable *filter.Table,
 	originTI *model.TableInfo,
+	routeResolver TableRouteResolver,
 ) (*DownstreamTableInfo, error) {
 	tableID := utils.GenTableID(targetTable)
 	dti, err := tr.GetDownStreamTableInfoWithoutForeignKey(tctx, tableID, originTI)
@@ -431,7 +436,31 @@ func (tr *Tracker) InitDownStreamForeignKeyRelations(
 		return nil, err
 	}
 
-	if err := dti.initForeignKeyRelations(tr, tctx, tableID, sourceTable, targetTable, originTI); err != nil {
+	// Routed FK relations depend on the source table and resolver, so keep them
+	// out of the downstream table cache that is keyed only by target table ID.
+	if routeResolver != nil {
+		relations, err := tr.buildForeignKeyRelations(
+			tctx,
+			tableID,
+			sourceTable,
+			targetTable,
+			dti.TableInfo,
+			originTI,
+			routeResolver,
+			make(map[string][]sqlmodel.ForeignKeyCausalityRelation),
+			make(map[string]struct{}),
+		)
+		if err != nil {
+			return nil, err
+		}
+		return &DownstreamTableInfo{
+			TableInfo:           dti.TableInfo,
+			WhereHandle:         dti.WhereHandle,
+			ForeignKeyRelations: relations,
+		}, nil
+	}
+
+	if err := dti.initForeignKeyRelations(tr, tctx, tableID, sourceTable, targetTable, originTI, routeResolver); err != nil {
 		return nil, err
 	}
 	return dti, nil
@@ -484,6 +513,7 @@ func (dti *DownstreamTableInfo) initForeignKeyRelations(
 	sourceTable *filter.Table,
 	targetTable *filter.Table,
 	originTI *model.TableInfo,
+	routeResolver TableRouteResolver,
 ) error {
 	dti.foreignKeyInitOnce.Do(func() {
 		relations, err := tr.buildForeignKeyRelations(
@@ -493,6 +523,7 @@ func (dti *DownstreamTableInfo) initForeignKeyRelations(
 			targetTable,
 			dti.TableInfo,
 			originTI,
+			routeResolver,
 			make(map[string][]sqlmodel.ForeignKeyCausalityRelation),
 			make(map[string]struct{}),
 		)
@@ -574,6 +605,7 @@ func (tr *Tracker) buildForeignKeyRelations(
 	targetTable *filter.Table,
 	downstreamTI *model.TableInfo,
 	originTI *model.TableInfo,
+	routeResolver TableRouteResolver,
 	cache map[string][]sqlmodel.ForeignKeyCausalityRelation,
 	visiting map[string]struct{},
 ) ([]sqlmodel.ForeignKeyCausalityRelation, error) {
@@ -594,11 +626,22 @@ func (tr *Tracker) buildForeignKeyRelations(
 		targetTable = utils.UnpackTableID(tableID)
 	}
 
-	if len(downstreamTI.ForeignKeys) > 0 && !sameTableIdentity(sourceTable, targetTable) {
+	routedSourceTable := resolveTableRoute(routeResolver, sourceTable)
+	if len(downstreamTI.ForeignKeys) > 0 && !sameTableIdentity(routedSourceTable, targetTable) {
+		if routeResolver == nil {
+			return nil, newForeignKeyRouteUnsupportedError(
+				fmt.Sprintf(
+					"foreign key causality with route under foreign_key_checks=1 and worker_count>1 is not supported yet; child table %s routes to %s; please use worker_count=1",
+					sourceTable,
+					targetTable,
+				),
+			)
+		}
 		return nil, newForeignKeyRouteUnsupportedError(
 			fmt.Sprintf(
-				"foreign key causality with route under foreign_key_checks=1 and worker_count>1 is not supported yet; child table %s routes to %s; please use worker_count=1",
+				"foreign key causality with route under foreign_key_checks=1 and worker_count>1 requires 1:1 route alignment; source child table %s routes to %s, but downstream child table is %s",
 				sourceTable,
+				routedSourceTable,
 				targetTable,
 			),
 		)
@@ -617,20 +660,6 @@ func (tr *Tracker) buildForeignKeyRelations(
 			continue
 		}
 
-		// childIdxs are the current child row value indexes (after hidden columns are
-		// skipped) for this direct FK, and are reused by both direct and lifted relations.
-		childIdxs := make([]int, 0, len(fk.Cols))
-		for _, col := range fk.Cols {
-			idx, ok := childNameToIdx[col.L]
-			if !ok {
-				return nil, newForeignKeySchemaAlignmentError(
-					tableID,
-					fmt.Sprintf("downstream FK column %s was not found in the tracked schema", col.L),
-				)
-			}
-			childIdxs = append(childIdxs, idx)
-		}
-
 		sourceFK := findMatchingForeignKey(originTI, fk, i)
 		if sourceFK == nil {
 			return nil, newForeignKeyRouteUnsupportedError(
@@ -640,6 +669,26 @@ func (tr *Tracker) buildForeignKeyRelations(
 					fk.Name.O,
 				),
 			)
+		}
+		if len(sourceFK.Cols) == 0 || len(sourceFK.Cols) != len(sourceFK.RefCols) {
+			return nil, newForeignKeySchemaAlignmentError(
+				sourceTable.String(),
+				fmt.Sprintf("source FK %s has unexpected child/ref column metadata", sourceFK.Name.O),
+			)
+		}
+
+		// childIdxs are the current child row value indexes (after hidden columns are
+		// skipped) for this direct FK, and are reused by both direct and lifted relations.
+		childIdxs := make([]int, 0, len(sourceFK.Cols))
+		for _, col := range sourceFK.Cols {
+			idx, ok := childNameToIdx[col.L]
+			if !ok {
+				return nil, newForeignKeySchemaAlignmentError(
+					sourceTable.String(),
+					fmt.Sprintf("source FK column %s was not found in the tracked schema", col.L),
+				)
+			}
+			childIdxs = append(childIdxs, idx)
 		}
 
 		sourceParentSchema := sourceFK.RefSchema.O
@@ -653,11 +702,24 @@ func (tr *Tracker) buildForeignKeyRelations(
 			targetParentSchema = targetTable.Schema
 		}
 		targetParentTable := &filter.Table{Schema: targetParentSchema, Name: fk.RefTable.O}
-		if !sameTableIdentity(sourceParentTable, targetParentTable) {
+		routedSourceParent := resolveTableRoute(routeResolver, sourceParentTable)
+		if !sameTableIdentity(routedSourceParent, targetParentTable) {
+			if routeResolver == nil {
+				return nil, newForeignKeyRouteUnsupportedError(
+					fmt.Sprintf(
+						"foreign key causality with route under foreign_key_checks=1 and worker_count>1 is not supported yet; upstream parent table %s and downstream parent table %s do not align for FK %s on table %s; please use worker_count=1",
+						sourceParentTable,
+						targetParentTable,
+						fk.Name.O,
+						sourceTable,
+					),
+				)
+			}
 			return nil, newForeignKeyRouteUnsupportedError(
 				fmt.Sprintf(
-					"foreign key causality with route under foreign_key_checks=1 and worker_count>1 is not supported yet; upstream parent table %s and downstream parent table %s do not align for FK %s on table %s; please use worker_count=1",
+					"foreign key causality with route under foreign_key_checks=1 and worker_count>1 requires 1:1 route alignment; upstream parent table %s routes to %s, but downstream parent table is %s for FK %s on table %s",
 					sourceParentTable,
+					routedSourceParent,
 					targetParentTable,
 					fk.Name.O,
 					sourceTable,
@@ -666,7 +728,7 @@ func (tr *Tracker) buildForeignKeyRelations(
 		}
 
 		parentTableID := utils.GenTableID(targetParentTable)
-		parentTableName := (&cdcmodel.TableName{Schema: targetParentSchema, Table: fk.RefTable.O}).String()
+		parentTableName := (&cdcmodel.TableName{Schema: sourceParentSchema, Table: sourceFK.RefTable.O}).String()
 
 		parentOriginTI, err := tr.GetTableInfo(sourceParentTable)
 		if err != nil {
@@ -676,7 +738,7 @@ func (tr *Tracker) buildForeignKeyRelations(
 		if err != nil {
 			return nil, err
 		}
-		parentColumns, err := getColumnsByNames(parentDTI.TableInfo, fk.RefCols)
+		parentColumns, err := getColumnsByNames(parentOriginTI, sourceFK.RefCols)
 		if err != nil {
 			return nil, err
 		}
@@ -696,6 +758,7 @@ func (tr *Tracker) buildForeignKeyRelations(
 			targetParentTable,
 			parentDTI.TableInfo,
 			parentOriginTI,
+			routeResolver,
 			cache,
 			visiting,
 		)
@@ -710,8 +773,8 @@ func (tr *Tracker) buildForeignKeyRelations(
 
 		// Map the direct parent column positions referenced by the current FK back to
 		// the current child row's visible-column indexes.
-		parentIndexToChild := make(map[int]int, len(fk.RefCols))
-		for i, refCol := range fk.RefCols {
+		parentIndexToChild := make(map[int]int, len(sourceFK.RefCols))
+		for i, refCol := range sourceFK.RefCols {
 			if idx, ok := parentNameToIdx[refCol.L]; ok {
 				parentIndexToChild[idx] = childIdxs[i]
 			}
@@ -765,24 +828,34 @@ func findMatchingForeignKey(originTI *model.TableInfo, downstreamFK *model.FKInf
 
 	if downstreamFK.Name.L != "" {
 		if fk := model.FindFKInfoByName(originTI.ForeignKeys, downstreamFK.Name.L); fk != nil {
-			return fk
+			if sameForeignKeyColumns(fk, downstreamFK) {
+				return fk
+			}
+			return nil
 		}
 	}
 
 	if idx < len(originTI.ForeignKeys) {
 		candidate := originTI.ForeignKeys[idx]
-		if sameColumns(candidate.Cols, downstreamFK.Cols) && sameColumns(candidate.RefCols, downstreamFK.RefCols) {
+		if sameForeignKeyColumns(candidate, downstreamFK) {
 			return candidate
 		}
 	}
 
 	for _, fk := range originTI.ForeignKeys {
-		if sameColumns(fk.Cols, downstreamFK.Cols) && sameColumns(fk.RefCols, downstreamFK.RefCols) {
+		if sameForeignKeyColumns(fk, downstreamFK) {
 			return fk
 		}
 	}
 
 	return nil
+}
+
+func sameForeignKeyColumns(sourceFK *model.FKInfo, downstreamFK *model.FKInfo) bool {
+	if sourceFK == nil || downstreamFK == nil {
+		return false
+	}
+	return sameColumns(sourceFK.Cols, downstreamFK.Cols) && sameColumns(sourceFK.RefCols, downstreamFK.RefCols)
 }
 
 func sameColumns(a []ast.CIStr, b []ast.CIStr) bool {
@@ -802,6 +875,17 @@ func sameTableIdentity(a *filter.Table, b *filter.Table) bool {
 		return a == b
 	}
 	return a.Schema == b.Schema && a.Name == b.Name
+}
+
+func resolveTableRoute(routeResolver TableRouteResolver, table *filter.Table) *filter.Table {
+	if routeResolver == nil || table == nil {
+		return table
+	}
+	routed := routeResolver(table)
+	if routed == nil {
+		return table
+	}
+	return routed
 }
 
 func newForeignKeyRouteUnsupportedError(msg string) error {

--- a/dm/pkg/schema/tracker_test.go
+++ b/dm/pkg/schema/tracker_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pingcap/tiflow/dm/pkg/terror"
 	"github.com/pingcap/tiflow/dm/pkg/utils"
 	"github.com/pingcap/tiflow/dm/syncer/dbconn"
+	"github.com/pingcap/tiflow/pkg/sqlmodel"
 	"github.com/stretchr/testify/require"
 )
 
@@ -955,6 +956,78 @@ func TestForeignKeyRelationBuildsSourceDomainRootParentForRouteChain(t *testing.
 	require.Equal(t, []int{0}, relation.ChildColumnIdx)
 	require.Len(t, relation.ParentColumns, 1)
 	require.Equal(t, "id", relation.ParentColumns[0].Name.L)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestForeignKeyRelationInternalCacheUsesSourceIdentityForUnsupportedSharedTarget(t *testing.T) {
+	ctx := context.Background()
+	p := parser.New()
+
+	dbConn, mock := mockBaseConn(t)
+	tracker, err := NewTestTracker(ctx, "test-tracker", dbConn, dlog.L())
+	require.NoError(t, err)
+	defer tracker.Close()
+
+	createAndExec := func(sql string, db string) {
+		stmt, parseErr := p.ParseOneStmt(sql, "", "")
+		require.NoError(t, parseErr)
+		require.NoError(t, tracker.Exec(ctx, db, stmt))
+	}
+
+	createAndExec("create database db", "")
+	createAndExec("create table gp1(id int primary key)", "db")
+	createAndExec("create table gp2(id int primary key)", "db")
+	createAndExec("create table p1(id int primary key, constraint fk_p1_gp1 foreign key (id) references gp1(id))", "db")
+	createAndExec("create table p2(id int primary key, constraint fk_p2_gp2 foreign key (id) references gp2(id))", "db")
+	createAndExec("create table child(p1_id int not null, p2_id int not null, primary key(p1_id, p2_id), constraint fk_child_p1 foreign key (p1_id) references p1(id), constraint fk_child_p2 foreign key (p2_id) references p2(id))", "db")
+
+	mock.ExpectBegin()
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", mysql.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	sourceChild := &filter.Table{Schema: "db", Name: "child"}
+	targetChild := &filter.Table{Schema: "db_r", Name: "child_r"}
+	targetParent := &filter.Table{Schema: "db_r", Name: "parent_r"}
+	targetGrandparent := &filter.Table{Schema: "db_r", Name: "grandparent_r"}
+	mock.ExpectQuery("SHOW CREATE TABLE " + utils.GenTableID(targetChild)).WillReturnRows(
+		sqlmock.NewRows([]string{"Table", "Create Table"}).
+			AddRow("child_r", "create table child_r(p1_id int not null, p2_id int not null, primary key(p1_id, p2_id), constraint fk_child_p1 foreign key (p1_id) references parent_r(id), constraint fk_child_p2 foreign key (p2_id) references parent_r(id))"))
+	mock.ExpectQuery("SHOW CREATE TABLE " + utils.GenTableID(targetParent)).WillReturnRows(
+		sqlmock.NewRows([]string{"Table", "Create Table"}).
+			AddRow("parent_r", "create table parent_r(id int primary key, constraint fk_parent_grandparent foreign key (id) references grandparent_r(id))"))
+	mock.ExpectQuery("SHOW CREATE TABLE " + utils.GenTableID(targetGrandparent)).WillReturnRows(
+		sqlmock.NewRows([]string{"Table", "Create Table"}).
+			AddRow("grandparent_r", "create table grandparent_r(id int primary key)"))
+
+	// This unsupported shared-target shape isolates the builder's source-domain
+	// cache identity. Production routed multi-worker FK causality must reject it
+	// before calling the route-aware builder.
+	routeResolver := func(table *filter.Table) *filter.Table {
+		switch table.Name {
+		case "child":
+			return &filter.Table{Schema: "db_r", Name: "child_r"}
+		case "p1", "p2":
+			return &filter.Table{Schema: "db_r", Name: "parent_r"}
+		case "gp1", "gp2":
+			return &filter.Table{Schema: "db_r", Name: "grandparent_r"}
+		default:
+			return table
+		}
+	}
+
+	originTI, err := tracker.GetTableInfo(sourceChild)
+	require.NoError(t, err)
+	dti, err := tracker.InitDownStreamForeignKeyRelations(tcontext.Background(), sourceChild, targetChild, originTI, routeResolver)
+	require.NoError(t, err)
+	require.Len(t, dti.ForeignKeyRelations, 2)
+
+	relationByChildIdx := make(map[int]sqlmodel.ForeignKeyCausalityRelation, 2)
+	for _, relation := range dti.ForeignKeyRelations {
+		require.Len(t, relation.ChildColumnIdx, 1)
+		relationByChildIdx[relation.ChildColumnIdx[0]] = relation
+	}
+	require.Equal(t, (&cdcmodel.TableName{Schema: "db", Table: "gp1"}).String(), relationByChildIdx[0].ParentTable)
+	require.Equal(t, (&cdcmodel.TableName{Schema: "db", Table: "gp2"}).String(), relationByChildIdx[1].ParentTable)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/dm/pkg/schema/tracker_test.go
+++ b/dm/pkg/schema/tracker_test.go
@@ -36,6 +36,7 @@ import (
 	tcontext "github.com/pingcap/tiflow/dm/pkg/context"
 	dlog "github.com/pingcap/tiflow/dm/pkg/log"
 	"github.com/pingcap/tiflow/dm/pkg/terror"
+	"github.com/pingcap/tiflow/dm/pkg/utils"
 	"github.com/pingcap/tiflow/dm/syncer/dbconn"
 	"github.com/stretchr/testify/require"
 )
@@ -737,6 +738,226 @@ func TestForeignKeyRelationBuildsRootParentsWithHiddenColumns(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestForeignKeyRelationBuildsSourceDomainParentForRoute(t *testing.T) {
+	ctx := context.Background()
+	p := parser.New()
+
+	dbConn, mock := mockBaseConn(t)
+	tracker, err := NewTestTracker(ctx, "test-tracker", dbConn, dlog.L())
+	require.NoError(t, err)
+	defer tracker.Close()
+
+	createAndExec := func(sql string, db string) {
+		stmt, parseErr := p.ParseOneStmt(sql, "", "")
+		require.NoError(t, parseErr)
+		require.NoError(t, tracker.Exec(ctx, db, stmt))
+	}
+
+	createAndExec("create database db", "")
+	createAndExec("create table parent(id int primary key)", "db")
+	createAndExec("create table child(parent_id int primary key, constraint fk_child_parent foreign key (parent_id) references parent(id))", "db")
+
+	mock.ExpectBegin()
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", mysql.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	sourceChild := &filter.Table{Schema: "db", Name: "child"}
+	targetChild := &filter.Table{Schema: "db_r", Name: "child_r"}
+	targetParent := &filter.Table{Schema: "db_r", Name: "parent_r"}
+	mock.ExpectQuery("SHOW CREATE TABLE " + utils.GenTableID(targetChild)).WillReturnRows(
+		sqlmock.NewRows([]string{"Table", "Create Table"}).
+			AddRow("child_r", "create table child_r(parent_id int primary key, constraint fk_child_parent foreign key (parent_id) references parent_r(id))"))
+	mock.ExpectQuery("SHOW CREATE TABLE " + utils.GenTableID(targetParent)).WillReturnRows(
+		sqlmock.NewRows([]string{"Table", "Create Table"}).
+			AddRow("parent_r", "create table parent_r(id int primary key)"))
+
+	routeResolver := func(table *filter.Table) *filter.Table {
+		switch table.Name {
+		case "child":
+			return &filter.Table{Schema: "db_r", Name: "child_r"}
+		case "parent":
+			return &filter.Table{Schema: "db_r", Name: "parent_r"}
+		default:
+			return table
+		}
+	}
+
+	originTI, err := tracker.GetTableInfo(sourceChild)
+	require.NoError(t, err)
+	dti, err := tracker.InitDownStreamForeignKeyRelations(tcontext.Background(), sourceChild, targetChild, originTI, routeResolver)
+	require.NoError(t, err)
+	require.Len(t, dti.ForeignKeyRelations, 1)
+
+	relation := dti.ForeignKeyRelations[0]
+	require.Equal(t, (&cdcmodel.TableName{Schema: "db", Table: "parent"}).String(), relation.ParentTable)
+	require.Equal(t, []int{0}, relation.ChildColumnIdx)
+	require.Len(t, relation.ParentColumns, 1)
+	require.Equal(t, "id", relation.ParentColumns[0].Name.L)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestForeignKeyRelationRouteAwareInitIgnoresCachedIdentityError(t *testing.T) {
+	ctx := context.Background()
+	p := parser.New()
+
+	dbConn, mock := mockBaseConn(t)
+	tracker, err := NewTestTracker(ctx, "test-tracker", dbConn, dlog.L())
+	require.NoError(t, err)
+	defer tracker.Close()
+
+	createAndExec := func(sql string, db string) {
+		stmt, parseErr := p.ParseOneStmt(sql, "", "")
+		require.NoError(t, parseErr)
+		require.NoError(t, tracker.Exec(ctx, db, stmt))
+	}
+
+	createAndExec("create database db", "")
+	createAndExec("create table parent(id int primary key)", "db")
+	createAndExec("create table child(parent_id int primary key, constraint fk_child_parent foreign key (parent_id) references parent(id))", "db")
+
+	mock.ExpectBegin()
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", mysql.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	sourceChild := &filter.Table{Schema: "db", Name: "child"}
+	targetChild := &filter.Table{Schema: "db_r", Name: "child_r"}
+	targetParent := &filter.Table{Schema: "db_r", Name: "parent_r"}
+	mock.ExpectQuery("SHOW CREATE TABLE " + utils.GenTableID(targetChild)).WillReturnRows(
+		sqlmock.NewRows([]string{"Table", "Create Table"}).
+			AddRow("child_r", "create table child_r(parent_id int primary key, constraint fk_child_parent foreign key (parent_id) references parent_r(id))"))
+
+	originTI, err := tracker.GetTableInfo(sourceChild)
+	require.NoError(t, err)
+	_, err = tracker.InitDownStreamForeignKeyRelations(tcontext.Background(), sourceChild, targetChild, originTI, nil)
+	require.ErrorContains(t, err, "not supported yet")
+
+	mock.ExpectQuery("SHOW CREATE TABLE " + utils.GenTableID(targetParent)).WillReturnRows(
+		sqlmock.NewRows([]string{"Table", "Create Table"}).
+			AddRow("parent_r", "create table parent_r(id int primary key)"))
+
+	routeResolver := func(table *filter.Table) *filter.Table {
+		switch table.Name {
+		case "child":
+			return &filter.Table{Schema: "db_r", Name: "child_r"}
+		case "parent":
+			return &filter.Table{Schema: "db_r", Name: "parent_r"}
+		default:
+			return table
+		}
+	}
+
+	dti, err := tracker.InitDownStreamForeignKeyRelations(tcontext.Background(), sourceChild, targetChild, originTI, routeResolver)
+	require.NoError(t, err)
+	require.Len(t, dti.ForeignKeyRelations, 1)
+	require.Equal(t, (&cdcmodel.TableName{Schema: "db", Table: "parent"}).String(), dti.ForeignKeyRelations[0].ParentTable)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestForeignKeyRelationRouteResolverMismatch(t *testing.T) {
+	ctx := context.Background()
+	p := parser.New()
+
+	dbConn, mock := mockBaseConn(t)
+	tracker, err := NewTestTracker(ctx, "test-tracker", dbConn, dlog.L())
+	require.NoError(t, err)
+	defer tracker.Close()
+
+	createAndExec := func(sql string, db string) {
+		stmt, parseErr := p.ParseOneStmt(sql, "", "")
+		require.NoError(t, parseErr)
+		require.NoError(t, tracker.Exec(ctx, db, stmt))
+	}
+
+	createAndExec("create database db", "")
+	createAndExec("create table parent(id int primary key)", "db")
+	createAndExec("create table child(parent_id int primary key, constraint fk_child_parent foreign key (parent_id) references parent(id))", "db")
+
+	mock.ExpectBegin()
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", mysql.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	sourceChild := &filter.Table{Schema: "db", Name: "child"}
+	targetChild := &filter.Table{Schema: "db_r", Name: "child_r"}
+	mock.ExpectQuery("SHOW CREATE TABLE " + utils.GenTableID(targetChild)).WillReturnRows(
+		sqlmock.NewRows([]string{"Table", "Create Table"}).
+			AddRow("child_r", "create table child_r(parent_id int primary key, constraint fk_child_parent foreign key (parent_id) references parent_r(id))"))
+
+	routeResolver := func(table *filter.Table) *filter.Table {
+		switch table.Name {
+		case "child":
+			return &filter.Table{Schema: "db_r", Name: "child_r"}
+		case "parent":
+			return &filter.Table{Schema: "db_r", Name: "wrong_parent"}
+		default:
+			return table
+		}
+	}
+
+	originTI, err := tracker.GetTableInfo(sourceChild)
+	require.NoError(t, err)
+	_, err = tracker.InitDownStreamForeignKeyRelations(tcontext.Background(), sourceChild, targetChild, originTI, routeResolver)
+	require.ErrorContains(t, err, "requires 1:1 route alignment")
+	require.ErrorContains(t, err, "`db`.`parent`")
+	require.ErrorContains(t, err, "`db_r`.`parent_r`")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestForeignKeyRelationBuildsSourceDomainRootParentForRouteChain(t *testing.T) {
+	ctx := context.Background()
+	p := parser.New()
+
+	dbConn, mock := mockBaseConn(t)
+	tracker, err := NewTestTracker(ctx, "test-tracker", dbConn, dlog.L())
+	require.NoError(t, err)
+	defer tracker.Close()
+
+	createAndExec := func(sql string, db string) {
+		stmt, parseErr := p.ParseOneStmt(sql, "", "")
+		require.NoError(t, parseErr)
+		require.NoError(t, tracker.Exec(ctx, db, stmt))
+	}
+
+	createAndExec("create database db", "")
+	createAndExec("create table a(id int primary key)", "db")
+	createAndExec("create table b(a_id int primary key, constraint fk_b_a foreign key (a_id) references a(id))", "db")
+	createAndExec("create table c(b_a_id int primary key, constraint fk_c_b foreign key (b_a_id) references b(a_id))", "db")
+
+	mock.ExpectBegin()
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", mysql.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	sourceC := &filter.Table{Schema: "db", Name: "c"}
+	targetA := &filter.Table{Schema: "db_r", Name: "a_r"}
+	targetB := &filter.Table{Schema: "db_r", Name: "b_r"}
+	targetC := &filter.Table{Schema: "db_r", Name: "c_r"}
+	mock.ExpectQuery("SHOW CREATE TABLE " + utils.GenTableID(targetC)).WillReturnRows(
+		sqlmock.NewRows([]string{"Table", "Create Table"}).
+			AddRow("c_r", "create table c_r(b_a_id int primary key, constraint fk_c_b foreign key (b_a_id) references b_r(a_id))"))
+	mock.ExpectQuery("SHOW CREATE TABLE " + utils.GenTableID(targetB)).WillReturnRows(
+		sqlmock.NewRows([]string{"Table", "Create Table"}).
+			AddRow("b_r", "create table b_r(a_id int primary key, constraint fk_b_a foreign key (a_id) references a_r(id))"))
+	mock.ExpectQuery("SHOW CREATE TABLE " + utils.GenTableID(targetA)).WillReturnRows(
+		sqlmock.NewRows([]string{"Table", "Create Table"}).
+			AddRow("a_r", "create table a_r(id int primary key)"))
+
+	routeResolver := func(table *filter.Table) *filter.Table {
+		return &filter.Table{Schema: "db_r", Name: table.Name + "_r"}
+	}
+
+	originTI, err := tracker.GetTableInfo(sourceC)
+	require.NoError(t, err)
+	dti, err := tracker.InitDownStreamForeignKeyRelations(tcontext.Background(), sourceC, targetC, originTI, routeResolver)
+	require.NoError(t, err)
+	require.Len(t, dti.ForeignKeyRelations, 1)
+
+	relation := dti.ForeignKeyRelations[0]
+	require.Equal(t, (&cdcmodel.TableName{Schema: "db", Table: "a"}).String(), relation.ParentTable)
+	require.Equal(t, []int{0}, relation.ChildColumnIdx)
+	require.Len(t, relation.ParentColumns, 1)
+	require.Equal(t, "id", relation.ParentColumns[0].Name.L)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestForeignKeyRelationSchemaAlignmentErrorGuidesRepair(t *testing.T) {
 	ctx := context.Background()
 	p := parser.New()
@@ -774,6 +995,42 @@ func TestForeignKeyRelationSchemaAlignmentErrorGuidesRepair(t *testing.T) {
 	require.ErrorContains(t, err, "foreign key causality initialization failed")
 	require.ErrorContains(t, err, "schema metadata used for FK causality are out of sync")
 	require.ErrorContains(t, err, "binlog-schema update")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestForeignKeyRelationRejectsSameNameDifferentColumns(t *testing.T) {
+	ctx := context.Background()
+	p := parser.New()
+
+	dbConn, mock := mockBaseConn(t)
+	tracker, err := NewTestTracker(ctx, "test-tracker", dbConn, dlog.L())
+	require.NoError(t, err)
+	defer tracker.Close()
+
+	createAndExec := func(sql string, db string) {
+		stmt, parseErr := p.ParseOneStmt(sql, "", "")
+		require.NoError(t, parseErr)
+		require.NoError(t, tracker.Exec(ctx, db, stmt))
+	}
+
+	createAndExec("create database db", "")
+	createAndExec("create table parent(id int primary key)", "db")
+	createAndExec("create table child(id int primary key, parent1_id int not null, parent2_id int not null, key idx_parent1(parent1_id), constraint fk_child_parent foreign key (parent1_id) references parent(id))", "db")
+
+	mock.ExpectBegin()
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", mysql.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	tableIDChild := "`db`.`child`"
+	mock.ExpectQuery("SHOW CREATE TABLE " + tableIDChild).WillReturnRows(
+		sqlmock.NewRows([]string{"Table", "Create Table"}).
+			AddRow("child", "create table child(id int primary key, parent1_id int not null, parent2_id int not null, key idx_parent2(parent2_id), constraint fk_child_parent foreign key (parent2_id) references parent(id))"))
+
+	originTI, err := tracker.GetTableInfo(&filter.Table{Schema: "db", Name: "child"})
+	require.NoError(t, err)
+	_, err = tracker.GetDownStreamTableInfo(tcontext.Background(), tableIDChild, originTI)
+	require.ErrorContains(t, err, "failed to match source foreign key metadata")
+	require.ErrorContains(t, err, "aligned source and downstream FK metadata")
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -3827,10 +3827,7 @@ func (s *Syncer) prepareDownStreamTableInfo(
 	if !s.needForeignKeyCausality() {
 		return basicDownStreamTableInfo(dti), nil
 	}
-	if err := s.precheckForeignKeyCausality(sourceTable, targetTable, dti); err != nil {
-		return nil, err
-	}
-	return s.schemaTracker.InitDownStreamForeignKeyRelations(tctx, sourceTable, targetTable, originTI, nil)
+	return s.schemaTracker.InitDownStreamForeignKeyRelations(tctx, sourceTable, targetTable, originTI, s.route)
 }
 
 func (s *Syncer) getDownStreamTableInfo(

--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -3830,7 +3830,7 @@ func (s *Syncer) prepareDownStreamTableInfo(
 	if err := s.precheckForeignKeyCausality(sourceTable, targetTable, dti); err != nil {
 		return nil, err
 	}
-	return s.schemaTracker.InitDownStreamForeignKeyRelations(tctx, sourceTable, targetTable, originTI)
+	return s.schemaTracker.InitDownStreamForeignKeyRelations(tctx, sourceTable, targetTable, originTI, nil)
 }
 
 func (s *Syncer) getDownStreamTableInfo(


### PR DESCRIPTION
Test-fix PR based on #12654.

Purpose: validate whether the failing DM integration CI is related to the route-aware FK relation path not being wired into syncer.

Change: pass syncer's route resolver into schema tracker FK relation initialization, so the new route-aware builder can validate route alignment instead of always using identity route.

Issue Number: ref #12654

Tests:
- git diff --check
- Local go test was attempted but stopped because first-time dependency compilation did not finish quickly; leaving full validation to CI.

Release note: None