### PR TITLE
openapi(dm): support task safe mode

### DIFF
--- a/dm/config/task_converters.go
+++ b/dm/config/task_converters.go
@@ -281,6 +281,9 @@ func OpenAPITaskToSubTaskConfigs(task *openapi.Task, toDBCfg *dbconfig.DBConfig,
 			if incrCfg.ReplBatch != nil {
 				subTaskCfg.SyncerConfig.Batch = *incrCfg.ReplBatch
 			}
+			if incrCfg.SafeMode != nil {
+				subTaskCfg.SyncerConfig.SafeMode = *incrCfg.SafeMode
+			}
 		}
 		subTaskCfg.ValidatorCfg = defaultValidatorConfig()
 		// set route,blockAllowList,filter config
@@ -582,6 +585,7 @@ func SubTaskConfigsToOpenAPITask(subTaskConfigList []*SubTaskConfig) *openapi.Ta
 	taskSourceConfig.IncrMigrateConf = &openapi.TaskIncrMigrateConf{
 		ReplBatch:   &oneSubtaskConfig.SyncerConfig.Batch,
 		ReplThreads: &oneSubtaskConfig.SyncerConfig.WorkerCount,
+		SafeMode:    &oneSubtaskConfig.SyncerConfig.SafeMode,
 	}
 	if oneSubtaskConfig.LoaderConfig.Security != nil {
 		var certAllowedCN []string

--- a/dm/config/task_converters_test.go
+++ b/dm/config/task_converters_test.go
@@ -109,6 +109,7 @@ func testNoShardTaskToSubTaskConfigs(c *check.C) {
 	c.Assert(subTaskConfig.LoaderConfig.PoolSize, check.Equals, *task.SourceConfig.FullMigrateConf.ImportThreads)
 	c.Assert(subTaskConfig.SyncerConfig.WorkerCount, check.Equals, *task.SourceConfig.IncrMigrateConf.ReplThreads)
 	c.Assert(subTaskConfig.SyncerConfig.Batch, check.Equals, *task.SourceConfig.IncrMigrateConf.ReplBatch)
+	c.Assert(subTaskConfig.SyncerConfig.SafeMode, check.Equals, *task.SourceConfig.IncrMigrateConf.SafeMode)
 	// check route
 	c.Assert(subTaskConfig.RouteRules, check.HasLen, 1)
 	rule := subTaskConfig.RouteRules[0]
@@ -200,6 +201,7 @@ func testShardAndFilterTaskToSubTaskConfigs(c *check.C) {
 	c.Assert(subTask1Config.LoaderConfig.PoolSize, check.Equals, *task.SourceConfig.FullMigrateConf.ImportThreads)
 	c.Assert(subTask1Config.SyncerConfig.WorkerCount, check.Equals, *task.SourceConfig.IncrMigrateConf.ReplThreads)
 	c.Assert(subTask1Config.SyncerConfig.Batch, check.Equals, *task.SourceConfig.IncrMigrateConf.ReplBatch)
+	c.Assert(subTask1Config.SyncerConfig.SafeMode, check.Equals, *task.SourceConfig.IncrMigrateConf.SafeMode)
 	// check route
 	c.Assert(subTask1Config.RouteRules, check.HasLen, 1)
 	rule := subTask1Config.RouteRules[0]
@@ -264,6 +266,7 @@ func testShardAndFilterTaskToSubTaskConfigs(c *check.C) {
 	c.Assert(subTask2Config.LoaderConfig.PoolSize, check.Equals, *task.SourceConfig.FullMigrateConf.ImportThreads)
 	c.Assert(subTask2Config.SyncerConfig.WorkerCount, check.Equals, *task.SourceConfig.IncrMigrateConf.ReplThreads)
 	c.Assert(subTask2Config.SyncerConfig.Batch, check.Equals, *task.SourceConfig.IncrMigrateConf.ReplBatch)
+	c.Assert(subTask2Config.SyncerConfig.SafeMode, check.Equals, *task.SourceConfig.IncrMigrateConf.SafeMode)
 	// check route
 	c.Assert(subTask2Config.RouteRules, check.HasLen, 1)
 	rule = subTask2Config.RouteRules[0]
@@ -418,6 +421,43 @@ func TestConvertWithIgnoreCheckItems(t *testing.T) {
 	newTask := taskList[0]
 	require.Equal(t, *newTask.IgnoreCheckingItems, ignoreCheckingItems)
 	require.Equal(t, *newTask, task)
+}
+
+func TestOpenAPITaskSafeModeDefaults(t *testing.T) {
+	task, err := fixtures.GenNoShardOpenAPITaskForTest()
+	require.NoError(t, err)
+	sourceCfg, err := SourceCfgFromYamlAndVerify(SampleSourceConfig)
+	require.NoError(t, err)
+	sourceName := task.SourceConfig.SourceConf[0].SourceName
+	sourceCfg.SourceID = sourceName
+	sourceCfgMap := map[string]*SourceConfig{sourceName: sourceCfg}
+	toDBCfg := GetTargetDBCfgFromOpenAPITask(&task)
+
+	safeModeFalse := false
+	safeModeTrue := true
+	testCases := []struct {
+		name     string
+		safeMode *bool
+		expected bool
+	}{
+		{name: "omitted", safeMode: nil, expected: false},
+		{name: "false", safeMode: &safeModeFalse, expected: false},
+		{name: "true", safeMode: &safeModeTrue, expected: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			task.SourceConfig.IncrMigrateConf.SafeMode = testCase.safeMode
+			subTaskCfgs, convertErr := OpenAPITaskToSubTaskConfigs(&task, toDBCfg, sourceCfgMap)
+			require.NoError(t, convertErr)
+			require.Len(t, subTaskCfgs, 1)
+			require.Equal(t, testCase.expected, subTaskCfgs[0].SyncerConfig.SafeMode)
+
+			convertedTask := SubTaskConfigsToOpenAPITask(subTaskCfgs)
+			require.NotNil(t, convertedTask.SourceConfig.IncrMigrateConf.SafeMode)
+			require.Equal(t, testCase.expected, *convertedTask.SourceConfig.IncrMigrateConf.SafeMode)
+		})
+	}
 }
 
 func TestOpenAPITaskImportIntoMultiSourceRejected(t *testing.T) {

--- a/dm/master/openapi_view_test.go
+++ b/dm/master/openapi_view_test.go
@@ -552,6 +552,7 @@ func (s *OpenAPIViewSuite) TestTaskTemplatesAPI() {
 	s.NoError(result.UnmarshalBodyToObject(&createTaskResp))
 	s.Equal(createTaskResp.Name, task.Name)
 	s.EqualValues(task.Timezone, createTaskResp.Timezone)
+	s.EqualValues(task.SourceConfig.IncrMigrateConf.SafeMode, createTaskResp.SourceConfig.IncrMigrateConf.SafeMode)
 
 	// create again will fail
 	result = testutil.NewRequest().Post(url).WithJsonBody(task).GoWithHTTPHandler(s.T(), s1.openapiHandles)
@@ -568,6 +569,7 @@ func (s *OpenAPIViewSuite) TestTaskTemplatesAPI() {
 	s.Equal(1, resultTaskList.Total)
 	s.Equal(task.Name, resultTaskList.Data[0].Name)
 	s.EqualValues(task.Timezone, resultTaskList.Data[0].Timezone)
+	s.EqualValues(task.SourceConfig.IncrMigrateConf.SafeMode, resultTaskList.Data[0].SourceConfig.IncrMigrateConf.SafeMode)
 
 	// get detail
 	oneURL := fmt.Sprintf("%s/%s", url, task.Name)
@@ -577,6 +579,7 @@ func (s *OpenAPIViewSuite) TestTaskTemplatesAPI() {
 	s.NoError(result.UnmarshalBodyToObject(&respTask))
 	s.Equal(task.Name, respTask.Name)
 	s.EqualValues(task.Timezone, respTask.Timezone)
+	s.EqualValues(task.SourceConfig.IncrMigrateConf.SafeMode, respTask.SourceConfig.IncrMigrateConf.SafeMode)
 
 	// get not exist
 	notExistURL := fmt.Sprintf("%s/%s", url, "notexist")
@@ -591,6 +594,7 @@ func (s *OpenAPIViewSuite) TestTaskTemplatesAPI() {
 	s.Equal(http.StatusOK, result.Code())
 	s.NoError(result.UnmarshalBodyToObject(&respTask))
 	s.Equal(task.Name, respTask.Name)
+	s.EqualValues(task.SourceConfig.IncrMigrateConf.SafeMode, respTask.SourceConfig.IncrMigrateConf.SafeMode)
 
 	// update not exist will fail
 	task.Name = "notexist"
@@ -1006,10 +1010,12 @@ func (s *OpenAPIViewSuite) TestTaskAPI() {
 	s.NoError(result.UnmarshalBodyToObject(&createTaskResp))
 	s.Equal(createTaskResp.Task.Name, task.Name)
 	s.EqualValues(task.Timezone, createTaskResp.Task.Timezone)
+	s.EqualValues(task.SourceConfig.IncrMigrateConf.SafeMode, createTaskResp.Task.SourceConfig.IncrMigrateConf.SafeMode)
 	subTaskM := s1.scheduler.GetSubTaskCfgsByTask(task.Name)
 	s.Len(subTaskM, 1)
 	s.Equal(task.Name, subTaskM[source1Name].Name)
 	s.Equal(*task.Timezone, subTaskM[source1Name].Timezone)
+	s.Equal(*task.SourceConfig.IncrMigrateConf.SafeMode, subTaskM[source1Name].SyncerConfig.SafeMode)
 
 	// get task
 	task1URL := fmt.Sprintf("%s/%s", taskURL, task.Name)
@@ -1019,6 +1025,7 @@ func (s *OpenAPIViewSuite) TestTaskAPI() {
 	s.NoError(result.UnmarshalBodyToObject(&task1FromHTTP))
 	s.Equal(task1FromHTTP.Name, task.Name)
 	s.EqualValues(task.Timezone, task1FromHTTP.Timezone)
+	s.EqualValues(task.SourceConfig.IncrMigrateConf.SafeMode, task1FromHTTP.SourceConfig.IncrMigrateConf.SafeMode)
 
 	// changing timezone through PUT is rejected by the bottom update guard.
 	updatedTimezone := "UTC"
@@ -1057,6 +1064,43 @@ func (s *OpenAPIViewSuite) TestTaskAPI() {
 	storedSubTaskCfgs := s1.scheduler.GetSubTaskCfgsByTask(task.Name)
 	s.Equal(*task.Timezone, storedSubTaskCfgs[source1Name].Timezone)
 
+	// changing safe mode through PUT is rejected by the bottom update guard.
+	updatedSafeMode := !*task.SourceConfig.IncrMigrateConf.SafeMode
+	safeModeUpdateTask := task
+	incrMigrateConf := *task.SourceConfig.IncrMigrateConf
+	safeModeUpdateTask.SourceConfig.IncrMigrateConf = &incrMigrateConf
+	safeModeUpdateTask.SourceConfig.IncrMigrateConf.SafeMode = &updatedSafeMode
+	mockSafeModeUpdateWorkerClient := pbmock.NewMockWorkerClient(ctrl)
+	mockSafeModeUpdateWorkerClient.EXPECT().CheckSubtasksCanUpdate(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req *pb.CheckSubtasksCanUpdateRequest, _ ...grpc.CallOption) (*pb.CheckSubtasksCanUpdateResponse, error) {
+			newSubTaskCfg := config.NewSubTaskConfig()
+			decodeErr := newSubTaskCfg.Decode(req.SubtaskCfgTomlString, false)
+			s.NoError(decodeErr)
+			if decodeErr != nil {
+				return &pb.CheckSubtasksCanUpdateResponse{Msg: decodeErr.Error()}, nil
+			}
+			s.Equal(updatedSafeMode, newSubTaskCfg.SyncerConfig.SafeMode)
+
+			guardErr := syncUnit.CheckCanUpdateCfg(newSubTaskCfg)
+			s.Error(guardErr)
+			resp := &pb.CheckSubtasksCanUpdateResponse{Success: guardErr == nil}
+			if guardErr != nil {
+				resp.Msg = guardErr.Error()
+			}
+			return resp, nil
+		},
+	)
+	s1.scheduler.SetWorkerClientForTest(workerName1, newMockRPCClient(mockSafeModeUpdateWorkerClient))
+	safeModeUpdateReq := openapi.UpdateTaskRequest{Task: safeModeUpdateTask}
+	result = testutil.NewRequest().Put(task1URL).WithJsonBody(safeModeUpdateReq).GoWithHTTPHandler(s.T(), s1.openapiHandles)
+	s.Equal(http.StatusBadRequest, result.Code())
+	var safeModeUpdateErr openapi.ErrorWithMessage
+	s.NoError(result.UnmarshalBodyToObject(&safeModeUpdateErr))
+	s.Equal(int(terror.ErrSchedulerSubTaskCfgUpdate.Code()), safeModeUpdateErr.ErrorCode)
+	s.Contains(safeModeUpdateErr.ErrorMsg, "safe-mode")
+	storedSubTaskCfgs = s1.scheduler.GetSubTaskCfgsByTask(task.Name)
+	s.Equal(*task.SourceConfig.IncrMigrateConf.SafeMode, storedSubTaskCfgs[source1Name].SyncerConfig.SafeMode)
+
 	// update a task
 	s.NoError(failpoint.Enable("github.com/pingcap/tiflow/dm/master/scheduler/operateCheckSubtasksCanUpdate", `return("success")`))
 	clone := task
@@ -1078,6 +1122,7 @@ func (s *OpenAPIViewSuite) TestTaskAPI() {
 	s.Equal(1, resultTaskList.Total)
 	s.Equal(task.Name, resultTaskList.Data[0].Name)
 	s.EqualValues(task.Timezone, resultTaskList.Data[0].Timezone)
+	s.EqualValues(task.SourceConfig.IncrMigrateConf.SafeMode, resultTaskList.Data[0].SourceConfig.IncrMigrateConf.SafeMode)
 
 	s.testImportTaskTemplate(&task, s1)
 

--- a/dm/openapi/fixtures/task.go
+++ b/dm/openapi/fixtures/task.go
@@ -42,7 +42,7 @@ var (
 			  "cert_allowed_cn": ["PD1", "PD2"]
 			}
 		  },
-		  "incr_migrate_conf": { "repl_batch": 200, "repl_threads": 32 },
+		  "incr_migrate_conf": { "repl_batch": 200, "repl_threads": 32, "safe_mode": true },
 		  "source_conf": [{ "source_name": "mysql-replica-01" }]
 		},
 		"table_migrate_rule": [
@@ -127,7 +127,7 @@ var (
 			"import_mode": "logical",
 			"import_threads": 16
 		  },
-		  "incr_migrate_conf": { "repl_batch": 200, "repl_threads": 32 },
+		  "incr_migrate_conf": { "repl_batch": 200, "repl_threads": 32, "safe_mode": true },
 		  "source_conf": [
 			{
 			  "binlog_gtid": "",

--- a/dm/openapi/gen.server.go
+++ b/dm/openapi/gen.server.go
@@ -161,6 +161,7 @@ type MiddlewareFunc func(c *gin.Context)
 
 // DMAPIGetClusterInfo operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetClusterInfo(c *gin.Context) {
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -170,6 +171,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetClusterInfo(c *gin.Context) {
 
 // DMAPIUpdateClusterInfo operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIUpdateClusterInfo(c *gin.Context) {
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -179,6 +181,7 @@ func (siw *ServerInterfaceWrapper) DMAPIUpdateClusterInfo(c *gin.Context) {
 
 // DMAPIGetClusterMasterList operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetClusterMasterList(c *gin.Context) {
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -188,6 +191,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetClusterMasterList(c *gin.Context) {
 
 // DMAPIOfflineMasterNode operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIOfflineMasterNode(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "master-name" -------------
@@ -208,6 +212,7 @@ func (siw *ServerInterfaceWrapper) DMAPIOfflineMasterNode(c *gin.Context) {
 
 // DMAPIGetClusterWorkerList operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetClusterWorkerList(c *gin.Context) {
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -217,6 +222,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetClusterWorkerList(c *gin.Context) {
 
 // DMAPIOfflineWorkerNode operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIOfflineWorkerNode(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "worker-name" -------------
@@ -237,6 +243,7 @@ func (siw *ServerInterfaceWrapper) DMAPIOfflineWorkerNode(c *gin.Context) {
 
 // GetDocJSON operation middleware
 func (siw *ServerInterfaceWrapper) GetDocJSON(c *gin.Context) {
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -246,6 +253,7 @@ func (siw *ServerInterfaceWrapper) GetDocJSON(c *gin.Context) {
 
 // GetDocHTML operation middleware
 func (siw *ServerInterfaceWrapper) GetDocHTML(c *gin.Context) {
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -255,6 +263,7 @@ func (siw *ServerInterfaceWrapper) GetDocHTML(c *gin.Context) {
 
 // DMAPIGetSourceList operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetSourceList(c *gin.Context) {
+
 	var err error
 
 	// Parameter object where we will unmarshal all parameters from the context
@@ -262,6 +271,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSourceList(c *gin.Context) {
 
 	// ------------- Optional query parameter "with_status" -------------
 	if paramValue := c.Query("with_status"); paramValue != "" {
+
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "with_status", c.Request.URL.Query(), &params.WithStatus)
@@ -272,6 +282,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSourceList(c *gin.Context) {
 
 	// ------------- Optional query parameter "enable_relay" -------------
 	if paramValue := c.Query("enable_relay"); paramValue != "" {
+
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "enable_relay", c.Request.URL.Query(), &params.EnableRelay)
@@ -289,6 +300,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSourceList(c *gin.Context) {
 
 // DMAPICreateSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPICreateSource(c *gin.Context) {
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -298,6 +310,7 @@ func (siw *ServerInterfaceWrapper) DMAPICreateSource(c *gin.Context) {
 
 // DMAPIDeleteSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIDeleteSource(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -314,6 +327,7 @@ func (siw *ServerInterfaceWrapper) DMAPIDeleteSource(c *gin.Context) {
 
 	// ------------- Optional query parameter "force" -------------
 	if paramValue := c.Query("force"); paramValue != "" {
+
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "force", c.Request.URL.Query(), &params.Force)
@@ -331,6 +345,7 @@ func (siw *ServerInterfaceWrapper) DMAPIDeleteSource(c *gin.Context) {
 
 // DMAPIGetSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetSource(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -347,6 +362,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSource(c *gin.Context) {
 
 	// ------------- Optional query parameter "with_status" -------------
 	if paramValue := c.Query("with_status"); paramValue != "" {
+
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "with_status", c.Request.URL.Query(), &params.WithStatus)
@@ -364,6 +380,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSource(c *gin.Context) {
 
 // DMAPIUpdateSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIUpdateSource(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -384,6 +401,7 @@ func (siw *ServerInterfaceWrapper) DMAPIUpdateSource(c *gin.Context) {
 
 // DMAPIDisableSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIDisableSource(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -404,6 +422,7 @@ func (siw *ServerInterfaceWrapper) DMAPIDisableSource(c *gin.Context) {
 
 // DMAPIEnableSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIEnableSource(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -424,6 +443,7 @@ func (siw *ServerInterfaceWrapper) DMAPIEnableSource(c *gin.Context) {
 
 // DMAPIDisableRelay operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIDisableRelay(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -444,6 +464,7 @@ func (siw *ServerInterfaceWrapper) DMAPIDisableRelay(c *gin.Context) {
 
 // DMAPIEnableRelay operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIEnableRelay(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -464,6 +485,7 @@ func (siw *ServerInterfaceWrapper) DMAPIEnableRelay(c *gin.Context) {
 
 // DMAPIPurgeRelay operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIPurgeRelay(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -484,6 +506,7 @@ func (siw *ServerInterfaceWrapper) DMAPIPurgeRelay(c *gin.Context) {
 
 // DMAPIGetSourceSchemaList operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetSourceSchemaList(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -504,6 +527,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSourceSchemaList(c *gin.Context) {
 
 // DMAPIGetSourceTableList operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetSourceTableList(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -533,6 +557,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSourceTableList(c *gin.Context) {
 
 // DMAPIGetSourceStatus operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetSourceStatus(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -553,6 +578,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSourceStatus(c *gin.Context) {
 
 // DMAPITransferSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPITransferSource(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -573,6 +599,7 @@ func (siw *ServerInterfaceWrapper) DMAPITransferSource(c *gin.Context) {
 
 // DMAPIGetTaskList operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetTaskList(c *gin.Context) {
+
 	var err error
 
 	// Parameter object where we will unmarshal all parameters from the context
@@ -580,6 +607,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskList(c *gin.Context) {
 
 	// ------------- Optional query parameter "with_status" -------------
 	if paramValue := c.Query("with_status"); paramValue != "" {
+
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "with_status", c.Request.URL.Query(), &params.WithStatus)
@@ -590,6 +618,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskList(c *gin.Context) {
 
 	// ------------- Optional query parameter "stage" -------------
 	if paramValue := c.Query("stage"); paramValue != "" {
+
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "stage", c.Request.URL.Query(), &params.Stage)
@@ -600,6 +629,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskList(c *gin.Context) {
 
 	// ------------- Optional query parameter "source_name_list" -------------
 	if paramValue := c.Query("source_name_list"); paramValue != "" {
+
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "source_name_list", c.Request.URL.Query(), &params.SourceNameList)
@@ -617,6 +647,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskList(c *gin.Context) {
 
 // DMAPICreateTask operation middleware
 func (siw *ServerInterfaceWrapper) DMAPICreateTask(c *gin.Context) {
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -626,6 +657,7 @@ func (siw *ServerInterfaceWrapper) DMAPICreateTask(c *gin.Context) {
 
 // DMAPIConvertTask operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIConvertTask(c *gin.Context) {
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -635,6 +667,7 @@ func (siw *ServerInterfaceWrapper) DMAPIConvertTask(c *gin.Context) {
 
 // DMAPIGetTaskTemplateList operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetTaskTemplateList(c *gin.Context) {
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -644,6 +677,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskTemplateList(c *gin.Context) {
 
 // DMAPICreateTaskTemplate operation middleware
 func (siw *ServerInterfaceWrapper) DMAPICreateTaskTemplate(c *gin.Context) {
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -653,6 +687,7 @@ func (siw *ServerInterfaceWrapper) DMAPICreateTaskTemplate(c *gin.Context) {
 
 // DMAPIImportTaskTemplate operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIImportTaskTemplate(c *gin.Context) {
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -662,6 +697,7 @@ func (siw *ServerInterfaceWrapper) DMAPIImportTaskTemplate(c *gin.Context) {
 
 // DMAPIDeleteTaskTemplate operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIDeleteTaskTemplate(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -682,6 +718,7 @@ func (siw *ServerInterfaceWrapper) DMAPIDeleteTaskTemplate(c *gin.Context) {
 
 // DMAPIGetTaskTemplate operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetTaskTemplate(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -702,6 +739,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskTemplate(c *gin.Context) {
 
 // DMAPUpdateTaskTemplate operation middleware
 func (siw *ServerInterfaceWrapper) DMAPUpdateTaskTemplate(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -722,6 +760,7 @@ func (siw *ServerInterfaceWrapper) DMAPUpdateTaskTemplate(c *gin.Context) {
 
 // DMAPIDeleteTask operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIDeleteTask(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -738,6 +777,7 @@ func (siw *ServerInterfaceWrapper) DMAPIDeleteTask(c *gin.Context) {
 
 	// ------------- Optional query parameter "force" -------------
 	if paramValue := c.Query("force"); paramValue != "" {
+
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "force", c.Request.URL.Query(), &params.Force)
@@ -748,6 +788,7 @@ func (siw *ServerInterfaceWrapper) DMAPIDeleteTask(c *gin.Context) {
 
 	// ------------- Optional query parameter "keep_meta" -------------
 	if paramValue := c.Query("keep_meta"); paramValue != "" {
+
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "keep_meta", c.Request.URL.Query(), &params.KeepMeta)
@@ -765,6 +806,7 @@ func (siw *ServerInterfaceWrapper) DMAPIDeleteTask(c *gin.Context) {
 
 // DMAPIGetTask operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetTask(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -781,6 +823,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTask(c *gin.Context) {
 
 	// ------------- Optional query parameter "with_status" -------------
 	if paramValue := c.Query("with_status"); paramValue != "" {
+
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "with_status", c.Request.URL.Query(), &params.WithStatus)
@@ -798,6 +841,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTask(c *gin.Context) {
 
 // DMAPIUpdateTask operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIUpdateTask(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -818,6 +862,7 @@ func (siw *ServerInterfaceWrapper) DMAPIUpdateTask(c *gin.Context) {
 
 // DMAPIGetTaskMigrateTargets operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetTaskMigrateTargets(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -843,6 +888,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskMigrateTargets(c *gin.Context) {
 
 	// ------------- Optional query parameter "schema_pattern" -------------
 	if paramValue := c.Query("schema_pattern"); paramValue != "" {
+
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "schema_pattern", c.Request.URL.Query(), &params.SchemaPattern)
@@ -853,6 +899,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskMigrateTargets(c *gin.Context) {
 
 	// ------------- Optional query parameter "table_pattern" -------------
 	if paramValue := c.Query("table_pattern"); paramValue != "" {
+
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "table_pattern", c.Request.URL.Query(), &params.TablePattern)
@@ -870,6 +917,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskMigrateTargets(c *gin.Context) {
 
 // DMAPIGetSchemaListByTaskAndSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetSchemaListByTaskAndSource(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -899,6 +947,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSchemaListByTaskAndSource(c *gin.Cont
 
 // DMAPIGetTableListByTaskAndSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetTableListByTaskAndSource(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -937,6 +986,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTableListByTaskAndSource(c *gin.Conte
 
 // DMAPIDeleteTableStructure operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIDeleteTableStructure(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -984,6 +1034,7 @@ func (siw *ServerInterfaceWrapper) DMAPIDeleteTableStructure(c *gin.Context) {
 
 // DMAPIGetTableStructure operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetTableStructure(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -1031,6 +1082,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTableStructure(c *gin.Context) {
 
 // DMAPIOperateTableStructure operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIOperateTableStructure(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -1078,6 +1130,7 @@ func (siw *ServerInterfaceWrapper) DMAPIOperateTableStructure(c *gin.Context) {
 
 // DMAPIStartTask operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIStartTask(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -1098,6 +1151,7 @@ func (siw *ServerInterfaceWrapper) DMAPIStartTask(c *gin.Context) {
 
 // DMAPIGetTaskStatus operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetTaskStatus(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -1114,6 +1168,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskStatus(c *gin.Context) {
 
 	// ------------- Optional query parameter "source_name_list" -------------
 	if paramValue := c.Query("source_name_list"); paramValue != "" {
+
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "source_name_list", c.Request.URL.Query(), &params.SourceNameList)
@@ -1131,6 +1186,7 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskStatus(c *gin.Context) {
 
 // DMAPIStopTask operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIStopTask(c *gin.Context) {
+
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -1258,126 +1314,131 @@ func RegisterHandlersWithOptions(router *gin.Engine, si ServerInterface, options
 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
-	"H4sIAAAAAAAC/+x9W3fbNtboX8HROQ9NR1fbcRLPmoc0djM+x7ms2D39Zk36yRAJShiTAAOAdtUs//dv",
-	"4UISJAGSsi3XajIPU0fEZWNj37Gx8XUQ0CSlBBHBB0dfBzxYoQSqP1/HiIl3kMAlYhc0pTFdruXvKaMp",
-	"YgIj1WpFuZD/Rb/DJI3R4Ggw23sxno6n49lgOBDrVP7EBcNkObgdDlLKqs1fTV/tF+0wEWiJ2OD2djhg",
-	"6EuGGQoHR//Wk5jOvxWt6eI/KBBy1DdxxgVi76D8/yaMMAzVryHiAcOpwJQMjtSviHNAIyBWCAQZY4gI",
-	"kKhBAKEhGgxdyzp6uXfoXBuM8TVqzkNJjAkCXECRmdkwN9PYMwiWoWLUBaUxgkQOGyMYIgf8mNsjqTWY",
-	"pj0GJTBB1W3TwzgWVtsL1TNfbAHdUCO5ZXP8JAQloc0TTWlzYbX7PwxFg6PB/56URDoxFDpxkuftcLBk",
-	"MIIE9h7nrW5vD6FRUYwwj7GmcSxQwrvG00RoD2cwAhmD6t8powkSK5Tx3kB+LLrYA99QdnVnOH9Vnf1w",
-	"3vq3Unf90/hsQTMSzjnNWIDmOSFX59QfgfwIVHMgqOYWjbPmtMmaf4lH07YJBVw6ptLDq48Fc/smUW1d",
-	"MzTZUQ/Rnx0l6quQuhDl5E9KrhGTNAv51Sf0JUOaiqp7KyC/6iIpOYAiJMiv5gElEV7OIxw7kKY/AvkR",
-	"YALWMIlBRFkCBVgJkfKjySSkAR+nmCwDmI4Dmkz+WE0EDhcTLuAiRhM5yUiPkzEoxx3J4UZRFsdjJ9q6",
-	"Vs5TSjj6Sy7dphi1HAekTtpgCAp0rijISxqawLowpAexxJaP5kfdRG9m9EP8QKTswpxr0mPM5cZ8QjFc",
-	"W9PW5GAg/5CCiAuaAgiYbA6YaT+sQWlhqRDs3fL8PUzQmWztJPjjLEnPlR3iEJmFfRJmSQoygpswLVL1",
-	"H02u2l47PBg0zbehsipjJFA4VyRb7RbSbBGjsh/JkoXuhrjACRRoLqiA8ZzRm749I0wwX6FwvlgLtHGn",
-	"DSZKGV1KfaYoqS7HNdiOJfswVacwu78Di4111tfgRuFQ7ZwFu4uIT8hmNAyZ6CRi9XW+wCSmy/lS4NBJ",
-	"d0xgsgRvL06PcyMhS7lgCCZAd60oUfQKzqJgb2+EgunL0WyGXo0WezAYTfcO9mAwm02n0/2j2ejFy4NX",
-	"g+GAZHEs11Uzhcstq4DosSZyEKWcVDZFDzC1QbHAZDyV/9vrD0uIjRUVwSyWxDOe6A96iipsEowQMxQI",
-	"ytbgZoUYUqDpfYnpEmAuBY4ksB4QbEPqnDBG2a9YrN4hzp02lCQZpccAkm0bZKR+nQfSnGr0Vd9AoE2t",
-	"piDSXRO+9PVMDFBdOqccaGjD4+Kkt0gYS/mURNRvWAS60dzFFuYbwHLbCjGS+SVuX1ei7o7V12kB1b42",
-	"7ejIbfevMIQC9vZIql68w3FSEs2Su61SVHKKnL19EZp+H34RxkXa8iK0TfWA0JdG2vbB1obIgwJubJst",
-	"gy9twwfEeeE6bBnkd3jJlGnMlkjwBwS+MvBjrORhKSdblGM+BvQXUgGfC5YFImPIvwoN4DxQDs2cf4mr",
-	"ztKbTyevL07Axeufzk7ApZhdgh8ucXgJMBE/zGbPwPsPF+D9L2dn4PUvFx/mp+/ffDp5d/L+Yvjx0+m7",
-	"15/+Bf7fyb90j2dg8uPF//q3kfsonGMSot9/A2/Ofjm/OPl0cgx+nDwDJ+/fnr4/+ccpIfT4J3B88vPr",
-	"X84uwJt/vv50fnLxj0xEL5PFAXjz4ezs9cVJ/m9pVrnCHWZpTQ8wXDgDMMr6dTRXv896eLxF93wsC6vO",
-	"raoFBR887L0/nU7vHfY+ozDsdudiCsP7unMt3pW/U4IENIa101myvhe+QRNz3e5Wf5hq+G34UvZ41tTV",
-	"pTgA1/6Va4tq0eD70pEvbN+L5l7uHc46cWK4pIv0PiiLHbUHzoIVCq7mDHHlxtQpNGVopFoA08L2nsqP",
-	"mIMUco7CMXCLhvsEc4ZVGDtWWpfcnU6y9msQUDLH6yRHccZXFY9PO2fVUX9lWCCufDu9Lh3SRkCtIKWY",
-	"CMDlL1CA43cggERzPhYARtKTYKjwY2W3PAzYOBriX+J5QIlAxLE2/iUGa5qBG0iEtcLK3jk0E7gMZqVq",
-	"yrWHVE9DcBns+T/tuz/dQx/93amQ1iRoLvaXNIQ5zmkqcIK5wAHgK8hCiUYpB6S2BzdYrHTk32wNJfEa",
-	"ZByF0iMnABrHFtAgyBgHmHjHPD4+A0nFmS22ph4EtfbJRbiOM6NtnN7eX419zJgrKFBGMAK5/iwFKY1x",
-	"sAaVyHczVvB7ipmxA3N+mtaZSTXSEQeBdTynmM72t3NF4ombWMpO/smutaFYzLt/OG1MfbFCIG8sOShF",
-	"DNMQBzCO18CIvKgZwtHLCofADA6uYZyhI6CmkATFUUBJyO8GPUMJxGTOUxigygpmz+vwv8MEJ1kCIoYQ",
-	"CDG/AqqXguHtT3eZ/tZHEw8aT3/EOF9XXK8yZ4oCHK0N8DxbWNG8iDLQAHsMTiNAqAC6J5Y0oc7+pagS",
-	"gBIEbnAcgwVSAmgMzhWk5ozpCOxB9OLwYP9gFL14FY1mM/RytAjRXh4+lYbpS72UWXfAsMbpTRy7+F1t",
-	"6xvFxE18KI2mj8hypmyyuIpUz/XH0i60dNj3uPNOxZ1vfVTS7d3YYrtKJSaLo3RAqkPUcJgfyGo20Yql",
-	"ROoPNazOhmD26sWrZy5mr8zrIT4Xzd2D2NqJyw2CRlyejSEBengAAiiC1TxL50mRmVUF4mYlLRQmhbhq",
-	"C7JUG1PF7lhOmI/NnXJ1M/os1z2e8GyhhnSZie4UkByJmiorw33KCJGduyRnlVidRGQv17XDPqTnYLtE",
-	"8bkyV4vjmyafaXNWyR51HDQsg2rdUZtaIO0cBRnDYt2cRhnRJmeH87hq4Wn1FmEUh4VmW+EwREQb10sk",
-	"CqfGHqgyCIgYTVQTZXtF0s5piqWa+4qYmMM4pjconAekCfYbmiSUgPdGMp+fnwHZB0c4gDqEUCCrEzmc",
-	"x/MA+h0va2AtqvKWNrU5aVYOLFfiHfpnazi5jo8n74y1MPmv59NXeXZKbWnds16htX/SN+V8cldShq/l",
-	"0q7QukiNsSbvmK/uGVVx6cBBE0Andxin7C2jWeoIM4dxM+Wuc6MjzLiYxzTQWsbVRXqjKNxsWKGj766m",
-	"Gdl8wEawRI0+LNfcWEgBtjWhE6lFtpArZc9j61XskgjGvBEeKTSJ8sK1BJBuk+peEfGme1ObGLOyVJe9",
-	"5qPSzNZGpPTmMimglFTmWua41LsXhCiG19ShzfTvRX5hgaua2efixNzFdyZImtxMdwKmMwIAOb+hLPSO",
-	"WDSoDrl/8PywjyWaRxjcY8uP1rj7+9NDlzeb5gGF1pRa1ag0VQp/pK2T7bpIRrU0WusZU95O9umZt9o7",
-	"O1VbHZsl/3Yel0J+1T8J5ALyqzIFZDjIuMvWM2uTHxvrY5SKnll/c0eE2kxZZeH8Xy1SqMXwsRKI/YaP",
-	"bjXqZ/3YKPfNV1iQrvyX7iQWbRBxFfeTJtENoy7bM6d5XgDTSfMlqdyDfhlKYxxADx3X0kKbUTOTVW2s",
-	"7XhtZ3Yjl0zcMJ80pywbECftSLe8NcOUoYReo3mC9Dl0b02i+6m4sjJlF5ArSyikN8T4Q/nP7tA9jNA8",
-	"oSGaC5ygeZjHSJveEU4QyD9LtSJ75nFnS25PuVPilOjqJR9qzKZlFhMKSAdskF+Z9ELZYAw+MhQhBj79",
-	"/GZ/f//VKMZXSEc/uQm84wT9QYm0wSOOBPjh8m/Tl0fT6SWgDMi/p9PLZ2NwhpYwWNs9aSbKzpAZ3yBl",
-	"SKBQor1wQvNG4wp29qbTw9F0NpruXcyeH00PjqbP9cT9ss/PBU1bqej+aJZw00z0JoQbiLUrpbeAplVq",
-	"eM57rqySUtG0m7Mk7Sl7rITlDXL5eovBmMKwJyTWWbt1Duug3DzNoIVpuuSmP+7QpYXPVUPjQvRc2fma",
-	"BOXKVKKAe2XyE1Cw2VShjs6GLq+DIU7jaxTOldNAg6u554y/VfLnd2mcqHEfXvvFeY5Ks06ndC/R0RJ2",
-	"lKv2JFXokIwe17HYhcQEJkuJFdcU9kHgzQoHqyJGhznIO28UWlD8huncly3RklR6t16NyGvPGKnDTAkQ",
-	"EXPRO0/FHILNF2iFSWiFHfv0LZxkh2KV31pXVGnhX5HGJrrO79v2gMvcCeiNA4vxloxmaRuR6QY1OpOa",
-	"MCOjfBSb1lrlSCVa0hlRsBFhL7Ky68N+gdHq9jg3o854LjxZIQybi31k1WAPN6u5hIzKJLlv2NWX/daU",
-	"ABcmSaYp1H3iK8KxRDPLdOwFhiGWvWD8sdK6Sx/9hMkZXf6sBvskx3KZC4isIAnQXF+Unud5jytIlqgz",
-	"LcaynrW7B3iWSqdQnZ6qLAt9/zoMY5DG2RKTPvej8ZJQhubqPF7STIH+2h1s1QykDJmTe9XMuVvXiHEd",
-	"J+vcLpVfptFQPZALk5HyKepIcPgHavlcUJYnqnjPtspBvelmfjPHpkZ+5faEKZmHmfL8hGO0Fb2Rm7eC",
-	"JNRh6CjGgTTAVR6tpI4s0WfLaayj9vkdEY18i78saSxlkfKE3CdDN3CtzpwolSILCiTVrTVZijg3qTmD",
-	"4aDM03FPps2NfhEkZaWpDlYY6S4RnK60ZQlfIOYl7PM6Uno6pTlbqfEaOUsNp9HHUTrvNtG54oVgqVOW",
-	"nMm0AarNsH8euhKqJhm9JmxqYfIN9kpntR9DAX+SXnceG3OTVg55jhNDTVEWx3IhJGAoQUSniUP1m1QY",
-	"A+2ISNoq2Ul/booK44l6uFK5c8pTBacRoAkWkpMoAyhJxXqoQtXqnMwhMIq+FbZ+zTGUqp0sVxD3NcBL",
-	"FHVI95pwqO+Pk2rqDOfWrw7d4zr4EkgJSDkwB1DkyQAxukZxQzcapaCMFocLKn/O/SOPvqi0qWw2CJO4",
-	"j24wMJjrAM3kzBQKgZhKi9I63A+Mr3kJ138fMxUD6D4scu7Az1kcG36Uws53F94KQ0lOKfhfUlEzFgoJ",
-	"jNd/uBiAqkNMRmOdRsezRA6ZrtYcBzAGOMnPDwqNYghXS3hp3cg/o6jKida3Bh7yiZ4INDRJGeJ8dHU9",
-	"SiFmvB0s0xpcXQPV2g2fYxbCMReIBOvW8XM9i4nxL9ThvE5lpEzKpUhd3CxGA5DzjElhUWWOTFAXHHI4",
-	"d+7HuaAMLlEtk07Rll7W+DP5TN5TgfjRZzICv64QAZf6kxJblxJM88MIE0Evh6bWTsYFWCAAlfJDobKw",
-	"5FS/fDoFP8hZDNxDcMn3jyaTRRZcITFJGYrw75fPxnK6MyoRHOEY8TUXKJFMuOL17hO5vsl4PNZhzPEk",
-	"R9tcfrh8ptw0hiS/5WnG7UsY1/JcKuM5EYz51fxLRvMgdsXixPwKqG8Ktw6yLmZ6OX3rGl1PPxcrhmBY",
-	"Tdc9qFsjaut0B0mkASXGV3UHLUosNAE/VR+Vhi4EjpMoKrgDIUVcZ10a76JwoScgyWKBRyaEp4RWbS/1",
-	"5sgv49IGUxvEkRiq7a2otLH1r0vFTxATrudJ4/yog2tqqsJppAgHlzl7XErZfj+S/Uz+P4xxaBJpII4z",
-	"OcMP1ZhrAtdyGoZExggKnzmQ+LcCaxMbZ0fg88Bqp/fGi/DPA9fAseKpctHOMQvkVDHxeWCJ4ZguJSFL",
-	"tWNoejC0R6pK47J1g74NFbroe3boJHDdoweB2zbTPAehSxTnPeQeqsBHpkP+kjYThETRAAFGb7hiazO2",
-	"S1n5nTHrVLdo1eoTzgtMb2MNfo1LtK2bQJLBuAq5+dRMTwjnnUWuUmeFJybt3Xmxsbnu9F1QsBauegKr",
-	"Z6uergZD75CdoDKOPbnq+qPUqzo21SX6xxPZxZ1N6TMaT0nANjMaLb/KYzNKQpwvoAiq16xmzdsZ9lh8",
-	"TYIVowT/UUylxgDodxRoypMm9JcMEoHVVO6rFWncUwrUF9IpCnw4rN7IdruKpZWt7oM3cGZ0UBmG6sz3",
-	"ND1EnrBlxYZ813qVs7fBFKZH3yncx/xmvhrAdXBqk/m8TH8QtwiTtYZw+VXvCG4ZNmqeqdbOHcoZpvtR",
-	"MN073B/tvQxejGYz9GIED5/vjw6D6eLlQfj8VbQ/PZqNXkwPZgd7+8Pp84MXB+F+YDV/uf98b7Q33Q8X",
-	"eweHYbgfHs1GsxdTZ6G86m0Gq/Cd+lBeK/H1TGkVQQdOubadDJSWnBDf5lcCeR5QRgzFUJro7dfWpAVQ",
-	"xDkCs8ddwam6g32rg0wbj1OXudWgphfJ9RX1jtRZlNx1TmTD4d2G/Hg81+zngqapcqXL/PufzWXvwXDw",
-	"EWa8kp1a0qEzjui/O6IDloLaATU7fMl7nq/UrEH1UQ2QE7JDdsjP/VLP+hXocy3dqgdT6JJNx8jrgvSv",
-	"4dcCyf2YzD5T8Zy3DcENjsMAsjD3PKqHJYvRj/fM7mikD/qyPkSZ+dwMkveAVThhbU19s3SfUnqezfAZ",
-	"FiUXPOSGNFzBfNW8tjWzO2Kx5wQ+E8NDv5VzgxZUlRH4dlw9qUTu7SRu38Vj2VKysTO9uMCJV2qhJJV0",
-	"783po9eI3TAsNjuCK3ppt0CYWYo/uosFlPN2g+4r5xFBHKtSlPyqeVbZkrDsrNlRiMruYrW5cCoHda2h",
-	"ofSyIECce8Dd7PpLc6xhExsuoHQFiQetn9tfjerJH7kUbq0gZFs6X4tf5M/cbm50OaO3VICpCcBBrpUE",
-	"NdnkvK3ublcy4h0yzbtyy2tV2R++XpC3rvhWCwbdqoC/kMI4PqaB42Dq+B34kCLy+uMpOP7wRopcFg+O",
-	"Bl0lsUdSeY60yY0pMRWytSMUUUXiWKiFNybIE3KOBocSgSoqmSICUzw4Guyrn6TEFysF7QSmeHI9m5gy",
-	"aZN8eGMHFRVMT0M11+uPp9UqoCqvTUtWNd7edKrumJb3I2FaBDcn/+E6Wbu0j1qfMHDXG1VYr6lFLcjU",
-	"JvIsSSBbD47kGkBRb5REFPAsWAHIQaUIqYBLbhUIVcZhmvlWr4VPHQGKDX+i4frB1t4sZ9pYtJkWLOS8",
-	"t094HzKFs8pWjJ2Ivx026FHnJPK+JFkWb30cwnQUi21Dy3Bw8IBgNAoQO6bW6ryFMaz3KnLFtcnGTL7q",
-	"P5S3d6vlX4y0HejYqQ9RFGOCNNre60yaFDKYIL3L/26kHlng5TEDVWUNitUgVwQDC4aBLcZ10pYrEOt/",
-	"Fua3BuEcOOzwJ7ajVOO19vpIr43MDYaeHFZWFn4cDnNUMt4xDrNeTdmIw8zGTL4aK2wjDjPWYw8Os8Hz",
-	"c5gFw7fNYdU3cFo3MkzGOXBOznqLxDEN/u/5h/ceVqqCJccqymM0yS2kAVDTlVCFNKhBZGzUFnD+efHu",
-	"rBc4smEHOCuhk/984JiEj07RU9YD7yJmyV95mQR1ibK4eaxo+kuG2NoiaixW86KFg4jdSb+3Q8dbaGuT",
-	"IqIO9HVu8cgUP8tv8LpAqNT82gSG37YrfR0l2B2cYtelifOHEmp0UG9S0kPu4ysfjfv2336rZ1vGtuM5",
-	"oM0N7tmDwVPERJ68ntP1pgEkYZ5PDwFBN/auuza8KQMmX61Tg24td6w+FkTRKhOWMV2oKpQZwV+yajEl",
-	"v8KrHmL0UnjeYhZNgRFRXRaBpjkkMOam4mNezksFdEzeh0t0qDHuKTN2QPFqOgCwi6aGfXTILtLK4+i0",
-	"beqTFnlWHMQeOGnRYJ4KEKk3Bpv6pY0gusI4O0MTv21H77nC+LfVQKgE9/bPIY0nJodMFAveV7dNQv2q",
-	"ngqC+80e8/bebpFol8/w5HSLRvIDbGpZz61lT/VTdN+3dJtbWpih991R5ZJtxqyf8rLO36Y6cT0Xemv0",
-	"ya5KhrKubpQRXZk9v4D/MAS2geD4xsnL8ZDnrlKXEVJbJ66iYmQLbZVPEny7pNV8lqG/Gfy0KU1RQKWa",
-	"/Oa0ZIDoGabVtbf7BGu3QDr+ypXbdXCr9cZ35IAqL86pk1J9wdm+5DH5qv8oI3g9iEVl4D49Whm2JO56",
-	"pi/X3nN6Z17vVqm0Wp1pt4hU5zXfnUaLynd9JFhRrfbpaMPWGz6PchZUe510R8hHvbtTecciL81/XwtL",
-	"MEh4pJO0W8yrC9PsW481NtNZ/yomVk4IhaiiAOpnxHSuQAd16SOeLsmUP87cSUCS5iG/eszTb3Ova7HO",
-	"C+zqUqSuOfNvfRVWUfq1bVYHf9SnrZccHm4UnrZ05pZFbeMNbgcRKiTHphTy0xG0BVQluets+j7H+xe6",
-	"ZuP2Dvft6wJ/5tG+64HZHTrnL55Xre5wXZxNAkquEcszd9u2Xzfc5v7noHSQAI40DWMOMEkzoSsjGVmq",
-	"n2fKV6WL80N+ZQrb6Kd9KAPXOEDgGjEOt0pEtSXtDhldqAQphWVi3jcwrzDRCMD601YNpI57UF5+d6yf",
-	"Ss1vhz1CPuuOi/bict69ZPxFebNvG7xu7nT9eeLdB8ATleeVnd2EuSamKk67cNdFyR5p3+t3VDcng70t",
-	"wbM78tmU6ro7WXxV5ZI3yeGrUcdG3rFdsdnhFhew9HSKfaWedzpvzn+zui7AeyvL3dmm6Tcn2Jv6um3L",
-	"vQly5R3r75u+M6lpffe9Ib/vJrWfKkW0JVsrGNA1IgBH6iUlwLNF7vaxoqjSw6RbNwD5tSx9cYVQaldX",
-	"UsWUU4qJ4CqbniGeJerMQz3eRWCsXjtQ8WBVF1JtUv4+sKrB+pl8qBexPz4+K7thDmB8A9fcvMcWjj8T",
-	"SW1ArewfahFA3WSBMUMwXI9SxFQR49ACT8UU1RukDAmICQr/bmChpKw4E8UZX9nv95cDjD+T8zzNXWFe",
-	"LvcG4vJlC7VTBenpBw0kogUCCxRRhsrFY6Gx4ZypKGucQypRJNeXcaQ2QL1kpxYOYCQQAzCOwfE7c4uS",
-	"6xdj0iWDIQqHYIECKHvSOEQMmGv2HJi3MjJyRegNAYpqQMkYYw85FfNXSKpeOuWvndHvDib1sER2RvQ8",
-	"Qjj+z1CAtTjFga9KZEvevn/3u7L2nzIBbDVR/34x7Om3HsMuEvh7xrAtq8hzBJzXo8xrzfaJOFZq2PKd",
-	"EWSPnn/jPMbTj6yYxz0GvryaH/uPqN9haR9Qtfnx8dMumtSyc8kX6jjYTuCRtp7mFvMDo5kw1x1x5e76",
-	"3bmyd7pikaj401ri+jUJ75ak8Y0w5fcEyjb6dmdR3puKN8yqLPIpv5P09zzPneUlZ7LnA7OS7LeI0YZR",
-	"r0WMzgXLApGx7zz11Hhq6C+G7EN5TgG9ce5+mnb3T4gqnMctEt80OPOdQ75zyOzPcZaqxLf7zlIrG/qj",
-	"ZEV45jsrbjz5t8KIDx+itIKCdT78a6X7a47bUG22W60CdqZSncs232Dku1j3rl/5Vpt8x+Bzv8tr1rvp",
-	"Oyjsi6r5u359Y0fvyZmbO5p6NqNOmnYKL5p+k7JLL3v3RRdN/ZJLvW/DrvMdrb5vsKbZOKQJxES9bjCQ",
-	"qDYDuGXBoOtBhZAGvV9RMM8mTL5kOLgaKQk80pnPo7LwXEXGDFyWmVr2dqG6wWI1ChMLHjVtE5q80HDR",
-	"Lv/h9rfb/wkAAP//yy9UmfXEAAA=",
+
+	"H4sIAAAAAAAC/+x9WXfcNtbgX8HUzEOcrlWSN/XpB8dS3JqRbB9LmXx92vlKKBKsQosEaACUUvHRf/8O",
+	"NhIkwaUklaKK3Q8duYjl4uLuuLj4OghoklKCiOCDw68DHqxQAtWfb2LExBkkcInYBU1pTJdr+XvKaIqY",
+	"wEi1WlEu5H/R7zBJYzQ4HMz2Xo6n4+l4NhgOxDqVP3HBMFkOboeDlLJy89fT1/t5O0wEWiI2uL0dDhj6",
+	"kmGGwsHhv/UkpvNveWu6+A8KhBz1bZxxgdgZlP9fhxGGofo1RDxgOBWYksGh+hVxDmgExAqBIGMMEQES",
+	"NQggNESDoW9Zh6/2XnjXBmN8jerzUBJjggAXUGRmNszNNO4MgmUoH3VBaYwgkcPGCIbIAz/m7khqDaZp",
+	"j0EJTFB52/QwnoVV9kL1tIvNoRtqJLdsTjMJQUlo80RT2lw47f4PQ9HgcPC/JwWRTgyFTrzkeTscLBmM",
+	"IIG9x3mn27tDaFTkI8xjrGkcC5TwrvE0EbrDGYxAxqD6d8pogsQKZbw3kB/zLu7AN5Rd3RnOX1XnZjhv",
+	"m7dSd/3T+GxBMxLOOc1YgOaWkMtz6o9AfgSqORBUc4vGWX3aZM2/xKNp24QCLj1T6eHVx5y5myZRbX0z",
+	"1NlRD9GfHSXqy5D6EOXlT0quEZM0C/nVJ/QlQ5qKynsrIL/qIik5gCIkyK/mASURXs4jHHuQpj8C+RFg",
+	"AtYwiUFEWQIFWAmR8sPJJKQBH6eYLAOYjgOaTP5YTQQOFxMu4CJGEznJSI+TMSjHHcnhRlEWx2Mv2rpW",
+	"zlNKOPpLLt2lGLUcD6Re2mAICnSuKKiRNDSBdWFID+KIrSaaH3UTvZmxGeIHImUf5nyTHmEuN+YTiuHa",
+	"mbYiBwP5hxREXNAUQMBkc8BM+2EFSgdLuWDvlufvYYJOZWsvwR9lSXqu7BCPyMztkzBLUpARXIdpkar/",
+	"aHLV9tqLg0HdfBsqqzJGAoVzRbLlbiHNFjEq+pEsWehuiAucQIHmggoYzxm96dszwgTzFQrni7VAG3fa",
+	"YKKU0aXUZ4qSqnJcg+1ZchOmqhTm9vdgsbbO6hr8KByqnXNg9xHxMdmMhiETnUSsvs4XmMR0OV8KHHrp",
+	"jglMluDdxcmRNRKylAuGYAJ015ISRa/hLAr29kYomL4azWbo9WixB4PRdO9gDwaz2XQ63T+cjV6+Ong9",
+	"GA5IFsdyXRVTuNiyEogN1oQFUcpJZVP0AFMbFAtMxlP5v73+sITYWFERzGJJPOOJ/qCnKMMmwQgxQ4Gg",
+	"bA1uVoghBZrel5guAeZS4EgC6wHBNqTOMWOU/YrF6gxx7rWhJMkoPQaQbFsjI/XrPJDmVK2v+gYCbWrV",
+	"BZHumvBlU8/EANWlc4qBhi48Pk56h4SxlE9IRJsNi0A3mvvYwnwDWG5bLkayZonb15WoumPVdTpAta9N",
+	"Ozpy25tXGEIBe3skZS/e4zgpiebI3VYpKjlFzt6+CE2/D78I4yJteRHapnpA6Asjbftga0PkQQE3ts2W",
+	"wZe24QPiPHcdtgzyGV4yZRqzJRL8AYEvDfwYK3lYyskWxZiPAf2FVMDngmWByBhqXoUGcB4oh2bOv8Rl",
+	"Z+ntp+M3F8fg4s1Pp8fgUswuwQ+XOLwEmIgfZrNn4P2HC/D+l9NT8OaXiw/zk/dvPx2fHb+/GH78dHL2",
+	"5tO/wP87/pfu8QxMfrz4X/82ch+Fc0xC9Ptv4O3pL+cXx5+Oj8CPk2fg+P27k/fH/zghhB79BI6Of37z",
+	"y+kFePvPN5/Ojy/+kYnoVbI4AG8/nJ6+uTi2/5ZmlS/cYZZW9wDDhTcAo6xfT3P1+6yHx5t3t2M5WPVu",
+	"VSUo+OBh7/3pdHrvsPcphWG3OxdTGN7XnWvxrpo7JUhAY1h7nSXne+4b1DHX7W71h6mC35ov5Y7nTF1e",
+	"igdw7V/5tqgSDb4vHTWF7XvR3Ku9F7NOnBgu6SK9D8piR+2Bs2CFgqs5Q1y5MVUKTRkaqRbAtHC9p+Ij",
+	"5iCFnKNwDPyi4T7BnGEZxo6VViV3p5Os/RoElMxpdJKjOOOrksennbPyqL8yLBBXvp1elw5pI6BWkFJM",
+	"BODyFyjA0RkIINGcjwWAkfQkGMr9WNnNhgFrR0P8SzwPKBGIeNbGv8RgTTNwA4lwVljaO49mApfBrFBN",
+	"VntI9TQEl8Fe86d9/6d76KO/exXSmgT1xf6ShtDinKYCJ5gLHAC+giyUaJRyQGp7cIPFSkf+zdZQEq9B",
+	"xlEoPXICoHFsAQ2CjHGASeOYR0enICk5s/nWVIOgzj75CNdzZrSN09v7q7GPGfMFBYoIRiDXn6UgpTEO",
+	"1qAU+a7HCn5PMTN2oOWnaZWZVCMdcRBYx3Py6Vx/2yqShriJo+zkn+xaG4r5vPsvprWpL1YI2MaSg1LE",
+	"MA1xAON4DYzIi+ohHL2scAjM4OAaxhk6BGoKSVAcBZSE/G7QM5RATOY8hQEqrWD2vAr/GSY4yRIQMYRA",
+	"iPkVUL0UDO9+usv0t0008aDx9EeM83XF9UpzpijA0doAz7OFE82LKAM1sMfgJAKECqB7YkkT6uxfiioB",
+	"KEHgBscxWCAlgMbgXEFqzpgOwR5EL18c7B+Mopevo9Fshl6NFiHas+FTaZi+0kuZdQcMK5xex7GP39W2",
+	"vlVMXMeH0mj6iMwyZZ3FVaR6rj8WdqGjw77HnXcq7nzbRCXd3o0rtstUYrI4CgekPEQFh/ZAVrOJViwF",
+	"Un+oYHU2BLPXL18/8zF7ad4G4vPR3D2IrZ24/CBoxNlsDAnQwwMQQBGs5lk6T/LMrDIQNytpoTApxFVb",
+	"kKXamMp3x3HCmtjcK1c3o89i3eMJzxZqSJ+Z6E8BsUjUVFka7lNGiOzcJTnLxOolIne5vh1uQroF2yeK",
+	"z5W5mh/f1PlMm7NK9qjjoGERVOuO2lQCaecoyBgW6/o0yog2OTucx2ULT6u3CKM4zDXbCochItq4XiKR",
+	"OzXuQKVBQMRoopoo2yuSdk5dLFXcV8TEHMYxvUHhPCB1sN/SJKEEvDeS+fz8FMg+OMIB1CGEHFmdyOE8",
+	"ngew2fFyBtaiyrZ0qc1Ls3JguZLGoX92hpPr+Hh8ZqyFyX89n7622SmVpXXPeoXWzZO+LeaTu5IyfC2X",
+	"doXWeWqMM3nHfFXPqIxLDw7qAHq5wzhl7xjNUk+YOYzrKXedGx1hxsU8poHWMr4u0htF4WbDCh199zXN",
+	"yOYD1oIlavRhsebaQnKwnQm9SM2zhXwpew22XskuiWDMa+GRXJMoL1xLAOk2qe4lEW+617WJMSsLddlr",
+	"PirNbG1ESm8ukwJKSWWuZY5PvTeCEMXwmnq0mf49zy/McVUx+3ycaF18b4Kkyc30J2B6IwCQ8xvKwsYR",
+	"8wblIfcPnr/oY4naCIN/bPnRGXd/f/rC582mNqDQmlKrGhWmSu6PtHVyXRfJqI5Gaz1jsu1kn555q72z",
+	"U7XVsVnyb+dxKeRX/ZNALiC/KlJAhoOM+2w9szb5sbY+RqnomfU390SozZRlFrb/apFCLYaPk0DcbPjo",
+	"VqN+1o+L8qb5cgvSl//SncSiDSKu4n7SJLph1Gd7WprnOTCdNF+Qyj3ol6E0xgFsoONKWmg9amayqo21",
+	"Ha/dzG7kk4kb5pNaynIB8dKOdMtbM0wZSug1midIn0P31iS6n4orK1N2AbmyhEJ6Q4w/ZH/2h+5hhOYJ",
+	"DdFc4ATNQxsjrXtHOEHAfpZqRfa0cWdHbk+5V+IU6OolHyrMpmUWEwpID2yQX5n0QtlgDD4yFCEGPv38",
+	"dn9///UoxldIRz+5CbzjBP1BibTBI44E+OHyb9NXh9PpJaAMyL+n08tnY3CKljBYuz1pJorOkBnfIGVI",
+	"oFCiPXdCbaNxCTt70+mL0XQ2mu5dzJ4fTg8Op8/1xP2yz88FTVup6P5olnDTTPQmhBuItSult4CmZWp4",
+	"znuurJRSUbebsyTtKXuchOUNcvl6i8GYwrAnJM5Zu3MO66Fcm2bQwjRdcrM57tClhc9VQ+NC9FzZ+ZoE",
+	"xcpUooB/ZfITULC5VKGOzoY+r4MhTuNrFM6V00CDq3nDGX+r5Ld3abyo8R9eN4tzi0qzTq90L9DREnaU",
+	"q25IqtAhGT2uZ7ELiQlMlhIrvincg8CbFQ5WeYwOc2A7bxRaUPyG6bwpW6IlqfRuvWqR154xUo+ZEiAi",
+	"5qJ3noo5BJsv0AqT0Ak79umbO8kexSq/ta6o1KJ5RRqb6Nret+0Bl7kT0BsHDuMtGc3SNiLTDSp0JjVh",
+	"RkZ2FJfWWuVIKVrSGVFwEeEusrTrw36B0fL2eDejyng+PDkhDJeLm8iqxh5+VvMJGZVJct+wa1P2W10C",
+	"XJgkmbpQbxJfEY4lmlmmYy8wDLHsBeOPpdZd+ugnTE7p8mc12Cc5ls9cQGQFSYDm+qL03OY9riBZos60",
+	"GMd61u4e4FkqnUJ1eqqyLPT96zCMQRpnS0z63I/GS0IZmqvzeEkzOford7BVM5AyZE7uVTPvbl0jxnWc",
+	"rHO7VH6ZRkP5QC5MRsqnqCLB4x+o5XNBmU1UaTzbKgZtTDdrNnNcauRXfk+YknmYKc9PeEZb0Ru5eStI",
+	"Qh2GjmIcSANc5dFK6sgSfbacxjpqb++IaOQ7/OVIYymLlCfkPxm6gWt15kSpFFlQIKlunclSxLlJzRkM",
+	"B0Wejn8ybW70iyApK011cMJId4ngdKUtS/gCMS9gn1eR0tMptWylxqvlLNWcxiaO0nm3ic4VzwVLlbLk",
+	"TKYNUG2G/fPQlVA1yegVYVMJk2+wVzqr/QgK+JP0um1szE9aFnKLE0NNURbHciEkYChBRKeJQ/WbVBgD",
+	"7YhI2irYSX+uiwrjiTZwpXLnlKcKTiJAEywkJ1EGUJKK9VCFqtU5mUdg5H1LbP2GYyhVO1muIO5rgBco",
+	"6pDuFeFQ3R8v1VQZzq9fPbrHd/AlkBKQcmAOoLDJADG6RnFNNxqloIwWjwsqf7b+UYO+KLUpbTYIk7iP",
+	"bjAwmOsA9eTMFAqBmEqL0jq8GZim5gVc/33EVAyg+7DIuwM/Z3Fs+FEKu6a78E4YSnJKzv+SiuqxUEhg",
+	"vP7DxwBUHWIyGus0Op4lcsh0teY4gDHAiT0/yDWKIVwt4aV1I/+MojInOt9qeLATPRFoaJIyxPno6nqU",
+	"Qsx4O1imNbi6Bqq1Hz7PLIRjLhAJ1q3jWz2LifEv1OG8TmWkTMqlSF3czEcDkPOMSWFRZo5MUB8ccjh/",
+	"7se5oAwuUSWTTtGWXtb4M/lM3lOB+OFnMgK/rhABl/qTEluXEkzzwwgTQS+HptZOxgVYIACV8kOhsrDk",
+	"VL98OgE/yFkM3ENwyfcPJ5NFFlwhMUkZivDvl8/GcrpTKhEc4RjxNRcokUy44tXuE7m+yXg81mHM8cSi",
+	"bS4/XD5TbhpDkt9smnH7EsaVPJfSeF4EY341/5JRG8QuWZyYXwH1TeHWQ9b5TK+m73yj6+nnYsUQDMvp",
+	"ugdVa0Rtne4giTSgxPiq/qBFgYU64Cfqo9LQucDxEkUJdyCkiOusS+Nd5C70BCRZLPDIhPCU0Krspd4c",
+	"+WVc2GBqgzgSQ7W9JZU2dv51qfgJYsL1PGlsjzq4pqYynEaKcHBp2eNSyvb7kexn8v9hjEOTSANxnMkZ",
+	"fijHXBO4ltMwJDJGUPjMg8S/5VibuDg7BJ8HTju9N40I/zzwDRwrnioW7R0zR04ZE58HjhiO6VISslQ7",
+	"hqYHQ3eksjQuWtfo21Chj75nL7wErnv0IHDXZppbELpEse0h91AFPjId8pe0mSAk8gYIMHrDFVubsX3K",
+	"qtkZc05181atPuE8x/Q21tCscYm2dRNIMhiXITef6ukJ4byzyFXqrfDEpL07zzfW6s6mCwrOwlVP4PRs",
+	"1dPlYOgdshNUxnFDrrr+KPWqjk11if7xRHbxZ1M2GY0nJGCbGY2OX9VgM0pCnC+gCMrXrGb12xnuWHxN",
+	"ghWjBP+RT6XGAOh3FGjKkyb0lwwSgdVU/qsVadxTClQX0kMU5Ce+3S79r4VLf4VQWhz52iQpEGbKGXLB",
+	"MEf2cojxZ6IMJcer1POYnCSThpkL7sokKWIJJPrg3kw4/kyOzgAXOI4BTNMYIw6wkAYi5kJDggWGsd0A",
+	"SELnttuIoYBeI7YGKaMCBQbGNyBiiK+qfQllibpio+fmDmQCScqFDMdru0aGeJaozHtGE3W1RKpg5E4/",
+	"dEaQug/9jgXASYJCDAWK1xI/+uKdyk6A1yjUbfRVPcwBQzBYKSycRFI9qyNvc30FwJjT/IoHB5cNR/uX",
+	"Q3B0Jt16rm/+5aijBI2UR6+HXaAVvMaUAUy4QDDMU8lSxLT9LfId1IFTKHTX8Wfywdxm0z10Jq5emnRc",
+	"j85MLT+uNkgft3F9ipAuGQyRytGAwERAzdharcsNH/vvunmlQ7nWgD8IUviPqtJBTRoY66oIsHZmMpse",
+	"wqYiOlHPpgvrKoyxwRSmR98p/AksZr4KwFVwKpM1xU+ajyfyAHDr4QS/6n02UQRE69kClRO1YobpfhRM",
+	"917sj/ZeBS9Hsxl6OYIvnu+PXgTTxauD8PnraH96OBu9nB7MDvb2h9PnBy8Pwv3Aaf5q//neaG+6Hy72",
+	"Dl6E4X54OBvNXk69JSDL93Scko7qQ3FhqqlnSssIOvBK8+3kVrVkOzVtfilE3QDKiKEYSk3QfiFT2rZ5",
+	"BC8we9wVdq2Gjm51+HTjcarWRDlc34jk6op6x6AdSu46AXXhaNwGm/hhbdZzQdNUBYmKmyU/mzIGg+Hg",
+	"I8x4Ke+6oENvhLz5VpQOxQvqhordwDzveXJY8XPURzWAJWSP7JCf+yVV9is96Vu6U+ko1yWbjmEr3vSv",
+	"TtkCyf2YzD0tbDhJHoIbHIcBZKFVvuVjwMXox3vmLdUSY5vymUSR018//ukBq/DC2prU6eg+pfQaNqPJ",
+	"sCi44CE3pBbksKvmla2Z3RGLPSdoMjEa6Ld0ItaCquJsqR1XT+qKwnauJNzFF99SGr03cT7HSaPUQkkq",
+	"6b4xW1W6YjcMi80Ol/Ne2uEVZpb8j+4yGMW83aA3FaqJII5VkVV+VT+Fb0nF91ajyUVldxlmK5yKQX1r",
+	"qCm9LAgQ5w3gbnaxqz7WsI4NH1C6NsqDVobur0b15I9c5LlS6rQtUbXFL2q+k1Df6GLGxiIYJlzAgdVK",
+	"gloPvK2idFea7R3uUHTdmqi8N/DwlbAaK+ZvtRTWrTrKElIYx0c08By5Hp2BDykibz6egKMPb6XIZfHg",
+	"cNBV7H0kledIm9yYElP7XTtCEVUkjoVaeG0Cm2p2OHghEaji7SkiMMWDw8G++klKfLFS0E5giifXs4kp",
+	"ADixwxs7KK/NexKqud58PCnXt1UZm1qyqvH2plN1e7q4+atiezqIOPkP19cQCvuo9XEOfyVdhfWKWtSC",
+	"TG0iz5IEsvXgUK4B5JV0SUQBz4IVgByUyusKuORO6VtlHKZZ0+q18KkiQLHhTzRcP9ja64V6a4u2wcKF",
+	"nPf2Ce9DpnBW2oqxF/G3wxo9muBiX5IsyhI/DmF6yiC3oWU4OHhAMGqltT1Ta3XewhjOSyxWcW2yMZOv",
+	"+g/l7d1q+RcjbQd6dupDFMWYII229zpHLIUMJkjv8r9rSXUOeDZmoOoHQrEaWEUwcGAYuGJcpyP6ArHN",
+	"Dx79ViOcA48d/sR2lGq8Vt7V6bWR1mDoyWFFzezH4TBPje4d4zDnPaCNOMxszOSrscI24jBjPfbgMBe8",
+	"Zg5zYPi2Oaz8ulPrRobJ2ALn5ax3SBzR4P+ef3jfwEplsORYeeGXOrmFNABqugKqkAYViIyN2gLOPy/O",
+	"TnuBIxt2gLMSOq21CRyTytQpeopK913ELPnLFgBR14PzO/WKpr9kiK0dosZiNc9beIjYn85+O/S88rc2",
+	"yU/qwFcfM49MWT97N90HQqma3SYw/LZd6et5XMDDKW7Fpdg+AVKhg2qTgh6sj698NN60/+4rVNsytj0P",
+	"XW1ucM8eDJ48JvLk9ZyupK6O/s1NEQgIunF33bfhdRkw+eqcGnRruSP1MSeKVpmwjOlCJX9kBH/JymXC",
+	"mhVe+RCjl8JrLNNSFxgR1QU/aGoh0Skf8gdbqE4FdExGk090qDHuKTN2QPFqOgCwi6aGfXTILtLK4+i0",
+	"beqTFnmWH8QeeGnRYJ4KEKnXM+v6pY0gusI4O0MTv21H7/nC+LflQKgE9/bPIY0nJodMFAveV7dNQv1e",
+	"pAqCN5s95lXJ3SLRLp/hyekWjeQH2NSiUmHLnupHFr9v6Ta3NDdD77ujyiXbjFk/2YLl36Y68T2Ee2v0",
+	"ya5KhqJidJQR/eaALS3xMAS2geD4xsnL80TtrlKXEVJbJ668FmoLbRWPbXy7pFV/cKS/Gfy0KU1RQOmd",
+	"hM1pyQDRM0yrq8r3CdZugXSaa7Ju18EtV9LfkQMqW3ZWJ6U2BWf7ksfkq/6jiOD1IBaVgfv0aGXYkrjb",
+	"MH2x9p7Te/N6t0ql5bpju0WkOq/57jSa13TsI8HyOsxPRxu23vB5lLOgyru7O0I+6kWp0gst9tGJ+1pY",
+	"gkHCI52k3WJeXZhm33qssZ7O+lcxsSwh5KKKAqgfyNO5Ah3UpY94uiSTfXa8k4AkzUN+9Zin3+Ze12Jt",
+	"S0frIru+Oe23vgorL2rcNquHP6rTVotpDzcKTzs6c8uitva6vIcIFZJjU+T76QjaHKqC3HU2fZ/j/Qtd",
+	"jXR7h/vudYE/82jf93TyDp3z5w8Hl3e4Ks4mASXXiNnM3bbt1w23uf8WlA4SwJGmYcwBJmkmdL0DI0v1",
+	"w2N2VfrZCcivTMkm/WgVZeAaB0hVOoBbJaLKknaHjC5UgpTCMjEvd5j3xWgEYPXRthpSxz0oz94d66dS",
+	"7e2wR8hn3XHRnl/Ou5eMvyhu9m2D182drj9PvDcB8ETleWlnN2Guian31C7cdbm9R9r36h3Vzclgb0vw",
+	"7I58NkXo7k4WX1Uh8E1y+CrUsZF37NYi97jFOSw9neKmIuY7nTfXfLO6KsB7K8vd2abpNyfY6/q6bcsb",
+	"E+SKO9bfN31nUtP67ntNft9Naj9VimhLtlYwoGtEAI7UG2GAZwvr9rG8qNLDpFvXAKkWYXSKpRSlBXUh",
+	"PVWDUJ15qGfpCIzVOx4qHqwqnqpNsi9fq+rCn8mH6vMMR0enRTfMAYxv4JqblwbD8WciqQ2olf1DLQKo",
+	"mywwZgiG65EtD+hWPlQxRaQrGOqyiH83sFBSVJyJ4oyvFGjKLhDOAOPP5NymuSvMq7qBEBdvtqidyklP",
+	"P9UhES0QWKCIMlQsHguNDe9MecFuC6lbzVBugHqjUS28oaKhU8VwCBYogLInjUPEbD1DDswrMBm5IvSG",
+	"AEU1oGCMcQM55fOXSKpaOuWvndHvDyb1sER2RvQ8Qjj+z1CAlTjFQVOVyJa8/ebd78raf8oEsNVE/fvF",
+	"sKffegw7T+DvGcN2rKKGI2Bbj9LWmu0TcSzVsOU7I8gePf/Ge4ynnw8yz9YMmvJqfuw/on5hqH1A1ebH",
+	"x0+7qFPLziVfqONgN4FH2nqaW8wPjGbCXHfEpbvrd+fK3umKeaLiT2uJ6zckvFuSxjfClN8TKNvo259F",
+	"eW8q3jCrMs+n/E7S3/M8d5aXvMmeD8xKst8iRhtGvRYxOhcsC0TGvvPUU+OpYXMx5CaUWwrojXP/o8u7",
+	"f0JU4jzukPimwZnvHPKdQ2Z/jrNUJr7dd5Za2bA5SpaHZ76z4saTfyuM+PAhSicoWOXDv1a6v+a4DdVm",
+	"u9UqYGcq1bls8w1GvvN17/qVb/0S292Cz/0ur5nbEne4uvYUhH1eNX/Xr2/s6D05c3NHU89m1EnTTuFF",
+	"029Sdull777oommz5FLv27Bru6Pl9w3WNBuHNIGYqNcNBhLVZgC/LBh0PagQ0qD3Kwrm2YTJlwwHVyMl",
+	"gUc683lUFJ4ryZiBzzJTy94uVDdYrEZh4sCjpq1DYwsN5+3sD7e/3f5PAAAA//9jTuWzz8cAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/dm/openapi/gen.server.go
+++ b/dm/openapi/gen.server.go
@@ -161,7 +161,6 @@ type MiddlewareFunc func(c *gin.Context)
 
 // DMAPIGetClusterInfo operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetClusterInfo(c *gin.Context) {
-
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -171,7 +170,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetClusterInfo(c *gin.Context) {
 
 // DMAPIUpdateClusterInfo operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIUpdateClusterInfo(c *gin.Context) {
-
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -181,7 +179,6 @@ func (siw *ServerInterfaceWrapper) DMAPIUpdateClusterInfo(c *gin.Context) {
 
 // DMAPIGetClusterMasterList operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetClusterMasterList(c *gin.Context) {
-
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -191,7 +188,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetClusterMasterList(c *gin.Context) {
 
 // DMAPIOfflineMasterNode operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIOfflineMasterNode(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "master-name" -------------
@@ -212,7 +208,6 @@ func (siw *ServerInterfaceWrapper) DMAPIOfflineMasterNode(c *gin.Context) {
 
 // DMAPIGetClusterWorkerList operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetClusterWorkerList(c *gin.Context) {
-
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -222,7 +217,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetClusterWorkerList(c *gin.Context) {
 
 // DMAPIOfflineWorkerNode operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIOfflineWorkerNode(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "worker-name" -------------
@@ -243,7 +237,6 @@ func (siw *ServerInterfaceWrapper) DMAPIOfflineWorkerNode(c *gin.Context) {
 
 // GetDocJSON operation middleware
 func (siw *ServerInterfaceWrapper) GetDocJSON(c *gin.Context) {
-
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -253,7 +246,6 @@ func (siw *ServerInterfaceWrapper) GetDocJSON(c *gin.Context) {
 
 // GetDocHTML operation middleware
 func (siw *ServerInterfaceWrapper) GetDocHTML(c *gin.Context) {
-
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -263,7 +255,6 @@ func (siw *ServerInterfaceWrapper) GetDocHTML(c *gin.Context) {
 
 // DMAPIGetSourceList operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetSourceList(c *gin.Context) {
-
 	var err error
 
 	// Parameter object where we will unmarshal all parameters from the context
@@ -271,7 +262,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSourceList(c *gin.Context) {
 
 	// ------------- Optional query parameter "with_status" -------------
 	if paramValue := c.Query("with_status"); paramValue != "" {
-
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "with_status", c.Request.URL.Query(), &params.WithStatus)
@@ -282,7 +272,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSourceList(c *gin.Context) {
 
 	// ------------- Optional query parameter "enable_relay" -------------
 	if paramValue := c.Query("enable_relay"); paramValue != "" {
-
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "enable_relay", c.Request.URL.Query(), &params.EnableRelay)
@@ -300,7 +289,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSourceList(c *gin.Context) {
 
 // DMAPICreateSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPICreateSource(c *gin.Context) {
-
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -310,7 +298,6 @@ func (siw *ServerInterfaceWrapper) DMAPICreateSource(c *gin.Context) {
 
 // DMAPIDeleteSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIDeleteSource(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -327,7 +314,6 @@ func (siw *ServerInterfaceWrapper) DMAPIDeleteSource(c *gin.Context) {
 
 	// ------------- Optional query parameter "force" -------------
 	if paramValue := c.Query("force"); paramValue != "" {
-
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "force", c.Request.URL.Query(), &params.Force)
@@ -345,7 +331,6 @@ func (siw *ServerInterfaceWrapper) DMAPIDeleteSource(c *gin.Context) {
 
 // DMAPIGetSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetSource(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -362,7 +347,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSource(c *gin.Context) {
 
 	// ------------- Optional query parameter "with_status" -------------
 	if paramValue := c.Query("with_status"); paramValue != "" {
-
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "with_status", c.Request.URL.Query(), &params.WithStatus)
@@ -380,7 +364,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSource(c *gin.Context) {
 
 // DMAPIUpdateSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIUpdateSource(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -401,7 +384,6 @@ func (siw *ServerInterfaceWrapper) DMAPIUpdateSource(c *gin.Context) {
 
 // DMAPIDisableSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIDisableSource(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -422,7 +404,6 @@ func (siw *ServerInterfaceWrapper) DMAPIDisableSource(c *gin.Context) {
 
 // DMAPIEnableSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIEnableSource(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -443,7 +424,6 @@ func (siw *ServerInterfaceWrapper) DMAPIEnableSource(c *gin.Context) {
 
 // DMAPIDisableRelay operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIDisableRelay(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -464,7 +444,6 @@ func (siw *ServerInterfaceWrapper) DMAPIDisableRelay(c *gin.Context) {
 
 // DMAPIEnableRelay operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIEnableRelay(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -485,7 +464,6 @@ func (siw *ServerInterfaceWrapper) DMAPIEnableRelay(c *gin.Context) {
 
 // DMAPIPurgeRelay operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIPurgeRelay(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -506,7 +484,6 @@ func (siw *ServerInterfaceWrapper) DMAPIPurgeRelay(c *gin.Context) {
 
 // DMAPIGetSourceSchemaList operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetSourceSchemaList(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -527,7 +504,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSourceSchemaList(c *gin.Context) {
 
 // DMAPIGetSourceTableList operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetSourceTableList(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -557,7 +533,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSourceTableList(c *gin.Context) {
 
 // DMAPIGetSourceStatus operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetSourceStatus(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -578,7 +553,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSourceStatus(c *gin.Context) {
 
 // DMAPITransferSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPITransferSource(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "source-name" -------------
@@ -599,7 +573,6 @@ func (siw *ServerInterfaceWrapper) DMAPITransferSource(c *gin.Context) {
 
 // DMAPIGetTaskList operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetTaskList(c *gin.Context) {
-
 	var err error
 
 	// Parameter object where we will unmarshal all parameters from the context
@@ -607,7 +580,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskList(c *gin.Context) {
 
 	// ------------- Optional query parameter "with_status" -------------
 	if paramValue := c.Query("with_status"); paramValue != "" {
-
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "with_status", c.Request.URL.Query(), &params.WithStatus)
@@ -618,7 +590,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskList(c *gin.Context) {
 
 	// ------------- Optional query parameter "stage" -------------
 	if paramValue := c.Query("stage"); paramValue != "" {
-
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "stage", c.Request.URL.Query(), &params.Stage)
@@ -629,7 +600,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskList(c *gin.Context) {
 
 	// ------------- Optional query parameter "source_name_list" -------------
 	if paramValue := c.Query("source_name_list"); paramValue != "" {
-
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "source_name_list", c.Request.URL.Query(), &params.SourceNameList)
@@ -647,7 +617,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskList(c *gin.Context) {
 
 // DMAPICreateTask operation middleware
 func (siw *ServerInterfaceWrapper) DMAPICreateTask(c *gin.Context) {
-
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -657,7 +626,6 @@ func (siw *ServerInterfaceWrapper) DMAPICreateTask(c *gin.Context) {
 
 // DMAPIConvertTask operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIConvertTask(c *gin.Context) {
-
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -667,7 +635,6 @@ func (siw *ServerInterfaceWrapper) DMAPIConvertTask(c *gin.Context) {
 
 // DMAPIGetTaskTemplateList operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetTaskTemplateList(c *gin.Context) {
-
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -677,7 +644,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskTemplateList(c *gin.Context) {
 
 // DMAPICreateTaskTemplate operation middleware
 func (siw *ServerInterfaceWrapper) DMAPICreateTaskTemplate(c *gin.Context) {
-
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -687,7 +653,6 @@ func (siw *ServerInterfaceWrapper) DMAPICreateTaskTemplate(c *gin.Context) {
 
 // DMAPIImportTaskTemplate operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIImportTaskTemplate(c *gin.Context) {
-
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -697,7 +662,6 @@ func (siw *ServerInterfaceWrapper) DMAPIImportTaskTemplate(c *gin.Context) {
 
 // DMAPIDeleteTaskTemplate operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIDeleteTaskTemplate(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -718,7 +682,6 @@ func (siw *ServerInterfaceWrapper) DMAPIDeleteTaskTemplate(c *gin.Context) {
 
 // DMAPIGetTaskTemplate operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetTaskTemplate(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -739,7 +702,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskTemplate(c *gin.Context) {
 
 // DMAPUpdateTaskTemplate operation middleware
 func (siw *ServerInterfaceWrapper) DMAPUpdateTaskTemplate(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -760,7 +722,6 @@ func (siw *ServerInterfaceWrapper) DMAPUpdateTaskTemplate(c *gin.Context) {
 
 // DMAPIDeleteTask operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIDeleteTask(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -777,7 +738,6 @@ func (siw *ServerInterfaceWrapper) DMAPIDeleteTask(c *gin.Context) {
 
 	// ------------- Optional query parameter "force" -------------
 	if paramValue := c.Query("force"); paramValue != "" {
-
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "force", c.Request.URL.Query(), &params.Force)
@@ -788,7 +748,6 @@ func (siw *ServerInterfaceWrapper) DMAPIDeleteTask(c *gin.Context) {
 
 	// ------------- Optional query parameter "keep_meta" -------------
 	if paramValue := c.Query("keep_meta"); paramValue != "" {
-
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "keep_meta", c.Request.URL.Query(), &params.KeepMeta)
@@ -806,7 +765,6 @@ func (siw *ServerInterfaceWrapper) DMAPIDeleteTask(c *gin.Context) {
 
 // DMAPIGetTask operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetTask(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -823,7 +781,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTask(c *gin.Context) {
 
 	// ------------- Optional query parameter "with_status" -------------
 	if paramValue := c.Query("with_status"); paramValue != "" {
-
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "with_status", c.Request.URL.Query(), &params.WithStatus)
@@ -841,7 +798,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTask(c *gin.Context) {
 
 // DMAPIUpdateTask operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIUpdateTask(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -862,7 +818,6 @@ func (siw *ServerInterfaceWrapper) DMAPIUpdateTask(c *gin.Context) {
 
 // DMAPIGetTaskMigrateTargets operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetTaskMigrateTargets(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -888,7 +843,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskMigrateTargets(c *gin.Context) {
 
 	// ------------- Optional query parameter "schema_pattern" -------------
 	if paramValue := c.Query("schema_pattern"); paramValue != "" {
-
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "schema_pattern", c.Request.URL.Query(), &params.SchemaPattern)
@@ -899,7 +853,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskMigrateTargets(c *gin.Context) {
 
 	// ------------- Optional query parameter "table_pattern" -------------
 	if paramValue := c.Query("table_pattern"); paramValue != "" {
-
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "table_pattern", c.Request.URL.Query(), &params.TablePattern)
@@ -917,7 +870,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskMigrateTargets(c *gin.Context) {
 
 // DMAPIGetSchemaListByTaskAndSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetSchemaListByTaskAndSource(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -947,7 +899,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetSchemaListByTaskAndSource(c *gin.Cont
 
 // DMAPIGetTableListByTaskAndSource operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetTableListByTaskAndSource(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -986,7 +937,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTableListByTaskAndSource(c *gin.Conte
 
 // DMAPIDeleteTableStructure operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIDeleteTableStructure(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -1034,7 +984,6 @@ func (siw *ServerInterfaceWrapper) DMAPIDeleteTableStructure(c *gin.Context) {
 
 // DMAPIGetTableStructure operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetTableStructure(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -1082,7 +1031,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTableStructure(c *gin.Context) {
 
 // DMAPIOperateTableStructure operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIOperateTableStructure(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -1130,7 +1078,6 @@ func (siw *ServerInterfaceWrapper) DMAPIOperateTableStructure(c *gin.Context) {
 
 // DMAPIStartTask operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIStartTask(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -1151,7 +1098,6 @@ func (siw *ServerInterfaceWrapper) DMAPIStartTask(c *gin.Context) {
 
 // DMAPIGetTaskStatus operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIGetTaskStatus(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -1168,7 +1114,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskStatus(c *gin.Context) {
 
 	// ------------- Optional query parameter "source_name_list" -------------
 	if paramValue := c.Query("source_name_list"); paramValue != "" {
-
 	}
 
 	err = runtime.BindQueryParameter("form", true, false, "source_name_list", c.Request.URL.Query(), &params.SourceNameList)
@@ -1186,7 +1131,6 @@ func (siw *ServerInterfaceWrapper) DMAPIGetTaskStatus(c *gin.Context) {
 
 // DMAPIStopTask operation middleware
 func (siw *ServerInterfaceWrapper) DMAPIStopTask(c *gin.Context) {
-
 	var err error
 
 	// ------------- Path parameter "task-name" -------------
@@ -1314,131 +1258,127 @@ func RegisterHandlersWithOptions(router *gin.Engine, si ServerInterface, options
 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
-
-	"H4sIAAAAAAAC/+x9WXfcNtbgX8HUzEOcrlWSN/XpB8dS3JqRbB9LmXx92vlKKBKsQosEaACUUvHRf/8O",
-	"NhIkwaUklaKK3Q8duYjl4uLuuLj4OghoklKCiOCDw68DHqxQAtWfb2LExBkkcInYBU1pTJdr+XvKaIqY",
-	"wEi1WlEu5H/R7zBJYzQ4HMz2Xo6n4+l4NhgOxDqVP3HBMFkOboeDlLJy89fT1/t5O0wEWiI2uL0dDhj6",
-	"kmGGwsHhv/UkpvNveWu6+A8KhBz1bZxxgdgZlP9fhxGGofo1RDxgOBWYksGh+hVxDmgExAqBIGMMEQES",
-	"NQggNESDoW9Zh6/2XnjXBmN8jerzUBJjggAXUGRmNszNNO4MgmUoH3VBaYwgkcPGCIbIAz/m7khqDaZp",
-	"j0EJTFB52/QwnoVV9kL1tIvNoRtqJLdsTjMJQUlo80RT2lw47f4PQ9HgcPC/JwWRTgyFTrzkeTscLBmM",
-	"IIG9x3mn27tDaFTkI8xjrGkcC5TwrvE0EbrDGYxAxqD6d8pogsQKZbw3kB/zLu7AN5Rd3RnOX1XnZjhv",
-	"m7dSd/3T+GxBMxLOOc1YgOaWkMtz6o9AfgSqORBUc4vGWX3aZM2/xKNp24QCLj1T6eHVx5y5myZRbX0z",
-	"1NlRD9GfHSXqy5D6EOXlT0quEZM0C/nVJ/QlQ5qKynsrIL/qIik5gCIkyK/mASURXs4jHHuQpj8C+RFg",
-	"AtYwiUFEWQIFWAmR8sPJJKQBH6eYLAOYjgOaTP5YTQQOFxMu4CJGEznJSI+TMSjHHcnhRlEWx2Mv2rpW",
-	"zlNKOPpLLt2lGLUcD6Re2mAICnSuKKiRNDSBdWFID+KIrSaaH3UTvZmxGeIHImUf5nyTHmEuN+YTiuHa",
-	"mbYiBwP5hxREXNAUQMBkc8BM+2EFSgdLuWDvlufvYYJOZWsvwR9lSXqu7BCPyMztkzBLUpARXIdpkar/",
-	"aHLV9tqLg0HdfBsqqzJGAoVzRbLlbiHNFjEq+pEsWehuiAucQIHmggoYzxm96dszwgTzFQrni7VAG3fa",
-	"YKKU0aXUZ4qSqnJcg+1ZchOmqhTm9vdgsbbO6hr8KByqnXNg9xHxMdmMhiETnUSsvs4XmMR0OV8KHHrp",
-	"jglMluDdxcmRNRKylAuGYAJ015ISRa/hLAr29kYomL4azWbo9WixB4PRdO9gDwaz2XQ63T+cjV6+Ong9",
-	"GA5IFsdyXRVTuNiyEogN1oQFUcpJZVP0AFMbFAtMxlP5v73+sITYWFERzGJJPOOJ/qCnKMMmwQgxQ4Gg",
-	"bA1uVoghBZrel5guAeZS4EgC6wHBNqTOMWOU/YrF6gxx7rWhJMkoPQaQbFsjI/XrPJDmVK2v+gYCbWrV",
-	"BZHumvBlU8/EANWlc4qBhi48Pk56h4SxlE9IRJsNi0A3mvvYwnwDWG5bLkayZonb15WoumPVdTpAta9N",
-	"Ozpy25tXGEIBe3skZS/e4zgpiebI3VYpKjlFzt6+CE2/D78I4yJteRHapnpA6Asjbftga0PkQQE3ts2W",
-	"wZe24QPiPHcdtgzyGV4yZRqzJRL8AYEvDfwYK3lYyskWxZiPAf2FVMDngmWByBhqXoUGcB4oh2bOv8Rl",
-	"Z+ntp+M3F8fg4s1Pp8fgUswuwQ+XOLwEmIgfZrNn4P2HC/D+l9NT8OaXiw/zk/dvPx2fHb+/GH78dHL2",
-	"5tO/wP87/pfu8QxMfrz4X/82ch+Fc0xC9Ptv4O3pL+cXx5+Oj8CPk2fg+P27k/fH/zghhB79BI6Of37z",
-	"y+kFePvPN5/Ojy/+kYnoVbI4AG8/nJ6+uTi2/5ZmlS/cYZZW9wDDhTcAo6xfT3P1+6yHx5t3t2M5WPVu",
-	"VSUo+OBh7/3pdHrvsPcphWG3OxdTGN7XnWvxrpo7JUhAY1h7nSXne+4b1DHX7W71h6mC35ov5Y7nTF1e",
-	"igdw7V/5tqgSDb4vHTWF7XvR3Ku9F7NOnBgu6SK9D8piR+2Bs2CFgqs5Q1y5MVUKTRkaqRbAtHC9p+Ij",
-	"5iCFnKNwDPyi4T7BnGEZxo6VViV3p5Os/RoElMxpdJKjOOOrksennbPyqL8yLBBXvp1elw5pI6BWkFJM",
-	"BODyFyjA0RkIINGcjwWAkfQkGMr9WNnNhgFrR0P8SzwPKBGIeNbGv8RgTTNwA4lwVljaO49mApfBrFBN",
-	"VntI9TQEl8Fe86d9/6d76KO/exXSmgT1xf6ShtDinKYCJ5gLHAC+giyUaJRyQGp7cIPFSkf+zdZQEq9B",
-	"xlEoPXICoHFsAQ2CjHGASeOYR0enICk5s/nWVIOgzj75CNdzZrSN09v7q7GPGfMFBYoIRiDXn6UgpTEO",
-	"1qAU+a7HCn5PMTN2oOWnaZWZVCMdcRBYx3Py6Vx/2yqShriJo+zkn+xaG4r5vPsvprWpL1YI2MaSg1LE",
-	"MA1xAON4DYzIi+ohHL2scAjM4OAaxhk6BGoKSVAcBZSE/G7QM5RATOY8hQEqrWD2vAr/GSY4yRIQMYRA",
-	"iPkVUL0UDO9+usv0t0008aDx9EeM83XF9UpzpijA0doAz7OFE82LKAM1sMfgJAKECqB7YkkT6uxfiioB",
-	"KEHgBscxWCAlgMbgXEFqzpgOwR5EL18c7B+Mopevo9Fshl6NFiHas+FTaZi+0kuZdQcMK5xex7GP39W2",
-	"vlVMXMeH0mj6iMwyZZ3FVaR6rj8WdqGjw77HnXcq7nzbRCXd3o0rtstUYrI4CgekPEQFh/ZAVrOJViwF",
-	"Un+oYHU2BLPXL18/8zF7ad4G4vPR3D2IrZ24/CBoxNlsDAnQwwMQQBGs5lk6T/LMrDIQNytpoTApxFVb",
-	"kKXamMp3x3HCmtjcK1c3o89i3eMJzxZqSJ+Z6E8BsUjUVFka7lNGiOzcJTnLxOolIne5vh1uQroF2yeK",
-	"z5W5mh/f1PlMm7NK9qjjoGERVOuO2lQCaecoyBgW6/o0yog2OTucx2ULT6u3CKM4zDXbCochItq4XiKR",
-	"OzXuQKVBQMRoopoo2yuSdk5dLFXcV8TEHMYxvUHhPCB1sN/SJKEEvDeS+fz8FMg+OMIB1CGEHFmdyOE8",
-	"ngew2fFyBtaiyrZ0qc1Ls3JguZLGoX92hpPr+Hh8ZqyFyX89n7622SmVpXXPeoXWzZO+LeaTu5IyfC2X",
-	"doXWeWqMM3nHfFXPqIxLDw7qAHq5wzhl7xjNUk+YOYzrKXedGx1hxsU8poHWMr4u0htF4WbDCh199zXN",
-	"yOYD1oIlavRhsebaQnKwnQm9SM2zhXwpew22XskuiWDMa+GRXJMoL1xLAOk2qe4lEW+617WJMSsLddlr",
-	"PirNbG1ESm8ukwJKSWWuZY5PvTeCEMXwmnq0mf49zy/McVUx+3ycaF18b4Kkyc30J2B6IwCQ8xvKwsYR",
-	"8wblIfcPnr/oY4naCIN/bPnRGXd/f/rC582mNqDQmlKrGhWmSu6PtHVyXRfJqI5Gaz1jsu1kn555q72z",
-	"U7XVsVnyb+dxKeRX/ZNALiC/KlJAhoOM+2w9szb5sbY+RqnomfU390SozZRlFrb/apFCLYaPk0DcbPjo",
-	"VqN+1o+L8qb5cgvSl//SncSiDSKu4n7SJLph1Gd7WprnOTCdNF+Qyj3ol6E0xgFsoONKWmg9amayqo21",
-	"Ha/dzG7kk4kb5pNaynIB8dKOdMtbM0wZSug1midIn0P31iS6n4orK1N2AbmyhEJ6Q4w/ZH/2h+5hhOYJ",
-	"DdFc4ATNQxsjrXtHOEHAfpZqRfa0cWdHbk+5V+IU6OolHyrMpmUWEwpID2yQX5n0QtlgDD4yFCEGPv38",
-	"dn9///UoxldIRz+5CbzjBP1BibTBI44E+OHyb9NXh9PpJaAMyL+n08tnY3CKljBYuz1pJorOkBnfIGVI",
-	"oFCiPXdCbaNxCTt70+mL0XQ2mu5dzJ4fTg8Op8/1xP2yz88FTVup6P5olnDTTPQmhBuItSult4CmZWp4",
-	"znuurJRSUbebsyTtKXuchOUNcvl6i8GYwrAnJM5Zu3MO66Fcm2bQwjRdcrM57tClhc9VQ+NC9FzZ+ZoE",
-	"xcpUooB/ZfITULC5VKGOzoY+r4MhTuNrFM6V00CDq3nDGX+r5Ld3abyo8R9eN4tzi0qzTq90L9DREnaU",
-	"q25IqtAhGT2uZ7ELiQlMlhIrvincg8CbFQ5WeYwOc2A7bxRaUPyG6bwpW6IlqfRuvWqR154xUo+ZEiAi",
-	"5qJ3noo5BJsv0AqT0Ak79umbO8kexSq/ta6o1KJ5RRqb6Nret+0Bl7kT0BsHDuMtGc3SNiLTDSp0JjVh",
-	"RkZ2FJfWWuVIKVrSGVFwEeEusrTrw36B0fL2eDejyng+PDkhDJeLm8iqxh5+VvMJGZVJct+wa1P2W10C",
-	"XJgkmbpQbxJfEY4lmlmmYy8wDLHsBeOPpdZd+ugnTE7p8mc12Cc5ls9cQGQFSYDm+qL03OY9riBZos60",
-	"GMd61u4e4FkqnUJ1eqqyLPT96zCMQRpnS0z63I/GS0IZmqvzeEkzOford7BVM5AyZE7uVTPvbl0jxnWc",
-	"rHO7VH6ZRkP5QC5MRsqnqCLB4x+o5XNBmU1UaTzbKgZtTDdrNnNcauRXfk+YknmYKc9PeEZb0Ru5eStI",
-	"Qh2GjmIcSANc5dFK6sgSfbacxjpqb++IaOQ7/OVIYymLlCfkPxm6gWt15kSpFFlQIKlunclSxLlJzRkM",
-	"B0Wejn8ybW70iyApK011cMJId4ngdKUtS/gCMS9gn1eR0tMptWylxqvlLNWcxiaO0nm3ic4VzwVLlbLk",
-	"TKYNUG2G/fPQlVA1yegVYVMJk2+wVzqr/QgK+JP0um1szE9aFnKLE0NNURbHciEkYChBRKeJQ/WbVBgD",
-	"7YhI2irYSX+uiwrjiTZwpXLnlKcKTiJAEywkJ1EGUJKK9VCFqtU5mUdg5H1LbP2GYyhVO1muIO5rgBco",
-	"6pDuFeFQ3R8v1VQZzq9fPbrHd/AlkBKQcmAOoLDJADG6RnFNNxqloIwWjwsqf7b+UYO+KLUpbTYIk7iP",
-	"bjAwmOsA9eTMFAqBmEqL0jq8GZim5gVc/33EVAyg+7DIuwM/Z3Fs+FEKu6a78E4YSnJKzv+SiuqxUEhg",
-	"vP7DxwBUHWIyGus0Op4lcsh0teY4gDHAiT0/yDWKIVwt4aV1I/+MojInOt9qeLATPRFoaJIyxPno6nqU",
-	"Qsx4O1imNbi6Bqq1Hz7PLIRjLhAJ1q3jWz2LifEv1OG8TmWkTMqlSF3czEcDkPOMSWFRZo5MUB8ccjh/",
-	"7se5oAwuUSWTTtGWXtb4M/lM3lOB+OFnMgK/rhABl/qTEluXEkzzwwgTQS+HptZOxgVYIACV8kOhsrDk",
-	"VL98OgE/yFkM3ENwyfcPJ5NFFlwhMUkZivDvl8/GcrpTKhEc4RjxNRcokUy44tXuE7m+yXg81mHM8cSi",
-	"bS4/XD5TbhpDkt9smnH7EsaVPJfSeF4EY341/5JRG8QuWZyYXwH1TeHWQ9b5TK+m73yj6+nnYsUQDMvp",
-	"ugdVa0Rtne4giTSgxPiq/qBFgYU64Cfqo9LQucDxEkUJdyCkiOusS+Nd5C70BCRZLPDIhPCU0Krspd4c",
-	"+WVc2GBqgzgSQ7W9JZU2dv51qfgJYsL1PGlsjzq4pqYynEaKcHBp2eNSyvb7kexn8v9hjEOTSANxnMkZ",
-	"fijHXBO4ltMwJDJGUPjMg8S/5VibuDg7BJ8HTju9N40I/zzwDRwrnioW7R0zR04ZE58HjhiO6VISslQ7",
-	"hqYHQ3eksjQuWtfo21Chj75nL7wErnv0IHDXZppbELpEse0h91AFPjId8pe0mSAk8gYIMHrDFVubsX3K",
-	"qtkZc05181atPuE8x/Q21tCscYm2dRNIMhiXITef6ukJ4byzyFXqrfDEpL07zzfW6s6mCwrOwlVP4PRs",
-	"1dPlYOgdshNUxnFDrrr+KPWqjk11if7xRHbxZ1M2GY0nJGCbGY2OX9VgM0pCnC+gCMrXrGb12xnuWHxN",
-	"ghWjBP+RT6XGAOh3FGjKkyb0lwwSgdVU/qsVadxTClQX0kMU5Ce+3S79r4VLf4VQWhz52iQpEGbKGXLB",
-	"MEf2cojxZ6IMJcer1POYnCSThpkL7sokKWIJJPrg3kw4/kyOzgAXOI4BTNMYIw6wkAYi5kJDggWGsd0A",
-	"SELnttuIoYBeI7YGKaMCBQbGNyBiiK+qfQllibpio+fmDmQCScqFDMdru0aGeJaozHtGE3W1RKpg5E4/",
-	"dEaQug/9jgXASYJCDAWK1xI/+uKdyk6A1yjUbfRVPcwBQzBYKSycRFI9qyNvc30FwJjT/IoHB5cNR/uX",
-	"Q3B0Jt16rm/+5aijBI2UR6+HXaAVvMaUAUy4QDDMU8lSxLT9LfId1IFTKHTX8Wfywdxm0z10Jq5emnRc",
-	"j85MLT+uNkgft3F9ipAuGQyRytGAwERAzdharcsNH/vvunmlQ7nWgD8IUviPqtJBTRoY66oIsHZmMpse",
-	"wqYiOlHPpgvrKoyxwRSmR98p/AksZr4KwFVwKpM1xU+ajyfyAHDr4QS/6n02UQRE69kClRO1YobpfhRM",
-	"917sj/ZeBS9Hsxl6OYIvnu+PXgTTxauD8PnraH96OBu9nB7MDvb2h9PnBy8Pwv3Aaf5q//neaG+6Hy72",
-	"Dl6E4X54OBvNXk69JSDL93Scko7qQ3FhqqlnSssIOvBK8+3kVrVkOzVtfilE3QDKiKEYSk3QfiFT2rZ5",
-	"BC8we9wVdq2Gjm51+HTjcarWRDlc34jk6op6x6AdSu46AXXhaNwGm/hhbdZzQdNUBYmKmyU/mzIGg+Hg",
-	"I8x4Ke+6oENvhLz5VpQOxQvqhordwDzveXJY8XPURzWAJWSP7JCf+yVV9is96Vu6U+ko1yWbjmEr3vSv",
-	"TtkCyf2YzD0tbDhJHoIbHIcBZKFVvuVjwMXox3vmLdUSY5vymUSR018//ukBq/DC2prU6eg+pfQaNqPJ",
-	"sCi44CE3pBbksKvmla2Z3RGLPSdoMjEa6Ld0ItaCquJsqR1XT+qKwnauJNzFF99SGr03cT7HSaPUQkkq",
-	"6b4xW1W6YjcMi80Ol/Ne2uEVZpb8j+4yGMW83aA3FaqJII5VkVV+VT+Fb0nF91ajyUVldxlmK5yKQX1r",
-	"qCm9LAgQ5w3gbnaxqz7WsI4NH1C6NsqDVobur0b15I9c5LlS6rQtUbXFL2q+k1Df6GLGxiIYJlzAgdVK",
-	"gloPvK2idFea7R3uUHTdmqi8N/DwlbAaK+ZvtRTWrTrKElIYx0c08By5Hp2BDykibz6egKMPb6XIZfHg",
-	"cNBV7H0kledIm9yYElP7XTtCEVUkjoVaeG0Cm2p2OHghEaji7SkiMMWDw8G++klKfLFS0E5giifXs4kp",
-	"ADixwxs7KK/NexKqud58PCnXt1UZm1qyqvH2plN1e7q4+atiezqIOPkP19cQCvuo9XEOfyVdhfWKWtSC",
-	"TG0iz5IEsvXgUK4B5JV0SUQBz4IVgByUyusKuORO6VtlHKZZ0+q18KkiQLHhTzRcP9ja64V6a4u2wcKF",
-	"nPf2Ce9DpnBW2oqxF/G3wxo9muBiX5IsyhI/DmF6yiC3oWU4OHhAMGqltT1Ta3XewhjOSyxWcW2yMZOv",
-	"+g/l7d1q+RcjbQd6dupDFMWYII229zpHLIUMJkjv8r9rSXUOeDZmoOoHQrEaWEUwcGAYuGJcpyP6ArHN",
-	"Dx79ViOcA48d/sR2lGq8Vt7V6bWR1mDoyWFFzezH4TBPje4d4zDnPaCNOMxszOSrscI24jBjPfbgMBe8",
-	"Zg5zYPi2Oaz8ulPrRobJ2ALn5ax3SBzR4P+ef3jfwEplsORYeeGXOrmFNABqugKqkAYViIyN2gLOPy/O",
-	"TnuBIxt2gLMSOq21CRyTytQpeopK913ELPnLFgBR14PzO/WKpr9kiK0dosZiNc9beIjYn85+O/S88rc2",
-	"yU/qwFcfM49MWT97N90HQqma3SYw/LZd6et5XMDDKW7Fpdg+AVKhg2qTgh6sj698NN60/+4rVNsytj0P",
-	"XW1ucM8eDJ48JvLk9ZyupK6O/s1NEQgIunF33bfhdRkw+eqcGnRruSP1MSeKVpmwjOlCJX9kBH/JymXC",
-	"mhVe+RCjl8JrLNNSFxgR1QU/aGoh0Skf8gdbqE4FdExGk090qDHuKTN2QPFqOgCwi6aGfXTILtLK4+i0",
-	"beqTFnmWH8QeeGnRYJ4KEKnXM+v6pY0gusI4O0MTv21H7/nC+LflQKgE9/bPIY0nJodMFAveV7dNQv1e",
-	"pAqCN5s95lXJ3SLRLp/hyekWjeQH2NSiUmHLnupHFr9v6Ta3NDdD77ujyiXbjFk/2YLl36Y68T2Ee2v0",
-	"ya5KhqJidJQR/eaALS3xMAS2geD4xsnL80TtrlKXEVJbJ668FmoLbRWPbXy7pFV/cKS/Gfy0KU1RQOmd",
-	"hM1pyQDRM0yrq8r3CdZugXSaa7Ju18EtV9LfkQMqW3ZWJ6U2BWf7ksfkq/6jiOD1IBaVgfv0aGXYkrjb",
-	"MH2x9p7Te/N6t0ql5bpju0WkOq/57jSa13TsI8HyOsxPRxu23vB5lLOgyru7O0I+6kWp0gst9tGJ+1pY",
-	"gkHCI52k3WJeXZhm33qssZ7O+lcxsSwh5KKKAqgfyNO5Ah3UpY94uiSTfXa8k4AkzUN+9Zin3+Ze12Jt",
-	"S0frIru+Oe23vgorL2rcNquHP6rTVotpDzcKTzs6c8uitva6vIcIFZJjU+T76QjaHKqC3HU2fZ/j/Qtd",
-	"jXR7h/vudYE/82jf93TyDp3z5w8Hl3e4Ks4mASXXiNnM3bbt1w23uf8WlA4SwJGmYcwBJmkmdL0DI0v1",
-	"w2N2VfrZCcivTMkm/WgVZeAaB0hVOoBbJaLKknaHjC5UgpTCMjEvd5j3xWgEYPXRthpSxz0oz94d66dS",
-	"7e2wR8hn3XHRnl/Ou5eMvyhu9m2D182drj9PvDcB8ETleWlnN2Guian31C7cdbm9R9r36h3Vzclgb0vw",
-	"7I58NkXo7k4WX1Uh8E1y+CrUsZF37NYi97jFOSw9neKmIuY7nTfXfLO6KsB7K8vd2abpNyfY6/q6bcsb",
-	"E+SKO9bfN31nUtP67ntNft9Naj9VimhLtlYwoGtEAI7UG2GAZwvr9rG8qNLDpFvXAKkWYXSKpRSlBXUh",
-	"PVWDUJ15qGfpCIzVOx4qHqwqnqpNsi9fq+rCn8mH6vMMR0enRTfMAYxv4JqblwbD8WciqQ2olf1DLQKo",
-	"mywwZgiG65EtD+hWPlQxRaQrGOqyiH83sFBSVJyJ4oyvFGjKLhDOAOPP5NymuSvMq7qBEBdvtqidyklP",
-	"P9UhES0QWKCIMlQsHguNDe9MecFuC6lbzVBugHqjUS28oaKhU8VwCBYogLInjUPEbD1DDswrMBm5IvSG",
-	"AEU1oGCMcQM55fOXSKpaOuWvndHvDyb1sER2RvQ8Qjj+z1CAlTjFQVOVyJa8/ebd78raf8oEsNVE/fvF",
-	"sKffegw7T+DvGcN2rKKGI2Bbj9LWmu0TcSzVsOU7I8gePf/Ge4ynnw8yz9YMmvJqfuw/on5hqH1A1ebH",
-	"x0+7qFPLziVfqONgN4FH2nqaW8wPjGbCXHfEpbvrd+fK3umKeaLiT2uJ6zckvFuSxjfClN8TKNvo259F",
-	"eW8q3jCrMs+n/E7S3/M8d5aXvMmeD8xKst8iRhtGvRYxOhcsC0TGvvPUU+OpYXMx5CaUWwrojXP/o8u7",
-	"f0JU4jzukPimwZnvHPKdQ2Z/jrNUJr7dd5Za2bA5SpaHZ76z4saTfyuM+PAhSicoWOXDv1a6v+a4DdVm",
-	"u9UqYGcq1bls8w1GvvN17/qVb/0S292Cz/0ur5nbEne4uvYUhH1eNX/Xr2/s6D05c3NHU89m1EnTTuFF",
-	"029Sdull777oommz5FLv27Bru6Pl9w3WNBuHNIGYqNcNBhLVZgC/LBh0PagQ0qD3Kwrm2YTJlwwHVyMl",
-	"gUc683lUFJ4ryZiBzzJTy94uVDdYrEZh4sCjpq1DYwsN5+3sD7e/3f5PAAAA//9jTuWzz8cAAA==",
+	"H4sIAAAAAAAC/+x9W3fbNtboX8HROQ9NR1fbcRLPmoc0djM+x7ms2D39Zk36yRAJShiTAAOAdtUs//dv",
+	"4UISJAGSsi3XajIPU0fEZWNj37Gx8XUQ0CSlBBHBB0dfBzxYoQSqP1/HiIl3kMAlYhc0pTFdruXvKaMp",
+	"YgIj1WpFuZD/Rb/DJI3R4Ggw23sxno6n49lgOBDrVP7EBcNkObgdDlLKqs1fTV/tF+0wEWiJ2OD2djhg",
+	"6EuGGQoHR//Wk5jOvxWt6eI/KBBy1DdxxgVi76D8/yaMMAzVryHiAcOpwJQMjtSviHNAIyBWCAQZY4gI",
+	"kKhBAKEhGgxdyzp6uXfoXBuM8TVqzkNJjAkCXECRmdkwN9PYMwiWoWLUBaUxgkQOGyMYIgf8mNsjqTWY",
+	"pj0GJTBB1W3TwzgWVtsL1TNfbAHdUCO5ZXP8JAQloc0TTWlzYbX7PwxFg6PB/56URDoxFDpxkuftcLBk",
+	"MIIE9h7nrW5vD6FRUYwwj7GmcSxQwrvG00RoD2cwAhmD6t8powkSK5Tx3kB+LLrYA99QdnVnOH9Vnf1w",
+	"3vq3Unf90/hsQTMSzjnNWIDmOSFX59QfgfwIVHMgqOYWjbPmtMmaf4lH07YJBVw6ptLDq48Fc/smUW1d",
+	"MzTZUQ/Rnx0l6quQuhDl5E9KrhGTNAv51Sf0JUOaiqp7KyC/6iIpOYAiJMiv5gElEV7OIxw7kKY/AvkR",
+	"YALWMIlBRFkCBVgJkfKjySSkAR+nmCwDmI4Dmkz+WE0EDhcTLuAiRhM5yUiPkzEoxx3J4UZRFsdjJ9q6",
+	"Vs5TSjj6Sy7dphi1HAekTtpgCAp0rijISxqawLowpAexxJaP5kfdRG9m9EP8QKTswpxr0mPM5cZ8QjFc",
+	"W9PW5GAg/5CCiAuaAgiYbA6YaT+sQWlhqRDs3fL8PUzQmWztJPjjLEnPlR3iEJmFfRJmSQoygpswLVL1",
+	"H02u2l47PBg0zbehsipjJFA4VyRb7RbSbBGjsh/JkoXuhrjACRRoLqiA8ZzRm749I0wwX6FwvlgLtHGn",
+	"DSZKGV1KfaYoqS7HNdiOJfswVacwu78Di4111tfgRuFQ7ZwFu4uIT8hmNAyZ6CRi9XW+wCSmy/lS4NBJ",
+	"d0xgsgRvL06PcyMhS7lgCCZAd60oUfQKzqJgb2+EgunL0WyGXo0WezAYTfcO9mAwm02n0/2j2ejFy4NX",
+	"g+GAZHEs11Uzhcstq4DosSZyEKWcVDZFDzC1QbHAZDyV/9vrD0uIjRUVwSyWxDOe6A96iipsEowQMxQI",
+	"ytbgZoUYUqDpfYnpEmAuBY4ksB4QbEPqnDBG2a9YrN4hzp02lCQZpccAkm0bZKR+nQfSnGr0Vd9AoE2t",
+	"piDSXRO+9PVMDFBdOqccaGjD4+Kkt0gYS/mURNRvWAS60dzFFuYbwHLbCjGS+SVuX1ei7o7V12kB1b42",
+	"7ejIbfevMIQC9vZIql68w3FSEs2Su61SVHKKnL19EZp+H34RxkXa8iK0TfWA0JdG2vbB1obIgwJubJst",
+	"gy9twwfEeeE6bBnkd3jJlGnMlkjwBwS+MvBjrORhKSdblGM+BvQXUgGfC5YFImPIvwoN4DxQDs2cf4mr",
+	"ztKbTyevL07Axeufzk7ApZhdgh8ucXgJMBE/zGbPwPsPF+D9L2dn4PUvFx/mp+/ffDp5d/L+Yvjx0+m7",
+	"15/+Bf7fyb90j2dg8uPF//q3kfsonGMSot9/A2/Ofjm/OPl0cgx+nDwDJ+/fnr4/+ccpIfT4J3B88vPr",
+	"X84uwJt/vv50fnLxj0xEL5PFAXjz4ezs9cVJ/m9pVrnCHWZpTQ8wXDgDMMr6dTRXv896eLxF93wsC6vO",
+	"raoFBR887L0/nU7vHfY+ozDsdudiCsP7unMt3pW/U4IENIa101myvhe+QRNz3e5Wf5hq+G34UvZ41tTV",
+	"pTgA1/6Va4tq0eD70pEvbN+L5l7uHc46cWK4pIv0PiiLHbUHzoIVCq7mDHHlxtQpNGVopFoA08L2nsqP",
+	"mIMUco7CMXCLhvsEc4ZVGDtWWpfcnU6y9msQUDLH6yRHccZXFY9PO2fVUX9lWCCufDu9Lh3SRkCtIKWY",
+	"CMDlL1CA43cggERzPhYARtKTYKjwY2W3PAzYOBriX+J5QIlAxLE2/iUGa5qBG0iEtcLK3jk0E7gMZqVq",
+	"yrWHVE9DcBns+T/tuz/dQx/93amQ1iRoLvaXNIQ5zmkqcIK5wAHgK8hCiUYpB6S2BzdYrHTk32wNJfEa",
+	"ZByF0iMnABrHFtAgyBgHmHjHPD4+A0nFmS22ph4EtfbJRbiOM6NtnN7eX419zJgrKFBGMAK5/iwFKY1x",
+	"sAaVyHczVvB7ipmxA3N+mtaZSTXSEQeBdTynmM72t3NF4ombWMpO/smutaFYzLt/OG1MfbFCIG8sOShF",
+	"DNMQBzCO18CIvKgZwtHLCofADA6uYZyhI6CmkATFUUBJyO8GPUMJxGTOUxigygpmz+vwv8MEJ1kCIoYQ",
+	"CDG/AqqXguHtT3eZ/tZHEw8aT3/EOF9XXK8yZ4oCHK0N8DxbWNG8iDLQAHsMTiNAqAC6J5Y0oc7+pagS",
+	"gBIEbnAcgwVSAmgMzhWk5ozpCOxB9OLwYP9gFL14FY1mM/RytAjRXh4+lYbpS72UWXfAsMbpTRy7+F1t",
+	"6xvFxE18KI2mj8hypmyyuIpUz/XH0i60dNj3uPNOxZ1vfVTS7d3YYrtKJSaLo3RAqkPUcJgfyGo20Yql",
+	"ROoPNazOhmD26sWrZy5mr8zrIT4Xzd2D2NqJyw2CRlyejSEBengAAiiC1TxL50mRmVUF4mYlLRQmhbhq",
+	"C7JUG1PF7lhOmI/NnXJ1M/os1z2e8GyhhnSZie4UkByJmiorw33KCJGduyRnlVidRGQv17XDPqTnYLtE",
+	"8bkyV4vjmyafaXNWyR51HDQsg2rdUZtaIO0cBRnDYt2cRhnRJmeH87hq4Wn1FmEUh4VmW+EwREQb10sk",
+	"CqfGHqgyCIgYTVQTZXtF0s5piqWa+4qYmMM4pjconAekCfYbmiSUgPdGMp+fnwHZB0c4gDqEUCCrEzmc",
+	"x/MA+h0va2AtqvKWNrU5aVYOLFfiHfpnazi5jo8n74y1MPmv59NXeXZKbWnds16htX/SN+V8cldShq/l",
+	"0q7QukiNsSbvmK/uGVVx6cBBE0Andxin7C2jWeoIM4dxM+Wuc6MjzLiYxzTQWsbVRXqjKNxsWKGj766m",
+	"Gdl8wEawRI0+LNfcWEgBtjWhE6lFtpArZc9j61XskgjGvBEeKTSJ8sK1BJBuk+peEfGme1ObGLOyVJe9",
+	"5qPSzNZGpPTmMimglFTmWua41LsXhCiG19ShzfTvRX5hgaua2efixNzFdyZImtxMdwKmMwIAOb+hLPSO",
+	"WDSoDrl/8PywjyWaRxjcY8uP1rj7+9NDlzeb5gGF1pRa1ag0VQp/pK2T7bpIRrU0WusZU95O9umZt9o7",
+	"O1VbHZsl/3Yel0J+1T8J5ALyqzIFZDjIuMvWM2uTHxvrY5SKnll/c0eE2kxZZeH8Xy1SqMXwsRKI/YaP",
+	"bjXqZ/3YKPfNV1iQrvyX7iQWbRBxFfeTJtENoy7bM6d5XgDTSfMlqdyDfhlKYxxADx3X0kKbUTOTVW2s",
+	"7XhtZ3Yjl0zcMJ80pywbECftSLe8NcOUoYReo3mC9Dl0b02i+6m4sjJlF5ArSyikN8T4Q/nP7tA9jNA8",
+	"oSGaC5ygeZjHSJveEU4QyD9LtSJ75nFnS25PuVPilOjqJR9qzKZlFhMKSAdskF+Z9ELZYAw+MhQhBj79",
+	"/GZ/f//VKMZXSEc/uQm84wT9QYm0wSOOBPjh8m/Tl0fT6SWgDMi/p9PLZ2NwhpYwWNs9aSbKzpAZ3yBl",
+	"SKBQor1wQvNG4wp29qbTw9F0NpruXcyeH00PjqbP9cT9ss/PBU1bqej+aJZw00z0JoQbiLUrpbeAplVq",
+	"eM57rqySUtG0m7Mk7Sl7rITlDXL5eovBmMKwJyTWWbt1Duug3DzNoIVpuuSmP+7QpYXPVUPjQvRc2fma",
+	"BOXKVKKAe2XyE1Cw2VShjs6GLq+DIU7jaxTOldNAg6u554y/VfLnd2mcqHEfXvvFeY5Ks06ndC/R0RJ2",
+	"lKv2JFXokIwe17HYhcQEJkuJFdcU9kHgzQoHqyJGhznIO28UWlD8huncly3RklR6t16NyGvPGKnDTAkQ",
+	"EXPRO0/FHILNF2iFSWiFHfv0LZxkh2KV31pXVGnhX5HGJrrO79v2gMvcCeiNA4vxloxmaRuR6QY1OpOa",
+	"MCOjfBSb1lrlSCVa0hlRsBFhL7Ky68N+gdHq9jg3o854LjxZIQybi31k1WAPN6u5hIzKJLlv2NWX/daU",
+	"ABcmSaYp1H3iK8KxRDPLdOwFhiGWvWD8sdK6Sx/9hMkZXf6sBvskx3KZC4isIAnQXF+Unud5jytIlqgz",
+	"LcaynrW7B3iWSqdQnZ6qLAt9/zoMY5DG2RKTPvej8ZJQhubqPF7STIH+2h1s1QykDJmTe9XMuVvXiHEd",
+	"J+vcLpVfptFQPZALk5HyKepIcPgHavlcUJYnqnjPtspBvelmfjPHpkZ+5faEKZmHmfL8hGO0Fb2Rm7eC",
+	"JNRh6CjGgTTAVR6tpI4s0WfLaayj9vkdEY18i78saSxlkfKE3CdDN3CtzpwolSILCiTVrTVZijg3qTmD",
+	"4aDM03FPps2NfhEkZaWpDlYY6S4RnK60ZQlfIOYl7PM6Uno6pTlbqfEaOUsNp9HHUTrvNtG54oVgqVOW",
+	"nMm0AarNsH8euhKqJhm9JmxqYfIN9kpntR9DAX+SXnceG3OTVg55jhNDTVEWx3IhJGAoQUSniUP1m1QY",
+	"A+2ISNoq2Ul/booK44l6uFK5c8pTBacRoAkWkpMoAyhJxXqoQtXqnMwhMIq+FbZ+zTGUqp0sVxD3NcBL",
+	"FHVI95pwqO+Pk2rqDOfWrw7d4zr4EkgJSDkwB1DkyQAxukZxQzcapaCMFocLKn/O/SOPvqi0qWw2CJO4",
+	"j24wMJjrAM3kzBQKgZhKi9I63A+Mr3kJ138fMxUD6D4scu7Az1kcG36Uws53F94KQ0lOKfhfUlEzFgoJ",
+	"jNd/uBiAqkNMRmOdRsezRA6ZrtYcBzAGOMnPDwqNYghXS3hp3cg/o6jKida3Bh7yiZ4INDRJGeJ8dHU9",
+	"SiFmvB0s0xpcXQPV2g2fYxbCMReIBOvW8XM9i4nxL9ThvE5lpEzKpUhd3CxGA5DzjElhUWWOTFAXHHI4",
+	"d+7HuaAMLlEtk07Rll7W+DP5TN5TgfjRZzICv64QAZf6kxJblxJM88MIE0Evh6bWTsYFWCAAlfJDobKw",
+	"5FS/fDoFP8hZDNxDcMn3jyaTRRZcITFJGYrw75fPxnK6MyoRHOEY8TUXKJFMuOL17hO5vsl4PNZhzPEk",
+	"R9tcfrh8ptw0hiS/5WnG7UsY1/JcKuM5EYz51fxLRvMgdsXixPwKqG8Ktw6yLmZ6OX3rGl1PPxcrhmBY",
+	"Tdc9qFsjaut0B0mkASXGV3UHLUosNAE/VR+Vhi4EjpMoKrgDIUVcZ10a76JwoScgyWKBRyaEp4RWbS/1",
+	"5sgv49IGUxvEkRiq7a2otLH1r0vFTxATrudJ4/yog2tqqsJppAgHlzl7XErZfj+S/Uz+P4xxaBJpII4z",
+	"OcMP1ZhrAtdyGoZExggKnzmQ+LcCaxMbZ0fg88Bqp/fGi/DPA9fAseKpctHOMQvkVDHxeWCJ4ZguJSFL",
+	"tWNoejC0R6pK47J1g74NFbroe3boJHDdoweB2zbTPAehSxTnPeQeqsBHpkP+kjYThETRAAFGb7hiazO2",
+	"S1n5nTHrVLdo1eoTzgtMb2MNfo1LtK2bQJLBuAq5+dRMTwjnnUWuUmeFJybt3Xmxsbnu9F1QsBauegKr",
+	"Z6uergZD75CdoDKOPbnq+qPUqzo21SX6xxPZxZ1N6TMaT0nANjMaLb/KYzNKQpwvoAiq16xmzdsZ9lh8",
+	"TYIVowT/UUylxgDodxRoypMm9JcMEoHVVO6rFWncUwrUF9JDFBQnvt0u/a+lS3+FUFoe+eZJUiDMlDNk",
+	"g2GO7OUQ489EGUp6cHD8Tol8LrDUzTpGgAUQSJIBZDhel+NhgWFcoJHZV9YYCug1YuvxZ3LpOb6+BAJe",
+	"Ia6ibChEJMgP+PILENJxK0+Nx+6rU05iq15dd/vUpTuiLs43iMso6zJe15kYa3qIPLPNCqL57j8rr3iD",
+	"KUyPvlO48yHMfDWA6+DUJvO54/5odxFPbI1186veoe4yvtY8fK4d0JQzTPejYLp3uD/aexm8GM1m6MUI",
+	"Hj7fHx0G08XLg/D5q2h/ejQbvZgezA729ofT5wcvDsL9wGr+cv/53mhvuh8u9g4Ow3A/PJqNZi+mzoqC",
+	"1WsfVoVA9aG8f+PrmdIqgg6cwmE7qTotyTO+za9EPD2gjBiKofRl2u/3SVOpCAgFZo+7onj1SMStjsZt",
+	"PE5dOVWjv14k11fUO6RpUXLXgZoNh3cb8jyC3AQ6FzRNVcyhvKjws7kVPxgOPsKMV9J4Szp0Blz9l2x0",
+	"ZFdQO/Jox3l5z4OomtmsPqoBckJ2yA75uV+OXr9Khq6lW4VzCl2y6Rh5AZX+xQ5bILkfk9mHT56DySG4",
+	"wXEYQBbmLlr1VGkx+vGeaTCNPEtfeowoU8Sbpwk9YBVOWFtzBC3dp5SeZzN8hkXJBQ+5IQ2fOV81r23N",
+	"7I5Y7DmBz8Tw0G/lgKUFVeVRRTuunlTG+3Yy3O/i2m0pK9uZh13gxCu1UJJKuvcmP0qn4IZhsdlZZdFL",
+	"+wPCzFL80V1VoZy3G3Rf3ZMI4ljV7ORXzUPdlsxuZ3GTQlR2V/XNhVM5qGsNDaWXBQHi3APuZveEmmMN",
+	"m9hwAaVLbTxooeH+alRP/sg1g2uVM9vyHlv8In+Ke3Ojyxm9NRVM8QQOcq0kqEm7520FiruyNu+Qkt+V",
+	"hF8rX//whZW8Bdi3WlnpVp2MCCmM42MaOE7wjt+BDykirz+eguMPb6TIZfHgaNBVO3wkledIm9yYElNK",
+	"XDtCEVUkjoVaeGOCPHPpaHAoEajCtykiMMWDo8G++klKfLFS0E5giifXs4mpJzfJhzd2UFHq9TRUc73+",
+	"eFotl6oSALVkVePtTafqMm55kRSmRUxq8h+us9pL+6j1rQd3YVaF9Zpa1IJMbSLPkgSy9eBIrgEUhVlJ",
+	"RAHPghWAHFSqtQq45FYlVWUcpplv9Vr41BGg2PAnGq4fbO3Nuq+NRZtpwULOe/uE9yFTOKtsxdiJ+Nth",
+	"gx518ibvS5JlldvHIUxHVd02tAwHBw8IRqNSs2Nqrc5bGMN62CNXXJtszOSr/kN5e7da/sVI24GOnfoQ",
+	"RTEmSKPtvU45SiGDCdK7/O9GjpYFXh4zUOXooFgNckUwsGAY2GJcZ7e5ArH+93N+axDOgcMOf2I7SjVe",
+	"a8+09NrI3GDoyWFlCebH4TBHyecd4zDreZmNOMxszOSrscI24jBjPfbgMBs8P4dZMHzbHFZ9LKh1I8Nk",
+	"nAPn5Ky3SBzT4P+ef3jvYaUqWHKsoo5Ik9xCGgA1XQlVSIMaRMZGbQHnnxfvznqBIxt2gLMSOkvSB47J",
+	"jOkUPWXh9C5ilvyV15NQt02LK9qKpr9kiK0tosZiNS9aOIjYnR19O3Q8Grc2uTQq80EfsI5Mlbj8qrML",
+	"hEpxtE1g+G270tdRq97BKXYBnzh/UaJGB/UmJT3kPr7y0bhv/+1HjbZlbDveTdrc4J49GDxFTOTJ6zld",
+	"mBtAEuZJBRAQdGPvumvDmzJg8tU6NejWcsfqY0EUrTJhGdOFKteZEfwlq1ad8iu86iFGL4XnrfrRFBgR",
+	"1fUjaJpDAmNuSmPmdc9UQMckyLhEhxrjnjJjBxSvpgMAu2hq2EeH7CKtPI5O26Y+aZFnxUHsgZMWDeap",
+	"AJF6jLGpX9oIoiuMszM08dt29J4rjH9bDYRKcG//HNJ4YnLIRLHgfXXbJNTPD6oguN/sMY8U7haJdvkM",
+	"T063aCQ/wKaWhe9a9lS/2fd9S7e5pYUZet8dVS7ZZsz6Ka9//W2qE9e7qrdGn+yqZCgLEEcZ0SXs80oF",
+	"D0NgGwiOb5y8HC+e7ip1GSG1deIqSmu20Fb5dsO3S1rN9yv6m8FPm9IUBVTK7m9OSwaInmFaXaS8T7B2",
+	"C6TjL/G5XQe3Wph9Rw6o8iqmOinVF5ztSx6Tr/qPMoLXg1hUBu7To5VhS+KuZ/py7T2nd+b1bpVKq2Ws",
+	"dotIdV7z3Wm0KBHYR4IVZX2fjjZsveHzKGdBtWdcd4R81ANFlQc/8jcM7mthCQYJj3SSdot5dWGafeux",
+	"xmY661/FxMoJoRBVFED93prOFeigLn3E0yWZ8lesOwkImcu1j3j6be51LdbFtd6l77g7/9ZXYRU1cttm",
+	"dfBHfdp6bebhRuFpS2duWdQ2Hit3EKFCcmxqRj8dQVtAVZK7zqbvc7x/oYtbbu9w374u8Gce7bte4t2h",
+	"c/7iHdrqDtfF2SSg5BqxPHO3bft1w23ufw5KBwngSNMw5gCTNBO6hJSRpfodq3xV+hUDyK9MBSD9BhJl",
+	"4BoHCFwjxuFWiai2pN0howuVIKWwTMxDEOa5KhoBWH8DrIHUcQ/Ky++O9VOp+e2wR8hn3XHRXlzOu5eM",
+	"vyhv9m2D182drj9PvPsAeKLyvLKzmzDXxJQPahfuunrbI+17/Y7q5mSwtyV4dkc+m5pmdyeLr6qu9CY5",
+	"fDXq2Mg7tktbO9ziApaeTrGvJvZO5835b1bXBXhvZbk72zT95gR7U1+3bbk3Qa68Y/1903cmNa3vvjfk",
+	"992k9lOliLZkawUDukYE4Eg9OQV4tsjdPlYUVXqYdOsGIPWaflaxlLLGHlfZ9AzxLNFV+oi+X66ehVDx",
+	"YFVOT21S/pCyKlb7mXyoV/s/Pj4ru2EOYHwD19w8XBeOPxNJbUCt7B9qEUDdZIExQzBcj1LEVLXn0C4B",
+	"yIWkLokuJCAmKPy7gYWSsuJMFGd8pUBTdoGwBhh/Jud5mrvCvFzuDcTlEyBqpwrS0y8/SEQLBBYoogyV",
+	"i8dCY8M5U1H/OYdUokiuL+NIbYB68k8tHMBIIAZgHOtKiepuq35aJ10yGKJwCBYogLInjUPEgLlmz4F5",
+	"VCQjV4TeEKCoBpSMMfaQUzF/haTqpVP+2hn97mBSD0tkZ0TPI4Tj/wwFWItTHPiqRLbk7ft3vytr/ykT",
+	"wFYT9e8Xw55+6zHsIoG/Zwzbsoo8R8B5Pcq81myfiGOlhi3fGUH26Pk3zmM8/RqNeQVl4Mur+bH/iPrB",
+	"mvYBVZsfHz/tokktO5d8oY6D7QQeaetpbjE/MJoJc90RV+6u350re6crFomKP60lrl+T8G5JGt8IU35P",
+	"oGyjb3cW5b2peMOsyiKf8jtJf8/z3FleciZ7PjAryX6LGG0Y9VrE6FywLBAZ+85TT42nhv5iyD6U5xTQ",
+	"G+fuN3x3/4SownncIvFNgzPfOeQ7h8z+HGepSny77yy1sqE/SlaEZ76z4saTfyuM+PAhSisoWOfDv1a6",
+	"v+a4DdVmu9UqYGcq1bls8w1Gvot17/qVb7XJdww+97u8Zj0wv4PCvqiav+vXN3b0npy5uaOpZzPqpGmn",
+	"8KLpNym79LJ3X3TR1C+51Ps27Drf0er7BmuajUOaQEzU6wYDiWozgFsWDLoeVAhp0PsVBfNswuRLhoOr",
+	"kZLAI535PCoLz1VkzMBlmallbxeqGyxWozCx4FHTNqHJCw0X7fIfbn+7/Z8AAAD//7RXjcEexgAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/dm/openapi/gen.types.go
+++ b/dm/openapi/gen.types.go
@@ -686,12 +686,8 @@ type TaskIncrMigrateConf struct {
 	ReplThreads *int `json:"repl_threads,omitempty"`
 
 	// Whether to keep safe mode enabled during incremental replication.
-	// When omitted or false, this setting does not keep safe mode permanently enabled.
-	// DM still applies its existing initialization and checkpoint-recovery protection.
-	// A fresh initialization normally enables safe mode temporarily.
-	// When resuming from a retained checkpoint, safe mode may exit immediately or after the saved exit point is reached.
-	// If a start request also specifies `safe_mode_time_duration`, DM uses that existing one-time start behavior instead of this persistent setting for that start.
-	// Only use this field after all DM masters and workers are upgraded to a version that supports it.
+	// When false, DM may still enable it temporarily during initialization or checkpoint recovery.
+	// `safe_mode_time_duration` takes precedence when specified at task start.
 	SafeMode *bool `json:"safe_mode,omitempty"`
 }
 

--- a/dm/openapi/gen.types.go
+++ b/dm/openapi/gen.types.go
@@ -684,6 +684,15 @@ type TaskIncrMigrateConf struct {
 
 	// incremental task of concurrent
 	ReplThreads *int `json:"repl_threads,omitempty"`
+
+	// Whether to keep safe mode enabled during incremental replication.
+	// When omitted or false, this setting does not keep safe mode permanently enabled.
+	// DM still applies its existing initialization and checkpoint-recovery protection.
+	// A fresh initialization normally enables safe mode temporarily.
+	// When resuming from a retained checkpoint, safe mode may exit immediately or after the saved exit point is reached.
+	// If a start request also specifies `safe_mode_time_duration`, DM uses that existing one-time start behavior instead of this persistent setting for that start.
+	// Only use this field after all DM masters and workers are upgraded to a version that supports it.
+	SafeMode *bool `json:"safe_mode,omitempty"`
 }
 
 // task migrate targets

--- a/dm/openapi/spec/dm.yaml
+++ b/dm/openapi/spec/dm.yaml
@@ -1807,6 +1807,17 @@ components:
           type: integer
           description: incremental synchronization of batch execution sql quantities
           default: 100
+        safe_mode:
+          type: boolean
+          description: |-
+            Whether to keep safe mode enabled during incremental replication.
+            When omitted or false, this setting does not keep safe mode permanently enabled.
+            DM still applies its existing initialization and checkpoint-recovery protection.
+            A fresh initialization normally enables safe mode temporarily.
+            When resuming from a retained checkpoint, safe mode may exit immediately or after the saved exit point is reached.
+            If a start request also specifies `safe_mode_time_duration`, DM uses that existing one-time start behavior instead of this persistent setting for that start.
+            Only use this field after all DM masters and workers are upgraded to a version that supports it.
+          default: false
     TaskSourceConf:
       type: object
       properties:

--- a/dm/openapi/spec/dm.yaml
+++ b/dm/openapi/spec/dm.yaml
@@ -1811,12 +1811,8 @@ components:
           type: boolean
           description: |-
             Whether to keep safe mode enabled during incremental replication.
-            When omitted or false, this setting does not keep safe mode permanently enabled.
-            DM still applies its existing initialization and checkpoint-recovery protection.
-            A fresh initialization normally enables safe mode temporarily.
-            When resuming from a retained checkpoint, safe mode may exit immediately or after the saved exit point is reached.
-            If a start request also specifies `safe_mode_time_duration`, DM uses that existing one-time start behavior instead of this persistent setting for that start.
-            Only use this field after all DM masters and workers are upgraded to a version that supports it.
+            When false, DM may still enable it temporarily during initialization or checkpoint recovery.
+            `safe_mode_time_duration` takes precedence when specified at task start.
           default: false
     TaskSourceConf:
       type: object

--- a/dm/syncer/safe_mode_test.go
+++ b/dm/syncer/safe_mode_test.go
@@ -70,6 +70,7 @@ func TestEnableSafeModeInitializationPhase(t *testing.T) {
 	// test enable by task cliArgs (disable is tested in it test)
 	duration, err := time.ParseDuration("2s")
 	require.NoError(t, err)
+	s.cfg.SafeMode = true // task cliArgs take precedence over persistent safe mode
 	s.cliArgs = &config.TaskCliArgs{SafeModeDuration: duration.String()}
 	s.enableSafeModeInitializationPhase(s.tctx)
 	require.True(t, s.safeMode.Enable())

--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -3401,6 +3401,12 @@ func (s *Syncer) CheckCanUpdateCfg(newCfg *config.SubTaskConfig) error {
 	if err := config.CheckForeignKeyChecksSyncerOptions(newCfg.To.Session, newCfg.SyncerConfig); err != nil {
 		return err
 	}
+	if s.cfg.SyncerConfig.SafeMode != newCfg.SyncerConfig.SafeMode {
+		return terror.ErrWorkerUpdateSubTaskConfig.Generatef(
+			"can't update safe-mode for syncer because it requires reinitialization, task: %s",
+			s.cfg.Name,
+		)
+	}
 	// can't update when in sharding merge
 	if s.cfg.ShardMode == config.ShardPessimistic {
 		_, tables := s.sgk.UnresolvedTables()

--- a/dm/syncer/syncer_test.go
+++ b/dm/syncer/syncer_test.go
@@ -2061,6 +2061,21 @@ func TestCheckCanUpdateCfgRejectsTimezoneChange(t *testing.T) {
 	require.ErrorContains(t, err, "fields that should not be changed")
 }
 
+func TestCheckCanUpdateCfgRejectsSafeModeChange(t *testing.T) {
+	for _, oldSafeMode := range []bool{false, true} {
+		cfg := genDefaultSubTaskConfig4Test()
+		cfg.SyncerConfig.SafeMode = oldSafeMode
+		syncer := NewSyncer(cfg, nil, nil)
+		newCfg, err := cfg.Clone()
+		require.NoError(t, err)
+		newCfg.SyncerConfig.SafeMode = !oldSafeMode
+
+		err = syncer.CheckCanUpdateCfg(newCfg)
+		require.Truef(t, terror.ErrWorkerUpdateSubTaskConfig.Equal(err), "err: %v", err)
+		require.ErrorContains(t, err, "safe-mode")
+	}
+}
+
 func TestCheckCanUpdateCfgRejectsForeignKeyChecksDMLBoundaryOptions(t *testing.T) {
 	cfg := genDefaultSubTaskConfig4Test()
 	syncer := NewSyncer(cfg, nil, nil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: ref #12756

DM task configuration supports persistent safe mode, but OpenAPI only exposes
the one-time safe-mode duration used when starting a task.

### What is changed and how it works?

- Add an optional `safe_mode` field to the OpenAPI task schema.
- Preserve it when converting between OpenAPI tasks and subtask configurations.
- Reject changing `safe_mode` through PUT because the syncer must be
  reinitialized for the change to take effect.

The precedence of `safe_mode_time_duration` over task-level `safe_mode` is
existing DM behavior, not introduced by this PR. Changing that behavior is out
of scope.

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Manual testing with DM, MySQL 8.4, and TiDB nightly covered `all` and `full`
replication, OpenAPI create and readback, persistent safe mode after the default
initialization window, and rejection of a PUT that changes `safe_mode`.

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No. The field is optional, and omitting it preserves the existing behavior.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No additional documentation update is needed. The new field and its interaction
with `safe_mode_time_duration` are documented in the OpenAPI schema.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
Support configuring persistent safe mode for DM tasks through OpenAPI.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `safe_mode` setting for incremental migration tasks, defaulting to disabled.
  * Preserved safe-mode settings across task creation, retrieval, listing, and configuration conversions.
  * Command-line safe-mode duration settings take precedence when starting a task.

* **Bug Fixes**
  * Prevented changing safe mode while a task is running, avoiding configuration changes that require reinitialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->