### PR TITLE
checker: support HeatWave grants in precheck

### DIFF
--- a/dm/pkg/checker/conn_checker.go
+++ b/dm/pkg/checker/conn_checker.go
@@ -18,7 +18,6 @@ import (
 	"database/sql"
 
 	"github.com/pingcap/tidb/pkg/parser/mysql"
-	"github.com/pingcap/tidb/pkg/util/dbutil"
 	"github.com/pingcap/tiflow/dm/config"
 	"github.com/pingcap/tiflow/dm/pkg/conn"
 	tcontext "github.com/pingcap/tiflow/dm/pkg/context"
@@ -89,7 +88,7 @@ func (c *connNumberChecker) check(ctx context.Context, checkerName string, neede
 	}
 	// check super privilege for SHOW PROCESSLIST
 	usedConn := 0
-	grants, err := dbutil.ShowGrants(ctx, c.toCheckDB.DB, "", "")
+	grants, err := showGrants(ctx, c.toCheckDB.DB, "", "")
 	if err != nil {
 		markCheckError(result, err)
 		return result

--- a/dm/pkg/checker/privilege.go
+++ b/dm/pkg/checker/privilege.go
@@ -86,7 +86,7 @@ func (pc *SourceDumpPrivilegeChecker) Check(ctx context.Context) *Result {
 		Extra: fmt.Sprintf("address of db instance - %s:%d", pc.dbinfo.Host, pc.dbinfo.Port),
 	}
 
-	grants, err := dbutil.ShowGrants(ctx, pc.db, "", "")
+	grants, err := showGrants(ctx, pc.db, "", "")
 	if err != nil {
 		markCheckError(result, err)
 		return result
@@ -149,7 +149,7 @@ func (pc *SourceReplicatePrivilegeChecker) Check(ctx context.Context) *Result {
 		Extra: fmt.Sprintf("address of db instance - %s:%d", pc.dbinfo.Host, pc.dbinfo.Port),
 	}
 
-	grants, err := dbutil.ShowGrants(ctx, pc.db, "", "")
+	grants, err := showGrants(ctx, pc.db, "", "")
 	if err != nil {
 		markCheckError(result, err)
 		return result
@@ -193,7 +193,7 @@ func (t *TargetPrivilegeChecker) Check(ctx context.Context) *Result {
 		State: StateSuccess,
 		Extra: fmt.Sprintf("address of db instance - %s:%d", t.dbinfo.Host, t.dbinfo.Port),
 	}
-	grants, err := dbutil.ShowGrants(ctx, t.db, "", "")
+	grants, err := showGrants(ctx, t.db, "", "")
 	if err != nil {
 		markCheckError(result, err)
 		return result
@@ -303,9 +303,13 @@ func VerifyPrivileges(
 		p.SetMariaDB(true)
 	}
 
+	requiredPrivs := cloneRequiredPrivs(lackPrivs)
 	for _, grant := range grants {
-		if len(lackPrivs) == 0 {
-			break
+		if len(lackPrivs) == 0 && !isRevokeGrant(grant) {
+			continue
+		}
+		if shouldSkipGrantForPrivilegeCheck(grant) {
+			continue
 		}
 		node, err := p.ParseOneStmt(grant, "", "")
 		if err != nil {
@@ -313,8 +317,11 @@ func VerifyPrivileges(
 		}
 		grantStmt, ok := node.(*ast.GrantStmt)
 		if !ok {
-			switch node.(type) {
+			switch stmt := node.(type) {
 			case *ast.GrantProxyStmt, *ast.GrantRoleStmt:
+				continue
+			case *ast.RevokeStmt:
+				restoreRevokedPrivs(lackPrivs, requiredPrivs, stmt)
 				continue
 			default:
 				return nil, errors.Errorf("%s is not grant statement", grant)
@@ -330,6 +337,16 @@ func VerifyPrivileges(
 		switch grantStmt.Level.Level {
 		case ast.GrantLevelGlobal:
 			for _, privElem := range grantStmt.Privs {
+				if privElem.Priv == mysql.ExtendedPriv {
+					// MySQL 8.0/HeatWave expose FLUSH_TABLES as a dynamic privilege.
+					// It is sufficient for FLUSH TABLES WITH READ LOCK, which is the
+					// actual operation behind DM's historical RELOAD privilege check.
+					// Do not treat sibling FLUSH_* dynamic privileges as equivalent.
+					if strings.EqualFold(privElem.Name, "FLUSH_TABLES") {
+						delete(lackPrivs, mysql.ReloadPriv)
+					}
+					continue
+				}
 				// all privileges available at a given privilege level (except GRANT OPTION)
 				// from https://dev.mysql.com/doc/refman/5.7/en/privileges-provided.html#priv_all
 				if privElem.Priv == mysql.AllPriv {
@@ -339,7 +356,8 @@ func VerifyPrivileges(
 						}
 						continue
 					}
-					return nil, nil
+					lackPrivs = make(map[mysql.PrivilegeType]priv)
+					continue
 				}
 				// mysql> show master status;
 				// ERROR 1227 (42000): Access denied; you need (at least one of) the SUPER, REPLICATION CLIENT privilege(s) for this operation
@@ -434,6 +452,319 @@ func VerifyPrivileges(
 	}
 
 	return lackPrivs, nil
+}
+
+func cloneRequiredPrivs(requiredPrivs map[mysql.PrivilegeType]priv) map[mysql.PrivilegeType]priv {
+	cloned := make(map[mysql.PrivilegeType]priv, len(requiredPrivs))
+	for privName, privs := range requiredPrivs {
+		cloned[privName] = clonePriv(privs)
+	}
+	return cloned
+}
+
+func clonePriv(privs priv) priv {
+	cloned := priv{needGlobal: privs.needGlobal}
+	if privs.dbs == nil {
+		return cloned
+	}
+	cloned.dbs = make(map[string]dbPriv, len(privs.dbs))
+	for dbName, dbPrivs := range privs.dbs {
+		clonedDBPrivs := dbPriv{wholeDB: dbPrivs.wholeDB}
+		if dbPrivs.tables != nil {
+			clonedDBPrivs.tables = make(map[string]tablePriv, len(dbPrivs.tables))
+			for tableName, tablePrivs := range dbPrivs.tables {
+				clonedTablePrivs := tablePriv{wholeTable: tablePrivs.wholeTable}
+				if tablePrivs.columns != nil {
+					clonedTablePrivs.columns = make(map[string]struct{}, len(tablePrivs.columns))
+					for columnName := range tablePrivs.columns {
+						clonedTablePrivs.columns[columnName] = struct{}{}
+					}
+				}
+				clonedDBPrivs.tables[tableName] = clonedTablePrivs
+			}
+		}
+		cloned.dbs[dbName] = clonedDBPrivs
+	}
+	return cloned
+}
+
+func restoreRevokedPrivs(
+	lackPrivs map[mysql.PrivilegeType]priv,
+	requiredPrivs map[mysql.PrivilegeType]priv,
+	revokeStmt *ast.RevokeStmt,
+) {
+	if revokeStmt.Level == nil {
+		return
+	}
+
+	for privName, requiredPriv := range requiredPrivs {
+		for _, revokedPriv := range revokeStmt.Privs {
+			if !revokePrivCoversRequiredPriv(revokedPriv, privName, revokeStmt.Level.Level, requiredPriv.needGlobal) {
+				continue
+			}
+			restoreRequiredPrivAtLevel(lackPrivs, privName, requiredPriv, revokeStmt.Level)
+			break
+		}
+	}
+}
+
+func revokePrivCoversRequiredPriv(
+	revokedPriv *ast.PrivElem,
+	requiredPriv mysql.PrivilegeType,
+	level ast.GrantLevelType,
+	requiredGlobal bool,
+) bool {
+	switch revokedPriv.Priv {
+	case mysql.AllPriv:
+		if requiredGlobal && level != ast.GrantLevelGlobal && isGlobalOnlyPriv(requiredPriv) {
+			return false
+		}
+		return true
+	case mysql.SuperPriv:
+		return requiredPriv == mysql.SuperPriv || requiredPriv == mysql.ReplicationClientPriv
+	case mysql.ExtendedPriv:
+		return level == ast.GrantLevelGlobal &&
+			requiredPriv == mysql.ReloadPriv &&
+			strings.EqualFold(revokedPriv.Name, "FLUSH_TABLES")
+	default:
+		return revokedPriv.Priv == requiredPriv
+	}
+}
+
+func isGlobalOnlyPriv(privName mysql.PrivilegeType) bool {
+	switch privName {
+	case mysql.ReloadPriv, mysql.ReplicationSlavePriv, mysql.ReplicationClientPriv,
+		mysql.SuperPriv, mysql.GrantPriv:
+		return true
+	default:
+		return false
+	}
+}
+
+func restoreRequiredPrivAtLevel(
+	lackPrivs map[mysql.PrivilegeType]priv,
+	privName mysql.PrivilegeType,
+	requiredPriv priv,
+	revokeLevel *ast.GrantLevel,
+) {
+	if requiredPriv.needGlobal {
+		lackPrivs[privName] = priv{needGlobal: true}
+		return
+	}
+
+	switch revokeLevel.Level {
+	case ast.GrantLevelGlobal:
+		mergePriv(lackPrivs, privName, requiredPriv)
+	case ast.GrantLevelDB:
+		dbPatChar, dbPatType := stringutil.CompilePattern(revokeLevel.DBName, '\\')
+		toRestore := priv{dbs: make(map[string]dbPriv)}
+		for dbName, dbPrivs := range requiredPriv.dbs {
+			if stringutil.DoMatch(dbName, dbPatChar, dbPatType) {
+				toRestore.dbs[dbName] = cloneDBPriv(dbPrivs)
+			}
+		}
+		mergePriv(lackPrivs, privName, toRestore)
+	case ast.GrantLevelTable:
+		dbName := revokeLevel.DBName
+		tablePatChar, tablePatType := stringutil.CompilePattern(revokeLevel.TableName, '\\')
+		requiredDBPrivs, ok := requiredPriv.dbs[dbName]
+		if !ok {
+			return
+		}
+		if requiredDBPrivs.wholeDB {
+			mergePriv(lackPrivs, privName, priv{
+				dbs: map[string]dbPriv{dbName: cloneDBPriv(requiredDBPrivs)},
+			})
+			return
+		}
+		toRestoreDBPrivs := dbPriv{tables: make(map[string]tablePriv)}
+		for tableName, tablePrivs := range requiredDBPrivs.tables {
+			if stringutil.DoMatch(tableName, tablePatChar, tablePatType) {
+				toRestoreDBPrivs.tables[tableName] = cloneTablePriv(tablePrivs)
+			}
+		}
+		mergePriv(lackPrivs, privName, priv{
+			dbs: map[string]dbPriv{dbName: toRestoreDBPrivs},
+		})
+	}
+}
+
+func cloneDBPriv(dbPrivs dbPriv) dbPriv {
+	cloned := dbPriv{wholeDB: dbPrivs.wholeDB}
+	if dbPrivs.tables == nil {
+		return cloned
+	}
+	cloned.tables = make(map[string]tablePriv, len(dbPrivs.tables))
+	for tableName, tablePrivs := range dbPrivs.tables {
+		cloned.tables[tableName] = cloneTablePriv(tablePrivs)
+	}
+	return cloned
+}
+
+func cloneTablePriv(tablePrivs tablePriv) tablePriv {
+	cloned := tablePriv{wholeTable: tablePrivs.wholeTable}
+	if tablePrivs.columns == nil {
+		return cloned
+	}
+	cloned.columns = make(map[string]struct{}, len(tablePrivs.columns))
+	for columnName := range tablePrivs.columns {
+		cloned.columns[columnName] = struct{}{}
+	}
+	return cloned
+}
+
+func mergePriv(lackPrivs map[mysql.PrivilegeType]priv, privName mysql.PrivilegeType, toRestore priv) {
+	if toRestore.needGlobal {
+		lackPrivs[privName] = priv{needGlobal: true}
+		return
+	}
+	if len(toRestore.dbs) == 0 {
+		return
+	}
+
+	existingPriv := lackPrivs[privName]
+	if existingPriv.needGlobal {
+		return
+	}
+	if existingPriv.dbs == nil {
+		existingPriv.dbs = make(map[string]dbPriv, len(toRestore.dbs))
+	}
+	for dbName, dbPrivs := range toRestore.dbs {
+		if !dbPrivs.wholeDB && len(dbPrivs.tables) == 0 {
+			continue
+		}
+		existingDBPrivs, ok := existingPriv.dbs[dbName]
+		if !ok || dbPrivs.wholeDB || existingDBPrivs.wholeDB {
+			existingPriv.dbs[dbName] = cloneDBPriv(dbPrivs)
+			continue
+		}
+		if existingDBPrivs.tables == nil {
+			existingDBPrivs.tables = make(map[string]tablePriv, len(dbPrivs.tables))
+		}
+		for tableName, tablePrivs := range dbPrivs.tables {
+			existingDBPrivs.tables[tableName] = cloneTablePriv(tablePrivs)
+		}
+		existingPriv.dbs[dbName] = existingDBPrivs
+	}
+	lackPrivs[privName] = existingPriv
+}
+
+func showGrants(ctx context.Context, db dbutil.QueryExecutor, user, host string) ([]string, error) {
+	if host == "" {
+		host = "%"
+	}
+
+	query := "SHOW GRANTS FOR CURRENT_USER"
+	if user != "" {
+		query = fmt.Sprintf("SHOW GRANTS FOR '%s'@'%s'", user, host)
+	}
+
+	readGrants := func(query string) ([]string, error) {
+		rows, err := db.QueryContext(ctx, query)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		defer rows.Close()
+
+		grants := make([]string, 0, 8)
+		for rows.Next() {
+			var grant string
+			if err := rows.Scan(&grant); err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			// TiDB parser does not support parse `IDENTIFIED BY PASSWORD <secret>`,
+			// but it may appear in some cases, ref: https://dev.mysql.com/doc/refman/5.6/en/show-grants.html.
+			// We do not need the password in grant statement, so we can replace it.
+			grant = strings.Replace(grant, "IDENTIFIED BY PASSWORD <secret>", "IDENTIFIED BY PASSWORD 'secret'", 1)
+
+			// support parse `IDENTIFIED BY PASSWORD WITH {GRANT OPTION | resource_option} ...`
+			grant = strings.Replace(grant, "IDENTIFIED BY PASSWORD WITH", "IDENTIFIED BY PASSWORD 'secret' WITH", 1)
+
+			// support parse `IDENTIFIED BY PASSWORD`
+			if strings.HasSuffix(grant, "IDENTIFIED BY PASSWORD") {
+				grant = grant + " 'secret'"
+			}
+
+			grants = append(grants, grant)
+		}
+		if err := rows.Err(); err != nil {
+			return nil, errors.Trace(err)
+		}
+		return grants, nil
+	}
+
+	grants, err := readGrants(query)
+	if err != nil {
+		return nil, err
+	}
+
+	// For MySQL 8.0, collect granted roles and read grants using those roles.
+	// HeatWave SHOW GRANTS may append `WITH ADMIN OPTION` to role grants, which
+	// TiDB parser cannot parse yet. Strip the suffix for role discovery only.
+	var roles []string
+	p := parser.New()
+	for _, grant := range grants {
+		grantForParse := grant
+		if isRoleGrantWithAdminOption(grant) {
+			grantForParse = trimAdminOption(grant)
+		}
+		node, err := p.ParseOneStmt(grantForParse, "", "")
+		if err != nil {
+			log.L().Warn("failed to parse grant statement during role discovery",
+				zap.String("grant", grant), zap.Error(err))
+			continue
+		}
+		if grantRoleStmt, ok := node.(*ast.GrantRoleStmt); ok {
+			for _, role := range grantRoleStmt.Roles {
+				roles = append(roles, role.String())
+			}
+		}
+	}
+	if len(roles) == 0 {
+		return grants, nil
+	}
+
+	var builder strings.Builder
+	builder.WriteString(query)
+	builder.WriteString(" USING ")
+	for i, role := range roles {
+		if i > 0 {
+			builder.WriteString(", ")
+		}
+		builder.WriteString(role)
+	}
+	return readGrants(builder.String())
+}
+
+func shouldSkipGrantForPrivilegeCheck(grant string) bool {
+	return isRoleGrantWithAdminOption(grant)
+}
+
+func isRevokeGrant(grant string) bool {
+	return strings.HasPrefix(strings.ToUpper(strings.TrimSpace(grant)), "REVOKE ")
+}
+
+func isRoleGrantWithAdminOption(grant string) bool {
+	normalized := strings.ToUpper(strings.Join(strings.Fields(grant), " "))
+
+	// MySQL 8.0 and HeatWave SHOW GRANTS may return role grants with
+	// `WITH ADMIN OPTION`, while TiDB parser currently accepts GrantRoleStmt
+	// without this suffix only. Role grants do not directly grant the source
+	// privileges checked here, so ignore them just like parsed GrantRoleStmt.
+	return strings.HasPrefix(normalized, "GRANT ") &&
+		strings.Contains(normalized, " TO ") &&
+		strings.Contains(normalized, " WITH ADMIN OPTION") &&
+		!strings.Contains(normalized, " ON ")
+}
+
+func trimAdminOption(grant string) string {
+	trimmed := strings.TrimSpace(grant)
+	const suffix = " WITH ADMIN OPTION"
+	if len(trimmed) < len(suffix) || !strings.EqualFold(trimmed[len(trimmed)-len(suffix):], suffix) {
+		return grant
+	}
+	return strings.TrimSpace(trimmed[:len(trimmed)-len(suffix)])
 }
 
 func genTableLevelPrivs(tables []filter.Table) map[string]dbPriv {

--- a/dm/pkg/checker/privilege.go
+++ b/dm/pkg/checker/privilege.go
@@ -308,10 +308,7 @@ func VerifyPrivileges(
 		if len(lackPrivs) == 0 && !isRevokeGrant(grant) {
 			continue
 		}
-		if shouldSkipGrantForPrivilegeCheck(grant) {
-			continue
-		}
-		node, err := p.ParseOneStmt(grant, "", "")
+		node, err := p.ParseOneStmt(trimAdminOption(grant), "", "")
 		if err != nil {
 			return nil, errors.New(err.Error())
 		}
@@ -469,21 +466,7 @@ func clonePriv(privs priv) priv {
 	}
 	cloned.dbs = make(map[string]dbPriv, len(privs.dbs))
 	for dbName, dbPrivs := range privs.dbs {
-		clonedDBPrivs := dbPriv{wholeDB: dbPrivs.wholeDB}
-		if dbPrivs.tables != nil {
-			clonedDBPrivs.tables = make(map[string]tablePriv, len(dbPrivs.tables))
-			for tableName, tablePrivs := range dbPrivs.tables {
-				clonedTablePrivs := tablePriv{wholeTable: tablePrivs.wholeTable}
-				if tablePrivs.columns != nil {
-					clonedTablePrivs.columns = make(map[string]struct{}, len(tablePrivs.columns))
-					for columnName := range tablePrivs.columns {
-						clonedTablePrivs.columns[columnName] = struct{}{}
-					}
-				}
-				clonedDBPrivs.tables[tableName] = clonedTablePrivs
-			}
-		}
-		cloned.dbs[dbName] = clonedDBPrivs
+		cloned.dbs[dbName] = cloneDBPriv(dbPrivs)
 	}
 	return cloned
 }
@@ -701,15 +684,11 @@ func showGrants(ctx context.Context, db dbutil.QueryExecutor, user, host string)
 
 	// For MySQL 8.0, collect granted roles and read grants using those roles.
 	// HeatWave SHOW GRANTS may append `WITH ADMIN OPTION` to role grants, which
-	// TiDB parser cannot parse yet. Strip the suffix for role discovery only.
+	// TiDB parser cannot parse yet. trimAdminOption leaves other grants unchanged.
 	var roles []string
 	p := parser.New()
 	for _, grant := range grants {
-		grantForParse := grant
-		if isRoleGrantWithAdminOption(grant) {
-			grantForParse = trimAdminOption(grant)
-		}
-		node, err := p.ParseOneStmt(grantForParse, "", "")
+		node, err := p.ParseOneStmt(trimAdminOption(grant), "", "")
 		if err != nil {
 			log.L().Warn("failed to parse grant statement during role discovery",
 				zap.String("grant", grant), zap.Error(err))
@@ -737,25 +716,8 @@ func showGrants(ctx context.Context, db dbutil.QueryExecutor, user, host string)
 	return readGrants(builder.String())
 }
 
-func shouldSkipGrantForPrivilegeCheck(grant string) bool {
-	return isRoleGrantWithAdminOption(grant)
-}
-
 func isRevokeGrant(grant string) bool {
 	return strings.HasPrefix(strings.ToUpper(strings.TrimSpace(grant)), "REVOKE ")
-}
-
-func isRoleGrantWithAdminOption(grant string) bool {
-	normalized := strings.ToUpper(strings.Join(strings.Fields(grant), " "))
-
-	// MySQL 8.0 and HeatWave SHOW GRANTS may return role grants with
-	// `WITH ADMIN OPTION`, while TiDB parser currently accepts GrantRoleStmt
-	// without this suffix only. Role grants do not directly grant the source
-	// privileges checked here, so ignore them just like parsed GrantRoleStmt.
-	return strings.HasPrefix(normalized, "GRANT ") &&
-		strings.Contains(normalized, " TO ") &&
-		strings.Contains(normalized, " WITH ADMIN OPTION") &&
-		!strings.Contains(normalized, " ON ")
 }
 
 func trimAdminOption(grant string) string {

--- a/dm/pkg/checker/privilege.go
+++ b/dm/pkg/checker/privilege.go
@@ -556,17 +556,17 @@ func restoreRequiredPrivAtLevel(
 	case ast.GrantLevelGlobal:
 		mergePriv(lackPrivs, privName, requiredPriv)
 	case ast.GrantLevelDB:
-		dbPatChar, dbPatType := stringutil.CompilePattern(revokeLevel.DBName, '\\')
 		toRestore := priv{dbs: make(map[string]dbPriv)}
 		for dbName, dbPrivs := range requiredPriv.dbs {
-			if stringutil.DoMatch(dbName, dbPatChar, dbPatType) {
+			// MySQL partial revokes record schema names literally when
+			// partial_revokes is enabled, even if the name contains `_` or `%`.
+			if dbName == revokeLevel.DBName {
 				toRestore.dbs[dbName] = cloneDBPriv(dbPrivs)
 			}
 		}
 		mergePriv(lackPrivs, privName, toRestore)
 	case ast.GrantLevelTable:
 		dbName := revokeLevel.DBName
-		tablePatChar, tablePatType := stringutil.CompilePattern(revokeLevel.TableName, '\\')
 		requiredDBPrivs, ok := requiredPriv.dbs[dbName]
 		if !ok {
 			return
@@ -579,7 +579,7 @@ func restoreRequiredPrivAtLevel(
 		}
 		toRestoreDBPrivs := dbPriv{tables: make(map[string]tablePriv)}
 		for tableName, tablePrivs := range requiredDBPrivs.tables {
-			if stringutil.DoMatch(tableName, tablePatChar, tablePatType) {
+			if tableName == revokeLevel.TableName {
 				toRestoreDBPrivs.tables[tableName] = cloneTablePriv(tablePrivs)
 			}
 		}

--- a/dm/pkg/checker/privilege_test.go
+++ b/dm/pkg/checker/privilege_test.go
@@ -14,8 +14,11 @@
 package checker
 
 import (
+	"context"
+	"regexp"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	tc "github.com/pingcap/check"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/util/filter"
@@ -197,6 +200,42 @@ func TestVerifyDumpPrivileges(t *testing.T) {
 			},
 			dumpState: StateSuccess,
 		},
+		{
+			grants: []string{
+				"GRANT SELECT ON *.* TO `root`@`localhost`",
+				"GRANT FLUSH_TABLES ON *.* TO `root`@`localhost`",
+			},
+			dumpState: StateSuccess,
+		},
+		{
+			grants: []string{
+				"GRANT SELECT ON *.* TO `root`@`localhost`",
+				"GRANT FLUSH_STATUS ON *.* TO `root`@`localhost`",
+			},
+			dumpState: StateFailure,
+			errStr:    "lack of RELOAD global (*.*) privilege; ",
+		},
+		{
+			grants: []string{
+				"GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, PROCESS, REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER, CREATE ROLE, DROP ROLE ON *.* TO `dmtest`@`%` WITH GRANT OPTION",
+				"GRANT APPLICATION_PASSWORD_ADMIN,AUDIT_ADMIN,BACKUP_ADMIN,CONNECTION_ADMIN,EXPORT_QUERY_RESULTS,FIREWALL_ADMIN,FIREWALL_USER,FLUSH_OPTIMIZER_COSTS,FLUSH_STATUS,FLUSH_TABLES,FLUSH_USER_RESOURCES,LOAD_FROM_S3,REPLICATION_APPLIER,ROLE_ADMIN,SET_ANY_DEFINER,SHOW_ROUTINE,XA_RECOVER_ADMIN ON *.* TO `dmtest`@`%` WITH GRANT OPTION",
+				"REVOKE CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES, CREATE VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER ON `sys`.* FROM `dmtest`@`%`",
+				"GRANT PROXY ON ``@`` TO `dmtest`@`%` WITH GRANT OPTION",
+				"GRANT `administrator`@`%` TO `dmtest`@`%` WITH ADMIN OPTION",
+			},
+			dumpState: StateSuccess,
+		},
+		{
+			grants: []string{
+				"GRANT RELOAD, SELECT ON *.* TO `dmtest`@`%`",
+				"REVOKE SELECT ON `db1`.* FROM `dmtest`@`%`",
+			},
+			checkTables: []filter.Table{
+				{Schema: "db1", Name: "tb1"},
+			},
+			dumpState: StateFailure,
+			errStr:    "lack of Select privilege: {`db1`.`tb1`}; ",
+		},
 	}
 
 	for _, cs := range cases {
@@ -221,6 +260,59 @@ func TestVerifyDumpPrivileges(t *testing.T) {
 			require.Equal(t, cs.errStr, err.ShortErr, "grants: %v", cs.grants)
 		}
 	}
+}
+
+func TestShowGrantsWithHeatWaveRoleAdminOption(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SHOW GRANTS FOR CURRENT_USER")).WillReturnRows(
+		sqlmock.NewRows([]string{"Grants for User"}).
+			AddRow("GRANT SELECT ON *.* TO `dmtest`@`%`").
+			AddRow("GRANT `administrator`@`%` TO `dmtest`@`%` WITH ADMIN OPTION"),
+	)
+	mock.ExpectQuery(regexp.QuoteMeta("SHOW GRANTS FOR CURRENT_USER USING `administrator`@`%`")).WillReturnRows(
+		sqlmock.NewRows([]string{"Grants for User"}).
+			AddRow("GRANT SELECT ON *.* TO `dmtest`@`%`").
+			AddRow("GRANT FLUSH_TABLES ON *.* TO `dmtest`@`%`").
+			AddRow("GRANT `administrator`@`%` TO `dmtest`@`%` WITH ADMIN OPTION"),
+	)
+
+	grants, err := showGrants(context.Background(), db, "", "")
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"GRANT SELECT ON *.* TO `dmtest`@`%`",
+		"GRANT FLUSH_TABLES ON *.* TO `dmtest`@`%`",
+		"GRANT `administrator`@`%` TO `dmtest`@`%` WITH ADMIN OPTION",
+	}, grants)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestShowGrantsIgnoresUnparseableGrantForRoleDiscovery(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SHOW GRANTS FOR CURRENT_USER")).WillReturnRows(
+		sqlmock.NewRows([]string{"Grants for User"}).
+			AddRow("GRANT BINLOG MONITOR ON *.* TO `dmtest`@`%`").
+			AddRow("GRANT SELECT ON *.* TO `dmtest`@`%`"),
+	)
+
+	grants, err := showGrants(context.Background(), db, "", "")
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"GRANT BINLOG MONITOR ON *.* TO `dmtest`@`%`",
+		"GRANT SELECT ON *.* TO `dmtest`@`%`",
+	}, grants)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTrimAdminOptionWithNonASCIIGrant(t *testing.T) {
+	grant := "GRANT `admİN`@`%` TO `dmtest`@`%` WITH ADMIN OPTION"
+	require.True(t, isRoleGrantWithAdminOption(grant))
+	require.Equal(t, "GRANT `admİN`@`%` TO `dmtest`@`%`", trimAdminOption(grant))
 }
 
 func TestVerifyReplicationPrivileges(t *testing.T) {

--- a/dm/pkg/checker/privilege_test.go
+++ b/dm/pkg/checker/privilege_test.go
@@ -15,6 +15,7 @@ package checker
 
 import (
 	"context"
+	"errors"
 	"regexp"
 	"testing"
 
@@ -217,6 +218,23 @@ func TestVerifyDumpPrivileges(t *testing.T) {
 		},
 		{
 			grants: []string{
+				"GRANT SELECT ON *.* TO `root`@`localhost`",
+				"GRANT FLUSH_TABLES ON *.* TO `root`@`localhost`",
+				"REVOKE FLUSH_STATUS ON *.* FROM `root`@`localhost`",
+			},
+			dumpState: StateSuccess,
+		},
+		{
+			grants: []string{
+				"GRANT SELECT ON *.* TO `root`@`localhost`",
+				"GRANT FLUSH_TABLES ON *.* TO `root`@`localhost`",
+				"REVOKE FLUSH_TABLES ON *.* FROM `root`@`localhost`",
+			},
+			dumpState: StateFailure,
+			errStr:    "lack of RELOAD global (*.*) privilege; ",
+		},
+		{
+			grants: []string{
 				"GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, PROCESS, REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER, CREATE ROLE, DROP ROLE ON *.* TO `dmtest`@`%` WITH GRANT OPTION",
 				"GRANT APPLICATION_PASSWORD_ADMIN,AUDIT_ADMIN,BACKUP_ADMIN,CONNECTION_ADMIN,EXPORT_QUERY_RESULTS,FIREWALL_ADMIN,FIREWALL_USER,FLUSH_OPTIMIZER_COSTS,FLUSH_STATUS,FLUSH_TABLES,FLUSH_USER_RESOURCES,LOAD_FROM_S3,REPLICATION_APPLIER,ROLE_ADMIN,SET_ANY_DEFINER,SHOW_ROUTINE,XA_RECOVER_ADMIN ON *.* TO `dmtest`@`%` WITH GRANT OPTION",
 				"REVOKE CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES, CREATE VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER ON `sys`.* FROM `dmtest`@`%`",
@@ -232,6 +250,39 @@ func TestVerifyDumpPrivileges(t *testing.T) {
 			},
 			checkTables: []filter.Table{
 				{Schema: "db1", Name: "tb1"},
+			},
+			dumpState: StateFailure,
+			errStr:    "lack of Select privilege: {`db1`.`tb1`}; ",
+		},
+		{
+			grants: []string{
+				"GRANT RELOAD, SELECT ON *.* TO `dmtest`@`%`",
+				"REVOKE SELECT ON `db_%`.* FROM `dmtest`@`%`",
+			},
+			checkTables: []filter.Table{
+				{Schema: "db_01", Name: "tb1"},
+			},
+			dumpState: StateSuccess,
+		},
+		{
+			grants: []string{
+				"GRANT RELOAD, SELECT ON *.* TO `dmtest`@`%`",
+				"REVOKE SELECT ON `db_%`.* FROM `dmtest`@`%`",
+			},
+			checkTables: []filter.Table{
+				{Schema: "db_%", Name: "tb1"},
+			},
+			dumpState: StateFailure,
+			errStr:    "lack of Select privilege: {`db_%`.`tb1`}; ",
+		},
+		{
+			grants: []string{
+				"GRANT RELOAD, SELECT ON *.* TO `dmtest`@`%`",
+				"REVOKE SELECT ON `db1`.`tb1` FROM `dmtest`@`%`",
+			},
+			checkTables: []filter.Table{
+				{Schema: "db1", Name: "tb1"},
+				{Schema: "db1", Name: "tb2"},
 			},
 			dumpState: StateFailure,
 			errStr:    "lack of Select privilege: {`db1`.`tb1`}; ",
@@ -286,6 +337,65 @@ func TestShowGrantsWithHeatWaveRoleAdminOption(t *testing.T) {
 		"GRANT FLUSH_TABLES ON *.* TO `dmtest`@`%`",
 		"GRANT `administrator`@`%` TO `dmtest`@`%` WITH ADMIN OPTION",
 	}, grants)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestShowGrantsForNamedUser(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SHOW GRANTS FOR 'dmuser'@'%'")).WillReturnRows(
+		sqlmock.NewRows([]string{"Grants for User"}).
+			AddRow("GRANT SELECT ON *.* TO `dmuser`@`%`"),
+	)
+
+	grants, err := showGrants(context.Background(), db, "dmuser", "")
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"GRANT SELECT ON *.* TO `dmuser`@`%`",
+	}, grants)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestShowGrantsWithMultipleRoles(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SHOW GRANTS FOR CURRENT_USER")).WillReturnRows(
+		sqlmock.NewRows([]string{"Grants for User"}).
+			AddRow("GRANT `r1`@`%`,`r2`@`%` TO `dmtest`@`%` WITH ADMIN OPTION"),
+	)
+	mock.ExpectQuery(regexp.QuoteMeta("SHOW GRANTS FOR CURRENT_USER USING `r1`@`%`, `r2`@`%`")).WillReturnRows(
+		sqlmock.NewRows([]string{"Grants for User"}).
+			AddRow("GRANT SELECT ON *.* TO `dmtest`@`%`").
+			AddRow("GRANT FLUSH_TABLES ON *.* TO `dmtest`@`%`"),
+	)
+
+	grants, err := showGrants(context.Background(), db, "", "")
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"GRANT SELECT ON *.* TO `dmtest`@`%`",
+		"GRANT FLUSH_TABLES ON *.* TO `dmtest`@`%`",
+	}, grants)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestShowGrantsReturnsUsingQueryError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta("SHOW GRANTS FOR CURRENT_USER")).WillReturnRows(
+		sqlmock.NewRows([]string{"Grants for User"}).
+			AddRow("GRANT `r1`@`%` TO `dmtest`@`%` WITH ADMIN OPTION"),
+	)
+	mock.ExpectQuery(regexp.QuoteMeta("SHOW GRANTS FOR CURRENT_USER USING `r1`@`%`")).
+		WillReturnError(errors.New("show grants using failed"))
+
+	_, err = showGrants(context.Background(), db, "", "")
+	require.ErrorContains(t, err, "show grants using failed")
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -406,6 +516,21 @@ func TestVerifyReplicationPrivileges(t *testing.T) {
 				"GRANT LOAD FROM S3, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER, SELECT INTO S3, SELECT ON *.* TO 'root'@'%' WITH GRANT OPTION",
 			},
 			replicationState: StateSuccess,
+		},
+		{
+			grants: []string{
+				"GRANT ALL PRIVILEGES ON *.* TO `dmtest`@`%`",
+				"REVOKE ALL PRIVILEGES ON `db1`.* FROM `dmtest`@`%`",
+			},
+			replicationState: StateSuccess,
+		},
+		{
+			grants: []string{
+				"GRANT REPLICATION SLAVE, SUPER ON *.* TO `dmtest`@`%`",
+				"REVOKE SUPER ON *.* FROM `dmtest`@`%`",
+			},
+			replicationState: StateFailure,
+			errStr:           "lack of REPLICATION CLIENT global (*.*) privilege; ",
 		},
 	}
 

--- a/dm/pkg/checker/privilege_test.go
+++ b/dm/pkg/checker/privilege_test.go
@@ -210,6 +210,14 @@ func TestVerifyDumpPrivileges(t *testing.T) {
 		},
 		{
 			grants: []string{
+				"GRANT `administrator ON call`@`%` TO `dmtest`@`%` WITH ADMIN OPTION",
+				"GRANT SELECT ON *.* TO `dmtest`@`%`",
+				"GRANT FLUSH_TABLES ON *.* TO `dmtest`@`%`",
+			},
+			dumpState: StateSuccess,
+		},
+		{
+			grants: []string{
 				"GRANT SELECT ON *.* TO `root`@`localhost`",
 				"GRANT FLUSH_STATUS ON *.* TO `root`@`localhost`",
 			},
@@ -419,10 +427,12 @@ func TestShowGrantsIgnoresUnparseableGrantForRoleDiscovery(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestTrimAdminOptionWithNonASCIIGrant(t *testing.T) {
+func TestTrimAdminOption(t *testing.T) {
 	grant := "GRANT `admİN`@`%` TO `dmtest`@`%` WITH ADMIN OPTION"
-	require.True(t, isRoleGrantWithAdminOption(grant))
 	require.Equal(t, "GRANT `admİN`@`%` TO `dmtest`@`%`", trimAdminOption(grant))
+
+	grantWithoutAdminOption := "GRANT SELECT ON *.* TO `dmtest`@`%`"
+	require.Equal(t, grantWithoutAdminOption, trimAdminOption(grantWithoutAdminOption))
 }
 
 func TestVerifyReplicationPrivileges(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #12751

This PR fixes DM precheck compatibility with Oracle HeatWave/MySQL 8 style `SHOW GRANTS` output.

Problems addressed:

- HeatWave may return role grants with `WITH ADMIN OPTION`, which TiDB parser cannot parse as `GrantRoleStmt` yet.
- HeatWave may return partial revoke statements in `SHOW GRANTS`; overlapping revokes must not be reported as sufficient privileges.
- HeatWave grants `FLUSH_TABLES` as a dynamic privilege. It should satisfy the FTWRL dump privilege requirement currently modeled as `RELOAD` in DM precheck.

### What is changed and how it works?

- Add a DM checker-local `showGrants` helper to tolerate role grants with `WITH ADMIN OPTION` while still discovering active roles via `SHOW GRANTS ... USING ...`.
- Make role discovery best-effort: unsupported non-role grant syntax, such as MariaDB-specific grant rows, no longer fails before privilege verification can run with the correct parser mode.
- Skip role grants with `WITH ADMIN OPTION` during direct privilege verification, because role privileges are collected through `SHOW GRANTS ... USING ...`.
- Model overlapping `REVOKE` statements against the required privilege set, so a global grant plus a partial revoke on a checked schema/table fails conservatively.
- Treat global extended privilege `FLUSH_TABLES` as satisfying the dump privilege checker’s FTWRL requirement, without treating sibling `FLUSH_*` dynamic privileges as equivalent.
- Add unit coverage for HeatWave-style grants, role grants with `WITH ADMIN OPTION`, partial revokes, MariaDB-specific grant rows in role discovery, non-ASCII role grant suffix trimming, and `FLUSH_TABLES` dynamic privilege handling.

### Check List

Tests:

- [x] Unit test
- [x] Manual test with real HeatWave source

Manual validation:

- `go test ./dm/pkg/checker ./dm/checker`
- Built `dm-master`, `dm-worker`, and `dmctl` from this branch.
- Ran DM against Oracle HeatWave on AWS MySQL 9.7 with precheck enabled and without `ignore-checking-items`.
- `check-task` passed with only the MySQL version warning.
- `start-task` succeeded.
- Full load plus incremental insert/update/delete synced correctly to TiDB.

Related issue: https://github.com/pingcap/tiflow/issues/12751

### Release note

```release-note
Fix DM precheck compatibility with Oracle HeatWave `SHOW GRANTS` output and dynamic `FLUSH_TABLES` privileges.
```
