### PR TITLE
dm/checker: fix connection typo

### DIFF
--- a/dm/pkg/checker/conn_checker.go
+++ b/dm/pkg/checker/conn_checker.go
@@ -47,7 +47,7 @@ func newConnNumberChecker(toCheckDB *conn.BaseDB, stCfgs []*config.SubTaskConfig
 func (c *connNumberChecker) check(ctx context.Context, checkerName string, neededPriv map[mysql.PrivilegeType]priv) *Result {
 	result := &Result{
 		Name:  checkerName,
-		Desc:  "check if connetion concurrency exceeds database's maximum connection limit",
+		Desc:  "check if connection concurrency exceeds database's maximum connection limit",
 		State: StateSuccess,
 	}
 	baseConn, err := c.toCheckDB.GetBaseConn(ctx)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #12736

Fix a typo in a DM precheck description: `connetion` should be `connection`.

### What is changed and how it works?

Correct the spelling in the connection concurrency precheck description.

### Check List

#### Tests

 - Unit test

#### Questions

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
None
```

