### PR TITLE
loader(dm): strip external ID from import-into S3 URI

### DIFF
--- a/dm/loader/lightning.go
+++ b/dm/loader/lightning.go
@@ -130,6 +130,9 @@ func MakeGlobalConfig(cfg *config.SubTaskConfig) *lcfg.GlobalConfig {
 	}
 	lightningCfg.PostRestore.Checksum = lcfg.OpLevelOff
 	lightningCfg.Mydumper.SourceDir = cfg.Dir
+	if cfg.LoaderConfig.ImportMode == config.LoadModeImportInto {
+		lightningCfg.Mydumper.SourceDir = storage.StripS3ExternalID(cfg.Dir)
+	}
 	lightningCfg.App.Config.File = "" // make lightning not init logger, see more in https://github.com/pingcap/tidb/pull/29291
 	return lightningCfg
 }

--- a/dm/loader/lightning_test.go
+++ b/dm/loader/lightning_test.go
@@ -44,6 +44,34 @@ func TestSetLightningConfig(t *testing.T) {
 	require.Equal(t, stCfg.LoaderConfig.PoolSize, cfg.App.RegionConcurrency)
 }
 
+func TestMakeGlobalConfigStripsS3ExternalIDOnlyForImportInto(t *testing.T) {
+	t.Parallel()
+
+	dataDir := "s3://bucket/prefix/path?region=us-west-2&external-id=dump&role-arn=arn:aws:iam::123:role/dm&external_id=import&endpoint=https%3A%2F%2F127.0.0.1%3A9000&provider=aws"
+	importIntoDir := "s3://bucket/prefix/path?endpoint=https%3A%2F%2F127.0.0.1%3A9000&provider=aws&region=us-west-2&role-arn=arn%3Aaws%3Aiam%3A%3A123%3Arole%2Fdm"
+
+	stCfg := &config.SubTaskConfig{
+		LoaderConfig: config.LoaderConfig{
+			Dir:        dataDir,
+			ImportMode: config.LoadModeImportInto,
+		},
+	}
+	cfg := MakeGlobalConfig(stCfg)
+	require.Equal(t, lcfg.BackendImportInto, cfg.TikvImporter.Backend)
+	require.Equal(t, importIntoDir, cfg.Mydumper.SourceDir)
+	require.Equal(t, dataDir, stCfg.LoaderConfig.Dir)
+
+	stCfg.LoaderConfig.ImportMode = config.LoadModeLogical
+	cfg = MakeGlobalConfig(stCfg)
+	require.Equal(t, lcfg.BackendTiDB, cfg.TikvImporter.Backend)
+	require.Equal(t, dataDir, cfg.Mydumper.SourceDir)
+
+	stCfg.LoaderConfig.ImportMode = config.LoadModePhysical
+	cfg = MakeGlobalConfig(stCfg)
+	require.Equal(t, lcfg.BackendLocal, cfg.TikvImporter.Backend)
+	require.Equal(t, dataDir, cfg.Mydumper.SourceDir)
+}
+
 func TestConvertLightningError(t *testing.T) {
 	t.Parallel()
 

--- a/dm/pkg/storage/utils.go
+++ b/dm/pkg/storage/utils.go
@@ -31,6 +31,7 @@ import (
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/tidb/pkg/objstore"
 	"github.com/pingcap/tidb/pkg/objstore/objectio"
+	"github.com/pingcap/tidb/pkg/objstore/s3like"
 	"github.com/pingcap/tidb/pkg/objstore/storeapi"
 )
 
@@ -94,6 +95,34 @@ func IsS3Path(rawURL string) bool {
 		return false
 	}
 	return u.Scheme == "s3"
+}
+
+// StripS3ExternalID removes the S3 external-id query option from rawURL.
+// It keeps non-S3 paths, invalid URLs, and all other query parameters unchanged
+// semantically. Both external-id and external_id are supported, consistent with
+// storage query parameter normalization.
+func StripS3ExternalID(rawURL string) string {
+	if rawURL == "" {
+		return rawURL
+	}
+	u, err := objstore.ParseRawURL(rawURL)
+	if err != nil || u.Scheme != "s3" {
+		return rawURL
+	}
+
+	query := u.Query()
+	changed := false
+	for key := range query {
+		if strings.EqualFold(strings.ReplaceAll(key, "_", "-"), s3like.S3ExternalID) {
+			delete(query, key)
+			changed = true
+		}
+	}
+	if !changed {
+		return rawURL
+	}
+	u.RawQuery = query.Encode()
+	return u.String()
 }
 
 // IsLocalDiskPath judges if path is local disk path.

