### PR TITLE
build(all): bump Go version to 1.25.12

### DIFF
--- a/deployments/ticdc/docker/integration-test.Dockerfile
+++ b/deployments/ticdc/docker/integration-test.Dockerfile
@@ -29,7 +29,7 @@ RUN ./download-integration-test-binaries.sh $BRANCH $COMMUNITY $VERSION $OS $ARC
 RUN ls ./bin
 
 # Download go into /usr/local dir.
-ENV GOLANG_VERSION 1.25.10
+ENV GOLANG_VERSION 1.25.12
 ENV GOLANG_DOWNLOAD_URL https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& tar -C /usr/local -xzf golang.tar.gz \

--- a/examples/golang/avro-checksum-verification/go.mod
+++ b/examples/golang/avro-checksum-verification/go.mod
@@ -1,6 +1,6 @@
 module avro-checksum-sample
 
-go 1.25.10
+go 1.25.12
 
 require (
 	github.com/linkedin/goavro/v2 v2.11.1

--- a/examples/golang/canal-json-handle-key-only/go.mod
+++ b/examples/golang/canal-json-handle-key-only/go.mod
@@ -1,6 +1,6 @@
 module canal-json-handle-key-only-example
 
-go 1.25.10
+go 1.25.12
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/tiflow
 
-go 1.25.10
+go 1.25.12
 
 require (
 	cloud.google.com/go/storage v1.52.0

--- a/tests/integration_tests/debezium/go.mod
+++ b/tests/integration_tests/debezium/go.mod
@@ -1,6 +1,6 @@
 module github.com/breezewish/checker
 
-go 1.25.10
+go 1.25.12
 
 require (
 	github.com/alecthomas/chroma v0.10.0

--- a/tools/check/go.mod
+++ b/tools/check/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/tidb-cdc/_tools
 
-go 1.25.10
+go 1.25.12
 
 require (
 	github.com/AlekSi/gocov-xml v1.1.0


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #12771

TiFlow's maintained Go patch-version declarations still use 1.25.10. They need to use the latest Go 1.25 patch release consistently.

### What is changed and how it works?

Update the root and auxiliary module `go` directives and the TiCDC integration-test Docker download version to Go 1.25.12.

Patchless Go 1.25 base-image tags and application dependencies are unchanged.

### Check List

#### Tests

- No code
  - `go mod tidy -diff` in every changed module
  - `make cdc`

#### Questions

##### Will it cause performance regression or break compatibility?

No performance regression is expected. The minimum Go patch version used to build TiFlow becomes 1.25.12.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No. Existing documentation does not pin the previous patch version.

### Release note

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain to version 1.25.12 across the project, examples, integration tests, tooling, and container build environment.
  * No application behavior or dependency changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->