### PR TITLE
worker(dm): keep query status responsive during task operations

### DIFF
--- a/dm/worker/source_worker.go
+++ b/dm/worker/source_worker.go
@@ -741,7 +741,20 @@ func (w *SourceWorker) OperateSubTask(name string, op pb.TaskOp) error {
 
 // QueryStatus query worker's sub tasks' status. If relay enabled, also return source status.
 func (w *SourceWorker) QueryStatus(ctx context.Context, name string) ([]*pb.SubTaskStatus, *pb.RelayStatus, error) {
-	w.RLock()
+	// A subtask lifecycle operation can hold the worker lock while it waits for
+	// the current unit to exit. Do not queue status requests behind that wait:
+	// subTaskHolder and SubTask synchronize their own state, so we can still
+	// return a snapshot of the latest subtask stage and result safely. Detailed
+	// unit, source, and relay status is omitted in this fallback because it can
+	// race with the lifecycle operation or is protected by the worker lock.
+	if !w.TryRLock() {
+		if w.closed.Load() {
+			w.l.Warn("querying status from a closed worker")
+			return nil, nil, nil
+		}
+
+		return w.subTaskStatusSnapshot(name), nil, nil
+	}
 	defer w.RUnlock()
 
 	if w.closed.Load() {
@@ -1195,10 +1208,14 @@ func (w *SourceWorker) getAllSubTaskStatus() map[string]*pb.SubTaskStatus {
 	result := make(map[string]*pb.SubTaskStatus, len(sts))
 	for name, st := range sts {
 		st.RLock()
+		var processResult *pb.ProcessResult
+		if st.result != nil {
+			processResult = proto.Clone(st.result).(*pb.ProcessResult)
+		}
 		result[name] = &pb.SubTaskStatus{
 			Name:   name,
 			Stage:  st.stage,
-			Result: proto.Clone(st.result).(*pb.ProcessResult),
+			Result: processResult,
 		}
 		st.RUnlock()
 	}

--- a/dm/worker/source_worker_test.go
+++ b/dm/worker/source_worker_test.go
@@ -897,3 +897,174 @@ func TestQueryStatusSourceStatusTimeout(t *testing.T) {
 	require.Equal(t, subtaskCfg.Name, status[0].Name)
 	require.NotNil(t, w.getSourceStatusErr())
 }
+
+func TestQueryStatusDuringBlockedSubTaskOperation(t *testing.T) {
+	testCases := []struct {
+		name          string
+		op            pb.TaskOp
+		expectedStage pb.Stage
+	}{
+		{name: "pause", op: pb.TaskOp_Pause, expectedStage: pb.Stage_Pausing},
+		{name: "stop", op: pb.TaskOp_Stop, expectedStage: pb.Stage_Pausing},
+		{name: "delete", op: pb.TaskOp_Delete, expectedStage: pb.Stage_Stopping},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			w, st, release := newSourceWorkerWithBlockedSubTask(t)
+			defer w.Stop(true)
+			defer release()
+
+			opDone := make(chan error, 1)
+			go func() {
+				opDone <- w.OperateSubTask(st.cfg.Name, testCase.op)
+			}()
+
+			require.Eventually(t, func() bool {
+				return st.Stage() == testCase.expectedStage
+			}, time.Second, 10*time.Millisecond)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+			type queryResult struct {
+				status []*pb.SubTaskStatus
+				err    error
+			}
+			queryDone := make(chan queryResult, 1)
+			go func() {
+				status, _, err := w.QueryStatus(ctx, st.cfg.Name)
+				queryDone <- queryResult{status: status, err: err}
+			}()
+
+			select {
+			case result := <-queryDone:
+				require.NoError(t, result.err)
+				require.Len(t, result.status, 1)
+				require.Equal(t, testCase.expectedStage, result.status[0].Stage)
+			case <-time.After(500 * time.Millisecond):
+				release()
+				<-opDone
+				t.Fatal("QueryStatus blocked behind a subtask lifecycle operation")
+			}
+
+			release()
+			require.NoError(t, <-opDone)
+		})
+	}
+}
+
+func TestCanceledQueryStatusDoesNotQueueBehindSubTaskOperation(t *testing.T) {
+	w, st, release := newSourceWorkerWithBlockedSubTask(t)
+	defer w.Stop(true)
+	defer release()
+
+	opDone := make(chan error, 1)
+	go func() {
+		opDone <- w.OperateSubTask(st.cfg.Name, pb.TaskOp_Pause)
+	}()
+	require.Eventually(t, func() bool {
+		return st.Stage() == pb.Stage_Pausing
+	}, time.Second, 10*time.Millisecond)
+
+	const queryCount = 16
+	var wg sync.WaitGroup
+	errCh := make(chan error, queryCount)
+	wg.Add(queryCount)
+	for range queryCount {
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			status, _, err := w.QueryStatus(ctx, st.cfg.Name)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if len(status) != 1 || status[0].Stage != pb.Stage_Pausing {
+				errCh <- fmt.Errorf("unexpected status: %+v", status)
+			}
+		}()
+	}
+
+	queriesDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(queriesDone)
+	}()
+	select {
+	case <-queriesDone:
+	case <-time.After(500 * time.Millisecond):
+		release()
+		<-opDone
+		t.Fatal("canceled QueryStatus calls accumulated behind the worker lock")
+	}
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	release()
+	require.NoError(t, <-opDone)
+}
+
+func TestBlockedSubTaskOperationStillSerializesLifecycleOperations(t *testing.T) {
+	w, st, release := newSourceWorkerWithBlockedSubTask(t)
+	defer w.Stop(true)
+	defer release()
+
+	pauseDone := make(chan error, 1)
+	go func() {
+		pauseDone <- w.OperateSubTask(st.cfg.Name, pb.TaskOp_Pause)
+	}()
+	require.Eventually(t, func() bool {
+		return st.Stage() == pb.Stage_Pausing
+	}, time.Second, 10*time.Millisecond)
+
+	deleteDone := make(chan error, 1)
+	go func() {
+		deleteDone <- w.OperateSubTask(st.cfg.Name, pb.TaskOp_Delete)
+	}()
+	select {
+	case err := <-deleteDone:
+		t.Fatalf("concurrent delete was not serialized: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release()
+	require.NoError(t, <-pauseDone)
+	require.NoError(t, <-deleteDone)
+	require.Nil(t, w.subTaskHolder.findSubTask(st.cfg.Name))
+}
+
+func newSourceWorkerWithBlockedSubTask(t *testing.T) (*SourceWorker, *SubTask, func()) {
+	t.Helper()
+
+	cfg, err := config.SourceCfgFromYamlAndVerify(config.SampleSourceConfig)
+	require.NoError(t, err)
+	w, err := NewSourceWorker(cfg, nil, "worker", "")
+	require.NoError(t, err)
+	w.closed.Store(false)
+
+	st := NewSubTaskWithStage(&config.SubTaskConfig{
+		Name:     "blocked-subtask",
+		SourceID: cfg.SourceID,
+	}, pb.Stage_Running, nil, "worker")
+	st.resultWg.Add(1)
+	w.subTaskHolder.recordSubTask(st)
+
+	releaseCh := make(chan struct{})
+	go func() {
+		<-releaseCh
+		switch st.Stage() {
+		case pb.Stage_Pausing:
+			st.setStage(pb.Stage_Paused)
+		case pb.Stage_Stopping:
+			st.setStage(pb.Stage_Stopped)
+		}
+		st.resultWg.Done()
+	}()
+	var once sync.Once
+	return w, st, func() {
+		once.Do(func() { close(releaseCh) })
+	}
+}

--- a/dm/worker/status.go
+++ b/dm/worker/status.go
@@ -113,6 +113,37 @@ func (w *SourceWorker) Status(stName string, sourceStatus *binlog.SourceStatus) 
 	return status
 }
 
+// subTaskStatusSnapshot returns the subtask fields that can be read without
+// holding SourceWorker's lock. It is used when a lifecycle operation holds that
+// lock while waiting for a subtask to stop.
+func (w *SourceWorker) subTaskStatusSnapshot(stName string) []*pb.SubTaskStatus {
+	statuses := w.getAllSubTaskStatus()
+	if len(statuses) == 0 {
+		return nil
+	}
+
+	if stName != "" {
+		if status, ok := statuses[stName]; ok {
+			return []*pb.SubTaskStatus{status}
+		}
+		return []*pb.SubTaskStatus{{
+			Name:   stName,
+			Status: &pb.SubTaskStatus_Msg{Msg: common.NoSubTaskMsg(stName)},
+		}}
+	}
+
+	names := make([]string, 0, len(statuses))
+	for name := range statuses {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	result := make([]*pb.SubTaskStatus, 0, len(statuses))
+	for _, name := range names {
+		result = append(result, statuses[name])
+	}
+	return result
+}
+
 // GetUnitAndSourceStatusJSON returns the status of the worker and its unit as json string.
 // This function will also cause every unit to print its status to log.
 func (w *SourceWorker) GetUnitAndSourceStatusJSON(stName string, sourceStatus *binlog.SourceStatus) string {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #12778

A slow or stuck subtask Pause, Stop, or Delete operation holds `SourceWorker`'s write lock while waiting for the current unit to exit. `QueryStatus` used to block on the matching read lock, so status RPCs timed out and their handlers remained queued even after their contexts were canceled.

### What is changed and how it works?

- Use a non-blocking `SourceWorker` read-lock attempt in `QueryStatus`.
- When the worker lock is busy, return a concurrency-safe snapshot of each subtask's name, stage, and result instead of waiting.
- Keep the existing detailed source, unit, and relay status path unchanged when the worker lock is immediately available.
- Preserve the existing `SourceWorker` write-lock scope so lifecycle operations, worker Stop, and relay/subtask disable operations remain serialized.
- Add regression tests for blocked Pause, Stop, and Delete, canceled concurrent status calls, and lifecycle-operation serialization.

### Check List

#### Tests

- Unit test
  - `go test -race ./dm/worker -run 'Test(QueryStatusDuringBlockedSubTaskOperation|CanceledQueryStatusDoesNotQueueBehindSubTaskOperation|BlockedSubTaskOperationStillSerializesLifecycleOperations|QueryStatusSourceStatusTimeout)$' -count=1`
  - `go test -race ./dm/worker -run 'Test(QueryStatusDuringBlockedSubTaskOperation|CanceledQueryStatusDoesNotQueueBehindSubTaskOperation|BlockedSubTaskOperationStillSerializesLifecycleOperations)$' -count=10`
  - `go test -race ./dm/worker -run 'Test(Check|CheckTaskIndependent)$' -count=1`
- Manual test
  - `go vet ./dm/worker`
  - `make fmt`
  - `git diff --check`

The full `go test ./dm/worker -count=1` run encountered the existing `testServer.TestHandleSourceBoundAfterError` etcd-event timing failure. The same focused gocheck case fails unchanged on `upstream/master`; the new and affected tests above pass with the race detector.

#### Questions

##### Will it cause performance regression or break compatibility?

No protocol compatibility break is expected. The normal detailed `QueryStatus` path is unchanged. During `SourceWorker` write-lock contention, `QueryStatus` now returns a lightweight subtask state snapshot instead of blocking; unit, relay, and live source details are intentionally omitted only in that fallback response.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
Fix an issue where DM query-status could time out while a subtask was pausing, stopping, or being deleted.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Status checks now remain responsive while pause, stop, or delete operations are in progress.
  - Status queries return useful transitional subtask information instead of waiting behind blocked operations.
  - Canceled status requests no longer queue unnecessarily.
  - Closed workers and missing subtasks return appropriate empty or not-found results.
  - Improved handling of subtasks without available results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->