--- a/dm/pkg/storage/utils_test.go
+++ b/dm/pkg/storage/utils_test.go
@@ -99,6 +99,55 @@ func TestIsS3OrLocalDisk(t *testing.T) {
 	}
 }
 
+func TestStripS3ExternalID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "non-s3 path unchanged",
+			raw:  "gcs://bucket/prefix?external-id=keep&region=us-west-2",
+			want: "gcs://bucket/prefix?external-id=keep&region=us-west-2",
+		},
+		{
+			name: "invalid url unchanged",
+			raw:  "1invalid:",
+			want: "1invalid:",
+		},
+		{
+			name: "s3 without external id unchanged",
+			raw:  "s3://bucket/prefix/path?region=us-west-2&role-arn=arn:aws:iam::123:role/dm",
+			want: "s3://bucket/prefix/path?region=us-west-2&role-arn=arn:aws:iam::123:role/dm",
+		},
+		{
+			name: "strip hyphen underscore and case variants",
+			raw:  "s3://bucket/prefix/path?region=us-west-2&external-id=dump&role-arn=arn:aws:iam::123:role/dm&External_ID=import&endpoint=https%3A%2F%2F127.0.0.1%3A9000&provider=aws#part",
+			want: "s3://bucket/prefix/path?endpoint=https%3A%2F%2F127.0.0.1%3A9000&provider=aws&region=us-west-2&role-arn=arn%3Aaws%3Aiam%3A%3A123%3Arole%2Fdm#part",
+		},
+		{
+			name: "strip encoded key",
+			raw:  "s3://bucket/prefix/path?%65xternal_id=dump&region=us-west-2",
+			want: "s3://bucket/prefix/path?region=us-west-2",
+		},
+		{
+			name: "strip only query parameter",
+			raw:  "s3://bucket/prefix/path?external-id=dump",
+			want: "s3://bucket/prefix/path",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, StripS3ExternalID(tc.raw))
+		})
+	}
+}
+
 func TestIsS3AndAdjustAndTrimPath(t *testing.T) {
 	testPaths := []struct {
 		isURLFormat bool


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #12699

Backport #12698 to `release-nextgen-202603`.

DM reuses the same S3 data-dir for Dumpling and Lightning/IMPORT INTO. When the URI contains an explicit `external-id`, Dumpling may need it for AWS AssumeRole, but older TiDB IMPORT INTO rejects explicit external ID before pingcap/tidb#69045.

### What is changed and how does it work?

Keep the original DM data-dir unchanged for Dumpling and normal Lightning. Only when DM configures Lightning with `import-mode: import-into`, strip `external-id` and `external_id` from the S3 URI passed as `Mydumper.SourceDir` so TiDB can inject its own keyspace external ID.

The stripping logic is implemented as a reusable DM storage helper backed by TiDB objstore URL parsing, while preserving other S3 query parameters such as `role-arn`, `region`, `endpoint`, and `provider`.

### Check List

Tests

- Unit test

### Release note

```release-note
Fix DM import-into compatibility with S3 role ARN URIs that include explicit external ID.
```

### Test

- `go test ./dm/pkg/storage -run TestStripS3ExternalID -count=1`
- `go test ./dm/loader -run TestMakeGlobalConfigStripsS3ExternalIDOnlyForImportInto -count=1`
- `go test ./dm/pkg/storage -count=1`
- `go test ./dm/loader -count=1`
