### PR TITLE
metrics(ticdc): filter inactive tikv cdc metrics

### DIFF
--- a/metrics/grafana/ticdc.json
+++ b/metrics/grafana/ticdc.json
@@ -732,7 +732,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "scalar(max(pd_cluster_tso{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}))/1000 - avg(tikv_cdc_min_resolved_ts{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"}/1000) by (instance) > 0",
+              "expr": "scalar(max(pd_cluster_tso{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}))/1000 - avg((tikv_cdc_min_resolved_ts{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"}/1000) and (tikv_cdc_captured_region_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"} > 0)) by (instance) > 0",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -11439,7 +11439,7 @@
             },
             {
               "exemplar": true,
-              "expr": "max(tikv_cdc_min_resolved_ts_lag{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"}/1000)",
+              "expr": "max((tikv_cdc_min_resolved_ts_lag{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"}/1000) and (tikv_cdc_captured_region_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"} > 0))",
               "hide": false,
               "interval": "",
               "legendFormat": "tikv",
@@ -16549,7 +16549,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "scalar(max(pd_cluster_tso{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}))/1000 - avg(tikv_cdc_min_resolved_ts{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"}/1000) by (instance) > 0",
+              "expr": "scalar(max(pd_cluster_tso{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\"}))/1000 - avg((tikv_cdc_min_resolved_ts{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"}/1000) and (tikv_cdc_captured_region_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"} > 0)) by (instance) > 0",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -16570,7 +16570,7 @@
             },
             {
               "exemplar": true,
-              "expr": "sum(tikv_cdc_min_resolved_ts{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"}) by (instance)",
+              "expr": "sum(tikv_cdc_min_resolved_ts{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"} and (tikv_cdc_captured_region_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"} > 0)) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -16681,7 +16681,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(tikv_cdc_min_resolved_ts_region{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"}) by (instance)",
+              "expr": "sum(tikv_cdc_min_resolved_ts_region{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"} and (tikv_cdc_captured_region_total{k8s_cluster=\"$k8s_cluster\", tidb_cluster=\"$tidb_cluster\", instance=~\"$tikv_instance\"} > 0)) by (instance)",
               "format": "time_series",
               "hide": false,
               "interval": "",


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow!
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12734

### What is changed and how it works?

This PR updates the TiCDC Grafana dashboard queries for TiKV CDC min resolved-ts metrics to filter out inactive TiKV instances whose `tikv_cdc_captured_region_total` is `0`.

After CDC region leadership moves away from a TiKV instance, TiKV can still expose stale `tikv_cdc_min_resolved_ts`, `tikv_cdc_min_resolved_ts_region`, and `tikv_cdc_min_resolved_ts_lag` values. Filtering by `tikv_cdc_captured_region_total > 0` prevents these stale values from being shown as an increasing resolved-ts lag in the dashboard.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Manual test
   - `jq empty metrics/grafana/ticdc.json`
   - `bash scripts/check-ticdc-dashboard.sh`
   -  Verified Grafana dashboard after the fix
   before fix
   <img width="3024" height="1430" alt="修复前" src="https://github.com/user-attachments/assets/38429a6e-b42b-4e7a-9fe7-2a6c7a14da36" />
   now 
<img width="3022" height="1452" alt="修复后" src="https://github.com/user-attachments/assets/02eed50e-ca6d-4a47-b3f0-dce673713584" />




 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No. This only changes Grafana PromQL expressions and does not affect TiCDC runtime behavior.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No. This PR updates the TiCDC Grafana dashboard directly.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Fix the TiCDC Grafana dashboard to ignore inactive TiKV CDC instances when showing TiKV CDC min resolved-ts metrics.
```
