### PR TITLE
OWNERS_ALIASES: replace Benjamin2037 with bb7133

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,12 +8,12 @@ aliases:
     - yudongusa
     - BenMeadowcroft
   sig-approvers-dm:
-    - Benjamin2037
+    - bb7133
     - D3Hunter
     - GMHDBJD
     - lance6716
   sig-approvers-engine:
-    - Benjamin2037
+    - bb7133
     - D3Hunter
     - GMHDBJD
     - lance6716


### PR DESCRIPTION
<!--
Thank you for contributing to TiFlow! 
Please read MD's [CONTRIBUTING](https://github.com/pingcap/tiflow/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve?
<!--
Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.
 -->

Issue Number: close #12802

### What is changed and how it works?

Replace member `Benjamin2037` with `bb7133` in `OWNERS_ALIASES`, deduplicating members within each SIG. `sig-community-*` entries are left untouched (they are synced from pingcap/community).

### Check List <!--REMOVE the items that are not applicable-->

#### Tests <!-- At least one of them must be included. -->

 - No code

#### Questions <!-- Authors should answer these questions and reviewers should consider these questions. -->

##### Will it cause performance regression or break compatibility?

No.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note <!-- bugfixes or new features need a release note -->

```release-note
None
```
