### PR TITLE
sync-diff-inspector: fix bucket count interpretation

### DIFF
--- a/pkg/dbutil/buckets.go
+++ b/pkg/dbutil/buckets.go
@@ -70,22 +70,31 @@ func GetBucketsInfo(ctx context.Context, db QueryExecutor, schema, table string,
 		columnTypeMap[col.ID] = &col.FieldType
 	}
 
+	// For a partitioned table, tidb_table_id identifies its global statistics.
+	// Per-partition histograms cannot be concatenated because their bounds are
+	// not globally ordered. If global statistics are unavailable, returning no
+	// buckets lets the caller fall back to the random splitter.
 	query := `SELECT is_index, hist_id, bucket_id, count, lower_bound, upper_bound
 FROM mysql.stats_buckets
-WHERE table_id IN (
+WHERE table_id = (
 	SELECT tidb_table_id FROM information_schema.tables WHERE table_schema = ? AND table_name = ?
-	UNION ALL
-	SELECT tidb_partition_id FROM information_schema.partitions WHERE table_schema = ? AND table_name = ?
 )
 ORDER BY is_index, hist_id, bucket_id`
 
 	log.Debug("GetBucketsInfo", zap.String("sql", query), zap.String("schema", schema), zap.String("table", table))
 
-	rows, err := db.QueryContext(ctx, query, schema, table, schema, table)
+	rows, err := db.QueryContext(ctx, query, schema, table)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	defer rows.Close()
+	type histogramID struct {
+		isIndex int64
+		histID  int64
+	}
+	// mysql.stats_buckets persists each bucket's delta. Bucket splitter callers
+	// expect the cumulative counts returned by SHOW STATS_BUCKETS.
+	cumulativeCounts := make(map[histogramID]int64)
 
 	for rows.Next() {
 		var isIndex, histID, bucketID, count sql.NullInt64
@@ -158,8 +167,13 @@ ORDER BY is_index, hist_id, bucket_id`
 			}
 		}
 
+		histogram := histogramID{
+			isIndex: isIndex.Int64,
+			histID:  histID.Int64,
+		}
+		cumulativeCounts[histogram] += count.Int64
 		b := Bucket{
-			Count:      count.Int64,
+			Count:      cumulativeCounts[histogram],
 			LowerBound: lowerBoundStr,
 			UpperBound: upperBoundStr,
 		}

--- a/pkg/dbutil/buckets_test.go
+++ b/pkg/dbutil/buckets_test.go
@@ -1,0 +1,239 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbutil
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/testkit"
+	"github.com/pingcap/tidb/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBucketsInfoWithMockStore(t *testing.T) {
+	ctx := context.Background()
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("CREATE DATABASE bucket_test")
+	tk.MustExec("USE bucket_test")
+	tk.MustExec("CREATE TABLE test (a INT, b VARCHAR(10), PRIMARY KEY (a, b), KEY idx_b (b))")
+	tk.MustExec(buildInsertSQL("test", 320))
+	tk.MustExec("ANALYZE TABLE test WITH 5 BUCKETS, 0 TOPN")
+
+	tbl, err := dom.InfoSchema().TableByName(
+		ctx,
+		ast.NewCIStr("bucket_test"),
+		ast.NewCIStr("test"),
+	)
+	require.NoError(t, err)
+	tableInfo := tbl.Meta()
+	require.NotEmpty(t, tableInfo.Indices)
+
+	db := testkit.CreateMockDB(tk)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	buckets, err := GetBucketsInfo(ctx, db, "bucket_test", "test", tableInfo)
+	require.NoError(t, err)
+	for _, indexName := range []string{"PRIMARY", "idx_b"} {
+		indexInfo := tableInfo.FindIndexByName(strings.ToLower(indexName))
+		require.NotNil(t, indexInfo)
+		expectedCounts := getCumulativeCounts(t, ctx, db, tableInfo.ID, 1, indexInfo.ID)
+		require.Len(t, expectedCounts, 5)
+		require.Equal(t, int64(320), expectedCounts[len(expectedCounts)-1])
+
+		indexBuckets := buckets[indexName]
+		require.Len(t, indexBuckets, len(expectedCounts))
+		for i, bucket := range indexBuckets {
+			require.Equal(t, expectedCounts[i], bucket.Count)
+		}
+	}
+}
+
+func TestGetBucketsInfoForIntegerPrimaryKey(t *testing.T) {
+	ctx := context.Background()
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("CREATE DATABASE integer_pk_bucket_test")
+	tk.MustExec("USE integer_pk_bucket_test")
+	tk.MustExec("CREATE TABLE test (a INT PRIMARY KEY, b VARCHAR(10))")
+	tk.MustExec(buildInsertSQL("test", 320))
+	tk.MustExec("ANALYZE TABLE test WITH 5 BUCKETS, 0 TOPN")
+
+	tbl, err := dom.InfoSchema().TableByName(
+		ctx,
+		ast.NewCIStr("integer_pk_bucket_test"),
+		ast.NewCIStr("test"),
+	)
+	require.NoError(t, err)
+	tableInfo := tbl.Meta()
+	primaryKeyColumn := tableInfo.GetPkColInfo()
+	require.NotNil(t, primaryKeyColumn)
+	// sync-diff adds a synthetic PRIMARY index to PKIsHandle metadata; mockstore InfoSchema does not.
+	tableInfo.Indices = append(tableInfo.Indices, &model.IndexInfo{
+		Name:    ast.NewCIStr("PRIMARY"),
+		Primary: true,
+		Unique:  true,
+		State:   model.StatePublic,
+		Tp:      ast.IndexTypeBtree,
+		Columns: []*model.IndexColumn{{
+			Name:   primaryKeyColumn.Name,
+			Offset: primaryKeyColumn.Offset,
+			Length: types.UnspecifiedLength,
+		}},
+	})
+
+	db := testkit.CreateMockDB(tk)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	expectedCounts := getCumulativeCounts(t, ctx, db, tableInfo.ID, 0, primaryKeyColumn.ID)
+	require.Len(t, expectedCounts, 5)
+	require.Equal(t, int64(320), expectedCounts[len(expectedCounts)-1])
+
+	buckets, err := GetBucketsInfo(ctx, db, "integer_pk_bucket_test", "test", tableInfo)
+	require.NoError(t, err)
+	primaryBuckets := buckets["PRIMARY"]
+	require.Len(t, primaryBuckets, len(expectedCounts))
+	for i, bucket := range primaryBuckets {
+		require.Equal(t, expectedCounts[i], bucket.Count)
+	}
+	require.NotContains(t, buckets, primaryKeyColumn.Name.O)
+}
+
+func TestGetBucketsInfoForPartitionTable(t *testing.T) {
+	testCases := []struct {
+		pruneMode      string
+		hasGlobalStats bool
+	}{
+		{pruneMode: "dynamic", hasGlobalStats: true},
+		// Static pruning analyzes individual partitions without producing table-level global statistics.
+		{pruneMode: "static", hasGlobalStats: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.pruneMode, func(t *testing.T) {
+			ctx := context.Background()
+			store, dom := testkit.CreateMockStoreAndDomain(t)
+			tk := testkit.NewTestKit(t, store)
+			tk.MustExec("SET @@tidb_partition_prune_mode = '" + testCase.pruneMode + "'")
+			tk.MustExec("SET @@tidb_analyze_version = 2")
+			tk.MustExec("CREATE DATABASE partition_bucket_test")
+			tk.MustExec("USE partition_bucket_test")
+			tk.MustExec(`CREATE TABLE test (a INT, b VARCHAR(10), PRIMARY KEY (a, b))
+				PARTITION BY RANGE (a) (
+					PARTITION p0 VALUES LESS THAN (160),
+					PARTITION p1 VALUES LESS THAN MAXVALUE
+				)`)
+			tk.MustExec(buildInsertSQL("test", 320))
+			tk.MustExec("ANALYZE TABLE test WITH 5 BUCKETS, 0 TOPN")
+
+			tbl, err := dom.InfoSchema().TableByName(
+				ctx,
+				ast.NewCIStr("partition_bucket_test"),
+				ast.NewCIStr("test"),
+			)
+			require.NoError(t, err)
+			tableInfo := tbl.Meta()
+			require.NotEmpty(t, tableInfo.Indices)
+
+			db := testkit.CreateMockDB(tk)
+			t.Cleanup(func() {
+				require.NoError(t, db.Close())
+			})
+
+			var partitionBucketCount int
+			err = db.QueryRowContext(
+				ctx,
+				`SELECT COUNT(*) FROM mysql.stats_buckets
+				WHERE table_id IN (
+					SELECT tidb_partition_id FROM information_schema.partitions
+					WHERE table_schema = ? AND table_name = ?
+				) AND is_index = 1 AND hist_id = ?`,
+				"partition_bucket_test",
+				"test",
+				tableInfo.Indices[0].ID,
+			).Scan(&partitionBucketCount)
+			require.NoError(t, err)
+			require.Positive(t, partitionBucketCount)
+
+			expectedCounts := getCumulativeCounts(t, ctx, db, tableInfo.ID, 1, tableInfo.Indices[0].ID)
+			buckets, err := GetBucketsInfo(ctx, db, "partition_bucket_test", "test", tableInfo)
+			require.NoError(t, err)
+
+			if !testCase.hasGlobalStats {
+				require.Empty(t, expectedCounts)
+				require.Empty(t, buckets)
+				return
+			}
+
+			require.NotEmpty(t, expectedCounts)
+			require.Equal(t, int64(320), expectedCounts[len(expectedCounts)-1])
+			primaryBuckets := buckets["PRIMARY"]
+			require.Len(t, primaryBuckets, len(expectedCounts))
+			for i, bucket := range primaryBuckets {
+				require.Equal(t, expectedCounts[i], bucket.Count)
+			}
+		})
+	}
+}
+
+func getCumulativeCounts(
+	t *testing.T,
+	ctx context.Context,
+	db QueryExecutor,
+	tableID int64,
+	isIndex int64,
+	histID int64,
+) []int64 {
+	t.Helper()
+
+	rows, err := db.QueryContext(
+		ctx,
+		`SELECT count FROM mysql.stats_buckets
+		WHERE table_id = ? AND is_index = ? AND hist_id = ? ORDER BY bucket_id`,
+		tableID,
+		isIndex,
+		histID,
+	)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	counts := make([]int64, 0, 5)
+	var cumulativeCount int64
+	for rows.Next() {
+		var count int64
+		require.NoError(t, rows.Scan(&count))
+		cumulativeCount += count
+		counts = append(counts, cumulativeCount)
+	}
+	require.NoError(t, rows.Err())
+	return counts
+}
+
+func buildInsertSQL(table string, rowCount int) string {
+	values := make([]string, 0, rowCount)
+	for i := range rowCount {
+		values = append(values, fmt.Sprintf("(%d, '%d')", i, i%60))
+	}
+	return fmt.Sprintf("INSERT INTO %s VALUES %s", table, strings.Join(values, ","))
+}

--- a/pkg/diff/spliter_test.go
+++ b/pkg/diff/spliter_test.go
@@ -445,14 +445,15 @@ func createFakeResultForBucketSplit(mock sqlmock.Sqlmock, aRandomValues, bRandom
 		| Db_name | Table_name | Column_name | Is_index | Bucket_id | Count | Repeats | Lower_Bound | Upper_Bound |
 		+---------+------------+-------------+----------+-----------+-------+---------+-------------+-------------+
 		| test    | test       | PRIMARY     |        1 |         0 |    64 |       1 | (0, 0)      | (63, 11)    |
-		| test    | test       | PRIMARY     |        1 |         1 |   128 |       1 | (64, 12)    | (127, 23)   |
-		| test    | test       | PRIMARY     |        1 |         2 |   192 |       1 | (128, 24)   | (191, 35)   |
-		| test    | test       | PRIMARY     |        1 |         3 |   256 |       1 | (192, 36)   | (255, 47)   |
-		| test    | test       | PRIMARY     |        1 |         4 |   320 |       1 | (256, 48)   | (319, 59)   |
+		| test    | test       | PRIMARY     |        1 |         1 |    64 |       1 | (64, 12)    | (127, 23)   |
+		| test    | test       | PRIMARY     |        1 |         2 |    64 |       1 | (128, 24)   | (191, 35)   |
+		| test    | test       | PRIMARY     |        1 |         3 |    64 |       1 | (192, 36)   | (255, 47)   |
+		| test    | test       | PRIMARY     |        1 |         4 |    64 |       1 | (256, 48)   | (319, 59)   |
 		+---------+------------+-------------+----------+-----------+-------+---------+-------------+-------------+
 	*/
 
-	// Mock query with subquery to get all table_ids (main table + partitions) at once
+	// Mock query using the logical table ID. For partitioned tables this selects
+	// global statistics and avoids mixing per-partition histograms.
 	statsRows := sqlmock.NewRows([]string{"is_index", "hist_id", "bucket_id", "count", "lower_bound", "upper_bound"})
 	for i := 0; i < 5; i++ {
 		// Encode index bounds as real encoded keys: PRIMARY(a, b) where both a and b are integers.
@@ -465,10 +466,10 @@ func createFakeResultForBucketSplit(mock sqlmock.Sqlmock, aRandomValues, bRandom
 		lowerEncoded, _ := codec.EncodeKey(time.UTC, nil, lowerDatums...)
 		upperEncoded, _ := codec.EncodeKey(time.UTC, nil, upperDatums...)
 
-		statsRows.AddRow(1, 1, i, (i+1)*64, lowerEncoded, upperEncoded)
+		statsRows.AddRow(1, 1, i, 64, lowerEncoded, upperEncoded)
 	}
-	mock.ExpectQuery("SELECT is_index, hist_id, bucket_id, count, lower_bound, upper_bound FROM mysql.stats_buckets WHERE table_id IN \\(\\s*SELECT tidb_table_id FROM information_schema.tables WHERE table_schema = \\? AND table_name = \\? UNION ALL SELECT tidb_partition_id FROM information_schema.partitions WHERE table_schema = \\? AND table_name = \\?\\s*\\) ORDER BY is_index, hist_id, bucket_id").
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+	mock.ExpectQuery("SELECT is_index, hist_id, bucket_id, count, lower_bound, upper_bound FROM mysql.stats_buckets WHERE table_id = \\(\\s*SELECT tidb_table_id FROM information_schema.tables WHERE table_schema = \\? AND table_name = \\?\\s*\\) ORDER BY is_index, hist_id, bucket_id").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnRows(statsRows)
 
 	for i := 0; i < len(aRandomValues); i++ {

--- a/sync_diff_inspector/source/source_test.go
+++ b/sync_diff_inspector/source/source_test.go
@@ -21,11 +21,14 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/tidb/pkg/parser"
+	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
 	"github.com/pingcap/tidb/pkg/util/dbutil"
 	filter "github.com/pingcap/tidb/pkg/util/table-filter"
@@ -263,19 +266,6 @@ func TestTiDBSource(t *testing.T) {
 
 	rowIter.Close()
 
-	analyze := tidb.GetTableAnalyzer()
-	statsRows := sqlmock.NewRows([]string{"is_index", "hist_id", "bucket_id", "count", "lower_bound", "upper_bound"})
-	for i := 0; i < 5; i++ {
-		statsRows.AddRow(1, 1, i, (i+1)*64, fmt.Sprintf("(%d, %d)", i*64, i*12), fmt.Sprintf("(%d, %d)", (i+1)*64-1, (i+1)*12-1))
-	}
-	mock.ExpectQuery("SELECT is_index, hist_id, bucket_id, count, lower_bound, upper_bound FROM mysql.stats_buckets WHERE table_id IN \\(\\s*SELECT tidb_table_id FROM information_schema.tables WHERE table_schema = \\? AND table_name = \\? UNION ALL SELECT tidb_partition_id FROM information_schema.partitions WHERE table_schema = \\? AND table_name = \\?\\s*\\) ORDER BY is_index, hist_id, bucket_id").
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(statsRows)
-	countRows := sqlmock.NewRows([]string{"Cnt"}).AddRow(0)
-	mock.ExpectQuery("SELECT COUNT.*").WillReturnRows(countRows)
-	chunkIter, err := analyze.AnalyzeSplitter(ctx, tableDiffs[0], tableCase.rangeInfo)
-	require.NoError(t, err)
-	chunkIter.Close()
 	tidb.Close()
 }
 
@@ -292,10 +282,6 @@ func TestFallbackToRandomIfRangeIsSet(t *testing.T) {
 			AddRow("test1", "base", "NO", "single_tg"))
 	mock.ExpectQuery("SELECT version()*").WillReturnRows(sqlmock.NewRows([]string{"version()"}).AddRow("5.7.25-TiDB-v4.0.12"))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(1) cnt")).WillReturnRows(sqlmock.NewRows([]string{"cnt"}).AddRow(100))
-	statsRows := sqlmock.NewRows([]string{"hist_id", "is_index", "bucket_id", "count", "lower_bound", "upper_bound"})
-	for i := 0; i < 5; i++ {
-		statsRows.AddRow(1, 1, i, (i+1)*64, fmt.Sprintf("(%d, %d)", i*64, i*12), fmt.Sprintf("(%d, %d)", (i+1)*64-1, (i+1)*12-1))
-	}
 	f, err := filter.Parse([]string{"source_test.*"})
 	require.NoError(t, err)
 
@@ -1065,4 +1051,173 @@ func TestCheckTableMatched(t *testing.T) {
 	require.Equal(t, 0, tables[0].TableLack)
 	require.Equal(t, 1, tables[1].TableLack)
 	require.Equal(t, -1, tables[2].TableLack)
+}
+
+func TestTiDBTableAnalyzer(t *testing.T) {
+	ctx := context.Background()
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("CREATE DATABASE source_test")
+	tk.MustExec("USE source_test")
+	tk.MustExec("CREATE TABLE test (a INT, b VARCHAR(10), PRIMARY KEY (a, b))")
+	tk.MustExec(buildSourceInsertSQL("test", 320))
+	tk.MustExec("ANALYZE TABLE test WITH 5 BUCKETS, 0 TOPN")
+
+	tbl, err := dom.InfoSchema().TableByName(
+		ctx,
+		ast.NewCIStr("source_test"),
+		ast.NewCIStr("test"),
+	)
+	require.NoError(t, err)
+
+	db := testkit.CreateMockDB(tk)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+	tableDiff := &common.TableDiff{
+		Schema:    "source_test",
+		Table:     "test",
+		Info:      tbl.Meta(),
+		ChunkSize: 64,
+	}
+	analyzer := &TiDBTableAnalyzer{
+		dbConn:            db,
+		bucketSpliterPool: utils.NewWorkerPool(1, "bucket-analyzer"),
+	}
+
+	iter, err := analyzer.AnalyzeSplitter(ctx, tableDiff, nil)
+	require.NoError(t, err)
+	require.IsType(t, &splitter.BucketIterator{}, iter)
+	bucketIter := iter.(*splitter.BucketIterator)
+	chunks := requireChunksCoverTable(t, ctx, db, "source_test.test", iter, 320)
+	require.GreaterOrEqual(t, len(chunks), 3)
+	indexID := bucketIter.GetIndexID()
+	iter.Close()
+
+	checkpointChunk := chunks[2]
+	resumedIter, err := analyzer.AnalyzeSplitter(ctx, tableDiff, &splitter.RangeInfo{
+		ChunkRange: checkpointChunk,
+		IndexID:    indexID,
+	})
+	require.NoError(t, err)
+	require.IsType(t, &splitter.BucketIterator{}, resumedIter)
+	defer resumedIter.Close()
+
+	nextChunk, err := resumedIter.Next()
+	require.NoError(t, err)
+	require.NotNil(t, nextChunk)
+	for i, bound := range nextChunk.Bounds {
+		require.Equal(t, checkpointChunk.Bounds[i].Upper, bound.Lower)
+	}
+}
+
+func TestTiDBTableAnalyzerForPartitionTable(t *testing.T) {
+	testCases := []struct {
+		pruneMode        string
+		expectedIterator splitter.ChunkIterator
+	}{
+		{pruneMode: "dynamic", expectedIterator: &splitter.BucketIterator{}},
+		// Static pruning has no table-level global statistics, so the analyzer falls back to random splitting.
+		{pruneMode: "static", expectedIterator: &splitter.RandomIterator{}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.pruneMode, func(t *testing.T) {
+			ctx := context.Background()
+			store, dom := testkit.CreateMockStoreAndDomain(t)
+			tk := testkit.NewTestKit(t, store)
+			tk.MustExec("SET @@tidb_partition_prune_mode = '" + testCase.pruneMode + "'")
+			tk.MustExec("SET @@tidb_analyze_version = 2")
+			tk.MustExec("CREATE DATABASE partition_source_test")
+			tk.MustExec("USE partition_source_test")
+			tk.MustExec(`CREATE TABLE test (a INT, b VARCHAR(10), PRIMARY KEY (a, b))
+				PARTITION BY RANGE (a) (
+					PARTITION p0 VALUES LESS THAN (160),
+					PARTITION p1 VALUES LESS THAN MAXVALUE
+				)`)
+			tk.MustExec(buildSourceInsertSQL("test", 320))
+			tk.MustExec("ANALYZE TABLE test WITH 5 BUCKETS, 0 TOPN")
+
+			tbl, err := dom.InfoSchema().TableByName(
+				ctx,
+				ast.NewCIStr("partition_source_test"),
+				ast.NewCIStr("test"),
+			)
+			require.NoError(t, err)
+
+			db := testkit.CreateMockDB(tk)
+			t.Cleanup(func() {
+				require.NoError(t, db.Close())
+			})
+			tableDiff := &common.TableDiff{
+				Schema:    "partition_source_test",
+				Table:     "test",
+				Info:      tbl.Meta(),
+				Range:     "TRUE",
+				ChunkSize: 64,
+			}
+			analyzer := &TiDBTableAnalyzer{
+				dbConn:            db,
+				bucketSpliterPool: utils.NewWorkerPool(1, "partition-analyzer"),
+			}
+
+			iter, err := analyzer.AnalyzeSplitter(ctx, tableDiff, nil)
+			require.NoError(t, err)
+			require.IsType(t, testCase.expectedIterator, iter)
+			requireChunksCoverTable(t, ctx, db, "partition_source_test.test", iter, 320)
+			iter.Close()
+		})
+	}
+}
+
+type sourceTestRow struct {
+	a int
+	b string
+}
+
+func requireChunksCoverTable(
+	t *testing.T,
+	ctx context.Context,
+	db *sql.DB,
+	qualifiedTable string,
+	iter splitter.ChunkIterator,
+	expectedRows int,
+) []*chunk.Range {
+	t.Helper()
+
+	seen := make(map[sourceTestRow]struct{}, expectedRows)
+	chunks := make([]*chunk.Range, 0)
+	for {
+		chunkRange, err := iter.Next()
+		require.NoError(t, err)
+		if chunkRange == nil {
+			break
+		}
+		chunks = append(chunks, chunkRange)
+
+		where, args := chunkRange.ToString("")
+		rows, err := db.QueryContext(ctx, "SELECT a, b FROM "+qualifiedTable+" WHERE "+where, args...)
+		require.NoError(t, err)
+		for rows.Next() {
+			var row sourceTestRow
+			require.NoError(t, rows.Scan(&row.a, &row.b))
+			_, exists := seen[row]
+			require.False(t, exists, "row (%d, %s) is covered by multiple chunks", row.a, row.b)
+			seen[row] = struct{}{}
+		}
+		require.NoError(t, rows.Err())
+		require.NoError(t, rows.Close())
+	}
+
+	require.NotEmpty(t, chunks)
+	require.Len(t, seen, expectedRows)
+	return chunks
+}
+
+func buildSourceInsertSQL(table string, rowCount int) string {
+	values := make([]string, 0, rowCount)
+	for i := range rowCount {
+		values = append(values, fmt.Sprintf("(%d, '%d')", i, i%60))
+	}
+	return fmt.Sprintf("INSERT INTO %s VALUES %s", table, strings.Join(values, ","))
 }

--- a/sync_diff_inspector/splitter/splitter_test.go
+++ b/sync_diff_inspector/splitter/splitter_test.go
@@ -15,19 +15,18 @@ package splitter
 
 import (
 	"context"
+	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"sort"
-	"strconv"
+	"strings"
 	"testing"
-	"time"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/testkit"
 	"github.com/pingcap/tidb/pkg/testkit/testfailpoint"
-	ttypes "github.com/pingcap/tidb/pkg/types"
-	"github.com/pingcap/tidb/pkg/util/codec"
 	"github.com/pingcap/tiflow/sync_diff_inspector/chunk"
 	"github.com/pingcap/tiflow/sync_diff_inspector/source/common"
 	"github.com/pingcap/tiflow/sync_diff_inspector/utils"
@@ -429,345 +428,12 @@ func createFakeResultForRandomSplit(t *testing.T, mock sqlmock.Sqlmock, count in
 	mock.ExpectQuery("ORDER BY rand_value").WillReturnRows(randomRows)
 }
 
-func TestBucketSpliter(t *testing.T) {
-	ctx := context.Background()
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-
-	createTableSQL := "create table `test`.`test`(`a` int, `b` varchar(10), `c` float, `d` datetime, primary key(`a`, `b`))"
-	tableInfo, err := utils.GetTableInfoBySQL(createTableSQL, parser.New())
-	require.NoError(t, err)
-
-	testCases := []struct {
-		chunkSize     int64
-		aRandomValues []interface{}
-		bRandomValues []interface{}
-		expectResult  []chunkResult
-	}{
-		{
-			// chunk size less than the count of bucket 64, and the bucket's count 64 >= 32, so will split by random in every bucket
-			32,
-			[]interface{}{32, 32 * 3, 32 * 5, 32 * 7, 32 * 9},
-			[]interface{}{6, 6 * 3, 6 * 5, 6 * 7, 6 * 9},
-			[]chunkResult{
-				{
-					"(`a` < ?) OR (`a` = ? AND `b` <= ?)",
-					[]interface{}{"32", "32", "6"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"32", "32", "6", "63", "63", "11"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"63", "63", "11", "96", "96", "18"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"96", "96", "18", "127", "127", "23"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"127", "127", "23", "160", "160", "30"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"160", "160", "30", "191", "191", "35"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"191", "191", "35", "224", "224", "42"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"224", "224", "42", "255", "255", "47"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"255", "255", "47", "288", "288", "54"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"288", "288", "54", "319", "319", "59"},
-				}, {
-					"(`a` > ?) OR (`a` = ? AND `b` > ?)",
-					[]interface{}{"319", "319", "59"},
-				},
-			},
-		}, {
-			// chunk size less than the count of bucket 64, but 64 is  less than 2*50, so will not split every bucket
-			50,
-			nil,
-			nil,
-			[]chunkResult{
-				{
-					"(`a` < ?) OR (`a` = ? AND `b` <= ?)",
-					[]interface{}{"63", "63", "11"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"63", "63", "11", "127", "127", "23"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"127", "127", "23", "191", "191", "35"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"191", "191", "35", "255", "255", "47"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"255", "255", "47", "319", "319", "59"},
-				}, {
-					"(`a` > ?) OR (`a` = ? AND `b` > ?)",
-					[]interface{}{"319", "319", "59"},
-				},
-			},
-		}, {
-			// chunk size is equal to the count of bucket 64, so every becket will generate a chunk
-			64,
-			nil,
-			nil,
-			[]chunkResult{
-				{
-					"(`a` < ?) OR (`a` = ? AND `b` <= ?)",
-					[]interface{}{"63", "63", "11"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"63", "63", "11", "127", "127", "23"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"127", "127", "23", "191", "191", "35"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"191", "191", "35", "255", "255", "47"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"255", "255", "47", "319", "319", "59"},
-				}, {
-					"(`a` > ?) OR (`a` = ? AND `b` > ?)",
-					[]interface{}{"319", "319", "59"},
-				},
-			},
-		}, {
-			// chunk size is greater than the count of bucket 64, will combine two bucket into chunk
-			127,
-			nil,
-			nil,
-			[]chunkResult{
-				{
-					"(`a` < ?) OR (`a` = ? AND `b` <= ?)",
-					[]interface{}{"127", "127", "23"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"127", "127", "23", "255", "255", "47"},
-				}, {
-					"(`a` > ?) OR (`a` = ? AND `b` > ?)",
-					[]interface{}{"255", "255", "47"},
-				},
-			},
-		}, {
-			// chunk size is equal to the double count of bucket 64, will combine two bucket into one chunk
-			128,
-			nil,
-			nil,
-			[]chunkResult{
-				{
-					"(`a` < ?) OR (`a` = ? AND `b` <= ?)",
-					[]interface{}{"127", "127", "23"},
-				}, {
-					"((`a` > ?) OR (`a` = ? AND `b` > ?)) AND ((`a` < ?) OR (`a` = ? AND `b` <= ?))",
-					[]interface{}{"127", "127", "23", "255", "255", "47"},
-				}, {
-					"(`a` > ?) OR (`a` = ? AND `b` > ?)",
-					[]interface{}{"255", "255", "47"},
-				},
-			},
-		}, {
-			// chunk size is greater than the double count of bucket 64, will combine three bucket into one chunk
-			129,
-			nil,
-			nil,
-			[]chunkResult{
-				{
-					"(`a` < ?) OR (`a` = ? AND `b` <= ?)",
-					[]interface{}{"191", "191", "35"},
-				}, {
-					"(`a` > ?) OR (`a` = ? AND `b` > ?)",
-					[]interface{}{"191", "191", "35"},
-				},
-			},
-		}, {
-			// chunk size is greater than the total count, only generate one chunk
-			400,
-			nil,
-			nil,
-			[]chunkResult{
-				{
-					"TRUE",
-					nil,
-				},
-			},
-		},
-	}
-
-	tableDiff := &common.TableDiff{
-		Schema: "test",
-		Table:  "test",
-		Info:   tableInfo,
-	}
-
-	for i, testCase := range testCases {
-		fmt.Printf("%d", i)
-		createFakeResultForBucketSplit(mock, testCase.aRandomValues, testCase.bRandomValues)
-		tableDiff.ChunkSize = testCase.chunkSize
-		iter, err := NewBucketIterator(ctx, "", tableDiff, db)
-		require.NoError(t, err)
-		defer iter.Close()
-
-		obtainChunks := make([]chunkResult, 0, len(testCase.expectResult))
-		nextBeginBucket := 0
-		for {
-			chunk, err := iter.Next()
-			require.NoError(t, err)
-			if chunk == nil {
-				break
-			}
-			chunkStr, _ := chunk.ToString("")
-			if nextBeginBucket == 0 {
-				require.Equal(t, chunk.Index.BucketIndexLeft, 0)
-			} else {
-				require.Equal(t, chunk.Index.BucketIndexLeft, nextBeginBucket)
-			}
-			if chunk.Index.ChunkIndex+1 == chunk.Index.ChunkCnt {
-				nextBeginBucket = chunk.Index.BucketIndexRight + 1
-			}
-			obtainChunks = append(obtainChunks, chunkResult{chunkStr, chunk.Args})
-
-		}
-		sort.Slice(obtainChunks, func(i, j int) bool {
-			totalIndex := len(obtainChunks[i].args)
-			if totalIndex > len(obtainChunks[j].args) {
-				totalIndex = len(obtainChunks[j].args)
-			}
-			for index := 0; index < totalIndex; index++ {
-				a1, _ := strconv.Atoi(obtainChunks[i].args[index].(string))
-				a2, _ := strconv.Atoi(obtainChunks[j].args[index].(string))
-				if a1 < a2 {
-					return true
-				} else if a1 > a2 {
-					return false
-				}
-			}
-			if len(obtainChunks[i].args) == len(obtainChunks[j].args) {
-				// hack way for test case 6
-				return len(obtainChunks[i].chunkStr) > len(obtainChunks[j].chunkStr)
-			}
-			return len(obtainChunks[i].args) < len(obtainChunks[j].args)
-		})
-		// we expect chunk count is same after we generate chunk concurrently
-		require.Equal(t, len(obtainChunks), len(testCase.expectResult))
-		for i, e := range testCase.expectResult {
-			require.Equal(t, obtainChunks[i].args, e.args)
-			require.Equal(t, obtainChunks[i].chunkStr, e.chunkStr)
-		}
-	}
-
-	// Test Checkpoint
-	stopJ := 3
-	createFakeResultForBucketSplit(mock, testCases[0].aRandomValues, testCases[0].bRandomValues)
-	tableDiff.ChunkSize = testCases[0].chunkSize
-	iter, err := NewBucketIterator(ctx, "", tableDiff, db)
-	require.NoError(t, err)
-	j := 0
-	var chunk *chunk.Range
-	for ; j < stopJ; j++ {
-		chunk, err = iter.Next()
-		require.NoError(t, err)
-	}
-	for {
-		c, err := iter.Next()
-		require.NoError(t, err)
-		if c == nil {
-			break
-		}
-	}
-	iter.Close()
-
-	bounds1 := chunk.Bounds
-
-	rangeInfo := &RangeInfo{
-		ChunkRange: chunk,
-		IndexID:    iter.GetIndexID(),
-	}
-
-	// drop the origin db since we cannot ensure order of mock string after we concurrent produce chunks.
-	db, mock, err = sqlmock.New()
-	require.NoError(t, err)
-	createFakeResultForBucketSplit(mock, nil, nil)
-	createFakeResultForRandom(mock, testCases[0].aRandomValues[stopJ-1:], testCases[0].bRandomValues[stopJ-1:])
-	iter, err = NewBucketIteratorWithCheckpoint(ctx, "", tableDiff, db, rangeInfo, utils.NewWorkerPool(1, "bucketIter"))
-	require.NoError(t, err)
-	chunk, err = iter.Next()
-	require.NoError(t, err)
-
-	for i, bound := range chunk.Bounds {
-		require.Equal(t, bounds1[i].Upper, bound.Lower)
-	}
-	for {
-		c, err := iter.Next()
-		require.NoError(t, err)
-		if c == nil {
-			break
-		}
-	}
-	iter.Close()
-
-	// Mock column a is ignored.
-	tableDiff.Info, _ = utils.ResetColumns(tableInfo, []string{"a"})
-	createFakeResultForBucketSplit(mock, testCases[0].aRandomValues, testCases[0].bRandomValues)
-	_, err = NewBucketIterator(ctx, "", tableDiff, db)
-	require.Error(t, err)
-}
-
-func createFakeResultForBucketSplit(mock sqlmock.Sqlmock, aRandomValues, bRandomValues []interface{}) {
-	/*
-		+---------+------------+-------------+----------+-----------+-------+---------+-------------+-------------+
-		| Db_name | Table_name | Column_name | Is_index | Bucket_id | Count | Repeats | Lower_Bound | Upper_Bound |
-		+---------+------------+-------------+----------+-----------+-------+---------+-------------+-------------+
-		| test    | test       | PRIMARY     |        1 |         0 |    64 |       1 | (0, 0)      | (63, 11)    |
-		| test    | test       | PRIMARY     |        1 |         1 |   128 |       1 | (64, 12)    | (127, 23)   |
-		| test    | test       | PRIMARY     |        1 |         2 |   192 |       1 | (128, 24)   | (191, 35)   |
-		| test    | test       | PRIMARY     |        1 |         3 |   256 |       1 | (192, 36)   | (255, 47)   |
-		| test    | test       | PRIMARY     |        1 |         4 |   320 |       1 | (256, 48)   | (319, 59)   |
-		+---------+------------+-------------+----------+-----------+-------+---------+-------------+-------------+
-	*/
-
-	// Mock query with subquery to get all table_ids (main table + partitions) at once
-	statsRows := sqlmock.NewRows([]string{"is_index", "hist_id", "bucket_id", "count", "lower_bound", "upper_bound"})
-	for i := 0; i < 5; i++ {
-		// Encode index bounds as real encoded keys: PRIMARY(a, b) where both a and b are integers.
-		lowerA, lowerB := i*64, i*12
-		upperA, upperB := (i+1)*64-1, (i+1)*12-1
-
-		lowerDatums := []ttypes.Datum{ttypes.NewIntDatum(int64(lowerA)), ttypes.NewStringDatum(fmt.Sprintf("%d", lowerB))}
-		upperDatums := []ttypes.Datum{ttypes.NewIntDatum(int64(upperA)), ttypes.NewStringDatum(fmt.Sprintf("%d", upperB))}
-
-		lowerEncoded, _ := codec.EncodeKey(time.UTC, nil, lowerDatums...)
-		upperEncoded, _ := codec.EncodeKey(time.UTC, nil, upperDatums...)
-
-		statsRows.AddRow(1, 1, i, (i+1)*64, lowerEncoded, upperEncoded)
-	}
-	mock.ExpectQuery("SELECT is_index, hist_id, bucket_id, count, lower_bound, upper_bound FROM mysql.stats_buckets WHERE table_id IN \\(\\s*SELECT tidb_table_id FROM information_schema.tables WHERE table_schema = \\? AND table_name = \\? UNION ALL SELECT tidb_partition_id FROM information_schema.partitions WHERE table_schema = \\? AND table_name = \\?\\s*\\) ORDER BY is_index, hist_id, bucket_id").
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(statsRows)
-
-	createFakeResultForRandom(mock, aRandomValues, bRandomValues)
-}
-
 func createFakeResultForCount(t *testing.T, count int) {
 	if count > 0 {
-		// generate fake result for get the row count of this table
 		testfailpoint.Enable(t,
 			"github.com/pingcap/tiflow/sync_diff_inspector/splitter/getRowCount",
 			fmt.Sprintf("return(%d)", count),
 		)
-	}
-}
-
-func createFakeResultForRandom(mock sqlmock.Sqlmock, aRandomValues, bRandomValues []interface{}) {
-	for i := 0; i < len(aRandomValues); i++ {
-		aRandomRows := sqlmock.NewRows([]string{"a", "b"})
-		aRandomRows.AddRow(aRandomValues[i], bRandomValues[i])
-		mock.ExpectQuery("ORDER BY rand_value").WillReturnRows(aRandomRows)
 	}
 }
 
@@ -912,125 +578,6 @@ func TestRangeInfo(t *testing.T) {
 	require.Equal(t, rangeInfo2.GetTableIndex(), 1)
 }
 
-func TestChunkSize(t *testing.T) {
-	ctx := context.Background()
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-
-	createTableSQL := "create table `test`.`test`(`a` int, `b` varchar(10), `c` float, `d` datetime, primary key(`a`, `b`))"
-	tableInfo, err := utils.GetTableInfoBySQL(createTableSQL, parser.New())
-	require.NoError(t, err)
-
-	tableDiff := &common.TableDiff{
-		Schema:    "test",
-		Table:     "test",
-		Info:      tableInfo,
-		ChunkSize: 0,
-	}
-
-	// test bucket splitter chunksize
-	// Mock query with subquery to get all table_ids (main table + partitions) at once
-	statsRows := sqlmock.NewRows([]string{"is_index", "hist_id", "bucket_id", "count", "lower_bound", "upper_bound"})
-	// Notice, use wrong Bound to kill bucket producer
-	statsRows.AddRow(1, 1, 0, 1000000000, "(1, 2, wrong!)", "(2, 3, wrong!)")
-	mock.ExpectQuery("SELECT is_index, hist_id, bucket_id, count, lower_bound, upper_bound FROM mysql.stats_buckets WHERE table_id IN \\(\\s*SELECT tidb_table_id FROM information_schema.tables WHERE table_schema = \\? AND table_name = \\? UNION ALL SELECT tidb_partition_id FROM information_schema.partitions WHERE table_schema = \\? AND table_name = \\?\\s*\\) ORDER BY is_index, hist_id, bucket_id").
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(statsRows)
-
-	bucketIter, err := NewBucketIterator(ctx, "", tableDiff, db)
-	require.NoError(t, err)
-	require.Equal(t, bucketIter.chunkSize, int64(100000))
-
-	createFakeResultForBucketSplit(mock, nil, nil)
-	bucketIter, err = NewBucketIterator(ctx, "", tableDiff, db)
-	require.NoError(t, err)
-	require.Equal(t, bucketIter.chunkSize, int64(50000))
-
-	// test random splitter chunksize
-	// chunkNum is only 1, so don't need randomValues
-	createFakeResultForRandomSplit(t, mock, 1000, nil)
-	randomIter, err := NewRandomIterator(ctx, "", tableDiff, db)
-	require.NoError(t, err)
-	require.Equal(t, randomIter.chunkSize, int64(50000))
-
-	createFakeResultForRandomSplit(t, mock, 1000000000, [][]string{
-		{"1", "2", "3", "4", "5"},
-		{"a", "b", "c", "d", "e"},
-	})
-	randomIter, err = NewRandomIterator(ctx, "", tableDiff, db)
-	require.NoError(t, err)
-	require.Equal(t, randomIter.chunkSize, int64(100000))
-
-	createTableSQL = "create table `test`.`test`(`a` int, `b` varchar(10), `c` float, `d` datetime)"
-	tableInfo, err = utils.GetTableInfoBySQL(createTableSQL, parser.New())
-	require.NoError(t, err)
-
-	tableDiffNoIndex := &common.TableDiff{
-		Schema:    "test",
-		Table:     "test",
-		Info:      tableInfo,
-		ChunkSize: 0,
-	}
-	// no index
-	createFakeResultForRandomSplit(t, mock, 1000, nil)
-	randomIter, err = NewRandomIterator(ctx, "", tableDiffNoIndex, db)
-	require.NoError(t, err)
-	require.Equal(t, randomIter.chunkSize, int64(1001))
-
-	// test limit splitter chunksize
-	createFakeResultForCount(t, 1000)
-	mock.ExpectQuery("SELECT `a`,.*limit 50000.*").WillReturnRows(sqlmock.NewRows([]string{"a", "b"}))
-	_, err = NewLimitIterator(ctx, "", tableDiff, db)
-	require.NoError(t, err)
-}
-
-func TestBucketSpliterHint(t *testing.T) {
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	ctx := context.Background()
-
-	testCases := []struct {
-		tableSQL      string
-		indexCount    int
-		expectColumns []ast.CIStr
-	}{
-		{
-			"create table `test`.`test`(`a` int, `b` int, `c` int, primary key(`a`, `b`), unique key i1(`c`))",
-			0,
-			[]ast.CIStr{ast.NewCIStr("a"), ast.NewCIStr("b")},
-		},
-		{
-			"create table `test`.`test`(`a` int, `b` int, `c` int, unique key i1(`c`))",
-			0,
-			[]ast.CIStr{ast.NewCIStr("c")},
-		},
-		{
-			"create table `test`.`test`(`a` int, `b` int, `c` int, key i2(`b`))",
-			1,
-			[]ast.CIStr{ast.NewCIStr("b")},
-		},
-	}
-
-	for _, tc := range testCases {
-		tableInfo, err := utils.GetTableInfoBySQL(tc.tableSQL, parser.New())
-		require.NoError(t, err)
-
-		tableDiff := &common.TableDiff{
-			Schema: "test",
-			Table:  "test",
-			Info:   tableInfo,
-		}
-
-		createFakeResultForBucketIterator(mock, tc.indexCount)
-
-		iter, err := NewBucketIteratorWithCheckpoint(ctx, "", tableDiff, db, nil, utils.NewWorkerPool(1, "bucketIter"))
-		require.NoError(t, err)
-		chunk, err := iter.Next()
-		require.NoError(t, err)
-		require.Equal(t, tc.expectColumns, chunk.IndexColumnNames)
-	}
-}
-
 func TestRandomSpliterHint(t *testing.T) {
 	db, _, err := sqlmock.New()
 	require.NoError(t, err)
@@ -1085,31 +632,301 @@ func TestRandomSpliterHint(t *testing.T) {
 	}
 }
 
-func createFakeResultForBucketIterator(mock sqlmock.Sqlmock, indexCount int) {
-	/*
-		+---------+----------+-----------+-------+-------------+-------------+
-		| hist_id | is_index | bucket_id | count | lower_bound | upper_bound |
-		+---------+----------+-----------+-------+-------------+-------------+
-		| 1       |        1 |         0 |    64 | (0, 0)      | (63, 11)    |
-		| 1       |        1 |         1 |   128 | (64, 12)    | (127, 23)   |
-		| 1       |        1 |         2 |   192 | (128, 24)   | (191, 35)   |
-		| 1       |        1 |         3 |   256 | (192, 36)   | (255, 47)   |
-		| 1       |        1 |         4 |   320 | (256, 48)   | (319, 59)   |
-		+---------+----------+-----------+-------+-------------+-------------+
-	*/
-	// Mock query with subquery to get all table_ids (main table + partitions) at once
-	statsRows := sqlmock.NewRows([]string{"is_index", "hist_id", "bucket_id", "count", "lower_bound", "upper_bound"})
-	for i := range []string{"PRIMARY", "i1", "i2", "i3", "i4"} {
-		histID := int64(i + 1) // hist_id starts from 1
-		for j := 0; j < 5; j++ {
-			statsRows.AddRow(1, histID, j, (j+1)*64, fmt.Sprintf("(%d, %d)", j*64, j*12), fmt.Sprintf("(%d, %d)", (j+1)*64-1, (j+1)*12-1))
-		}
-	}
-	mock.ExpectQuery("SELECT is_index, hist_id, bucket_id, count, lower_bound, upper_bound FROM mysql.stats_buckets WHERE table_id IN \\(\\s*SELECT tidb_table_id FROM information_schema.tables WHERE table_schema = \\? AND table_name = \\? UNION ALL SELECT tidb_partition_id FROM information_schema.partitions WHERE table_schema = \\? AND table_name = \\?\\s*\\) ORDER BY is_index, hist_id, bucket_id").
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
-		WillReturnRows(statsRows)
+func TestBucketSpliter(t *testing.T) {
+	ctx := context.Background()
+	db, tableInfo := createAnalyzedBucketTable(t)
 
-	for range indexCount {
-		mock.ExpectQuery("SELECT COUNT\\(DISTINCT *").WillReturnRows(sqlmock.NewRows([]string{"SEL"}).AddRow("5"))
+	for _, chunkSize := range []int64{32, 50, 64, 127, 128, 129, 400} {
+		t.Run(fmt.Sprintf("chunk_size_%d", chunkSize), func(t *testing.T) {
+			tableDiff := &common.TableDiff{
+				Schema:    "bucket_test",
+				Table:     "test",
+				Info:      tableInfo,
+				Range:     "TRUE",
+				ChunkSize: chunkSize,
+			}
+
+			iter, err := NewBucketIterator(ctx, "", tableDiff, db)
+			require.NoError(t, err)
+			defer iter.Close()
+
+			chunkCount := requireBucketChunksCoverTable(t, ctx, db, iter, 320)
+			if chunkSize < 320 {
+				require.Greater(t, chunkCount, 1)
+			} else {
+				require.Equal(t, 1, chunkCount)
+			}
+		})
 	}
+
+	t.Run("checkpoint", func(t *testing.T) {
+		tableDiff := &common.TableDiff{
+			Schema:    "bucket_test",
+			Table:     "test",
+			Info:      tableInfo,
+			Range:     "TRUE",
+			ChunkSize: 64,
+		}
+		iter, err := NewBucketIterator(ctx, "", tableDiff, db)
+		require.NoError(t, err)
+
+		var lastChunk *chunk.Range
+		for range 3 {
+			lastChunk, err = iter.Next()
+			require.NoError(t, err)
+			require.NotNil(t, lastChunk)
+		}
+		rangeInfo := &RangeInfo{
+			ChunkRange: lastChunk,
+			IndexID:    iter.GetIndexID(),
+		}
+		for {
+			remainingChunk, err := iter.Next()
+			require.NoError(t, err)
+			if remainingChunk == nil {
+				break
+			}
+		}
+		iter.Close()
+
+		resumedIter, err := NewBucketIteratorWithCheckpoint(
+			ctx,
+			"",
+			tableDiff,
+			db,
+			rangeInfo,
+			utils.NewWorkerPool(1, "bucket-checkpoint"),
+		)
+		require.NoError(t, err)
+		defer resumedIter.Close()
+
+		nextChunk, err := resumedIter.Next()
+		require.NoError(t, err)
+		require.NotNil(t, nextChunk)
+		for i, bound := range nextChunk.Bounds {
+			require.Equal(t, lastChunk.Bounds[i].Upper, bound.Lower)
+		}
+	})
+
+	t.Run("ignored_index_column", func(t *testing.T) {
+		info, _ := utils.ResetColumns(tableInfo, []string{"a"})
+		tableDiff := &common.TableDiff{
+			Schema:    "bucket_test",
+			Table:     "test",
+			Info:      info,
+			Range:     "TRUE",
+			ChunkSize: 64,
+		}
+		_, err := NewBucketIterator(ctx, "", tableDiff, db)
+		require.Error(t, err)
+	})
+}
+
+func TestChunkSize(t *testing.T) {
+	ctx := context.Background()
+	bucketDB, tableInfo := createAnalyzedBucketTable(t)
+	tableDiff := &common.TableDiff{
+		Schema: "bucket_test",
+		Table:  "test",
+		Info:   tableInfo,
+		Range:  "TRUE",
+	}
+
+	bucketIter, err := NewBucketIterator(ctx, "", tableDiff, bucketDB)
+	require.NoError(t, err)
+	require.Equal(t, int64(50000), bucketIter.chunkSize)
+	bucketIter.Close()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Test random splitter chunk size. When chunkNum is 1, random values are not needed.
+	createFakeResultForRandomSplit(t, mock, 1000, nil)
+	randomIter, err := NewRandomIterator(ctx, "", tableDiff, db)
+	require.NoError(t, err)
+	require.Equal(t, int64(50000), randomIter.chunkSize)
+
+	createFakeResultForRandomSplit(t, mock, 1000000000, [][]string{
+		{"1", "2", "3", "4", "5"},
+		{"a", "b", "c", "d", "e"},
+	})
+	randomIter, err = NewRandomIterator(ctx, "", tableDiff, db)
+	require.NoError(t, err)
+	require.Equal(t, int64(100000), randomIter.chunkSize)
+
+	createTableSQL := "create table `test`.`test`(`a` int, `b` varchar(10), `c` float, `d` datetime)"
+	tableInfo, err = utils.GetTableInfoBySQL(createTableSQL, parser.New())
+	require.NoError(t, err)
+
+	tableDiffNoIndex := &common.TableDiff{
+		Schema: "test",
+		Table:  "test",
+		Info:   tableInfo,
+	}
+	createFakeResultForRandomSplit(t, mock, 1000, nil)
+	randomIter, err = NewRandomIterator(ctx, "", tableDiffNoIndex, db)
+	require.NoError(t, err)
+	require.Equal(t, int64(1001), randomIter.chunkSize)
+
+	// Test limit splitter chunk size.
+	createFakeResultForCount(t, 1000)
+	mock.ExpectQuery("SELECT `a`,.*limit 50000.*").
+		WillReturnRows(sqlmock.NewRows([]string{"a", "b"}))
+	_, err = NewLimitIterator(ctx, "", tableDiff, db)
+	require.NoError(t, err)
+}
+
+func TestBucketSpliterHint(t *testing.T) {
+	ctx := context.Background()
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("CREATE DATABASE bucket_hint_test")
+	tk.MustExec("USE bucket_hint_test")
+
+	testCases := []struct {
+		name            string
+		createTableSQL  string
+		expectedColumns []ast.CIStr
+	}{
+		{
+			name:            "primary_idx",
+			createTableSQL:  "CREATE TABLE primary_idx (a INT, b INT, c INT, PRIMARY KEY (a, b), UNIQUE KEY i1 (c))",
+			expectedColumns: []ast.CIStr{ast.NewCIStr("a"), ast.NewCIStr("b")},
+		},
+		{
+			name:            "unique_idx",
+			createTableSQL:  "CREATE TABLE unique_idx (a INT, b INT, c INT, UNIQUE KEY i1 (c))",
+			expectedColumns: []ast.CIStr{ast.NewCIStr("c")},
+		},
+		{
+			name:            "normal_idx",
+			createTableSQL:  "CREATE TABLE normal_idx (a INT, b INT, c INT, KEY i2 (b))",
+			expectedColumns: []ast.CIStr{ast.NewCIStr("b")},
+		},
+	}
+
+	for _, testCase := range testCases {
+		tk.MustExec(testCase.createTableSQL)
+		tk.MustExec(buildHintInsertSQL(testCase.name, 20))
+		tk.MustExec("ANALYZE TABLE " + testCase.name + " WITH 5 BUCKETS, 0 TOPN")
+	}
+
+	db := testkit.CreateMockDB(tk)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tbl, err := dom.InfoSchema().TableByName(
+				ctx,
+				ast.NewCIStr("bucket_hint_test"),
+				ast.NewCIStr(testCase.name),
+			)
+			require.NoError(t, err)
+
+			tableDiff := &common.TableDiff{
+				Schema:    "bucket_hint_test",
+				Table:     testCase.name,
+				Info:      tbl.Meta(),
+				ChunkSize: 1000,
+			}
+			iter, err := NewBucketIteratorWithCheckpoint(
+				ctx,
+				"",
+				tableDiff,
+				db,
+				nil,
+				utils.NewWorkerPool(1, "bucket-hint"),
+			)
+			require.NoError(t, err)
+
+			chunkRange, err := iter.Next()
+			require.NoError(t, err)
+			require.NotNil(t, chunkRange)
+			require.Equal(t, testCase.expectedColumns, chunkRange.IndexColumnNames)
+			iter.Close()
+		})
+	}
+}
+
+func createAnalyzedBucketTable(t *testing.T) (*sql.DB, *model.TableInfo) {
+	t.Helper()
+
+	ctx := context.Background()
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("CREATE DATABASE bucket_test")
+	tk.MustExec("USE bucket_test")
+	tk.MustExec("CREATE TABLE test (a INT, b VARCHAR(10), PRIMARY KEY (a, b))")
+	tk.MustExec(buildBucketInsertSQL("test", 320))
+	tk.MustExec("ANALYZE TABLE test WITH 5 BUCKETS, 0 TOPN")
+
+	tbl, err := dom.InfoSchema().TableByName(
+		ctx,
+		ast.NewCIStr("bucket_test"),
+		ast.NewCIStr("test"),
+	)
+	require.NoError(t, err)
+
+	db := testkit.CreateMockDB(tk)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+	return db, tbl.Meta()
+}
+
+func requireBucketChunksCoverTable(
+	t *testing.T,
+	ctx context.Context,
+	db *sql.DB,
+	iter *BucketIterator,
+	expectedRows int,
+) int {
+	t.Helper()
+
+	seen := make(map[int]struct{}, expectedRows)
+	chunkCount := 0
+	for {
+		chunkRange, err := iter.Next()
+		require.NoError(t, err)
+		if chunkRange == nil {
+			break
+		}
+		chunkCount++
+
+		where, args := chunkRange.ToString("")
+		rows, err := db.QueryContext(ctx, "SELECT a FROM bucket_test.test WHERE "+where, args...)
+		require.NoError(t, err)
+		for rows.Next() {
+			var value int
+			require.NoError(t, rows.Scan(&value))
+			_, exists := seen[value]
+			require.False(t, exists, "row %d is covered by multiple chunks", value)
+			seen[value] = struct{}{}
+		}
+		require.NoError(t, rows.Err())
+		require.NoError(t, rows.Close())
+	}
+
+	require.Positive(t, chunkCount)
+	require.Len(t, seen, expectedRows)
+	return chunkCount
+}
+
+func buildBucketInsertSQL(table string, rowCount int) string {
+	values := make([]string, 0, rowCount)
+	for i := range rowCount {
+		values = append(values, fmt.Sprintf("(%d, '%d')", i, i%60))
+	}
+	return fmt.Sprintf("INSERT INTO %s VALUES %s", table, strings.Join(values, ","))
+}
+
+func buildHintInsertSQL(table string, rowCount int) string {
+	values := make([]string, 0, rowCount)
+	for i := range rowCount {
+		values = append(values, fmt.Sprintf("(%d, %d, %d)", i, i%5, i))
+	}
+	return fmt.Sprintf("INSERT INTO %s VALUES %s", table, strings.Join(values, ","))
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #12803

sync-diff-inspector reads histogram buckets directly from `mysql.stats_buckets`. TiDB stores `count` there as the row-count delta of each bucket, while the bucket splitter expects the cumulative counts exposed by `SHOW STATS_BUCKETS`. Treating the stored deltas as cumulative values can therefore produce incorrect chunk boundaries.

For partitioned tables, the previous query also mixed the logical table's global histogram with every per-partition histogram, although their bucket bounds are not globally ordered.

### What is changed and how it works?

- Accumulate bucket counts independently for each column or index histogram before passing them to the splitter.
- Read statistics only for `information_schema.tables.tidb_table_id`. For partitioned tables in dynamic prune mode, this selects TiDB's global histogram instead of mixing per-partition histograms.
- Fall back to the random splitter when a partitioned table has no global histogram, such as in static prune mode.
- Replace the existing SQL-mocked bucket splitter, chunk-size, index-selection, and source-analyzer tests in their existing test files with TiDB mock-store tests that run `ANALYZE TABLE`.
- Verify index and column histograms, chunk coverage without overlap, analyzer checkpoint continuation, index selection, automatic chunk sizing, global partition statistics, and static-mode fallback.

### Check List

#### Tests

- [x] Unit test
- [x] Integration test

Verification commands:

```shell
make failpoint-enable
log_level=error GOMAXPROCS=2 go test -p 1 -tags=intest ./pkg/dbutil ./pkg/diff ./sync_diff_inspector/splitter ./sync_diff_inspector/source -count=1
make failpoint-disable
```

#### Questions

##### Will it cause performance regression or break compatibility?

No. The conversion is linear in the number of histogram buckets. Partitioned tables use TiDB's global histogram when available and safely fall back to random splitting otherwise.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

### Release note

```release-note
Fix incorrect chunk splitting caused by interpreting TiDB histogram bucket counts as cumulative values or mixing partition histograms.
```
