### PR TITLE
conn(dm): cap pooled DB connection lifetime and idle time

### DIFF
--- a/dm/config/dbconfig/config.go
+++ b/dm/config/dbconfig/config.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/pingcap/tiflow/dm/config/security"
@@ -49,6 +50,14 @@ type RawDBConfig struct {
 	MaxIdleConns int
 	ReadTimeout  string
 	WriteTimeout string
+	// ConnMaxLifetime caps the total lifetime of a pooled connection.
+	// A zero (or negative) value means the process-wide default is used
+	// (see basedb.Apply). Set explicitly to override.
+	ConnMaxLifetime time.Duration
+	// ConnMaxIdleTime caps how long a connection may sit idle in the pool
+	// before being closed. A zero (or negative) value means the process-wide
+	// default is used (see basedb.Apply). Set explicitly to override.
+	ConnMaxIdleTime time.Duration
 }
 
 // SetReadTimeout set readTimeout for raw database config.
@@ -68,6 +77,18 @@ func (c *RawDBConfig) SetWriteTimeout(writeTimeout string) *RawDBConfig {
 // set value > 0 then `value` idle connections are retained.
 func (c *RawDBConfig) SetMaxIdleConns(value int) *RawDBConfig {
 	c.MaxIdleConns = value
+	return c
+}
+
+// SetConnMaxLifetime sets the maximum lifetime of a pooled connection.
+func (c *RawDBConfig) SetConnMaxLifetime(d time.Duration) *RawDBConfig {
+	c.ConnMaxLifetime = d
+	return c
+}
+
+// SetConnMaxIdleTime sets the maximum idle time of a pooled connection.
+func (c *RawDBConfig) SetConnMaxIdleTime(d time.Duration) *RawDBConfig {
+	c.ConnMaxIdleTime = d
 	return c
 }
 

--- a/dm/pkg/conn/basedb.go
+++ b/dm/pkg/conn/basedb.go
@@ -44,6 +44,20 @@ var customID int64
 
 var netTimeout = DefaultDBTimeout
 
+const (
+	// defaultConnMaxLifetime is the default maximum lifetime of a pooled
+	// database/sql connection. It is set well below any reasonable server-side
+	// `wait_timeout` (MySQL/TiDB default is 8h) and any typical stateful
+	// middlebox idle timeout, so the pool never hands out a connection whose
+	// peer has silently gone away (rolling restart, `wait_timeout` expiry,
+	// keepalive miss). See https://pkg.go.dev/database/sql#DB.SetConnMaxLifetime.
+	defaultConnMaxLifetime = 30 * time.Minute
+	// defaultConnMaxIdleTime bounds how long a connection may sit idle in the
+	// pool. It complements defaultConnMaxLifetime for connections that are
+	// used rarely. See https://pkg.go.dev/database/sql#DB.SetConnMaxIdleTime.
+	defaultConnMaxIdleTime = 5 * time.Minute
+)
+
 // DBProvider providers BaseDB instance.
 type DBProvider interface {
 	Apply(config ScopedDBConfig) (*BaseDB, error)
@@ -148,6 +162,8 @@ func (d *DefaultDBProviderImpl) ApplyWithPingTimeout(config ScopedDBConfig, ping
 	}
 
 	var maxIdleConns int
+	connMaxLifetime := defaultConnMaxLifetime
+	connMaxIdleTime := defaultConnMaxIdleTime
 	rawCfg := config.RawDBCfg
 	if rawCfg != nil {
 		if rawCfg.ReadTimeout != "" {
@@ -157,6 +173,12 @@ func (d *DefaultDBProviderImpl) ApplyWithPingTimeout(config ScopedDBConfig, ping
 			dsn += fmt.Sprintf("&writeTimeout=%s", rawCfg.WriteTimeout)
 		}
 		maxIdleConns = rawCfg.MaxIdleConns
+		if rawCfg.ConnMaxLifetime > 0 {
+			connMaxLifetime = rawCfg.ConnMaxLifetime
+		}
+		if rawCfg.ConnMaxIdleTime > 0 {
+			connMaxIdleTime = rawCfg.ConnMaxIdleTime
+		}
 	}
 
 	var setFK bool
@@ -200,6 +222,14 @@ func (d *DefaultDBProviderImpl) ApplyWithPingTimeout(config ScopedDBConfig, ping
 	}
 
 	db.SetMaxIdleConns(maxIdleConns)
+	// Cap connection lifetime so the pool proactively closes and re-opens
+	// TCP connections before the server or any middlebox drops them.
+	// Without this, a pooled connection re-used after the peer has silently
+	// gone away surfaces as `mysql.ErrInvalidConn` on the next statement,
+	// which the DM retry classifier treats as unretryable and causes the
+	// syncer/loader/dumper unit to exit with an error.
+	db.SetConnMaxLifetime(connMaxLifetime)
+	db.SetConnMaxIdleTime(connMaxIdleTime)
 
 	return NewBaseDB(db, config.Scope, version, doFuncInClose), nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiFlow! -->

### What problem does this PR solve?

Issue Number: close #12789

`dm/pkg/conn/basedb.go#Apply` only calls `db.SetMaxIdleConns`; neither
`db.SetConnMaxLifetime` nor `db.SetConnMaxIdleTime` is ever set, so a
pooled `*sql.DB` connection to the upstream MySQL or the downstream
TiDB / MySQL lives for as long as the DM worker process.

When the peer server silently drops such a connection (rolling restart,
`wait_timeout` expiry, or a stateful middlebox timing out the flow), the
next statement re-using it surfaces as `mysql.ErrInvalidConn`, which
`dm/pkg/retry/errors.go#IsUnretryableConnectionError` classifies as
unretryable. The syncer / loader / dumper unit therefore exits with an
error and `dm_{syncer,loader,mydumper}_exit_with_error_count{resumable_err="true"}`
increments. Task-checker auto-resumes seconds later, so each individual
failure looks spurious, but with many concurrent tasks the aggregate
becomes a steady stream of DM "resumable error" alerts.

### What is changed and how it works?

Apply two conservative defaults in `Apply` so the pool proactively
closes and re-opens a connection before its peer can drop it:

* `SetConnMaxLifetime(30m)` — well below the MySQL/TiDB default
  `wait_timeout` of 28800 s (8 h) and any typical middlebox idle timeout.
  At the default `MaxIdleConns` this is roughly two reconnects per minute
  per pooled slot — negligible next to steady-state syncer traffic.
* `SetConnMaxIdleTime(5m)` — retires connections that are only used
  intermittently before the wall clock does.

Both defaults are also exposed as `ConnMaxLifetime` / `ConnMaxIdleTime`
on `RawDBConfig` (with matching `Set…` methods for symmetry), so callers
that build a `DBConfig` programmatically can raise or lower them without
touching package-level defaults. A zero (or negative) `RawDBCfg` value
keeps the package default, so this is fully backwards-compatible with
every existing caller.

### Check List

#### Tests

 - No code — behaviour of `database/sql` connection lifetime is
   documented and its handlers are simple setters; there is no additional
   observable behaviour beyond what `database/sql` already tests. The
   existing `dm/pkg/conn` test suite (including `TestGetBaseConn`,
   `TestFailDBPing`, `TestGetBaseConnWontBlock`) passes unchanged.

#### Questions

##### Will it cause performance regression or break compatibility?

No. Steady-state churn is on the order of `MaxIdleConns / 30 min` — a
handful of extra `sql.Open`s per minute per worker per unit — which is
negligible against the normal statement rate. Every caller keeps its
current behaviour unless it explicitly overrides `RawDBConfig`.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
dm: cap pooled DB connection lifetime and idle time so a peer server or middlebox silently dropping an idle TCP connection no longer surfaces as a non-retryable "invalid connection" unit exit.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable database connection lifetime and idle-time limits.
  * Introduced default limits to proactively refresh database connections.

* **Bug Fixes**
  * Reduced stale connection errors and improved database connection reliability during retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->