### PR TITLE
test(dm): deflake TestOptimistSuite/TestOptimist (manual cherry-pick of #12497 to release-8.5)

### DIFF
--- a/dm/master/shardddl/optimist_test.go
+++ b/dm/master/shardddl/optimist_test.go
@@ -447,12 +447,28 @@ func (t *testOptimistSuite) testOptimist(cli *clientv3.Client, restart int) {
 	_, err = optimism.PutSourceTables(cli, st32)
 	require.NoError(t.T(), err)
 	require.Eventually(t.T(), func() bool {
-		ready := o.Locks()[lockID].Ready()
-		return !ready[source2][i23.UpSchema][i23.UpTable]
+		lock := o.Locks()[lockID]
+		if lock == nil {
+			return false
+		}
+		ready := lock.Ready()
+		readySchemas, ok := ready[source2]
+		if !ok {
+			return false
+		}
+		readyTables, ok := readySchemas[i23.UpSchema]
+		if !ok {
+			return false
+		}
+		isReady, ok := readyTables[i23.UpTable]
+		if !ok {
+			return false
+		}
+		return !isReady
 	}, waitFor, tick)
 	synced, remain = o.Locks()[lockID].IsSynced()
 	require.False(t.T(), synced)
-	require.Equal(t.T(), remain, 2)
+	require.Equal(t.T(), 2, remain)
 	tts := o.tk.FindTables(task, downSchema, downTable)
 	require.Len(t.T(), tts, 2)
 	require.Equal(t.T(), source2, tts[1].Source)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #12673

> [!NOTE]
> This is a **manual cherry-pick** to release-8.5: the hardened version of this test already exists on master (bundled into commit 4f895a23b, #12497), so there is no standalone master PR for the bot to cherry-pick from.


`TestOptimistSuite/TestOptimist` is flaky on release-8.5. In CASE 3 the `require.Eventually` wait condition indexed nested maps directly:

```go
return !ready[source2][i23.UpSchema][i23.UpTable]
```

Because a missing key in a `map[string]bool` returns the zero value `false`, the negation evaluates to `true` **before** `PutSourceTables(st32)` has been processed and the new table added to the lock. `Eventually` therefore returns prematurely, `IsSynced()` still reports `remain=1`, and the following `require.Equal(2, remain)` fails intermittently.

### What is changed and how it works?

- Add explicit `nil`/`ok` guards for every map level inside the `Eventually` closure, so the wait only completes once the new table is actually registered.
- Fix the swapped argument order of `require.Equal` (`expected`, `actual`).

The hardened version already exists on master (introduced in #12497); this backports it to release-8.5.

### Check List

#### Tests

- [x] Unit test: `go test -race -run TestOptimistSuite ./dm/master/shardddl/` passes

#### Questions

##### Will it cause performance regression or break compatibility?

No. Test-only change; no production code is touched.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```


