### PR TITLE
syncer(dm): bound graceful stop during async DDL polling

### DIFF
--- a/dm/syncer/error.go
+++ b/dm/syncer/error.go
@@ -30,6 +30,7 @@ import (
 	tmysql "github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/util/dbterror"
 	"github.com/pingcap/tidb/pkg/util/dbutil"
+	"github.com/pingcap/tiflow/dm/pkg/binlog"
 	tcontext "github.com/pingcap/tiflow/dm/pkg/context"
 	"github.com/pingcap/tiflow/dm/pkg/log"
 	"github.com/pingcap/tiflow/dm/pkg/terror"
@@ -64,9 +65,218 @@ func isDropColumnWithIndexError(err error) bool {
 			strings.Contains(mysqlErr.Message, "with tidb_enable_change_multi_schema is disable"))
 }
 
+func cloneStrings(values []string) []string {
+	cloned := make([]string, len(values))
+	copy(cloned, values)
+	return cloned
+}
+
+func (s *Syncer) setAsyncDDLReconcileInfo(
+	ddls []string,
+	index int,
+	createTime int64,
+	startLocation binlog.Location,
+	currentLocation binlog.Location,
+) *asyncDDLReconcileInfo {
+	info := &asyncDDLReconcileInfo{
+		ddls:            cloneStrings(ddls),
+		index:           index,
+		createTime:      createTime,
+		startLocation:   startLocation.Clone(),
+		currentLocation: currentLocation.Clone(),
+	}
+	s.asyncDDLReconcileMu.Lock()
+	s.asyncDDLReconcile = info
+	s.asyncDDLReconcileMu.Unlock()
+	return info
+}
+
+func (s *Syncer) getAsyncDDLReconcileInfo() *asyncDDLReconcileInfo {
+	s.asyncDDLReconcileMu.Lock()
+	defer s.asyncDDLReconcileMu.Unlock()
+	return s.asyncDDLReconcile
+}
+
+func (s *Syncer) clearAsyncDDLReconcileInfo(info *asyncDDLReconcileInfo) {
+	s.asyncDDLReconcileMu.Lock()
+	if s.asyncDDLReconcile == info {
+		s.asyncDDLReconcile = nil
+	}
+	s.asyncDDLReconcileMu.Unlock()
+}
+
+func (s *Syncer) asyncDDLResolved(info *asyncDDLReconcileInfo) bool {
+	s.asyncDDLReconcileMu.Lock()
+	defer s.asyncDDLReconcileMu.Unlock()
+	return s.asyncDDLReconcile == info && info.resolved
+}
+
+func (s *Syncer) markAsyncDDLResolved(info *asyncDDLReconcileInfo) {
+	s.asyncDDLReconcileMu.Lock()
+	if s.asyncDDLReconcile == info {
+		info.resolved = true
+	}
+	s.asyncDDLReconcileMu.Unlock()
+}
+
+// clearResolvedAsyncDDL is called only after all post-DDL bookkeeping and the
+// DDL checkpoint flush succeed. Keeping a resolved descriptor until this point
+// prevents Resume from submitting the DDL again if bookkeeping fails after the
+// TiDB job itself has completed.
+func (s *Syncer) clearResolvedAsyncDDL(
+	ddls []string,
+	startLocation binlog.Location,
+	currentLocation binlog.Location,
+) {
+	info := s.getAsyncDDLReconcileInfo()
+	if info == nil || !s.asyncDDLResolved(info) ||
+		!info.matches(ddls, startLocation, currentLocation, s.cfg.EnableGTID) {
+		return
+	}
+	s.clearAsyncDDLReconcileInfo(info)
+}
+
+func (info *asyncDDLReconcileInfo) matches(
+	ddls []string,
+	startLocation binlog.Location,
+	currentLocation binlog.Location,
+	enableGTID bool,
+) bool {
+	if info == nil || len(info.ddls) != len(ddls) || info.index < 0 || info.index >= len(info.ddls) {
+		return false
+	}
+	for i := range ddls {
+		if info.ddls[i] != ddls[i] {
+			return false
+		}
+	}
+	return binlog.CompareLocation(info.startLocation, startLocation, enableGTID) == 0 &&
+		binlog.CompareLocation(info.currentLocation, currentLocation, enableGTID) == 0
+}
+
+// asyncDDLPollContext returns the graceful-run context when Syncer.Run has
+// initialized it. DDL execution continues to use syncCtx during the grace
+// period; only polling an already-submitted asynchronous DDL is interrupted by
+// the graceful deadline. The fallback keeps direct unit tests usable.
+func (s *Syncer) asyncDDLPollContext(fallback *tcontext.Context) *tcontext.Context {
+	if s.runCtx != nil {
+		return s.runCtx
+	}
+	return fallback
+}
+
+// pollAsyncDDL waits for the TiDB DDL identified by its SQL and creation time.
+// Canceling tctx only stops DM's polling query; it never sends a cancellation
+// request for the TiDB DDL job itself.
+func (s *Syncer) pollAsyncDDL(
+	tctx *tcontext.Context,
+	originErr error,
+	ddl string,
+	conn *dbconn.DBConn,
+	createTime int64,
+) error {
+	duration := 30
+	failpoint.Inject("ChangeDuration", func() {
+		duration = 1
+	})
+	ticker := time.NewTicker(time.Duration(duration) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		if ctxErr := tctx.Ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		status, err := getDDLStatusFromTiDB(tctx, conn, ddl, createTime)
+		if err != nil {
+			if ctxErr := tctx.Ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			s.tctx.L().Warn("error when getting DDL status from TiDB", zap.Error(err))
+		}
+		failpoint.Inject("TestStatus", func(val failpoint.Value) {
+			status = val.(string)
+			s.tctx.L().Info("injected test status:", zap.String("TestStatus", status))
+		})
+		// Cancellation wins even when the status query itself completed. Without
+		// this check, an empty or unexpected status racing with the graceful
+		// deadline could be reported as the original invalid-connection error.
+		if ctxErr := tctx.Ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		switch status {
+		case model.JobStateDone.String(), model.JobStateSynced.String():
+			return nil
+		case model.JobStateCancelled.String(), model.JobStateRollingback.String(), model.JobStateRollbackDone.String(), model.JobStateCancelling.String():
+			return terror.ErrSyncerCancelledDDL.Generate(ddl)
+		case model.JobStateRunning.String(), model.JobStateQueueing.String(), model.JobStateNone.String():
+		default:
+			tctx.L().Warn("Unexpected DDL status", zap.String("DDL status", status))
+			return originErr
+		}
+		select {
+		case <-tctx.Ctx.Done():
+			// Return the context error instead of the original invalid-connection
+			// error so intentional Pause/Stop is classified as cancellation.
+			return tctx.Ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// reconcileAsyncDDL resolves an asynchronous DDL left by a previous paused
+// run. The bool result reports whether a pending DDL matched the current job,
+// in which case the caller must not submit the DDL again.
+func (s *Syncer) reconcileAsyncDDL(
+	tctx *tcontext.Context,
+	ddls []string,
+	startLocation binlog.Location,
+	currentLocation binlog.Location,
+	conn *dbconn.DBConn,
+) (bool, error) {
+	info := s.getAsyncDDLReconcileInfo()
+	if info == nil {
+		return false, nil
+	}
+	if !info.matches(ddls, startLocation, currentLocation, s.cfg.EnableGTID) {
+		s.tctx.L().Error("pending asynchronous DDL does not match the current DDL",
+			zap.Strings("pending DDLs", info.ddls),
+			zap.Strings("current DDLs", ddls),
+			zap.Stringer("pending start location", info.startLocation),
+			zap.Stringer("current start location", startLocation),
+			zap.Stringer("pending end location", info.currentLocation),
+			zap.Stringer("current end location", currentLocation))
+		// Do not execute a later DDL past an unresolved DDL barrier.
+		return true, terror.ErrDBUnExpect.Generate("pending asynchronous DDL does not match the current DDL")
+	}
+	if s.asyncDDLResolved(info) {
+		return true, nil
+	}
+
+	err := s.pollAsyncDDL(s.asyncDDLPollContext(tctx), mysql.ErrInvalidConn, info.ddls[info.index], conn, info.createTime)
+	if err == nil {
+		s.markAsyncDDLResolved(info)
+	} else if terror.ErrSyncerCancelledDDL.Equal(err) {
+		// TiDB has reached a terminal non-success state, so no unknown
+		// downstream outcome remains to reconcile. Clear the descriptor after
+		// surfacing the error and preserve the existing explicit-Resume retry
+		// behavior.
+		s.clearAsyncDDLReconcileInfo(info)
+	}
+	return true, err
+}
+
 // handleSpecialDDLError handles special errors for DDL execution
 // if createTime equals to -1, skip the handle procedure for waitAsyncDDL.
-func (s *Syncer) handleSpecialDDLError(tctx *tcontext.Context, err error, ddls []string, index int, conn *dbconn.DBConn, createTime int64) error {
+func (s *Syncer) handleSpecialDDLError(
+	tctx *tcontext.Context,
+	err error,
+	ddls []string,
+	index int,
+	conn *dbconn.DBConn,
+	createTime int64,
+	startLocation binlog.Location,
+	currentLocation binlog.Location,
+) error {
 	// We use default parser because ddls are came from *Syncer.genDDLInfo, which is StringSingleQuotes, KeyWordUppercase and NameBackQuotes
 	parser2 := parser.New()
 
@@ -217,42 +427,21 @@ func (s *Syncer) handleSpecialDDLError(tctx *tcontext.Context, err error, ddls [
 
 	// it handles the operations for DDL when encountering `invalid connection` by waiting the asynchronous ddl to synchronize
 	waitAsyncDDL := func(tctx *tcontext.Context, err error, ddls []string, index int, conn *dbconn.DBConn, createTime int64) error {
-		if len(ddls) == 0 || index > len(ddls)-1 || errors.Cause(err) != mysql.ErrInvalidConn || createTime == -1 {
+		if len(ddls) == 0 || index < 0 || index > len(ddls)-1 || errors.Cause(err) != mysql.ErrInvalidConn || createTime == -1 {
 			return err // return the original error
 		}
 
-		duration := 30
-		failpoint.Inject("ChangeDuration", func() {
-			duration = 1
-		})
-		ticker := time.NewTicker(time.Duration(duration) * time.Second)
-		defer ticker.Stop()
-
-		for {
-			status, err2 := getDDLStatusFromTiDB(tctx, conn, ddls[index], createTime)
-			if err2 != nil {
-				s.tctx.L().Warn("error when getting DDL status from TiDB", zap.Error(err2))
-			}
-			failpoint.Inject("TestStatus", func(val failpoint.Value) {
-				status = val.(string)
-				s.tctx.L().Info("injected test status:", zap.String("TestStatus", status))
-			})
-			switch status {
-			case model.JobStateDone.String(), model.JobStateSynced.String():
-				return nil
-			case model.JobStateCancelled.String(), model.JobStateRollingback.String(), model.JobStateRollbackDone.String(), model.JobStateCancelling.String():
-				return terror.ErrSyncerCancelledDDL.Generate(ddls[index])
-			case model.JobStateRunning.String(), model.JobStateQueueing.String(), model.JobStateNone.String():
-			default:
-				tctx.L().Warn("Unexpected DDL status", zap.String("DDL status", status))
-				return err
-			}
-			select {
-			case <-tctx.Ctx.Done():
-				return err
-			case <-ticker.C:
-			}
+		info := s.setAsyncDDLReconcileInfo(ddls, index, createTime, startLocation, currentLocation)
+		retErr := s.pollAsyncDDL(s.asyncDDLPollContext(tctx), err, info.ddls[info.index], conn, info.createTime)
+		if retErr == nil {
+			s.markAsyncDDLResolved(info)
+		} else if terror.ErrSyncerCancelledDDL.Equal(retErr) {
+			// A terminal cancelled/rollback state is a known failure rather than
+			// an unknown async result. Surface it now and allow an explicit Resume
+			// to use the syncer's normal retry/recovery path.
+			s.clearAsyncDDLReconcileInfo(info)
 		}
+		return retErr
 	}
 
 	retErr := err

--- a/dm/syncer/error_test.go
+++ b/dm/syncer/error_test.go
@@ -16,13 +16,18 @@ package syncer
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/pkg/errno"
+	"github.com/pingcap/tiflow/dm/pkg/binlog"
 	"github.com/pingcap/tiflow/dm/pkg/conn"
 	tcontext "github.com/pingcap/tiflow/dm/pkg/context"
+	"github.com/pingcap/tiflow/dm/pkg/retry"
+	"github.com/pingcap/tiflow/dm/pkg/terror"
+	"github.com/pingcap/tiflow/dm/pkg/utils"
 	"github.com/pingcap/tiflow/dm/syncer/dbconn"
 	"github.com/pingcap/tiflow/dm/syncer/metrics"
 	"github.com/stretchr/testify/require"
@@ -147,7 +152,8 @@ func TestHandleSpecialDDLError(t *testing.T) {
 	syncer.metricsProxies = metrics.DefaultMetricsProxies.CacheForOneTask("task", "worker", "source")
 
 	for _, cs := range cases {
-		err2 := syncer.handleSpecialDDLError(tctx, cs.err, cs.ddls, cs.index, conn2, -1)
+		err2 := syncer.handleSpecialDDLError(
+			tctx, cs.err, cs.ddls, cs.index, conn2, -1, binlog.Location{}, binlog.Location{})
 		if cs.handled {
 			require.NoError(t, err2)
 		} else {
@@ -182,7 +188,8 @@ func TestHandleSpecialDDLError(t *testing.T) {
 	mock.ExpectExec(dropColumnWithIndex).WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
-	handledErr := syncer.handleSpecialDDLError(tctx, execErr, ddls, 0, conn2, -1)
+	handledErr := syncer.handleSpecialDDLError(
+		tctx, execErr, ddls, 0, conn2, -1, binlog.Location{}, binlog.Location{})
 	require.NoError(t, mock.ExpectationsWereMet())
 	require.NoError(t, handledErr)
 
@@ -192,9 +199,86 @@ func TestHandleSpecialDDLError(t *testing.T) {
 	mock.ExpectQuery("SELECT count\\(\\*\\) FROM information_schema.statistics WHERE.*").WillReturnRows(
 		sqlmock.NewRows([]string{"count(*)"}).AddRow(2))
 
-	handledErr = syncer.handleSpecialDDLError(tctx, execErr, ddls, 0, conn2, -1)
+	handledErr = syncer.handleSpecialDDLError(
+		tctx, execErr, ddls, 0, conn2, -1, binlog.Location{}, binlog.Location{})
 	require.NoError(t, mock.ExpectationsWereMet())
 	require.Error(t, execErr, handledErr)
+}
+
+func TestWaitAsyncDDLCanceled(t *testing.T) {
+	const ddlSQL = "ALTER TABLE `test`.`t` ADD COLUMN `c` INT"
+
+	cfg := genDefaultSubTaskConfig4Test()
+	syncer := NewSyncer(cfg, nil, nil)
+	syncer.metricsProxies = metrics.DefaultMetricsProxies.CacheForOneTask("task", "worker", "source")
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	sqlConn, err := db.Conn(context.Background())
+	require.NoError(t, err)
+	dbConn := dbconn.NewDBConn(cfg, conn.NewBaseConnForTest(sqlConn, &retry.FiniteRetryStrategy{}))
+	mock.ExpectQuery("ADMIN SHOW DDL JOBS 10").WillReturnRows(
+		sqlmock.NewRows([]string{"JOB_ID", "CREATE_TIME", "STATE"}).
+			AddRow(1, "2026-08-03 18:00:00", "running"))
+	mock.ExpectQuery("ADMIN SHOW DDL JOB QUERIES LIMIT 10 OFFSET 0").WillReturnRows(
+		sqlmock.NewRows([]string{"JOB_ID", "QUERY"}).AddRow(1, ddlSQL))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tctx := tcontext.Background().WithContext(ctx)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- syncer.handleSpecialDDLError(
+			tctx,
+			mysql.ErrInvalidConn,
+			[]string{ddlSQL},
+			0,
+			dbConn,
+			1,
+			binlog.Location{},
+			binlog.Location{},
+		)
+	}()
+
+	require.Eventually(t, func() bool {
+		return mock.ExpectationsWereMet() == nil
+	}, time.Second, 10*time.Millisecond)
+	cancel()
+
+	select {
+	case err = <-errCh:
+		require.True(t, utils.IsContextCanceledError(err), err)
+		require.NotEqual(t, mysql.ErrInvalidConn, errors.Cause(err))
+	case <-time.After(time.Second):
+		t.Fatal("waitAsyncDDL did not stop after its context was canceled")
+	}
+}
+
+func TestReconcileAsyncDDLMismatchIsBarrier(t *testing.T) {
+	cfg := genDefaultSubTaskConfig4Test()
+	syncer := NewSyncer(cfg, nil, nil)
+	startLocation := binlog.MustZeroLocation(cfg.Flavor)
+	currentLocation := startLocation.Clone()
+	currentLocation.Position.Pos++
+	info := syncer.setAsyncDDLReconcileInfo(
+		[]string{"ALTER TABLE `old_target`.`t` ADD COLUMN `c` INT"},
+		0,
+		1,
+		startLocation,
+		currentLocation,
+	)
+
+	reconciled, err := syncer.reconcileAsyncDDL(
+		tcontext.Background(),
+		[]string{"ALTER TABLE `new_target`.`t` ADD COLUMN `c` INT"},
+		startLocation,
+		currentLocation,
+		nil,
+	)
+	require.True(t, reconciled)
+	require.True(t, terror.ErrDBUnExpect.Equal(err), err)
+	require.Same(t, info, syncer.getAsyncDDLReconcileInfo())
+	require.False(t, syncer.asyncDDLResolved(info))
 }
 
 func TestIsConnectionRefusedError(t *testing.T) {

--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -113,6 +113,19 @@ const (
 	waitComplete
 )
 
+// asyncDDLReconcileInfo describes a TiDB DDL whose submission result was
+// unknown because the SQL connection became invalid. It is retained across a
+// Pause/Resume so the resumed syncer can resolve the original TiDB job before
+// it considers re-executing the binlog DDL.
+type asyncDDLReconcileInfo struct {
+	ddls            []string
+	index           int
+	createTime      int64
+	startLocation   binlog.Location
+	currentLocation binlog.Location
+	resolved        bool
+}
+
 // Syncer can sync your MySQL data to another MySQL database.
 type Syncer struct {
 	sync.RWMutex
@@ -164,6 +177,9 @@ type Syncer struct {
 	waitXIDJob          atomic.Int64
 	isTransactionEnd    bool
 	waitTransactionLock sync.Mutex
+
+	asyncDDLReconcileMu sync.Mutex
+	asyncDDLReconcile   *asyncDDLReconcileInfo
 
 	tableRouter     *regexprrouter.RouteTable
 	binlogFilter    *bf.BinlogEvent
@@ -1262,6 +1278,9 @@ func (s *Syncer) handleJob(job *job) (added2Queue bool, err error) {
 		})
 		skipCheckFlush = true
 		err = s.flushCheckPoints()
+		if err == nil {
+			s.clearResolvedAsyncDDL(job.ddls, job.startLocation, job.currentLocation)
+		}
 		// nolint:nakedret
 		return
 	case flush:
@@ -1463,6 +1482,9 @@ func (s *Syncer) syncDDL(queueBucket string, db *dbconn.DBConn, ddlJobChan chan 
 		if !ok {
 			return
 		}
+		// err is shared only within one worker goroutine but must not leak from
+		// an earlier DDL into a reconciled DDL that does not call ExecuteSQL.
+		err = nil
 
 		// add this ddl ts beacause we start to exec this ddl.
 		s.updateReplicationJobTS(ddlJob, ddlJobIdx)
@@ -1502,6 +1524,11 @@ func (s *Syncer) syncDDL(queueBucket string, db *dbconn.DBConn, ddlJobChan chan 
 				s.tctx.L().Info("skip save global point", zap.String("failpoint", "SkipSaveGlobalPoint"))
 				panic("SkipSaveGlobalPoint")
 			})
+		}
+		// A sharding operation can become ignorable after Pause. An unresolved
+		// async DDL is still a hard barrier, so reconcile it even in that case
+		// rather than advancing the checkpoint past an unknown downstream job.
+		if !ignore || s.getAsyncDDLReconcileInfo() != nil {
 			// set timezone
 			if ddlJob.timezone != "" {
 				s.timezoneLastTime = ddlJob.timezone
@@ -1522,33 +1549,56 @@ func (s *Syncer) syncDDL(queueBucket string, db *dbconn.DBConn, ddlJobChan chan 
 			setTimestampSQLDefault := "SET TIMESTAMP = DEFAULT"
 			ddlJob.ddls = append(ddlJob.ddls, setTimestampSQLDefault)
 
-			var affected int
-			var ddlCreateTime int64 = -1 // default when scan failed
-			row, err2 := db.QuerySQL(s.syncCtx, s.metricsProxies, "SELECT UNIX_TIMESTAMP()")
-			if err2 != nil {
-				s.tctx.L().Warn("selecting unix timestamp failed", zap.Error(err2))
-			} else {
-				for row.Next() {
-					err2 = row.Scan(&ddlCreateTime)
-					if err2 != nil {
-						s.tctx.L().Warn("getting ddlCreateTime failed", zap.Error(err2))
-					}
-				}
-				//nolint:sqlclosecheck
-				_ = row.Close()
-				_ = row.Err()
+			reconciled, reconcileErr := s.reconcileAsyncDDL(
+				s.syncCtx,
+				ddlJob.ddls,
+				ddlJob.startLocation,
+				ddlJob.currentLocation,
+				db,
+			)
+			if reconcileErr != nil {
+				err = terror.WithScope(reconcileErr, terror.ScopeDownstream)
+			} else if reconciled {
+				err = nil
 			}
-			affected, err = db.ExecuteSQLWithIgnore(s.syncCtx, s.metricsProxies, errorutil.IsIgnorableMySQLDDLError, ddlJob.ddls)
-			failpoint.Inject("TestHandleSpecialDDLError", func() {
-				err = mysql2.ErrInvalidConn
-				// simulate the value of affected along with the injected error due to the adding of SET SQL of timezone and timestamp
-				if affected == 0 {
-					affected++
+			if !ignore && !reconciled {
+				var affected int
+				var ddlCreateTime int64 = -1 // default when scan failed
+				row, err2 := db.QuerySQL(s.syncCtx, s.metricsProxies, "SELECT UNIX_TIMESTAMP()")
+				if err2 != nil {
+					s.tctx.L().Warn("selecting unix timestamp failed", zap.Error(err2))
+				} else {
+					for row.Next() {
+						err2 = row.Scan(&ddlCreateTime)
+						if err2 != nil {
+							s.tctx.L().Warn("getting ddlCreateTime failed", zap.Error(err2))
+						}
+					}
+					//nolint:sqlclosecheck
+					_ = row.Close()
+					_ = row.Err()
 				}
-			})
-			if err != nil {
-				err = s.handleSpecialDDLError(s.syncCtx, err, ddlJob.ddls, affected, db, ddlCreateTime)
-				err = terror.WithScope(err, terror.ScopeDownstream)
+				affected, err = db.ExecuteSQLWithIgnore(s.syncCtx, s.metricsProxies, errorutil.IsIgnorableMySQLDDLError, ddlJob.ddls)
+				failpoint.Inject("TestHandleSpecialDDLError", func() {
+					err = mysql2.ErrInvalidConn
+					// simulate the value of affected along with the injected error due to the adding of SET SQL of timezone and timestamp
+					if affected == 0 {
+						affected++
+					}
+				})
+				if err != nil {
+					err = s.handleSpecialDDLError(
+						s.syncCtx,
+						err,
+						ddlJob.ddls,
+						affected,
+						db,
+						ddlCreateTime,
+						ddlJob.startLocation,
+						ddlJob.currentLocation,
+					)
+					err = terror.WithScope(err, terror.ScopeDownstream)
+				}
 			}
 		}
 		failpoint.Label("bypass")
@@ -1669,6 +1719,14 @@ func (s *Syncer) syncDML() {
 
 func (s *Syncer) waitBeforeRunExit(ctx context.Context) {
 	defer s.runWg.Done()
+	// Capture the cancel functions for this run. Syncer can be resumed and its
+	// context fields replaced, so a late timeout must never cancel a later run.
+	runCancel := s.runCancel
+	forceStop := func() {
+		if runCancel != nil {
+			runCancel()
+		}
+	}
 	failpoint.Inject("checkCheckpointInMiddleOfTransaction", func() {
 		s.tctx.L().Info("incr maxPauseOrStopWaitTime time ")
 		defaultMaxPauseOrStopWaitTime = time.Minute * 10
@@ -1677,20 +1735,6 @@ func (s *Syncer) waitBeforeRunExit(ctx context.Context) {
 	case <-ctx.Done(): // hijack the root context from s.Run to wait for the transaction to end.
 		s.tctx.L().Info("received subtask's done, try graceful stop")
 		needToExitTime := time.Now()
-		s.waitTransactionLock.Lock()
-
-		failpoint.Inject("checkWaitDuration", func(_ failpoint.Value) {
-			s.isTransactionEnd = false
-		})
-		if s.isTransactionEnd {
-			s.waitXIDJob.Store(int64(waitComplete))
-			s.waitTransactionLock.Unlock()
-			s.tctx.L().Info("the last job is transaction end, done directly")
-			s.runCancel()
-			return
-		}
-		s.waitXIDJob.Store(int64(waiting))
-		s.waitTransactionLock.Unlock()
 		s.refreshCliArgs()
 
 		waitDuration := defaultMaxPauseOrStopWaitTime
@@ -1705,11 +1749,52 @@ func (s *Syncer) waitBeforeRunExit(ctx context.Context) {
 		failpoint.Inject("recordAndIgnorePrepareTime", func() {
 			waitBeforeRunExitDurationForTest = waitDuration
 		})
-		if waitDuration.Seconds() <= 0 {
+		if waitDuration <= 0 {
 			s.tctx.L().Info("wait transaction end timeout, exit now")
-			s.runCancel()
+			forceStop()
 			return
 		}
+
+		// The transaction lock can be held while handleJob waits for an
+		// asynchronous DDL. Start the deadline before taking the lock so the
+		// timeout can cancel that DDL poller and break the wait cycle.
+		timeoutDone := make(chan struct{})
+		timer := time.AfterFunc(waitDuration, func() {
+			s.tctx.L().Info("wait transaction end timeout, exit now")
+			forceStop()
+			close(timeoutDone)
+		})
+		defer func() {
+			// If the callback is already running, wait for it to finish. Together
+			// with the captured cancel funcs above, this prevents a timeout from
+			// leaking into a subsequent Resume run.
+			if !timer.Stop() {
+				<-timeoutDone
+			}
+		}()
+
+		s.waitTransactionLock.Lock()
+		select {
+		case <-timeoutDone:
+			s.waitTransactionLock.Unlock()
+			return
+		default:
+		}
+
+		failpoint.Inject("checkWaitDuration", func(_ failpoint.Value) {
+			s.isTransactionEnd = false
+		})
+		if s.isTransactionEnd {
+			s.waitXIDJob.Store(int64(waitComplete))
+			s.waitTransactionLock.Unlock()
+			s.tctx.L().Info("the last job is transaction end, done directly")
+			if runCancel != nil {
+				runCancel()
+			}
+			return
+		}
+		s.waitXIDJob.Store(int64(waiting))
+		s.waitTransactionLock.Unlock()
 		failpoint.Inject("checkWaitDuration", func(val failpoint.Value) {
 			if testDuration, testError := time.ParseDuration(val.(string)); testError == nil {
 				if testDuration.Seconds() == waitDuration.Seconds() {
@@ -1724,9 +1809,7 @@ func (s *Syncer) waitBeforeRunExit(ctx context.Context) {
 		select {
 		case <-s.runCtx.Ctx.Done():
 			s.tctx.L().Info("syncer run exit so runCtx done")
-		case <-time.After(waitDuration):
-			s.tctx.L().Info("wait transaction end timeout, exit now")
-			s.runCancel()
+		case <-timeoutDone:
 		}
 	case <-s.runCtx.Ctx.Done(): // when no graceful stop, run ctx will canceled first.
 		s.tctx.L().Info("received ungraceful exit ctx, exit now")
@@ -1782,12 +1865,12 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 	syncCtx, syncCancel := context.WithCancel(context.Background())
 	s.syncCtx, s.syncCancel = tcontext.NewContext(syncCtx, s.tctx.L()), syncCancel
 	defer func() {
-		s.runCancel()
+		runCancel()
 		s.closeJobChans()
 		s.checkpointFlushWorker.Close()
 		s.runWg.Wait()
-		// s.syncCancel won't be called when normal exit, this call just to follow the best practice of use context.
-		s.syncCancel()
+		// syncCancel won't be called when normal exit, this call just follows the best practice for using context.
+		syncCancel()
 	}()
 
 	// we should start this goroutine as soon as possible, because it's the only goroutine that cancel syncer.Run

--- a/dm/syncer/syncer_test.go
+++ b/dm/syncer/syncer_test.go
@@ -28,7 +28,7 @@ import (
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/replication"
-	_ "github.com/go-sql-driver/mysql"
+	gmysql "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
 	pclog "github.com/pingcap/log"
@@ -1972,6 +1972,317 @@ func TestWaitBeforeRunExit(t *testing.T) {
 	require.Equal(t, context.Canceled, syncer.runCtx.Ctx.Err())
 	require.Equal(t, 2*time.Second, waitBeforeRunExitDurationForTest)
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tiflow/dm/syncer/recordAndIgnorePrepareTime"))
+}
+
+type singleAttemptRetryStrategy struct{}
+
+func (singleAttemptRetryStrategy) Apply(
+	ctx *tcontext.Context,
+	_ retry.Params,
+	operateFn retry.OperateFunc,
+) (interface{}, int, error) {
+	ret, err := operateFn(ctx)
+	return ret, 0, err
+}
+
+func TestWaitBeforeRunExitCancelsBlockedAsyncDDL(t *testing.T) {
+	const (
+		ddlSQL      = "CREATE TABLE IF NOT EXISTS `test`.`t` (`id` INT)"
+		waitOnStop  = 200 * time.Millisecond
+		waitTimeout = 2 * time.Second
+	)
+	cfg := genDefaultSubTaskConfig4Test()
+	cfg.WorkerCount = 1
+	cfg.QueueSize = 16
+	syncer := NewSyncer(cfg, nil, nil)
+	syncer.metricsProxies = metrics.DefaultMetricsProxies.CacheForOneTask("task", "worker", "source")
+	syncer.cliArgs = &config.TaskCliArgs{WaitTimeOnStop: waitOnStop.String()}
+	syncer.reset()
+	syncer.runFatalChan = make(chan *pb.ProcessError, 1)
+
+	runCtx, runCancel := context.WithCancel(context.Background())
+	syncCtx, syncCancel := context.WithCancel(context.Background())
+	syncer.runCtx, syncer.runCancel = tcontext.NewContext(runCtx, syncer.tctx.L()), runCancel
+	syncer.syncCtx, syncer.syncCancel = tcontext.NewContext(syncCtx, syncer.tctx.L()), syncCancel
+	t.Cleanup(func() {
+		runCancel()
+		syncCancel()
+		syncer.closeJobChans()
+	})
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	sqlConn, err := db.Conn(context.Background())
+	require.NoError(t, err)
+	syncer.ddlDBConn = dbconn.NewDBConn(
+		cfg,
+		conn.NewBaseConnForTest(sqlConn, singleAttemptRetryStrategy{}),
+	)
+
+	mock.ExpectQuery("SELECT UNIX_TIMESTAMP\\(\\)").
+		WillReturnRows(sqlmock.NewRows([]string{"UNIX_TIMESTAMP()"}).AddRow(1000))
+	mock.ExpectBegin()
+	mock.ExpectExec("SET TIMESTAMP = 0").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS").WillReturnError(gmysql.ErrInvalidConn)
+	mock.ExpectRollback()
+	mock.ExpectQuery("ADMIN SHOW DDL JOBS 10").WillReturnRows(
+		sqlmock.NewRows([]string{"JOB_ID", "CREATE_TIME", "STATE"}).
+			AddRow(1, "2026-08-03 18:00:00", "running"))
+	mock.ExpectQuery("ADMIN SHOW DDL JOB QUERIES LIMIT 10 OFFSET 0").WillReturnRows(
+		sqlmock.NewRows([]string{"JOB_ID", "QUERY"}).AddRow(1, ddlSQL))
+
+	startLocation := binlog.MustZeroLocation(mysql.MySQLFlavor)
+	startLocation.Position = mysql.Position{Name: "mysql-bin.000001", Pos: 100}
+	currentLocation := startLocation.Clone()
+	currentLocation.Position.Pos = 200
+	ddlJob := newDummyJob(ddl, &filter.Table{Schema: "test", Name: "t"}, ddlSQL)
+	ddlJob.location = currentLocation
+	ddlJob.startLocation = startLocation
+	ddlJob.currentLocation = currentLocation
+	ddlJob.jobAddTime = time.Now()
+	ddlJob.eventHeader = &replication.EventHeader{}
+	checkpointBeforeDDL := syncer.checkpoint.GlobalPoint()
+
+	syncer.runWg.Add(1)
+	go syncer.syncDDL(adminQueueName, syncer.ddlDBConn, syncer.ddlJobCh)
+	handleJobDone := make(chan error, 1)
+	go func() {
+		_, handleErr := syncer.handleJob(ddlJob)
+		handleJobDone <- handleErr
+	}()
+
+	// Consuming the ADMIN SHOW DDL JOBS expectation proves syncDDL has entered
+	// waitAsyncDDL. At this point handleJob must still own the transaction lock
+	// while it waits on jobWg.
+	require.Eventually(t, func() bool {
+		return mock.ExpectationsWereMet() == nil
+	}, time.Second, 10*time.Millisecond)
+	if syncer.waitTransactionLock.TryLock() {
+		syncer.waitTransactionLock.Unlock()
+		t.Fatal("handleJob did not hold waitTransactionLock while async DDL polling was blocked")
+	}
+	require.NotNil(t, syncer.getAsyncDDLReconcileInfo())
+
+	outerCtx, outerCancel := context.WithCancel(context.Background())
+	syncer.runWg.Add(1)
+	go syncer.waitBeforeRunExit(outerCtx)
+	stopStarted := time.Now()
+	outerCancel()
+
+	select {
+	case <-runCtx.Done():
+	case <-time.After(waitTimeout):
+		t.Fatal("graceful deadline did not cancel runCtx while the transaction lock was held")
+	}
+	// Only the graceful run context owns async-DDL polling. The execution
+	// context remains alive, so the deadline cannot create a new ambiguous
+	// outcome by canceling a DDL that is still inside ExecuteSQL.
+	require.NoError(t, syncCtx.Err())
+
+	select {
+	case err = <-handleJobDone:
+		require.NoError(t, err)
+	case <-time.After(waitTimeout):
+		t.Fatal("handleJob did not return after the asynchronous DDL poller was canceled")
+	}
+	syncer.closeJobChans()
+	runDone := make(chan struct{})
+	go func() {
+		syncer.runWg.Wait()
+		close(runDone)
+	}()
+	select {
+	case <-runDone:
+	case <-time.After(waitTimeout):
+		t.Fatal("syncer goroutines did not drain after the graceful deadline")
+	}
+
+	stopDuration := time.Since(stopStarted)
+	require.GreaterOrEqual(t, stopDuration, waitOnStop/2)
+	require.Less(t, stopDuration, waitTimeout)
+	require.True(t, utils.IsContextCanceledError(syncer.execError.Load()), syncer.execError.Load())
+	require.Empty(t, syncer.runFatalChan)
+	require.Equal(t, checkpointBeforeDDL, syncer.checkpoint.GlobalPoint())
+	require.NotEqual(t, currentLocation, syncer.checkpoint.GlobalPoint())
+	// Cancellation leaves the descriptor unresolved for an in-memory Resume;
+	// it must not be cleared merely because the DM-side polling stopped.
+	require.NotNil(t, syncer.getAsyncDDLReconcileInfo())
+}
+
+type asyncDDLBarrierCheckpoint struct {
+	CheckPoint
+	mu     sync.Mutex
+	global binlog.Location
+}
+
+func (cp *asyncDDLBarrierCheckpoint) SaveGlobalPoint(location binlog.Location) {
+	cp.mu.Lock()
+	cp.global = location
+	cp.mu.Unlock()
+}
+
+func (cp *asyncDDLBarrierCheckpoint) GlobalPoint() binlog.Location {
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	return cp.global
+}
+
+func (*asyncDDLBarrierCheckpoint) Snapshot(bool) *SnapshotInfo { return nil }
+
+func (*asyncDDLBarrierCheckpoint) LastFlushOutdated() bool { return false }
+
+func TestSyncDDLReconcilesPendingAsyncDDL(t *testing.T) {
+	const ddlSQL = "CREATE TABLE IF NOT EXISTS `test`.`t` (`id` INT)"
+
+	testCases := []struct {
+		name               string
+		status             string
+		cancelPolling      bool
+		expectContextErr   bool
+		expectCancelled    bool
+		expectCheckpoint   bool
+		expectInfoRetained bool
+	}{
+		{
+			name:               "running",
+			status:             "running",
+			cancelPolling:      true,
+			expectContextErr:   true,
+			expectInfoRetained: true,
+		},
+		{
+			name:             "synced",
+			status:           "synced",
+			expectCheckpoint: true,
+		},
+		{
+			name:            "cancelled",
+			status:          "cancelled",
+			expectCancelled: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := genDefaultSubTaskConfig4Test()
+			cfg.WorkerCount = 1
+			cfg.QueueSize = 16
+			syncer := NewSyncer(cfg, nil, nil)
+			syncer.metricsProxies = metrics.DefaultMetricsProxies.CacheForOneTask(
+				"task-"+testCase.name, "worker", "source")
+			syncer.reset()
+			syncer.runFatalChan = make(chan *pb.ProcessError, 1)
+
+			runCtx, runCancel := context.WithCancel(context.Background())
+			syncer.runCtx, syncer.runCancel = tcontext.NewContext(runCtx, syncer.tctx.L()), runCancel
+			syncCtx, syncCancel := context.WithCancel(context.Background())
+			syncer.syncCtx, syncer.syncCancel = tcontext.NewContext(syncCtx, syncer.tctx.L()), syncCancel
+			t.Cleanup(func() {
+				runCancel()
+				syncCancel()
+				syncer.closeJobChans()
+			})
+
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, db.Close()) })
+			sqlConn, err := db.Conn(context.Background())
+			require.NoError(t, err)
+			syncer.ddlDBConn = dbconn.NewDBConn(
+				cfg,
+				conn.NewBaseConnForTest(sqlConn, &retry.FiniteRetryStrategy{}),
+			)
+			mock.ExpectQuery("ADMIN SHOW DDL JOBS 10").WillReturnRows(
+				sqlmock.NewRows([]string{"JOB_ID", "CREATE_TIME", "STATE"}).
+					AddRow(1, "2026-08-03 18:00:00", testCase.status))
+			mock.ExpectQuery("ADMIN SHOW DDL JOB QUERIES LIMIT 10 OFFSET 0").WillReturnRows(
+				sqlmock.NewRows([]string{"JOB_ID", "QUERY"}).AddRow(1, ddlSQL))
+
+			startLocation := binlog.MustZeroLocation(mysql.MySQLFlavor)
+			startLocation.Position = mysql.Position{Name: "mysql-bin.000001", Pos: 100}
+			currentLocation := startLocation.Clone()
+			currentLocation.Position.Pos = 200
+			wrappedDDLs := []string{
+				"SET TIMESTAMP = 0",
+				ddlSQL,
+				"SET TIMESTAMP = DEFAULT",
+			}
+			info := syncer.setAsyncDDLReconcileInfo(
+				wrappedDDLs, 1, 1000, startLocation, currentLocation)
+			wrappedDDLs[1] = "mutated after descriptor creation"
+			require.Equal(t, ddlSQL, info.ddls[1])
+			// reset is the same state transition used by Resume and must retain
+			// the unresolved async-DDL barrier.
+			syncer.reset()
+			require.Same(t, info, syncer.getAsyncDDLReconcileInfo())
+			checkpoint := &asyncDDLBarrierCheckpoint{
+				global: binlog.MustZeroLocation(mysql.MySQLFlavor),
+			}
+			syncer.checkpoint = checkpoint
+
+			ddlJob := newDummyJob(ddl, &filter.Table{Schema: "test", Name: "t"}, ddlSQL)
+			ddlJob.location = currentLocation
+			ddlJob.startLocation = startLocation
+			ddlJob.currentLocation = currentLocation
+			ddlJob.jobAddTime = time.Now()
+			ddlJob.eventHeader = &replication.EventHeader{}
+
+			syncer.runWg.Add(1)
+			go syncer.syncDDL(adminQueueName, syncer.ddlDBConn, syncer.ddlJobCh)
+			handleJobDone := make(chan error, 1)
+			go func() {
+				_, handleErr := syncer.handleJob(ddlJob)
+				handleJobDone <- handleErr
+			}()
+
+			require.Eventually(t, func() bool {
+				return mock.ExpectationsWereMet() == nil
+			}, time.Second, 10*time.Millisecond)
+			if testCase.cancelPolling {
+				runCancel()
+			}
+
+			select {
+			case err = <-handleJobDone:
+				require.NoError(t, err)
+			case <-time.After(2 * time.Second):
+				t.Fatal("handleJob did not finish while reconciling the pending asynchronous DDL")
+			}
+			syncer.closeJobChans()
+			runDone := make(chan struct{})
+			go func() {
+				syncer.runWg.Wait()
+				close(runDone)
+			}()
+			select {
+			case <-runDone:
+			case <-time.After(2 * time.Second):
+				t.Fatal("DDL worker did not drain after reconciliation")
+			}
+
+			execErr := syncer.execError.Load()
+			switch {
+			case testCase.expectContextErr:
+				require.True(t, utils.IsContextCanceledError(execErr), execErr)
+			case testCase.expectCancelled:
+				require.True(t, terror.ErrSyncerCancelledDDL.Equal(execErr), execErr)
+			default:
+				require.NoError(t, execErr)
+			}
+			if testCase.expectCheckpoint {
+				require.Equal(t, currentLocation, checkpoint.GlobalPoint())
+			} else {
+				require.NotEqual(t, currentLocation, checkpoint.GlobalPoint())
+			}
+			if testCase.expectInfoRetained {
+				require.Same(t, info, syncer.getAsyncDDLReconcileInfo())
+				require.False(t, syncer.asyncDDLResolved(info))
+			} else {
+				require.Nil(t, syncer.getAsyncDDLReconcileInfo())
+			}
+		})
+	}
 }
 
 func TestSyncerGetTableInfo(t *testing.T) {


### PR DESCRIPTION
### What problem does this PR solve?

When a downstream TiDB DDL continues asynchronously after its SQL connection
returns `mysql.ErrInvalidConn`, DM polls the TiDB DDL job from
`waitAsyncDDL`.

`handleJob` holds `waitTransactionLock` while waiting for the DDL worker, but
`waitBeforeRunExit` previously needed the same lock before it could reach the
graceful-stop timeout path. The DDL poller also used `syncCtx`, which was
canceled only after `runWg.Wait()`. Together these dependencies allowed
Pause/Stop to wait for the downstream DDL for hours instead of honoring
`wait-time-on-stop`.

Issue Number: close #12781

### What is changed and how it works?

- Arm the graceful-stop timer before waiting for `waitTransactionLock`, so the
  deadline can fire while `handleJob` owns the lock.
- Capture the current Run's cancel function in the timer callback, preventing a
  late callback from canceling a subsequent Resume.
- Use the graceful `runCtx` for asynchronous DDL status polling and
  reconciliation. Regular DDL execution remains on `syncCtx`, so reaching the
  graceful deadline does not cancel an in-progress `ExecuteSQL` and create a
  new unknown DDL submission result.
- Return the polling context error after Pause/Stop instead of surfacing the
  original `mysql.ErrInvalidConn` as a fatal downstream error.
- Retain an in-memory reconciliation descriptor across Pause/Resume with the
  routed/wrapped SQL list, failed statement index, TiDB DDL creation time, and
  binlog start/end locations.
- On same-instance Resume, reconcile the original TiDB job before continuing:
  - keep polling a running or queued job;
  - avoid duplicate execution for a completed job, then advance and flush its
    checkpoint;
  - surface a cancelled or rollback job without advancing the checkpoint.
- Reject a different SQL list or binlog location inside the reconciliation path
  instead of executing another DDL past the unresolved job.
- Clear a successful descriptor only after post-DDL bookkeeping and checkpoint
  flushing succeed.

The descriptor is intentionally scoped to Pause/Stop and Resume on the same
`Syncer` with unchanged DDL processing configuration. This change does not
persist the descriptor across worker restarts or add a global barrier for
configuration or `handle-error` changes.

### Check List

#### Tests

- [x] Unit test
  - `make dm_unit_test_pkg PKG=github.com/pingcap/tiflow/dm/syncer`
  - `go test -race ./dm/syncer -run 'Test(WaitAsyncDDLCanceled|ReconcileAsyncDDLMismatchIsBarrier|WaitBeforeRunExitCancelsBlockedAsyncDDL|SyncDDLReconcilesPendingAsyncDDL)$' -count=1`
  - `go test -race ./dm/syncer -run '^TestWaitBeforeRunExitCancelsBlockedAsyncDDL$' -count=10`
- [x] Manual test
  - `go vet ./dm/syncer`
  - `make fmt`
  - `git diff --check`

#### Questions

##### Will it cause performance regression or break compatibility?

No user-facing API or configuration compatibility change is expected. The
additional descriptor and status matching are used only after the existing
asynchronous-DDL invalid-connection recovery path and its subsequent Resume.
A terminal cancelled DDL remains an explicit task error and does not advance
the checkpoint.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
Fix an issue where DM Pause or Stop could wait indefinitely past the configured graceful-stop timeout while polling a downstream asynchronous TiDB DDL job.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of asynchronous DDL operations during synchronization, including pause, resume, and shutdown scenarios.
  * Pending DDL changes are now reconciled more reliably before processing continues.
  * Added cancellation safeguards to prevent shutdowns from leaving operations stuck.
  * Improved recovery from invalid database connections while preserving unresolved DDL state when needed.
* **Reliability**
  * Checkpoint and DDL state are now retained or cleared based on the reconciliation outcome, reducing inconsistent synchronization states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->