### PR TITLE
api(ticdc): return task_status for changefeeds in warning state

### DIFF
--- a/cdc/api/util.go
+++ b/cdc/api/util.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tiflow/cdc/capture"
 	"github.com/pingcap/tiflow/cdc/model"
+	"github.com/pingcap/tiflow/cdc/owner"
 	"github.com/pingcap/tiflow/cdc/scheduler"
 	"github.com/pingcap/tiflow/pkg/config"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
@@ -280,6 +281,31 @@ func ForwardToCapture(c *gin.Context, fromID, toAddr string) {
 		_ = c.Error(err)
 		return
 	}
+}
+
+// CollectTaskStatuses returns the per-capture task statuses of a changefeed.
+func CollectTaskStatuses(
+	ctx context.Context,
+	provider owner.StatusProvider,
+	changefeedID model.ChangeFeedID,
+) ([]model.CaptureTaskStatus, error) {
+	processorInfos, err := provider.GetAllTaskStatuses(ctx, changefeedID)
+	if err != nil {
+		return nil, err
+	}
+	taskStatus := make([]model.CaptureTaskStatus, 0, len(processorInfos))
+	for captureID, status := range processorInfos {
+		tables := make([]int64, 0, len(status.Tables))
+		for tableID := range status.Tables {
+			tables = append(tables, tableID)
+		}
+		taskStatus = append(taskStatus,
+			model.CaptureTaskStatus{
+				CaptureID: captureID, Tables: tables,
+				Operation: status.Operation,
+			})
+	}
+	return taskStatus, nil
 }
 
 // HandleOwnerDrainCapture schedule drain the target capture

