### PR TITLE
docs: update Go version requirement to 1.25.12 (release-8.5)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ your contribution accepted.
 
 Developing TiDB-CDC requires:
 
-* [Go 1.23+](https://go.dev/doc/code)
+* [Go 1.25.10+](https://go.dev/doc/code)
 * An internet connection to download the dependencies
 
 Simply run `make` to build the program.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ your contribution accepted.
 
 Developing TiDB-CDC requires:
 
-* [Go 1.25.10+](https://go.dev/doc/code)
+* [Go 1.25.12+](https://go.dev/doc/code)
 * An internet connection to download the dependencies
 
 Simply run `make` to build the program.

--- a/README_DM.md
+++ b/README_DM.md
@@ -19,7 +19,7 @@ To check the code style and build binaries, you can simply run:
 make build
 ```
 
-Note that DM supports building with the Go version `Go >= 1.23`. For unit test preparation, see [Running/Unit Test](dm/tests/README.md#Unit-Test).
+Note that DM supports building with the Go version `Go >= 1.25.10`. For unit test preparation, see [Running/Unit Test](dm/tests/README.md#Unit-Test).
 
 If you only want to build binaries, you can run:
 

--- a/README_DM.md
+++ b/README_DM.md
@@ -19,7 +19,7 @@ To check the code style and build binaries, you can simply run:
 make build
 ```
 
-Note that DM supports building with the Go version `Go >= 1.25.10`. For unit test preparation, see [Running/Unit Test](dm/tests/README.md#Unit-Test).
+Note that DM supports building with the Go version `Go >= 1.25.12`. For unit test preparation, see [Running/Unit Test](dm/tests/README.md#Unit-Test).
 
 If you only want to build binaries, you can run:
 

--- a/README_TiCDC.md
+++ b/README_TiCDC.md
@@ -27,7 +27,7 @@ $ make cdc
 $ make test
 ```
 
-Note that TiCDC supports building with the Go version `Go >= 1.23`.
+Note that TiCDC supports building with the Go version `Go >= 1.25.10`.
 
 When TiCDC is built successfully, you can find binary in the `bin` directory. Instructions for unit test and integration test can be found in [Running tests](./tests/integration_tests/README.md).
 

--- a/README_TiCDC.md
+++ b/README_TiCDC.md
@@ -27,7 +27,7 @@ $ make cdc
 $ make test
 ```
 
-Note that TiCDC supports building with the Go version `Go >= 1.25.10`.
+Note that TiCDC supports building with the Go version `Go >= 1.25.12`.
 
 When TiCDC is built successfully, you can find binary in the `bin` directory. Instructions for unit test and integration test can be found in [Running tests](./tests/integration_tests/README.md).
 


### PR DESCRIPTION
### What problem does this PR solve?

The `go.mod` declares `go 1.25.10`, but three documentation files still reference Go 1.23 as the minimum version requirement.

Issue Number: ref https://github.com/pingcap/tiflow/issues/xxx

### What is changed and how it works?

Update Go version requirement in 3 documentation files to match `go.mod`:
- `README_DM.md`: `Go >= 1.23` → `Go >= 1.25.10`
- `README_TiCDC.md`: `Go >= 1.23` → `Go >= 1.25.10`
- `CONTRIBUTING.md`: `Go 1.23+` → `Go 1.25.10+`

### Check List

#### Tests

- [x] No code

#### Questions

##### Will it cause performance regression or break compatibility?

No. Documentation-only change.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No. This PR itself is a documentation update.

### Release note

```release-note
None
```