### PR TITLE
checker(dm): improve same table precheck error

### DIFF
--- a/dm/checker/check_test.go
+++ b/dm/checker/check_test.go
@@ -834,6 +834,23 @@ func TestSameTargetTableDetectionBeforeRouteDupMatch(t *testing.T) {
 			IgnoreCheckingItems: ignoreExcept(map[string]struct{}{config.TableSchemaChecking: {}}),
 		},
 	}
+	cfgsWithInvalidTargetSchema := []*config.SubTaskConfig{
+		{
+			RouteRules: []*router.TableRule{
+				{
+					SchemaPattern: "test",
+					TablePattern:  "T",
+					TargetTable:   "T",
+				}, {
+					SchemaPattern: "test",
+					TablePattern:  "t",
+					TargetTable:   "t",
+				},
+			},
+			Mode:                config.ModeAll,
+			IgnoreCheckingItems: ignoreExcept(map[string]struct{}{config.TableSchemaChecking: {}}),
+		},
+	}
 
 	require.NoError(t, sameTargetTableNameDetectionForRouteRules(false, []*router.TableRule{
 		{
@@ -885,6 +902,12 @@ func TestSameTargetTableDetectionBeforeRouteDupMatch(t *testing.T) {
 	require.Contains(t, processErr.Message, "same table name in case-insensitive")
 	require.Contains(t, processErr.Message, "same target table `test`.`T` vs `test`.`T`")
 	require.Empty(t, processErr.RawCause)
+
+	msg, err = CheckSyncConfig(context.Background(), cfgsWithInvalidTargetSchema, common.DefaultErrorCnt, common.DefaultWarnCnt)
+	require.ErrorContains(t, err, "fail to initialize checker")
+	require.ErrorContains(t, err, "target schema of table route rule should not be empty")
+	require.NotContains(t, err.Error(), "same table name in case-insensitive")
+	require.Len(t, msg, 0)
 }
 
 func TestMetaPositionChecking(t *testing.T) {

--- a/dm/checker/check_test.go
+++ b/dm/checker/check_test.go
@@ -16,11 +16,14 @@ package checker
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	gmysql "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/util/filter"
+	regexprrouter "github.com/pingcap/tidb/pkg/util/regexpr-router"
 	router "github.com/pingcap/tidb/pkg/util/table-router"
 	"github.com/pingcap/tiflow/dm/config"
 	"github.com/pingcap/tiflow/dm/ctl/common"
@@ -795,19 +798,19 @@ func TestSameTargetTableDetection(t *testing.T) {
 	require.ErrorContains(t, err, "same table name in case-insensitive")
 }
 
-func TestSameTargetTableDetectionBeforeRouteDupMatch(t *testing.T) {
+func TestCheckTableRouteCaseCollisionsBeforeRouteDupMatch(t *testing.T) {
 	cfgs := []*config.SubTaskConfig{
 		{
 			RouteRules: []*router.TableRule{
 				{
-					SchemaPattern: "test",
+					SchemaPattern: schema,
 					TargetSchema:  "test",
-					TablePattern:  "T",
+					TablePattern:  "T_1",
 					TargetTable:   "T",
 				}, {
-					SchemaPattern: "test",
+					SchemaPattern: schema,
 					TargetSchema:  "test",
-					TablePattern:  "t",
+					TablePattern:  "t_1",
 					TargetTable:   "t",
 				},
 			},
@@ -819,14 +822,14 @@ func TestSameTargetTableDetectionBeforeRouteDupMatch(t *testing.T) {
 		{
 			RouteRules: []*router.TableRule{
 				{
-					SchemaPattern: "test",
+					SchemaPattern: schema,
 					TargetSchema:  "test",
-					TablePattern:  "T",
+					TablePattern:  "T_1",
 					TargetTable:   "T",
 				}, {
-					SchemaPattern: "test",
+					SchemaPattern: schema,
 					TargetSchema:  "test",
-					TablePattern:  "t",
+					TablePattern:  "t_1",
 					TargetTable:   "T",
 				},
 			},
@@ -852,62 +855,173 @@ func TestSameTargetTableDetectionBeforeRouteDupMatch(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, sameTargetTableNameDetectionForRouteRules(false, []*router.TableRule{
-		{
-			SchemaPattern: "test",
-			TargetSchema:  "test",
-			TablePattern:  "a",
-			TargetTable:   "T",
-		}, {
-			SchemaPattern: "test",
-			TargetSchema:  "test",
-			TablePattern:  "b",
-			TargetTable:   "t",
-		},
-	}))
-	require.NoError(t, sameTargetTableNameDetectionForRouteRules(true, cfgs[0].RouteRules))
-
+	mock := initMockDB(t)
 	msg, err := CheckSyncConfig(context.Background(), cfgs, common.DefaultErrorCnt, common.DefaultWarnCnt)
 	require.ErrorContains(t, err, "fail to initialize checker")
 	require.ErrorContains(t, err, "same table name in case-insensitive")
 	require.ErrorContains(t, err, "same target table `test`.`T` vs `test`.`t`")
 	require.NotContains(t, err.Error(), "matches more than one rule")
 	require.Len(t, msg, 0)
+	require.NoError(t, mock.ExpectationsWereMet())
 
+	mock = initMockDB(t)
 	_, err = RunCheckOnConfigs(context.Background(), cfgs, false, 100, 100)
 	require.ErrorContains(t, err, "fail to initialize checker")
 	require.ErrorContains(t, err, "same table name in case-insensitive")
 	require.ErrorContains(t, err, "same target table `test`.`T` vs `test`.`t`")
 	require.NotContains(t, err.Error(), "matches more than one rule")
+	require.NoError(t, mock.ExpectationsWereMet())
 
 	processErr := unit.NewProcessError(err)
 	require.Contains(t, processErr.Message, "same table name in case-insensitive")
 	require.Contains(t, processErr.Message, "same target table `test`.`T` vs `test`.`t`")
 	require.Empty(t, processErr.RawCause)
 
+	mock = initMockDB(t)
 	msg, err = CheckSyncConfig(context.Background(), cfgsWithSameTarget, common.DefaultErrorCnt, common.DefaultWarnCnt)
 	require.ErrorContains(t, err, "fail to initialize checker")
 	require.ErrorContains(t, err, "same table name in case-insensitive")
 	require.ErrorContains(t, err, "same target table `test`.`T` vs `test`.`T`")
 	require.NotContains(t, err.Error(), "matches more than one rule")
 	require.Len(t, msg, 0)
+	require.NoError(t, mock.ExpectationsWereMet())
 
+	mock = initMockDB(t)
 	_, err = RunCheckOnConfigs(context.Background(), cfgsWithSameTarget, false, 100, 100)
 	require.ErrorContains(t, err, "fail to initialize checker")
 	require.ErrorContains(t, err, "same table name in case-insensitive")
 	require.ErrorContains(t, err, "same target table `test`.`T` vs `test`.`T`")
 	require.NotContains(t, err.Error(), "matches more than one rule")
+	require.NoError(t, mock.ExpectationsWereMet())
 
 	processErr = unit.NewProcessError(err)
 	require.Contains(t, processErr.Message, "same table name in case-insensitive")
 	require.Contains(t, processErr.Message, "same target table `test`.`T` vs `test`.`T`")
 	require.Empty(t, processErr.RawCause)
 
+	mock, mockErr := conn.MockDefaultDBProvider()
+	require.NoError(t, mockErr)
 	msg, err = CheckSyncConfig(context.Background(), cfgsWithInvalidTargetSchema, common.DefaultErrorCnt, common.DefaultWarnCnt)
 	require.ErrorContains(t, err, "fail to initialize checker")
 	require.ErrorContains(t, err, "target schema of table route rule should not be empty")
 	require.NotContains(t, err.Error(), "same table name in case-insensitive")
 	require.Len(t, msg, 0)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCheckTableRouteCaseCollisionsUsesSelectedSourceTables(t *testing.T) {
+	caseCollisionRules := []*router.TableRule{
+		{
+			SchemaPattern: schema,
+			TargetSchema:  "test",
+			TablePattern:  "T_1",
+			TargetTable:   "T",
+		}, {
+			SchemaPattern: schema,
+			TargetSchema:  "test",
+			TablePattern:  "t_1",
+			TargetTable:   "t",
+		},
+	}
+
+	// A collision for a nonexistent source table must not affect selected tables.
+	mock := initMockDB(t)
+	tableMap, _, err := (&Checker{}).fetchSourceTargetDB(context.Background(), &mysqlInstance{
+		cfg: &config.SubTaskConfig{RouteRules: []*router.TableRule{
+			{
+				SchemaPattern: "missing",
+				TargetSchema:  "test",
+				TablePattern:  "T",
+				TargetTable:   "T",
+			}, {
+				SchemaPattern: "missing",
+				TargetSchema:  "test",
+				TablePattern:  "t",
+				TargetTable:   "t",
+			},
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, tableMap, 2)
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	// A block/allow list excluding the colliding table must also suppress it.
+	mock = initMockDB(t)
+	tableMap, _, err = (&Checker{}).fetchSourceTargetDB(context.Background(), &mysqlInstance{
+		cfg: &config.SubTaskConfig{
+			RouteRules: caseCollisionRules,
+			BAList: &filter.Rules{DoTables: []*filter.Table{
+				{Schema: schema, Name: tb2},
+			}},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, map[filter.Table][]filter.Table{
+		{Schema: schema, Name: tb2}: {{Schema: schema, Name: tb2}},
+	}, tableMap)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCheckTableRouteCaseCollisions(t *testing.T) {
+	selectedTables := map[string][]string{schema: {tb1, tb2}}
+	rules := []*router.TableRule{
+		{
+			SchemaPattern: schema,
+			TargetSchema:  "test",
+			TablePattern:  "T_1",
+			TargetTable:   "T",
+		}, {
+			SchemaPattern: schema,
+			TargetSchema:  "test",
+			TablePattern:  "t_1",
+			TargetTable:   "t",
+		},
+	}
+
+	err := checkTableRouteCaseCollisions(false, rules, selectedTables)
+	require.ErrorContains(t, err, "same target table `test`.`T` vs `test`.`t`")
+	require.NoError(t, checkTableRouteCaseCollisions(true, rules, selectedTables))
+	require.NoError(t, checkTableRouteCaseCollisions(false, rules, map[string][]string{schema: {tb2}}))
+
+	wildcardRules := []*router.TableRule{
+		{
+			SchemaPattern: schema,
+			TargetSchema:  "test",
+			TablePattern:  "T_*",
+			TargetTable:   "T",
+		}, {
+			SchemaPattern: schema,
+			TargetSchema:  "test",
+			TablePattern:  "t_1",
+			TargetTable:   "t",
+		},
+	}
+	err = checkTableRouteCaseCollisions(false, wildcardRules, selectedTables)
+	require.ErrorContains(t, err, "same target table `test`.`T` vs `test`.`t`")
+	require.Equal(t, 1, strings.Count(err.Error(), "same target table `test`.`T` vs `test`.`t`"))
+
+	implicitTargetRules := []*router.TableRule{
+		{SchemaPattern: schema, TargetSchema: "test", TablePattern: "T_*"},
+		{SchemaPattern: schema, TargetSchema: "test", TablePattern: "t_1", TargetTable: "T_1"},
+	}
+	err = checkTableRouteCaseCollisions(false, implicitTargetRules, selectedTables)
+	require.ErrorContains(t, err, "same target table `test`.`t_1` vs `test`.`T_1`")
+
+	require.NoError(t, checkTableRouteCaseCollisions(false, []*router.TableRule{
+		{SchemaPattern: schema, TargetSchema: "test", TablePattern: "a", TargetTable: "T"},
+		{SchemaPattern: schema, TargetSchema: "test", TablePattern: "b", TargetTable: "t"},
+	}, selectedTables))
+
+	differentTargetRules := []*router.TableRule{
+		{SchemaPattern: schema, TargetSchema: "test", TablePattern: "T_*", TargetTable: "left"},
+		{SchemaPattern: schema, TargetSchema: "test", TablePattern: "t_1", TargetTable: "right"},
+	}
+	require.NoError(t, checkTableRouteCaseCollisions(false, differentTargetRules, selectedTables))
+	tableRouter, err := regexprrouter.NewRegExprRouter(false, differentTargetRules)
+	require.NoError(t, err)
+	_, _, err = conn.RouteTargetDoTables("", map[string][]string{schema: {tb1}}, tableRouter)
+	require.ErrorContains(t, err, "matches more than one rule")
+	require.NotContains(t, err.Error(), "same table name in case-insensitive")
 }
 
 func TestMetaPositionChecking(t *testing.T) {

--- a/dm/checker/check_test.go
+++ b/dm/checker/check_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tiflow/dm/ctl/common"
 	"github.com/pingcap/tiflow/dm/pkg/conn"
 	"github.com/pingcap/tiflow/dm/pkg/cputil"
+	"github.com/pingcap/tiflow/dm/pkg/terror"
 	"github.com/pingcap/tiflow/dm/unit"
 	"github.com/stretchr/testify/require"
 )
@@ -818,7 +819,7 @@ func TestCheckTableRouteCaseCollisionsBeforeRouteDupMatch(t *testing.T) {
 			IgnoreCheckingItems: ignoreExcept(map[string]struct{}{config.TableSchemaChecking: {}}),
 		},
 	}
-	cfgsWithSameTarget := []*config.SubTaskConfig{
+	cfgsWithExactSameTarget := []*config.SubTaskConfig{
 		{
 			RouteRules: []*router.TableRule{
 				{
@@ -878,26 +879,25 @@ func TestCheckTableRouteCaseCollisionsBeforeRouteDupMatch(t *testing.T) {
 	require.Empty(t, processErr.RawCause)
 
 	mock = initMockDB(t)
-	msg, err = CheckSyncConfig(context.Background(), cfgsWithSameTarget, common.DefaultErrorCnt, common.DefaultWarnCnt)
+	msg, err = CheckSyncConfig(context.Background(), cfgsWithExactSameTarget, common.DefaultErrorCnt, common.DefaultWarnCnt)
 	require.ErrorContains(t, err, "fail to initialize checker")
-	require.ErrorContains(t, err, "same table name in case-insensitive")
-	require.ErrorContains(t, err, "same target table `test`.`T` vs `test`.`T`")
-	require.NotContains(t, err.Error(), "matches more than one rule")
+	require.ErrorContains(t, err, "matches more than one rule")
+	require.NotContains(t, err.Error(), "same table name in case-insensitive")
 	require.Len(t, msg, 0)
 	require.NoError(t, mock.ExpectationsWereMet())
 
 	mock = initMockDB(t)
-	_, err = RunCheckOnConfigs(context.Background(), cfgsWithSameTarget, false, 100, 100)
+	_, err = RunCheckOnConfigs(context.Background(), cfgsWithExactSameTarget, false, 100, 100)
 	require.ErrorContains(t, err, "fail to initialize checker")
-	require.ErrorContains(t, err, "same table name in case-insensitive")
-	require.ErrorContains(t, err, "same target table `test`.`T` vs `test`.`T`")
-	require.NotContains(t, err.Error(), "matches more than one rule")
+	require.ErrorContains(t, err, "matches more than one rule")
+	require.NotContains(t, err.Error(), "same table name in case-insensitive")
 	require.NoError(t, mock.ExpectationsWereMet())
 
 	processErr = unit.NewProcessError(err)
-	require.Contains(t, processErr.Message, "same table name in case-insensitive")
-	require.Contains(t, processErr.Message, "same target table `test`.`T` vs `test`.`T`")
-	require.Empty(t, processErr.RawCause)
+	require.Equal(t, int32(terror.ErrGenTableRouter.Code()), processErr.ErrCode)
+	require.Contains(t, processErr.Message, "generate table router")
+	require.Contains(t, processErr.RawCause, "table db_1.t_1 matches more than one rule")
+	require.Contains(t, processErr.Workaround, "`routes`")
 
 	mock, mockErr := conn.MockDefaultDBProvider()
 	require.NoError(t, mockErr)
@@ -1000,6 +1000,20 @@ func TestCheckTableRouteCaseCollisions(t *testing.T) {
 	require.ErrorContains(t, err, "same target table `test`.`T` vs `test`.`t`")
 	require.Equal(t, 1, strings.Count(err.Error(), "same target table `test`.`T` vs `test`.`t`"))
 
+	schemaRules := []*router.TableRule{
+		{SchemaPattern: "DB_*", TargetSchema: "archive"},
+		{SchemaPattern: schema, TargetSchema: "Archive"},
+	}
+	// Schema-level route conflicts intentionally retain the router's generic
+	// duplicate-rule error instead of the target-table diagnostic.
+	require.NoError(t, checkTableRouteCaseCollisions(false, schemaRules, map[string][]string{schema: {tb1}}))
+	tableRouter, err := regexprrouter.NewRegExprRouter(false, schemaRules)
+	require.NoError(t, err)
+	_, _, err = conn.RouteTargetDoTables("", map[string][]string{schema: {tb1}}, tableRouter)
+	require.True(t, terror.ErrGenTableRouter.Equal(err))
+	require.ErrorContains(t, err, "table db_1.t_1 matches more than one rule")
+	require.NotContains(t, err.Error(), "same table name in case-insensitive")
+
 	implicitTargetRules := []*router.TableRule{
 		{SchemaPattern: schema, TargetSchema: "test", TablePattern: "T_*"},
 		{SchemaPattern: schema, TargetSchema: "test", TablePattern: "t_1", TargetTable: "T_1"},
@@ -1017,7 +1031,7 @@ func TestCheckTableRouteCaseCollisions(t *testing.T) {
 		{SchemaPattern: schema, TargetSchema: "test", TablePattern: "t_1", TargetTable: "right"},
 	}
 	require.NoError(t, checkTableRouteCaseCollisions(false, differentTargetRules, selectedTables))
-	tableRouter, err := regexprrouter.NewRegExprRouter(false, differentTargetRules)
+	tableRouter, err = regexprrouter.NewRegExprRouter(false, differentTargetRules)
 	require.NoError(t, err)
 	_, _, err = conn.RouteTargetDoTables("", map[string][]string{schema: {tb1}}, tableRouter)
 	require.ErrorContains(t, err, "matches more than one rule")

--- a/dm/checker/check_test.go
+++ b/dm/checker/check_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tiflow/dm/ctl/common"
 	"github.com/pingcap/tiflow/dm/pkg/conn"
 	"github.com/pingcap/tiflow/dm/pkg/cputil"
+	"github.com/pingcap/tiflow/dm/unit"
 	"github.com/stretchr/testify/require"
 )
 
@@ -792,6 +793,98 @@ func TestSameTargetTableDetection(t *testing.T) {
 	mock.ExpectQuery("SHOW CREATE TABLE .*").WillReturnRows(sqlmock.NewRows([]string{"Table", "Create Table"}).AddRow(tb1, fmt.Sprintf(createTable1, tb2)))
 	_, err = RunCheckOnConfigs(context.Background(), cfgs, false, 100, 100)
 	require.ErrorContains(t, err, "same table name in case-insensitive")
+}
+
+func TestSameTargetTableDetectionBeforeRouteDupMatch(t *testing.T) {
+	cfgs := []*config.SubTaskConfig{
+		{
+			RouteRules: []*router.TableRule{
+				{
+					SchemaPattern: "test",
+					TargetSchema:  "test",
+					TablePattern:  "T",
+					TargetTable:   "T",
+				}, {
+					SchemaPattern: "test",
+					TargetSchema:  "test",
+					TablePattern:  "t",
+					TargetTable:   "t",
+				},
+			},
+			Mode:                config.ModeAll,
+			IgnoreCheckingItems: ignoreExcept(map[string]struct{}{config.TableSchemaChecking: {}}),
+		},
+	}
+	cfgsWithSameTarget := []*config.SubTaskConfig{
+		{
+			RouteRules: []*router.TableRule{
+				{
+					SchemaPattern: "test",
+					TargetSchema:  "test",
+					TablePattern:  "T",
+					TargetTable:   "T",
+				}, {
+					SchemaPattern: "test",
+					TargetSchema:  "test",
+					TablePattern:  "t",
+					TargetTable:   "T",
+				},
+			},
+			Mode:                config.ModeAll,
+			IgnoreCheckingItems: ignoreExcept(map[string]struct{}{config.TableSchemaChecking: {}}),
+		},
+	}
+
+	require.NoError(t, sameTargetTableNameDetectionForRouteRules(false, []*router.TableRule{
+		{
+			SchemaPattern: "test",
+			TargetSchema:  "test",
+			TablePattern:  "a",
+			TargetTable:   "T",
+		}, {
+			SchemaPattern: "test",
+			TargetSchema:  "test",
+			TablePattern:  "b",
+			TargetTable:   "t",
+		},
+	}))
+	require.NoError(t, sameTargetTableNameDetectionForRouteRules(true, cfgs[0].RouteRules))
+
+	msg, err := CheckSyncConfig(context.Background(), cfgs, common.DefaultErrorCnt, common.DefaultWarnCnt)
+	require.ErrorContains(t, err, "fail to initialize checker")
+	require.ErrorContains(t, err, "same table name in case-insensitive")
+	require.ErrorContains(t, err, "same target table `test`.`T` vs `test`.`t`")
+	require.NotContains(t, err.Error(), "matches more than one rule")
+	require.Len(t, msg, 0)
+
+	_, err = RunCheckOnConfigs(context.Background(), cfgs, false, 100, 100)
+	require.ErrorContains(t, err, "fail to initialize checker")
+	require.ErrorContains(t, err, "same table name in case-insensitive")
+	require.ErrorContains(t, err, "same target table `test`.`T` vs `test`.`t`")
+	require.NotContains(t, err.Error(), "matches more than one rule")
+
+	processErr := unit.NewProcessError(err)
+	require.Contains(t, processErr.Message, "same table name in case-insensitive")
+	require.Contains(t, processErr.Message, "same target table `test`.`T` vs `test`.`t`")
+	require.Empty(t, processErr.RawCause)
+
+	msg, err = CheckSyncConfig(context.Background(), cfgsWithSameTarget, common.DefaultErrorCnt, common.DefaultWarnCnt)
+	require.ErrorContains(t, err, "fail to initialize checker")
+	require.ErrorContains(t, err, "same table name in case-insensitive")
+	require.ErrorContains(t, err, "same target table `test`.`T` vs `test`.`T`")
+	require.NotContains(t, err.Error(), "matches more than one rule")
+	require.Len(t, msg, 0)
+
+	_, err = RunCheckOnConfigs(context.Background(), cfgsWithSameTarget, false, 100, 100)
+	require.ErrorContains(t, err, "fail to initialize checker")
+	require.ErrorContains(t, err, "same table name in case-insensitive")
+	require.ErrorContains(t, err, "same target table `test`.`T` vs `test`.`T`")
+	require.NotContains(t, err.Error(), "matches more than one rule")
+
+	processErr = unit.NewProcessError(err)
+	require.Contains(t, processErr.Message, "same table name in case-insensitive")
+	require.Contains(t, processErr.Message, "same target table `test`.`T` vs `test`.`T`")
+	require.Empty(t, processErr.RawCause)
 }
 
 func TestMetaPositionChecking(t *testing.T) {

--- a/dm/checker/checker.go
+++ b/dm/checker/checker.go
@@ -567,12 +567,12 @@ func (c *Checker) fetchSourceTargetDB(
 		return nil, nil, terror.ErrTaskCheckGenBAList.Delegate(err)
 	}
 	instance.baList = bAList
-	if err := sameTargetTableNameDetectionForRouteRules(instance.cfg.CaseSensitive, instance.cfg.RouteRules); err != nil {
-		return nil, nil, err
-	}
 	r, err := regexprrouter.NewRegExprRouter(instance.cfg.CaseSensitive, instance.cfg.RouteRules)
 	if err != nil {
 		return nil, nil, terror.ErrTaskCheckGenTableRouter.Delegate(err)
+	}
+	if err := sameTargetTableNameDetectionForRouteRules(instance.cfg.CaseSensitive, instance.cfg.RouteRules); err != nil {
+		return nil, nil, err
 	}
 
 	if err != nil {
@@ -892,7 +892,7 @@ func sameTargetTableNameDetectionForRouteRules(caseSensitive bool, rules []*rout
 	sourceTableToTargetNameSets := make(map[string]map[string]string)
 	var messages []string
 	for _, rule := range rules {
-		if rule == nil || rule.TablePattern == "" || rule.TargetSchema == "" {
+		if rule == nil || rule.TablePattern == "" {
 			continue
 		}
 
@@ -900,10 +900,6 @@ func sameTargetTableNameDetectionForRouteRules(caseSensitive bool, rules []*rout
 		if targetTable == "" {
 			targetTable = rule.TablePattern
 		}
-		if targetTable == "" {
-			continue
-		}
-
 		source := filter.Table{
 			Schema: rule.SchemaPattern,
 			Name:   rule.TablePattern,

--- a/dm/checker/checker.go
+++ b/dm/checker/checker.go
@@ -898,7 +898,9 @@ func checkTableRouteCaseCollisions(
 	// reports "matches more than one rule" before the checker can build target
 	// table mappings. Match table-level route rules with the same filter
 	// semantics, but only against source tables that exist and remain after
-	// block/allow filtering.
+	// block/allow filtering. Schema-level route conflicts intentionally keep the
+	// router's generic duplicate-rule error because they are outside this target-
+	// table diagnostic.
 	type matchableRule struct {
 		rule    *router.TableRule
 		matcher *filter.Filter
@@ -950,7 +952,7 @@ func checkTableRouteCaseCollisions(
 			nameL := strings.ToLower(name)
 			if nameO, ok := targetNameSets[nameL]; !ok {
 				targetNameSets[nameL] = name
-			} else {
+			} else if nameO != name {
 				message := fmt.Sprintf("same target table %v vs %s", nameO, name)
 				if _, ok := messageSet[message]; !ok {
 					messageSet[message] = struct{}{}

--- a/dm/checker/checker.go
+++ b/dm/checker/checker.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/pkg/util/dbutil"
 	"github.com/pingcap/tidb/pkg/util/filter"
 	regexprrouter "github.com/pingcap/tidb/pkg/util/regexpr-router"
+	router "github.com/pingcap/tidb/pkg/util/table-router"
 	"github.com/pingcap/tiflow/dm/config"
 	"github.com/pingcap/tiflow/dm/config/dbconfig"
 	"github.com/pingcap/tiflow/dm/loader"
@@ -566,6 +567,9 @@ func (c *Checker) fetchSourceTargetDB(
 		return nil, nil, terror.ErrTaskCheckGenBAList.Delegate(err)
 	}
 	instance.baList = bAList
+	if err := sameTargetTableNameDetectionForRouteRules(instance.cfg.CaseSensitive, instance.cfg.RouteRules); err != nil {
+		return nil, nil, err
+	}
 	r, err := regexprrouter.NewRegExprRouter(instance.cfg.CaseSensitive, instance.cfg.RouteRules)
 	if err != nil {
 		return nil, nil, terror.ErrTaskCheckGenTableRouter.Delegate(err)
@@ -861,6 +865,61 @@ func sameTableNameDetection(tables map[filter.Table][]filter.Table) error {
 
 	for tbl := range tables {
 		name := tbl.String()
+		nameL := strings.ToLower(name)
+		if nameO, ok := tableNameSets[nameL]; !ok {
+			tableNameSets[nameL] = name
+		} else {
+			messages = append(messages, fmt.Sprintf("same target table %v vs %s", nameO, name))
+		}
+	}
+
+	if len(messages) > 0 {
+		return terror.ErrTaskCheckSameTableName.Generate(messages)
+	}
+
+	return nil
+}
+
+func sameTargetTableNameDetectionForRouteRules(caseSensitive bool, rules []*router.TableRule) error {
+	if caseSensitive {
+		return nil
+	}
+
+	// regexprrouter matches source patterns case-insensitively in this mode and
+	// reports "matches more than one rule" before the checker can build target
+	// table mappings. Detect the same-target-table conflict from the route
+	// rules first so the precheck reports the actionable table names.
+	sourceTableToTargetNameSets := make(map[string]map[string]string)
+	var messages []string
+	for _, rule := range rules {
+		if rule == nil || rule.TablePattern == "" || rule.TargetSchema == "" {
+			continue
+		}
+
+		targetTable := rule.TargetTable
+		if targetTable == "" {
+			targetTable = rule.TablePattern
+		}
+		if targetTable == "" {
+			continue
+		}
+
+		source := filter.Table{
+			Schema: rule.SchemaPattern,
+			Name:   rule.TablePattern,
+		}
+		sourceNameL := strings.ToLower(source.String())
+		tableNameSets := sourceTableToTargetNameSets[sourceNameL]
+		if tableNameSets == nil {
+			tableNameSets = make(map[string]string)
+			sourceTableToTargetNameSets[sourceNameL] = tableNameSets
+		}
+
+		target := filter.Table{
+			Schema: rule.TargetSchema,
+			Name:   targetTable,
+		}
+		name := target.String()
 		nameL := strings.ToLower(name)
 		if nameO, ok := tableNameSets[nameL]; !ok {
 			tableNameSets[nameL] = name

--- a/dm/checker/checker.go
+++ b/dm/checker/checker.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -571,9 +572,6 @@ func (c *Checker) fetchSourceTargetDB(
 	if err != nil {
 		return nil, nil, terror.ErrTaskCheckGenTableRouter.Delegate(err)
 	}
-	if err := sameTargetTableNameDetectionForRouteRules(instance.cfg.CaseSensitive, instance.cfg.RouteRules); err != nil {
-		return nil, nil, err
-	}
 
 	if err != nil {
 		return nil, nil, terror.ErrTaskCheckGenColumnMapping.Delegate(err)
@@ -603,7 +601,14 @@ func (c *Checker) fetchSourceTargetDB(
 	if err != nil {
 		return nil, nil, terror.WithScope(terror.ErrTaskCheckFailedOpenDB.Delegate(err, instance.cfg.To.User, instance.cfg.To.Host, instance.cfg.To.Port), terror.ScopeDownstream)
 	}
-	return conn.FetchTargetDoTables(ctx, instance.cfg.SourceID, instance.sourceDB, instance.baList, r)
+	sourceTables, err := conn.FetchAllDoTables(ctx, instance.sourceDB, instance.baList)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := checkTableRouteCaseCollisions(instance.cfg.CaseSensitive, instance.cfg.RouteRules, sourceTables); err != nil {
+		return nil, nil, err
+	}
+	return conn.RouteTargetDoTables(instance.cfg.SourceID, sourceTables, r)
 }
 
 func (c *Checker) displayCheckingItems() string {
@@ -880,47 +885,78 @@ func sameTableNameDetection(tables map[filter.Table][]filter.Table) error {
 	return nil
 }
 
-func sameTargetTableNameDetectionForRouteRules(caseSensitive bool, rules []*router.TableRule) error {
-	if caseSensitive {
+func checkTableRouteCaseCollisions(
+	caseSensitive bool,
+	rules []*router.TableRule,
+	sourceTables map[string][]string,
+) error {
+	if caseSensitive || len(sourceTables) == 0 {
 		return nil
 	}
 
 	// regexprrouter matches source patterns case-insensitively in this mode and
 	// reports "matches more than one rule" before the checker can build target
-	// table mappings. Detect the same-target-table conflict from the route
-	// rules first so the precheck reports the actionable table names.
-	sourceTableToTargetNameSets := make(map[string]map[string]string)
-	var messages []string
+	// table mappings. Match table-level route rules with the same filter
+	// semantics, but only against source tables that exist and remain after
+	// block/allow filtering.
+	type matchableRule struct {
+		rule    *router.TableRule
+		matcher *filter.Filter
+	}
+	matchableRules := make([]matchableRule, 0, len(rules))
 	for _, rule := range rules {
 		if rule == nil || rule.TablePattern == "" {
 			continue
 		}
 
-		targetTable := rule.TargetTable
-		if targetTable == "" {
-			targetTable = rule.TablePattern
+		matcher, err := filter.New(false, &filter.Rules{
+			DoDBs: []string{rule.SchemaPattern},
+			DoTables: []*filter.Table{
+				{Schema: rule.SchemaPattern, Name: rule.TablePattern},
+			},
+		})
+		if err != nil {
+			return terror.ErrTaskCheckGenTableRouter.Delegate(err)
 		}
-		source := filter.Table{
-			Schema: rule.SchemaPattern,
-			Name:   rule.TablePattern,
-		}
-		sourceNameL := strings.ToLower(source.String())
-		tableNameSets := sourceTableToTargetNameSets[sourceNameL]
-		if tableNameSets == nil {
-			tableNameSets = make(map[string]string)
-			sourceTableToTargetNameSets[sourceNameL] = tableNameSets
-		}
+		matchableRules = append(matchableRules, matchableRule{rule: rule, matcher: matcher})
+	}
 
-		target := filter.Table{
-			Schema: rule.TargetSchema,
-			Name:   targetTable,
+	selectedTables := make([]filter.Table, 0)
+	for schema, tables := range sourceTables {
+		for _, table := range tables {
+			selectedTables = append(selectedTables, filter.Table{Schema: schema, Name: table})
 		}
-		name := target.String()
-		nameL := strings.ToLower(name)
-		if nameO, ok := tableNameSets[nameL]; !ok {
-			tableNameSets[nameL] = name
-		} else {
-			messages = append(messages, fmt.Sprintf("same target table %v vs %s", nameO, name))
+	}
+	sort.Slice(selectedTables, func(i, j int) bool {
+		return selectedTables[i].String() < selectedTables[j].String()
+	})
+
+	var messages []string
+	messageSet := make(map[string]struct{})
+	for i := range selectedTables {
+		targetNameSets := make(map[string]string)
+		for _, matchable := range matchableRules {
+			if !matchable.matcher.Match(&selectedTables[i]) {
+				continue
+			}
+
+			targetTable := matchable.rule.TargetTable
+			if targetTable == "" {
+				targetTable = selectedTables[i].Name
+			}
+
+			target := filter.Table{Schema: matchable.rule.TargetSchema, Name: targetTable}
+			name := target.String()
+			nameL := strings.ToLower(name)
+			if nameO, ok := targetNameSets[nameL]; !ok {
+				targetNameSets[nameL] = name
+			} else {
+				message := fmt.Sprintf("same target table %v vs %s", nameO, name)
+				if _, ok := messageSet[message]; !ok {
+					messageSet[message] = struct{}{}
+					messages = append(messages, message)
+				}
+			}
 		}
 	}
 

--- a/dm/pkg/conn/db.go
+++ b/dm/pkg/conn/db.go
@@ -519,6 +519,20 @@ func FetchTargetDoTables(
 ) (map[filter.Table][]filter.Table, map[filter.Table][]string, error) {
 	// fetch tables from source and filter them
 	sourceTables, err := FetchAllDoTables(ctx, db, bw)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return RouteTargetDoTables(source, sourceTables, router)
+}
+
+// RouteTargetDoTables routes filtered source tables to their target tables.
+func RouteTargetDoTables(
+	source string,
+	sourceTables map[string][]string,
+	router *regexprrouter.RouteTable,
+) (map[filter.Table][]filter.Table, map[filter.Table][]string, error) {
+	var err error
 
 	failpoint.Inject("FetchTargetDoTablesFailed", func(val failpoint.Value) {
 		err = tmysql.NewErr(uint16(val.(int)))

--- a/dm/pkg/conn/db_test.go
+++ b/dm/pkg/conn/db_test.go
@@ -696,6 +696,27 @@ func TestFetchTargetDoTables(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestRouteTargetDoTables(t *testing.T) {
+	t.Parallel()
+
+	r, err := regexprrouter.NewRegExprRouter(false, []*router.TableRule{
+		{SchemaPattern: "shard*", TablePattern: "tbl*", TargetSchema: "shard", TargetTable: "tbl"},
+	})
+	require.NoError(t, err)
+
+	tablesMap, extendedCols, err := RouteTargetDoTables("", map[string][]string{
+		"shard1": {"tbl1", "tbl2"},
+	}, r)
+	require.NoError(t, err)
+	require.Equal(t, map[filter.Table][]filter.Table{
+		{Schema: "shard", Name: "tbl"}: {
+			{Schema: "shard1", Name: "tbl1"},
+			{Schema: "shard1", Name: "tbl2"},
+		},
+	}, tablesMap)
+	require.Empty(t, extendedCols)
+}
+
 func addRowsForSchemas(rows *sqlmock.Rows, schemas []string) {
 	for _, d := range schemas {
 		rows.AddRow(d)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow!
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12737

DM precheck can report a confusing raw table-router error when multiple case-insensitive table route rules match the same selected source table, for example:

```text
RawCause: table test.T matches more than one rule
```

This hides the existing clearer same-target-table diagnostic.

### What is changed and how it works?

After validating the regular-expression router, DM now discovers source tables and applies the block/allow list before checking table-route collisions. For each selected source table, the checker uses the same filter semantics as the router to find matching table-level route rules.

When multiple matching table-level rules map to target tables whose fully qualified names differ only in letter case, the checker returns the existing `ErrTaskCheckSameTableName` error with actionable details such as:

```text
same target table `test`.`T` vs `test`.`t`
```

The check runs immediately before routing, so a real target-name case collision receives the clearer diagnostic while rules for nonexistent or block/allow-list-excluded tables keep their previous behavior. Exact-identical targets, different targets, and schema-level route conflicts continue to use the router's existing duplicate-rule error so the workaround correctly points users to the route rules.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test

Commands run:

```text
gofmt -w dm/checker/checker.go dm/checker/check_test.go dm/pkg/conn/db.go dm/pkg/conn/db_test.go
go test ./dm/checker ./dm/pkg/conn -count=1
git diff --check
```

Coverage includes actual selected-table collisions, nonexistent rules, block/allow-list-excluded tables, wildcard/exact pattern overlap, implicit target-table fallback, exact-identical targets retaining the source-route error, different targets, schema-level routes retaining the router error, invalid target schema, and the extracted routing helper.

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No compatibility break is expected. The new diagnostic is limited to selected source tables that would already fail with the router's multiple-rule error; unused and filtered-out route rules do not introduce new failures. The checker performs one additional route-rule matching pass during initialization.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix a confusing DM precheck error message when case-insensitive table route rules for a selected source table map to target table names that differ only in letter case.
```

