### PR TITLE
test(dm): add DDL option regression coverage

### DIFF
--- a/dm/pkg/parser/common_test.go
+++ b/dm/pkg/parser/common_test.go
@@ -380,6 +380,38 @@ func TestParser(t *testing.T) {
 	}
 }
 
+func TestParserSpecificCreateTableOptions(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"create table t2 (id int primary key, c1 varchar(255)) transactional=0",
+		"CREATE TABLE `help_topic` (`help_topic_id` int unsigned NOT NULL) ENGINE=Aria DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci PAGE_CHECKSUM=1 TRANSACTIONAL=0 COMMENT='help topics'",
+		"create table t_auto (id int primary key) AUTOEXTEND_SIZE=4M",
+	}
+	for _, sql := range cases {
+		t.Run(sql, func(t *testing.T) {
+			t.Parallel()
+			p := parser.New()
+
+			stmts, err := Parse(p, sql, "", "")
+			require.NoError(t, err)
+			require.Len(t, stmts, 1)
+
+			splitDDLs, err := SplitDDL(stmts[0], "test")
+			require.NoError(t, err)
+			require.Len(t, splitDDLs, 1)
+
+			stmts, err = Parse(p, splitDDLs[0], "", "")
+			require.NoError(t, err)
+			require.Len(t, stmts, 1)
+
+			tableNames, err := FetchDDLTables("test", stmts[0], conn.LCTableNamesSensitive)
+			require.NoError(t, err)
+			require.Len(t, tableNames, 1)
+		})
+	}
+}
+
 func TestError(t *testing.T) {
 	t.Parallel()
 	p := parser.New()

--- a/dm/pkg/schema/tracker_test.go
+++ b/dm/pkg/schema/tracker_test.go
@@ -167,6 +167,51 @@ func TestDDL(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDDLWithSpecificCreateTableOptions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	p := parser.New()
+
+	tracker, err := NewTestTracker(ctx, "test-tracker", nil, dlog.L())
+	require.NoError(t, err)
+	defer tracker.Close()
+
+	err = tracker.Exec(ctx, "", parseSQL(t, p, "create database testdb;"))
+	require.NoError(t, err)
+
+	cases := []struct {
+		sql             string
+		table           string
+		expectedColumns int
+	}{
+		{
+			sql:             "create table t2 (id int primary key, c1 varchar(255)) transactional=0",
+			table:           "t2",
+			expectedColumns: 2,
+		},
+		{
+			sql:             "CREATE TABLE `help_topic` (`help_topic_id` int unsigned NOT NULL) ENGINE=Aria DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci PAGE_CHECKSUM=1 TRANSACTIONAL=0 COMMENT='help topics'",
+			table:           "help_topic",
+			expectedColumns: 1,
+		},
+		{
+			sql:             "create table t_auto (id int primary key) AUTOEXTEND_SIZE=4M",
+			table:           "t_auto",
+			expectedColumns: 1,
+		},
+	}
+	for _, tc := range cases {
+		stmt := parseSQL(t, p, tc.sql)
+		err = tracker.Exec(ctx, "testdb", stmt)
+		require.NoError(t, err)
+
+		ti, err := tracker.GetTableInfo(&filter.Table{Schema: "testdb", Name: tc.table})
+		require.NoError(t, err)
+		require.Len(t, ti.Columns, tc.expectedColumns)
+	}
+}
+
 func TestGetSingleColumnIndices(t *testing.T) {
 	ctx := context.Background()
 	p := parser.New()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #12429

DM should continue to accept upstream CREATE TABLE DDLs that include MariaDB-specific table options such as `PAGE_CHECKSUM` and `TRANSACTIONAL`, and MySQL-specific table options such as `AUTOEXTEND_SIZE`.

On current `upstream/master`, the reported DDL statements are already accepted by the TiDB parser dependency, so the original parser/schema-tracker failure is not reproducible anymore. This PR adds focused regression coverage in DM to prevent this compatibility behavior from regressing.

### What is changed and how it works?

- Add parser regression coverage for CREATE TABLE statements using:
  - `TRANSACTIONAL=0`
  - `PAGE_CHECKSUM=1 TRANSACTIONAL=0`
  - `AUTOEXTEND_SIZE=4M`
- Add schema tracker regression coverage for the same DDL patterns and verify the tables/columns are tracked successfully.

### Check List

#### Tests

 - Unit test

Commands run:

```sh
go test ./dm/pkg/parser -run TestParserSpecificCreateTableOptions -count=1
go test ./dm/pkg/schema -run TestDDLWithSpecificCreateTableOptions -count=1
go test ./dm/pkg/parser ./dm/pkg/schema -count=1
make fmt
git diff --check
```

#### Questions

##### Will it cause performance regression or break compatibility?

No. This PR only adds regression tests and does not change runtime behavior.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No. This PR only adds regression test coverage for existing compatible behavior.

### Release note

```release-note
None
```