--- a/cdc/api/util_test.go
+++ b/cdc/api/util_test.go
@@ -14,9 +14,13 @@
 package api
 
 import (
+	"context"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tiflow/cdc/model"
+	mock_owner "github.com/pingcap/tiflow/cdc/owner/mock"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -31,4 +35,33 @@ func TestIsHTTPBadRequestError(t *testing.T) {
 	require.Equal(t, false, IsHTTPBadRequestError(err))
 	err = nil
 	require.Equal(t, false, IsHTTPBadRequestError(err))
+}
+
+func TestCollectTaskStatuses(t *testing.T) {
+	t.Parallel()
+	changefeedID := model.DefaultChangeFeedID("test-cf")
+
+	// success: task statuses are collected per capture.
+	ctrl := gomock.NewController(t)
+	provider := mock_owner.NewMockStatusProvider(ctrl)
+	provider.EXPECT().GetAllTaskStatuses(gomock.Any(), changefeedID).Return(
+		map[model.CaptureID]*model.TaskStatus{
+			"capture-1": {Tables: map[model.TableID]*model.TableReplicaInfo{
+				3508: {}, 3520: {},
+			}},
+		}, nil)
+	taskStatus, err := CollectTaskStatuses(context.Background(), provider, changefeedID)
+	require.NoError(t, err)
+	require.Len(t, taskStatus, 1)
+	require.Equal(t, "capture-1", taskStatus[0].CaptureID)
+	require.ElementsMatch(t, []model.TableID{3508, 3520}, taskStatus[0].Tables)
+
+	// a lookup failure is propagated to the caller, which decides whether the
+	// task_status can be omitted.
+	provider = mock_owner.NewMockStatusProvider(ctrl)
+	provider.EXPECT().GetAllTaskStatuses(gomock.Any(), changefeedID).Return(
+		nil, cerror.ErrChangeFeedNotExists.GenWithStackByArgs(changefeedID))
+	taskStatus, err = CollectTaskStatuses(context.Background(), provider, changefeedID)
+	require.Error(t, err)
+	require.Nil(t, taskStatus)
 }

--- a/cdc/api/v1/api.go
+++ b/cdc/api/v1/api.go
@@ -210,7 +210,7 @@ func (h *OpenAPI) GetChangefeed(c *gin.Context) {
 	}
 
 	taskStatus := make([]model.CaptureTaskStatus, 0)
-	if info.State == model.StateNormal {
+	if info.State.IsRunning() {
 		processorInfos, err := h.statusProvider().GetAllTaskStatuses(ctx, changefeedID)
 		if err != nil {
 			_ = c.Error(err)

--- a/cdc/api/v1/api.go
+++ b/cdc/api/v1/api.go
@@ -209,24 +209,11 @@ func (h *OpenAPI) GetChangefeed(c *gin.Context) {
 		return
 	}
 
-	taskStatus := make([]model.CaptureTaskStatus, 0)
+	var taskStatus []model.CaptureTaskStatus
 	if info.State.IsRunning() {
-		processorInfos, err := h.statusProvider().GetAllTaskStatuses(ctx, changefeedID)
-		if err != nil {
+		if taskStatus, err = api.CollectTaskStatuses(ctx, h.statusProvider(), changefeedID); err != nil {
 			log.Warn("failed to get task statuses, returning changefeed detail without task_status",
 				zap.String("changefeed", changefeedID.String()), zap.Error(err))
-		} else {
-			for captureID, status := range processorInfos {
-				tables := make([]int64, 0)
-				for tableID := range status.Tables {
-					tables = append(tables, tableID)
-				}
-				taskStatus = append(taskStatus,
-					model.CaptureTaskStatus{
-						CaptureID: captureID, Tables: tables,
-						Operation: status.Operation,
-					})
-			}
 		}
 	}
 	sinkURI, err := util.MaskSinkURI(info.SinkURI)

--- a/cdc/api/v1/api.go
+++ b/cdc/api/v1/api.go
@@ -213,19 +213,20 @@ func (h *OpenAPI) GetChangefeed(c *gin.Context) {
 	if info.State.IsRunning() {
 		processorInfos, err := h.statusProvider().GetAllTaskStatuses(ctx, changefeedID)
 		if err != nil {
-			_ = c.Error(err)
-			return
-		}
-		for captureID, status := range processorInfos {
-			tables := make([]int64, 0)
-			for tableID := range status.Tables {
-				tables = append(tables, tableID)
+			log.Warn("failed to get task statuses, returning changefeed detail without task_status",
+				zap.String("changefeed", changefeedID.String()), zap.Error(err))
+		} else {
+			for captureID, status := range processorInfos {
+				tables := make([]int64, 0)
+				for tableID := range status.Tables {
+					tables = append(tables, tableID)
+				}
+				taskStatus = append(taskStatus,
+					model.CaptureTaskStatus{
+						CaptureID: captureID, Tables: tables,
+						Operation: status.Operation,
+					})
 			}
-			taskStatus = append(taskStatus,
-				model.CaptureTaskStatus{
-					CaptureID: captureID, Tables: tables,
-					Operation: status.Operation,
-				})
 		}
 	}
 	sinkURI, err := util.MaskSinkURI(info.SinkURI)

--- a/cdc/api/v2/api_test.go
+++ b/cdc/api/v2/api_test.go
@@ -66,6 +66,7 @@ type mockStatusProvider struct {
 	changefeedInfo         *model.ChangeFeedInfo
 	processors             []*model.ProcInfoSnap
 	taskStatus             map[model.CaptureID]*model.TaskStatus
+	taskStatusErr          error
 	changefeedInfos        map[model.ChangeFeedID]*model.ChangeFeedInfo
 	changefeedStatuses     map[model.ChangeFeedID]*model.ChangeFeedStatusForAPI
 	changeFeedSyncedStatus *model.ChangeFeedSyncedStatusForAPI
@@ -102,6 +103,9 @@ func (m *mockStatusProvider) GetAllTaskStatuses(
 	map[model.CaptureID]*model.TaskStatus,
 	error,
 ) {
+	if m.taskStatusErr != nil {
+		return nil, m.taskStatusErr
+	}
 	return m.taskStatus, m.err
 }
 

--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -594,7 +594,7 @@ func (h *OpenAPIV2) getChangeFeed(c *gin.Context) {
 	}
 
 	taskStatus := make([]model.CaptureTaskStatus, 0)
-	if cfInfo.State == model.StateNormal {
+	if cfInfo.State.IsRunning() {
 		processorInfos, err := h.capture.StatusProvider().GetAllTaskStatuses(
 			ctx,
 			changefeedID,
@@ -718,7 +718,7 @@ func (h *OpenAPIV2) getChangeFeedMetaInfo(c *gin.Context) {
 		return
 	}
 	taskStatus := make([]model.CaptureTaskStatus, 0)
-	if info.State == model.StateNormal {
+	if info.State.IsRunning() {
 		processorInfos, err := h.capture.StatusProvider().GetAllTaskStatuses(
 			ctx,
 			changefeedID,

--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -600,19 +600,20 @@ func (h *OpenAPIV2) getChangeFeed(c *gin.Context) {
 			changefeedID,
 		)
 		if err != nil {
-			_ = c.Error(err)
-			return
-		}
-		for captureID, status := range processorInfos {
-			tables := make([]int64, 0)
-			for tableID := range status.Tables {
-				tables = append(tables, tableID)
+			log.Warn("failed to get task statuses, returning changefeed detail without task_status",
+				zap.String("changefeed", changefeedID.String()), zap.Error(err))
+		} else {
+			for captureID, status := range processorInfos {
+				tables := make([]int64, 0)
+				for tableID := range status.Tables {
+					tables = append(tables, tableID)
+				}
+				taskStatus = append(taskStatus,
+					model.CaptureTaskStatus{
+						CaptureID: captureID, Tables: tables,
+						Operation: status.Operation,
+					})
 			}
-			taskStatus = append(taskStatus,
-				model.CaptureTaskStatus{
-					CaptureID: captureID, Tables: tables,
-					Operation: status.Operation,
-				})
 		}
 	}
 	detail := toAPIModel(cfInfo, status.ResolvedTs,
@@ -724,19 +725,20 @@ func (h *OpenAPIV2) getChangeFeedMetaInfo(c *gin.Context) {
 			changefeedID,
 		)
 		if err != nil {
-			_ = c.Error(err)
-			return
-		}
-		for captureID, status := range processorInfos {
-			tables := make([]int64, 0)
-			for tableID := range status.Tables {
-				tables = append(tables, tableID)
+			log.Warn("failed to get task statuses, returning changefeed detail without task_status",
+				zap.String("changefeed", changefeedID.String()), zap.Error(err))
+		} else {
+			for captureID, status := range processorInfos {
+				tables := make([]int64, 0)
+				for tableID := range status.Tables {
+					tables = append(tables, tableID)
+				}
+				taskStatus = append(taskStatus,
+					model.CaptureTaskStatus{
+						CaptureID: captureID, Tables: tables,
+						Operation: status.Operation,
+					})
 			}
-			taskStatus = append(taskStatus,
-				model.CaptureTaskStatus{
-					CaptureID: captureID, Tables: tables,
-					Operation: status.Operation,
-				})
 		}
 	}
 	c.JSON(http.StatusOK, toAPIModel(info, status.ResolvedTs, status.CheckpointTs,

--- a/cdc/api/v2/changefeed.go
+++ b/cdc/api/v2/changefeed.go
@@ -593,27 +593,11 @@ func (h *OpenAPIV2) getChangeFeed(c *gin.Context) {
 		return
 	}
 
-	taskStatus := make([]model.CaptureTaskStatus, 0)
+	var taskStatus []model.CaptureTaskStatus
 	if cfInfo.State.IsRunning() {
-		processorInfos, err := h.capture.StatusProvider().GetAllTaskStatuses(
-			ctx,
-			changefeedID,
-		)
-		if err != nil {
+		if taskStatus, err = api.CollectTaskStatuses(ctx, h.capture.StatusProvider(), changefeedID); err != nil {
 			log.Warn("failed to get task statuses, returning changefeed detail without task_status",
 				zap.String("changefeed", changefeedID.String()), zap.Error(err))
-		} else {
-			for captureID, status := range processorInfos {
-				tables := make([]int64, 0)
-				for tableID := range status.Tables {
-					tables = append(tables, tableID)
-				}
-				taskStatus = append(taskStatus,
-					model.CaptureTaskStatus{
-						CaptureID: captureID, Tables: tables,
-						Operation: status.Operation,
-					})
-			}
 		}
 	}
 	detail := toAPIModel(cfInfo, status.ResolvedTs,
@@ -718,27 +702,11 @@ func (h *OpenAPIV2) getChangeFeedMetaInfo(c *gin.Context) {
 		_ = c.Error(err)
 		return
 	}
-	taskStatus := make([]model.CaptureTaskStatus, 0)
+	var taskStatus []model.CaptureTaskStatus
 	if info.State.IsRunning() {
-		processorInfos, err := h.capture.StatusProvider().GetAllTaskStatuses(
-			ctx,
-			changefeedID,
-		)
-		if err != nil {
+		if taskStatus, err = api.CollectTaskStatuses(ctx, h.capture.StatusProvider(), changefeedID); err != nil {
 			log.Warn("failed to get task statuses, returning changefeed detail without task_status",
 				zap.String("changefeed", changefeedID.String()), zap.Error(err))
-		} else {
-			for captureID, status := range processorInfos {
-				tables := make([]int64, 0)
-				for tableID := range status.Tables {
-					tables = append(tables, tableID)
-				}
-				taskStatus = append(taskStatus,
-					model.CaptureTaskStatus{
-						CaptureID: captureID, Tables: tables,
-						Operation: status.Operation,
-					})
-			}
 		}
 	}
 	c.JSON(http.StatusOK, toAPIModel(info, status.ResolvedTs, status.CheckpointTs,

--- a/cdc/api/v2/changefeed_test.go
+++ b/cdc/api/v2/changefeed_test.go
@@ -338,6 +338,44 @@ func TestGetChangeFeed(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, resp.ID, validID)
 	require.Nil(t, resp.Error)
+
+	// task_status should be returned for running changefeeds, including
+	// those in the warning state.
+	statusProvider.taskStatus = map[model.CaptureID]*model.TaskStatus{
+		"capture-1": {Tables: map[model.TableID]*model.TableReplicaInfo{
+			3508: {}, 3520: {},
+		}},
+	}
+	for _, tc := range []struct {
+		state          model.FeedState
+		wantTaskStatus bool
+	}{
+		{model.StateNormal, true},
+		{model.StateWarning, true},
+		{model.StateStopped, false},
+	} {
+		statusProvider.changefeedInfo = &model.ChangeFeedInfo{ID: validID, State: tc.state}
+		w = httptest.NewRecorder()
+		req, _ = http.NewRequestWithContext(
+			context.Background(),
+			cfInfo.method,
+			fmt.Sprintf(cfInfo.url, validID, "abc"),
+			nil,
+		)
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+		resp = ChangeFeedInfo{}
+		err = json.NewDecoder(w.Body).Decode(&resp)
+		require.Nil(t, err)
+		require.Equal(t, tc.state, resp.State)
+		if tc.wantTaskStatus {
+			require.Len(t, resp.TaskStatus, 1, "state %s should return task_status", tc.state)
+			require.Equal(t, "capture-1", resp.TaskStatus[0].CaptureID)
+			require.ElementsMatch(t, []model.TableID{3508, 3520}, resp.TaskStatus[0].Tables)
+		} else {
+			require.Empty(t, resp.TaskStatus, "state %s should not return task_status", tc.state)
+		}
+	}
 }
 
 func TestUpdateChangefeed(t *testing.T) {

--- a/cdc/api/v2/changefeed_test.go
+++ b/cdc/api/v2/changefeed_test.go
@@ -364,8 +364,9 @@ func TestGetChangeFeed(t *testing.T) {
 		)
 		router.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code)
+		body := w.Body.Bytes()
 		resp = ChangeFeedInfo{}
-		err = json.NewDecoder(w.Body).Decode(&resp)
+		err = json.Unmarshal(body, &resp)
 		require.Nil(t, err)
 		require.Equal(t, tc.state, resp.State)
 		if tc.wantTaskStatus {
@@ -374,8 +375,35 @@ func TestGetChangeFeed(t *testing.T) {
 			require.ElementsMatch(t, []model.TableID{3508, 3520}, resp.TaskStatus[0].Tables)
 		} else {
 			require.Empty(t, resp.TaskStatus, "state %s should not return task_status", tc.state)
+			// task_status has the omitempty tag, so the raw JSON must not
+			// contain the key at all for non-running changefeeds.
+			require.NotContains(t, string(body), "task_status",
+				"state %s should omit task_status from the raw JSON", tc.state)
 		}
 	}
+
+	// task-status lookup is best effort: when it fails for a running
+	// changefeed, the handler still returns 200 with the changefeed detail and
+	// simply omits task_status instead of propagating the error.
+	statusProvider.changefeedInfo = &model.ChangeFeedInfo{ID: validID, State: model.StateNormal}
+	statusProvider.taskStatusErr = cerrors.ErrChangeFeedNotExists.GenWithStackByArgs(validID)
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequestWithContext(
+		context.Background(),
+		cfInfo.method,
+		fmt.Sprintf(cfInfo.url, validID, "abc"),
+		nil,
+	)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.Bytes()
+	resp = ChangeFeedInfo{}
+	err = json.Unmarshal(body, &resp)
+	require.Nil(t, err)
+	require.Equal(t, model.StateNormal, resp.State)
+	require.Empty(t, resp.TaskStatus)
+	require.NotContains(t, string(body), "task_status")
+	statusProvider.taskStatusErr = nil
 }
 
 func TestUpdateChangefeed(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #12793

The changefeed query/detail OpenAPI endpoints normally return `task_status`, e.g. (as seen via `cdc cli changefeed query -c <CHANGEFEED_ID>`, which is just one client of this API):

```json
"task_status": [
  {
    "capture_id": "d4ecb27f-bb40-4655-bf72-192852e4ef80",
    "table_ids": [3508, 3520, 3523, 3529, 3531]
  }
]
```

However, when a changefeed is in the `warning` state, `task_status` is **not** returned — which is often exactly when this per-capture table assignment is most needed for debugging. This affects every caller of the query API (the `GET /api/v1/changefeeds/{id}`, `GET /api/v2/changefeeds/{id}`, and meta-info endpoints), not just the `cdc cli`.

The changefeed detail handlers gate the `task_status` population on an exact `info.State == model.StateNormal` check, so `GetAllTaskStatuses` is skipped for any other state, including `warning`.

### What is changed and how it works?

A changefeed in the `warning` state is still running (its processors are active), so its task statuses remain meaningful. `FeedState.IsRunning()` already encodes this exact semantic (`StateNormal || StateWarning`).

This PR replaces the exact `StateNormal` check with
`FeedState.IsRunning()` in the three changefeed-detail handlers:

- `cdc/api/v1/api.go` — `getChangefeed`
- `cdc/api/v2/changefeed.go` — `getChangeFeed`
- `cdc/api/v2/changefeed.go` — `getChangeFeedMetaInfo`

### Check List

#### Tests

- Unit test

Extended `TestGetChangeFeed` (`cdc/api/v2`) with a table-driven check asserting `task_status` is returned for `normal` and `warning` states and omitted for `stopped`.

#### Questions

##### Will it cause performance regression or break compatibility?

No. It adds one `GetAllTaskStatuses` call for changefeeds in the `warning` state (the same call already made for `normal`), and only widens the set of states for which `task_status` is populated — no field or format changes.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
Fix the changefeed query API not returning `task_status` for changefeeds in the warning state.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Changefeed details now include task status across all running states, including warning states.
* Temporary task-status retrieval failures no longer prevent changefeed details from loading.
* Stopped changefeeds correctly omit task-status information.
* Task statuses are now presented consistently across changefeed detail endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->