### PR TITLE
dm: keep S3 external ID in import-into source dir

### DIFF
--- a/dm/loader/lightning.go
+++ b/dm/loader/lightning.go
@@ -16,7 +16,6 @@ package loader
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -131,31 +130,8 @@ func MakeGlobalConfig(cfg *config.SubTaskConfig) *lcfg.GlobalConfig {
 	}
 	lightningCfg.PostRestore.Checksum = lcfg.OpLevelOff
 	lightningCfg.Mydumper.SourceDir = cfg.Dir
-	if lightningCfg.TikvImporter.Backend == lcfg.BackendImportInto {
-		lightningCfg.Mydumper.SourceDir = stripS3ExternalIDFromSourceDir(lightningCfg.Mydumper.SourceDir)
-	}
 	lightningCfg.App.Config.File = "" // make lightning not init logger, see more in https://github.com/pingcap/tidb/pull/29291
 	return lightningCfg
-}
-
-func stripS3ExternalIDFromSourceDir(sourceDir string) string {
-	u, err := url.Parse(sourceDir)
-	if err != nil || !strings.EqualFold(u.Scheme, "s3") || u.RawQuery == "" {
-		return sourceDir
-	}
-	values := u.Query()
-	changed := false
-	for key := range values {
-		if strings.EqualFold(key, "external-id") || strings.EqualFold(key, "external_id") {
-			values.Del(key)
-			changed = true
-		}
-	}
-	if !changed {
-		return sourceDir
-	}
-	u.RawQuery = values.Encode()
-	return u.String()
 }
 
 // Type implements Unit.Type.

--- a/dm/loader/lightning_test.go
+++ b/dm/loader/lightning_test.go
@@ -14,7 +14,6 @@
 package loader
 
 import (
-	"net/url"
 	"testing"
 
 	"github.com/pingcap/errors"
@@ -45,7 +44,7 @@ func TestSetLightningConfig(t *testing.T) {
 	require.Equal(t, stCfg.LoaderConfig.PoolSize, cfg.App.RegionConcurrency)
 }
 
-func TestMakeGlobalConfigStripsS3ExternalIDForImportInto(t *testing.T) {
+func TestMakeGlobalConfigKeepsS3ExternalIDForImportInto(t *testing.T) {
 	t.Parallel()
 
 	sourceDir := "s3://bucket/path?role-arn=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2Fimport&external-id=cluster-1&force_path_style=0"
@@ -59,12 +58,7 @@ func TestMakeGlobalConfigStripsS3ExternalIDForImportInto(t *testing.T) {
 	lightningCfg := MakeGlobalConfig(stCfg)
 	require.Equal(t, lcfg.BackendImportInto, lightningCfg.TikvImporter.Backend)
 	require.Equal(t, sourceDir, stCfg.Dir)
-
-	u, err := url.Parse(lightningCfg.Mydumper.SourceDir)
-	require.NoError(t, err)
-	require.Empty(t, u.Query().Get("external-id"))
-	require.Equal(t, "arn:aws:iam::123456789012:role/import", u.Query().Get("role-arn"))
-	require.Equal(t, "0", u.Query().Get("force_path_style"))
+	require.Equal(t, sourceDir, lightningCfg.Mydumper.SourceDir)
 }
 
 func TestMakeGlobalConfigKeepsS3ExternalIDForNonImportInto(t *testing.T) {


### PR DESCRIPTION
## Summary

- Keep `Mydumper.SourceDir` unchanged for DM import-into tasks, including S3 `external-id`.
- Remove the import-into-specific source-dir stripping added in pingcap/tiflow#12670.
- Update the DM loader tests to assert import-into keeps the original source dir.

## Why

DM import-into uses the same S3 location across dumpling, Lightning local metadata/file reads, and the final TiDB `IMPORT INTO` SQL. All of these paths need the keyspace role parameters to remain available.

Live dev validation on cluster `10492432391076049734` showed dumpling completed after the dataflow-service fix, but Lightning failed in the Load phase before submitting `IMPORT INTO` because `Mydumper.SourceDir` had already been stripped and the local import SDK could not assume the keyspace role.

TiDB `IMPORT INTO` now allows an explicit S3 `external-id`, so the correct fix is to keep the original S3 URI end to end instead of stripping it in Tiflow.

## How

- Revert `MakeGlobalConfig` to always set `lightningCfg.Mydumper.SourceDir = cfg.Dir`.
- Remove the S3 external ID stripping helper from DM loader.
- Keep the backend selection behavior unchanged: `LoadModeImportInto` still maps to `BackendImportInto`.

## Testing

- [x] Ran `gofmt` on changed files.
- [ ] Not run: full `go test`; this PR was prepared from GitHub contents without a full Tiflow checkout in the current workspace.
- [ ] Runtime validation remains required after the DM/Tiflow image consumes this PR.

## Risks and Reviewer Focus

- Please verify the current TiDB version used by this release branch accepts explicit S3 `external-id` in `IMPORT INTO` resource parameters.
- This change intentionally keeps the S3 URI unchanged for all consumers: dumpling, Lightning local source reads, and TiDB `IMPORT INTO`.
