### PR TITLE
dm: strip S3 external ID for import-into source dir

### DIFF
--- a/dm/loader/lightning.go
+++ b/dm/loader/lightning.go
@@ -16,6 +16,7 @@ package loader
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -130,8 +131,31 @@ func MakeGlobalConfig(cfg *config.SubTaskConfig) *lcfg.GlobalConfig {
 	}
 	lightningCfg.PostRestore.Checksum = lcfg.OpLevelOff
 	lightningCfg.Mydumper.SourceDir = cfg.Dir
+	if lightningCfg.TikvImporter.Backend == lcfg.BackendImportInto {
+		lightningCfg.Mydumper.SourceDir = stripS3ExternalIDFromSourceDir(lightningCfg.Mydumper.SourceDir)
+	}
 	lightningCfg.App.Config.File = "" // make lightning not init logger, see more in https://github.com/pingcap/tidb/pull/29291
 	return lightningCfg
+}
+
+func stripS3ExternalIDFromSourceDir(sourceDir string) string {
+	u, err := url.Parse(sourceDir)
+	if err != nil || !strings.EqualFold(u.Scheme, "s3") || u.RawQuery == "" {
+		return sourceDir
+	}
+	values := u.Query()
+	changed := false
+	for key := range values {
+		if strings.EqualFold(key, "external-id") || strings.EqualFold(key, "external_id") {
+			values.Del(key)
+			changed = true
+		}
+	}
+	if !changed {
+		return sourceDir
+	}
+	u.RawQuery = values.Encode()
+	return u.String()
 }
 
 // Type implements Unit.Type.

--- a/dm/loader/lightning_test.go
+++ b/dm/loader/lightning_test.go
@@ -14,6 +14,7 @@
 package loader
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/pingcap/errors"
@@ -42,6 +43,60 @@ func TestSetLightningConfig(t *testing.T) {
 	cfg, err := l.getLightningConfig()
 	require.NoError(t, err)
 	require.Equal(t, stCfg.LoaderConfig.PoolSize, cfg.App.RegionConcurrency)
+}
+
+func TestMakeGlobalConfigStripsS3ExternalIDForImportInto(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := "s3://bucket/path?role-arn=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2Fimport&external-id=cluster-1&force_path_style=0"
+	stCfg := &config.SubTaskConfig{
+		LoaderConfig: config.LoaderConfig{
+			Dir:        sourceDir,
+			ImportMode: config.LoadModeImportInto,
+		},
+	}
+
+	lightningCfg := MakeGlobalConfig(stCfg)
+	require.Equal(t, lcfg.BackendImportInto, lightningCfg.TikvImporter.Backend)
+	require.Equal(t, sourceDir, stCfg.Dir)
+
+	u, err := url.Parse(lightningCfg.Mydumper.SourceDir)
+	require.NoError(t, err)
+	require.Empty(t, u.Query().Get("external-id"))
+	require.Equal(t, "arn:aws:iam::123456789012:role/import", u.Query().Get("role-arn"))
+	require.Equal(t, "0", u.Query().Get("force_path_style"))
+}
+
+func TestMakeGlobalConfigKeepsS3ExternalIDForNonImportInto(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := "s3://bucket/path?role-arn=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2Fimport&external-id=cluster-1"
+	for name, tc := range map[string]struct {
+		importMode config.LoadMode
+		backend    lcfg.Backend
+	}{
+		"logical": {
+			importMode: config.LoadModeLogical,
+			backend:    lcfg.BackendTiDB,
+		},
+		"physical": {
+			importMode: config.LoadModePhysical,
+			backend:    lcfg.BackendLocal,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			stCfg := &config.SubTaskConfig{
+				LoaderConfig: config.LoaderConfig{
+					Dir:        sourceDir,
+					ImportMode: tc.importMode,
+				},
+			}
+
+			lightningCfg := MakeGlobalConfig(stCfg)
+			require.Equal(t, tc.backend, lightningCfg.TikvImporter.Backend)
+			require.Equal(t, sourceDir, lightningCfg.Mydumper.SourceDir)
+		})
+	}
 }
 
 func TestConvertLightningError(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

DM import-into can receive an S3 data source URI that includes `role-arn` and `external-id`. Dumpling needs the external ID to assume the role and access the dump storage, but TiDB NextGen SEM rejects explicit S3 `external-id` in `IMPORT INTO`; TiDB injects the keyspace name as the external ID itself.

When the same DM source dir is passed through to Lightning import-into unchanged, TiDB sees the explicit external ID and rejects the statement.

### What changed and how does it work?

This PR strips S3 `external-id` / `external_id` query parameters only from Lightning's `Mydumper.SourceDir` when the DM load mode maps to `BackendImportInto`.

- Non-S3 source dirs are unchanged.
- S3 source dirs without an external ID are unchanged.
- Other S3 query parameters such as `role-arn` are preserved.
- Logical and physical-local backends keep the source dir unchanged.

This keeps dumpling/storage access able to use the external ID while ensuring the import-into SQL-visible source dir does not pass an explicit external ID to TiDB.

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test
- [ ] No need to test

Unit tests:

- Added unit coverage for import-into stripping and non-import-into preservation in `dm/loader`.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
