### PR TITLE
CI: Use `docker compose` instead of `docker-compose`

### DIFF
--- a/.github/workflows/upgrade_dm_via_tiup.yaml
+++ b/.github/workflows/upgrade_dm_via_tiup.yaml
@@ -53,13 +53,13 @@ jobs:
         working-directory: ${{ env.working-directory }}
         run: |
           cd ${{ env.working-directory }}/dm/tests/tiup/docker
-          GOPATH=${GITHUB_WORKSPACE}/go docker-compose up -d
+          GOPATH=${GITHUB_WORKSPACE}/go docker compose up -d
 
       - name: Run test cases
         working-directory: ${{ env.working-directory }}
         run: |
           cd ${{ env.working-directory }}/dm/tests/tiup/docker
-          docker-compose exec -T control bash -c "cd /go/src/github.com/pingcap/tiflow/dm && ./tests/tiup/upgrade-from-v1.sh"
+          docker compose exec -T control bash -c "cd /go/src/github.com/pingcap/tiflow/dm && ./tests/tiup/upgrade-from-v1.sh"
 
   from_v2:
     name: From V2
@@ -126,7 +126,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
         run: |
           cd ${{ env.working-directory }}/dm/tests/tiup/docker
-          GOPATH=${GITHUB_WORKSPACE}/go docker-compose up -d
+          GOPATH=${GITHUB_WORKSPACE}/go docker compose up -d
 
       - name: Copy package files
         if: ${{ github.ref != 'refs/heads/master' || github.event.inputs.pr != '' }}
@@ -141,7 +141,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
         run: |
           cd ${{ env.working-directory }}/dm/tests/tiup/docker
-          docker-compose exec -e ref=${{ github.ref }} -e id=${{ github.event.inputs.pr }} -T control bash -c "cd /go/src/github.com/pingcap/tiflow/dm && ./tests/tiup/upgrade-from-v2.sh ${{ matrix.previous_v2 }} nightly"
+          docker compose exec -e ref=${{ github.ref }} -e id=${{ github.event.inputs.pr }} -T control bash -c "cd /go/src/github.com/pingcap/tiflow/dm && ./tests/tiup/upgrade-from-v2.sh ${{ matrix.previous_v2 }} nightly"
 
       # if above step is passed, logs will be removed by tiup dm destroy
       - name: Copy logs to hack permission
@@ -187,23 +187,23 @@ jobs:
         run: |
           cd ${{ env.working-directory }}/dm/tests/tiup/docker
           sed -i "s/tidb:v4.0.7/tidb:v3.0.19/g" docker-compose.yml
-          GOPATH=${GITHUB_WORKSPACE}/go docker-compose up -d
+          GOPATH=${GITHUB_WORKSPACE}/go docker compose up -d
 
       - name: Run test cases before upgrade
         working-directory: ${{ env.working-directory }}
         run: |
           cd ${{ env.working-directory }}/dm/tests/tiup/docker
-          docker-compose exec -T control bash -c "cd /go/src/github.com/pingcap/tiflow && ./dm/tests/tiup/upgrade-tidb.sh before_upgrade nightly"
+          docker compose exec -T control bash -c "cd /go/src/github.com/pingcap/tiflow && ./dm/tests/tiup/upgrade-tidb.sh before_upgrade nightly"
 
       - name: Upgrade TiDB
         working-directory: ${{ env.working-directory }}
         run: |
           cd ${{ env.working-directory }}/dm/tests/tiup/docker
           sed -i "s/tidb:v3.0.19/tidb:v4.0.7/g" docker-compose.yml
-          GOPATH=${GITHUB_WORKSPACE}/go docker-compose up -d
+          GOPATH=${GITHUB_WORKSPACE}/go docker compose up -d
 
       - name: Run test cases after upgrade
         working-directory: ${{ env.working-directory }}
         run: |
           cd ${{ env.working-directory }}/dm/tests/tiup/docker
-          docker-compose exec -T control bash -c "source /root/.profile && cd /go/src/github.com/pingcap/tiflow && ./dm/tests/tiup/upgrade-tidb.sh after_upgrade nightly"
+          docker compose exec -T control bash -c "source /root/.profile && cd /go/src/github.com/pingcap/tiflow && ./dm/tests/tiup/upgrade-tidb.sh after_upgrade nightly"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #12542

The "Upgrade DM via TiUP" workflow fails with:

```
line 3: docker-compose: command not found
```

The `ubuntu-24.04` runner image no longer ships the standalone `docker-compose` v1 binary; it only includes the Docker Compose v2 CLI plugin (`docker compose`).

See also: https://github.com/pingcap/tiflow/actions?query=branch%3Amaster+workflow%3A%22Upgrade%20DM%20via%20TiUP%22

### What is changed and how it works?

Replace all `docker-compose ...` invocations in `.github/workflows/upgrade_dm_via_tiup.yaml` with `docker compose ...`, which is provided by the runner image out of the box. No installation step is needed and the v1 command style is deprecated anyway.

The `docker-compose.yml` file name references are intentionally unchanged, since Compose v2 still picks up that file name by default.

### Check List

#### Tests

 - Manual test: the workflow can be verified via `workflow_dispatch` or the next scheduled run.
 - No code

#### Questions

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)