### PR TITLE
checker(dm): update MariaDB precheck instruction

### DIFF
--- a/dm/pkg/checker/mysql_server.go
+++ b/dm/pkg/checker/mysql_server.go
@@ -75,7 +75,7 @@ func (pc *MySQLVersionChecker) checkVersion(value string, result *Result) *Error
 	needVersion := SupportedVersion["mysql"]
 	if conn.IsMariaDB(value) {
 		err := NewWarn("Migrating from MariaDB is still experimental.")
-		err.Instruction = "It is recommended that you upgrade MariaDB to 10.1.2 or a later version."
+		err.Instruction = "It is recommended that you verify compatibility before performing data migration because migrating from MariaDB is still experimental. Otherwise data inconsistency or task exceptions might occur."
 		return err
 	}
 	if IsTiDBFromVersion(value) {

--- a/dm/pkg/checker/mysql_server_test.go
+++ b/dm/pkg/checker/mysql_server_test.go
@@ -76,3 +76,25 @@ func TestVersionInstruction(t *testing.T) {
 	require.Equal(t, result.Instruction,
 		"It is recommended that you select a database version that meets the requirements before performing data migration. Otherwise data inconsistency or task exceptions might occur.")
 }
+
+func TestMariaDBVersionInstruction(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	versionChecker := &MySQLVersionChecker{
+		db:     db,
+		dbinfo: &dbutil.DBConfig{},
+	}
+	mock.ExpectQuery("SHOW GLOBAL VARIABLES LIKE 'version';").WillReturnRows(
+		sqlmock.NewRows(
+			[]string{"Variable_name", "Value"},
+		).AddRow(
+			"version", "11.4.2-MariaDB"),
+	)
+	result := versionChecker.Check(context.Background())
+	require.Equal(t, result.State, StateWarning)
+	require.Len(t, result.Errors, 1)
+	require.Equal(t, result.Errors[0].ShortErr, "Migrating from MariaDB is still experimental.")
+	require.Equal(t, result.Instruction,
+		"It is recommended that you verify compatibility before performing data migration because migrating from MariaDB is still experimental. Otherwise data inconsistency or task exceptions might occur.")
+	require.NotContains(t, result.Instruction, "10.1.2")
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11734

### What is changed and how it works?

DM reports a warning for MariaDB upstreams because MariaDB migration is still experimental, but the precheck instruction still suggested upgrading MariaDB to 10.1.2 or later. That suggestion is obsolete and unhelpful for newer MariaDB versions such as 11.4.2.

This PR updates the MariaDB version precheck instruction to recommend verifying compatibility before migration, and adds a regression test for the MariaDB instruction so it no longer mentions 10.1.2.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
   - `go test ./dm/pkg/checker ./dm/checker -count=1`
 - Manual test (add detailed scripts or steps below)
   - `make fmt`
   - `git diff --check`

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No. This only changes the user-facing precheck instruction for MariaDB upstreams and adds a regression test.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Updated DM precheck to provide a helpful compatibility instruction when the upstream database is MariaDB.
```
