### PR TITLE
build(dm): bump Go version to 1.25.10

### DIFF
--- a/deployments/ticdc/docker/integration-test.Dockerfile
+++ b/deployments/ticdc/docker/integration-test.Dockerfile
@@ -29,7 +29,7 @@ RUN ./download-integration-test-binaries.sh $BRANCH $COMMUNITY $VERSION $OS $ARC
 RUN ls ./bin
 
 # Download go into /usr/local dir.
-ENV GOLANG_VERSION 1.25.8
+ENV GOLANG_VERSION 1.25.10
 ENV GOLANG_DOWNLOAD_URL https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& tar -C /usr/local -xzf golang.tar.gz \

--- a/examples/golang/avro-checksum-verification/go.mod
+++ b/examples/golang/avro-checksum-verification/go.mod
@@ -1,6 +1,6 @@
 module avro-checksum-sample
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/linkedin/goavro/v2 v2.11.1

--- a/examples/golang/canal-json-handle-key-only/go.mod
+++ b/examples/golang/canal-json-handle-key-only/go.mod
@@ -1,6 +1,6 @@
 module canal-json-handle-key-only-example
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/tiflow
 
-go 1.25.8
+go 1.25.10
 
 require (
 	cloud.google.com/go/storage v1.52.0

--- a/tests/integration_tests/debezium/go.mod
+++ b/tests/integration_tests/debezium/go.mod
@@ -1,6 +1,6 @@
 module github.com/breezewish/checker
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/alecthomas/chroma v0.10.0

--- a/tools/check/go.mod
+++ b/tools/check/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/tidb-cdc/_tools
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/AlekSi/gocov-xml v1.1.0


### PR DESCRIPTION
### What problem does this PR solve?

Bump the pinned Go version from 1.25.8 to 1.25.10 in the same places updated by #12668 so master stays aligned.

Issue Number: close #12667

### What is changed and how it works?

- update the root go.mod Go version to 1.25.10
- update Go versions in auxiliary and example modules
- update the integration test Dockerfile Go version to 1.25.10

### Check List

Tests

- No code logic changed
- No tests were run

#### Questions

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```