### PR TITLE
chore: update Go to 1.25.10

### DIFF
--- a/deployments/ticdc/docker/integration-test.Dockerfile
+++ b/deployments/ticdc/docker/integration-test.Dockerfile
@@ -29,7 +29,7 @@ RUN ./download-integration-test-binaries.sh $BRANCH $COMMUNITY $VERSION $OS $ARC
 RUN ls ./bin
 
 # Download go into /usr/local dir.
-ENV GOLANG_VERSION 1.25.8
+ENV GOLANG_VERSION 1.25.10
 ENV GOLANG_DOWNLOAD_URL https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& tar -C /usr/local -xzf golang.tar.gz \

--- a/examples/golang/avro-checksum-verification/go.mod
+++ b/examples/golang/avro-checksum-verification/go.mod
@@ -1,6 +1,6 @@
 module avro-checksum-sample
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/linkedin/goavro/v2 v2.11.1

--- a/examples/golang/canal-json-handle-key-only/go.mod
+++ b/examples/golang/canal-json-handle-key-only/go.mod
@@ -1,6 +1,6 @@
 module canal-json-handle-key-only-example
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/tiflow
 
-go 1.25.8
+go 1.25.10
 
 require (
 	cloud.google.com/go/storage v1.39.1

--- a/tests/integration_tests/debezium/go.mod
+++ b/tests/integration_tests/debezium/go.mod
@@ -1,6 +1,6 @@
 module github.com/breezewish/checker
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/alecthomas/chroma v0.10.0

--- a/tools/check/go.mod
+++ b/tools/check/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/tidb-cdc/_tools
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/AlekSi/gocov-xml v1.1.0


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #12667

### What is changed and how it works?

Update Go version declarations from 1.25.8 to 1.25.10 for release-8.5.

This PR updates:

- root go.mod
- tools/check/go.mod
- tests/integration_tests/debezium/go.mod
- examples/golang/*/go.mod
- deployments/ticdc/docker/integration-test.Dockerfile

No dependency versions are changed.

### Check List

#### Tests

- Manual test

Verified with:

```bash
GOMODCACHE=/private/tmp/go-mod-cache GOCACHE=/private/tmp/go-build-cache GOTOOLCHAIN=go1.25.10 go mod tidy
GOMODCACHE=/private/tmp/go-mod-cache GOCACHE=/private/tmp/go-build-cache GOTOOLCHAIN=go1.25.10 go list ./...
git diff --check
```

#### Questions

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```