### PR TITLE
test: enable a shard DDL test CONVERT TO charset

### DIFF
--- a/dm/tests/shardddl3/run.sh
+++ b/dm/tests/shardddl3/run.sh
@@ -67,12 +67,11 @@ function DM_073() {
      run_sql_source2 \"create table ${shardddl1}.${tb2} (a int primary key, b varchar(10)) default character set utf8 collate utf8_bin;\"" \
 		"clean_table" "pessimistic"
 
-	# schema comparer doesn't support to compare/diff charset now
-	# run_case 073 "double-source-optimistic" \
-	# "run_sql_source1 \"create table ${shardddl1}.${tb1} (a int primary key, b varchar(10)) default character set utf8 collate utf8_bin;\"; \
-	#  run_sql_source2 \"create table ${shardddl1}.${tb1} (a int primary key, b varchar(10)) default character set utf8 collate utf8_bin;\"; \
-	#  run_sql_source2 \"create table ${shardddl1}.${tb2} (a int primary key, b varchar(10)) default character set utf8 collate utf8_bin;\"" \
-	# "clean_table" "optimistic"
+	run_case 073 "double-source-optimistic" \
+		"run_sql_source1 \"create table ${shardddl1}.${tb1} (a int primary key, b varchar(10)) default character set utf8 collate utf8_bin;\"; \
+		run_sql_source2 \"create table ${shardddl1}.${tb1} (a int primary key, b varchar(10)) default character set utf8 collate utf8_bin;\"; \
+		run_sql_source2 \"create table ${shardddl1}.${tb2} (a int primary key, b varchar(10)) default character set utf8 collate utf8_bin;\"" \
+		"clean_table" "optimistic"
 }
 
 function DM_076_CASE() {

--- a/dm/tests/shardddl3/run.sh
+++ b/dm/tests/shardddl3/run.sh
@@ -33,12 +33,11 @@ function DM_071() {
      run_sql_source2 \"create table ${shardddl1}.${tb2} (a int primary key, b varchar(10)) default character set utf8 collate utf8_bin;\"" \
 		"clean_table" "pessimistic"
 
-	# schema comparer doesn't support to compare/diff charset now
-	# run_case 071 "double-source-optimistic" \
-	# "run_sql_source1 \"create table ${shardddl1}.${tb1} (a int primary key, b varchar(10)) default character set utf8 collate utf8_bin;\"; \
-	#  run_sql_source2 \"create table ${shardddl1}.${tb1} (a int primary key, b varchar(10)) default character set utf8 collate utf8_bin;\"; \
-	#  run_sql_source2 \"create table ${shardddl1}.${tb2} (a int primary key, b varchar(10)) default character set utf8 collate utf8_bin;\"" \
-	# "clean_table" "optimistic"
+	run_case 071 "double-source-optimistic" \
+		"run_sql_source1 \"create table ${shardddl1}.${tb1} (a int primary key, b varchar(10)) default character set utf8 collate utf8_bin;\"; \
+		 run_sql_source2 \"create table ${shardddl1}.${tb1} (a int primary key, b varchar(10)) default character set utf8 collate utf8_bin;\"; \
+		 run_sql_source2 \"create table ${shardddl1}.${tb2} (a int primary key, b varchar(10)) default character set utf8 collate utf8_bin;\"" \
+		"clean_table" "optimistic"
 }
 
 function DM_073_CASE() {

--- a/dm/tests/shardddl_optimistic/run.sh
+++ b/dm/tests/shardddl_optimistic/run.sh
@@ -468,13 +468,10 @@ function DM_CHANGE_UTF_CHARSET_CASE() {
 	run_sql_source1 "insert into ${shardddl1}.${tb2} values(2, 'b');"
 	run_sql_source2 "alter table ${shardddl1}.${tb1} character set utf8mb4 collate utf8mb4_bin;"
 	run_sql_source2 "insert into ${shardddl1}.${tb1} values(3, 'c');"
-	run_sql_source2 "alter table ${shardddl1}.${tb2} character set utf8mb4 collate utf8mb4_bin;"
-	run_sql_source2 "insert into ${shardddl1}.${tb2} values(4, 'd');"
+	# left 1 shard table not finished. optimistic mode should not block data sync
 
-	run_sql_tidb_with_retry "select count(1) from ${shardddl}.${tb};" "count(1): 4"
-	run_dm_ctl $WORK_DIR "127.0.0.1:$MASTER_PORT" \
-		"show-ddl-locks" \
-		"no DDL lock exists" 1
+	run_sql_tidb_with_retry "select count(1) from ${shardddl}.${tb};" "count(1): 3"
+	run_sql_tidb_with_retry "show create table ${shardddl}.${tb}" "CHARSET=utf8mb4"
 }
 
 function DM_CHANGE_UTF_CHARSET() {


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #11696

### What is changed and how it works?

a follow-up of #12763

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Integration test


#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

##### Do you need to update user documentation, design documentation or monitoring documentation?

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enabled coverage for the previously skipped double-source optimistic scenario, including the optimistic setup/cleanup and corresponding execution case.
  * Tightened post-DML validation for optimistic sharding by adjusting expected synchronized row counts and replacing the prior lock-related assertion with a downstream table schema/charset verification (`CHARSET` set to `utf8mb4`).
  * Kept the double-source pessimistic scenario validation intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->