### PR TITLE
sqlmodel(dm): fix panic comparing binary key columns

### DIFF
--- a/pkg/sqlmodel/reduce.go
+++ b/pkg/sqlmodel/reduce.go
@@ -83,12 +83,17 @@ func (r *RowChange) IsIdentityUpdated() bool {
 
 	r.lazyInitWhereHandle()
 	pre, post := r.IdentityValues()
+	return colValsUpdated(pre, post)
+}
+
+// colValsUpdated returns true when any value of pre differs from post.
+func colValsUpdated(pre, post []any) bool {
 	if len(pre) != len(post) {
 		// should not happen
 		return true
 	}
 	for i := range pre {
-		if pre[i] != post[i] {
+		if !colValEqual(pre[i], post[i]) {
 			return true
 		}
 	}
@@ -102,26 +107,14 @@ func (r *RowChange) IsPrimaryOrUniqueKeyUpdated() bool {
 	}
 
 	r.lazyInitWhereHandle()
-	identityUpdated := func(pre, post []any) bool {
-		if len(pre) != len(post) {
-			// should not happen
-			return true
-		}
-		for i := range pre {
-			if pre[i] != post[i] {
-				return true
-			}
-		}
-		return false
-	}
 
 	if idx := r.whereHandle.UniqueNotNullIdx; idx != nil {
 		pre, post := r.identityValuesByIndex(idx, r.preValues, r.postValues)
-		if identityUpdated(pre, post) {
+		if colValsUpdated(pre, post) {
 			return true
 		}
 	} else {
-		if identityUpdated(r.preValues, r.postValues) {
+		if colValsUpdated(r.preValues, r.postValues) {
 			return true
 		}
 	}
@@ -147,7 +140,7 @@ func (r *RowChange) IsPrimaryOrUniqueKeyUpdated() bool {
 			continue
 		}
 		pre, post := r.identityValuesByIndex(idx, preValues, postValues)
-		if identityUpdated(pre, post) {
+		if colValsUpdated(pre, post) {
 			return true
 		}
 	}

--- a/pkg/sqlmodel/reduce_test.go
+++ b/pkg/sqlmodel/reduce_test.go
@@ -72,6 +72,125 @@ func TestIdentityUpdatedWithUniqueKeys(t *testing.T) {
 	require.True(t, change.IsPrimaryOrUniqueKeyUpdated())
 }
 
+// TestIdentityUpdatedWithBinaryKeys covers key columns that reach sqlmodel as
+// []byte. Applying != to an interface that holds a slice panics with
+// "comparing uncomparable type []uint8", so equality has to go through
+// bytes.Equal. Values with equal contents but distinct backing arrays must
+// compare equal, otherwise a safe-mode UPDATE reports a spurious key change and
+// writes a needless DELETE.
+//
+// Two column kinds reach here as []byte:
+//   - BINARY and binary CHAR, which adjustValues converts from string because
+//     the column is TypeString with the binary flag set;
+//   - BLOB and TEXT, which the binlog decoder already returns as []byte.
+//
+// A GBK column takes the same conversion, so it behaves like the first kind.
+func TestIdentityUpdatedWithBinaryKeys(t *testing.T) {
+	t.Parallel()
+
+	source := &cdcmodel.TableName{Schema: "db", Table: "tb1"}
+
+	// A single BINARY primary key. The first comparison hits the binary column.
+	singleColTI := mockTableInfo(t, "CREATE TABLE tb1 ("+
+		"id BINARY(16) NOT NULL, val INT, PRIMARY KEY (id))")
+
+	change := NewRowChange(source, nil,
+		[]interface{}{[]byte("0123456789abcdef"), 7},
+		[]interface{}{[]byte("0123456789abcdef"), 9},
+		singleColTI, nil, nil)
+	require.False(t, change.IsIdentityUpdated())
+	require.False(t, change.IsPrimaryOrUniqueKeyUpdated())
+
+	change = NewRowChange(source, nil,
+		[]interface{}{[]byte("0123456789abcdef"), 7},
+		[]interface{}{[]byte("fedcba9876543210"), 7},
+		singleColTI, nil, nil)
+	require.True(t, change.IsIdentityUpdated())
+	require.True(t, change.IsPrimaryOrUniqueKeyUpdated())
+
+	// A multi-column primary key whose trailing columns are BINARY. All columns
+	// are NOT NULL, so the primary key becomes UniqueNotNullIdx and the fault
+	// would land on a later comparison rather than the first.
+	multiColTI := mockTableInfo(t, "CREATE TABLE tb1 ("+
+		"entity_id BIGINT NOT NULL, entity_type_id INT NOT NULL, "+
+		"principal BINARY(16) NOT NULL, reference BINARY(16) NOT NULL, "+
+		"val INT, "+
+		"PRIMARY KEY (entity_id, entity_type_id, principal, reference))")
+
+	change = NewRowChange(source, nil,
+		[]interface{}{1, 2, []byte("principal00000001"), []byte("reference00000001"), 7},
+		[]interface{}{1, 2, []byte("principal00000001"), []byte("reference00000001"), 9},
+		multiColTI, nil, nil)
+	require.False(t, change.IsIdentityUpdated())
+	require.False(t, change.IsPrimaryOrUniqueKeyUpdated())
+
+	change = NewRowChange(source, nil,
+		[]interface{}{1, 2, []byte("principal00000001"), []byte("reference00000001"), 7},
+		[]interface{}{1, 2, []byte("principal00000001"), []byte("reference00000002"), 7},
+		multiColTI, nil, nil)
+	require.True(t, change.IsIdentityUpdated())
+	require.True(t, change.IsPrimaryOrUniqueKeyUpdated())
+
+	// A secondary UNIQUE key over a BLOB prefix. The column is nullable, so the
+	// index lands in UniqueIdxs rather than UniqueNotNullIdx and only
+	// IsPrimaryOrUniqueKeyUpdated reads it.
+	blobUKTI := mockTableInfo(t, "CREATE TABLE tb1 ("+
+		"id INT PRIMARY KEY, acl BLOB, val INT, UNIQUE KEY uk_acl (acl(255)))")
+
+	change = NewRowChange(source, nil,
+		[]interface{}{1, []byte("acl"), 7},
+		[]interface{}{1, []byte("acl"), 9},
+		blobUKTI, nil, nil)
+	require.False(t, change.IsIdentityUpdated())
+	require.False(t, change.IsPrimaryOrUniqueKeyUpdated())
+
+	change = NewRowChange(source, nil,
+		[]interface{}{1, []byte("acl"), 7},
+		[]interface{}{1, []byte("acl2"), 7},
+		blobUKTI, nil, nil)
+	require.False(t, change.IsIdentityUpdated())
+	require.True(t, change.IsPrimaryOrUniqueKeyUpdated())
+
+	// A NULL binary key value on one side only.
+	change = NewRowChange(source, nil,
+		[]interface{}{1, nil, 7},
+		[]interface{}{1, []byte("acl"), 7},
+		blobUKTI, nil, nil)
+	require.False(t, change.IsIdentityUpdated())
+	require.True(t, change.IsPrimaryOrUniqueKeyUpdated())
+
+	// VARBINARY reaches sqlmodel as string today, because adjustValues only
+	// converts TypeString columns and VARBINARY parses to TypeVarchar. Cover
+	// both representations so the comparison does not depend on that detail.
+	varbinaryTI := mockTableInfo(t, "CREATE TABLE tb1 ("+
+		"id INT PRIMARY KEY, acl VARBINARY(255) UNIQUE, val INT)")
+
+	for _, v := range []struct {
+		name       string
+		base, same interface{}
+		diff       interface{}
+	}{
+		{"string", "acl", "acl", "acl2"},
+		{"bytes", []byte("acl"), []byte("acl"), []byte("acl2")},
+	} {
+		t.Run(v.name, func(t *testing.T) {
+			change := NewRowChange(source, nil,
+				[]interface{}{1, v.base, 7},
+				[]interface{}{1, v.same, 9},
+				varbinaryTI, nil, nil)
+			require.False(t, change.IsIdentityUpdated())
+			require.False(t, change.IsPrimaryOrUniqueKeyUpdated())
+
+			change = NewRowChange(source, nil,
+				[]interface{}{1, v.base, 7},
+				[]interface{}{1, v.diff, 7},
+				varbinaryTI, nil, nil)
+			require.False(t, change.IsIdentityUpdated())
+			require.True(t, change.IsPrimaryOrUniqueKeyUpdated())
+		})
+	}
+}
+
 func TestPrimaryOrUniqueKeyUpdatedWithExpressionIndex(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/sqlmodel/utils.go
+++ b/pkg/sqlmodel/utils.go
@@ -14,7 +14,9 @@
 package sqlmodel
 
 import (
+	"bytes"
 	"fmt"
+	"reflect"
 	"strings"
 
 	timodel "github.com/pingcap/tidb/pkg/meta/model"
@@ -44,6 +46,20 @@ func ColValAsStr(v interface{}) string {
 		return dv
 	}
 	return fmt.Sprintf("%v", v)
+}
+
+// colValEqual compares two column values. Applying == or != to an interface
+// that holds a slice panics with "comparing uncomparable type []uint8", and
+// BINARY, binary CHAR, BLOB and TEXT columns reach here as []byte, so those are
+// compared with bytes.Equal. reflect.DeepEqual keeps any other uncomparable
+// type safe too.
+func colValEqual(a, b any) bool {
+	aBytes, aOK := a.([]byte)
+	bBytes, bOK := b.([]byte)
+	if aOK || bOK {
+		return aOK && bOK && bytes.Equal(aBytes, bBytes)
+	}
+	return reflect.DeepEqual(a, b)
 }
 
 // writableSourceColumns returns source columns that are present in the row


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #9834

`IsIdentityUpdated` and `IsPrimaryOrUniqueKeyUpdated` in `pkg/sqlmodel/reduce.go` compare column values with `!=` on an `interface{}`. Go panics when that interface holds a slice:

```
panic: runtime error: comparing uncomparable type []uint8

github.com/pingcap/tiflow/pkg/sqlmodel.(*RowChange).IsPrimaryOrUniqueKeyUpdated.func1(...)
	pkg/sqlmodel/reduce.go:111
github.com/pingcap/tiflow/dm/syncer.(*DMLWorker).genSQLs(...)
	dm/syncer/dml_worker.go:413
```

#9834 reported this for `IsIdentityUpdated` in 2023. Since then `IsPrimaryOrUniqueKeyUpdated`, added by #12351, repeated the same pattern, and that widened the blast radius considerably. The original report's stack goes through `genDMLsWithSameOp`, where the suggested workaround was `multiple-rows: false` — the default. The newer call site in `DMLWorker.genSQLs` has no equivalent gate:

```go
case sqlmodel.RowChangeUpdate:
    if j.safeMode {
        if j.dml.IsPrimaryOrUniqueKeyUpdated() {   // no gate
```

So on a build carrying #12351, every safe-mode UPDATE on an affected table panics deterministically. We hit this in production: DM workers entered a crash loop and could not recover, because safe mode was enabled by config for the task rather than as a transient window after start, so nothing self-healed. No data was lost — the workers die before they write — but replication stopped until the build was rolled back.

#### Which columns trigger it

It is narrower than "binary columns", which is likely why test coverage has missed it. Two kinds reach `sqlmodel` as `[]byte`:

| DDL | parser type | `isBinary` at `dm/syncer/dml.go` | value compared |
|---|---|---|---|
| `BINARY(n)`, binary `CHAR` | 254 `TypeString` | true → converted to `[]byte` | `[]byte` → panics |
| `BLOB`, `TEXT` | 252 | n/a — binlog decoder returns `[]byte` | `[]byte` → panics |
| `VARBINARY(n)` | 15 `TypeVarchar` | false | `string` → safe |
| `VARCHAR(n)` | 15 `TypeVarchar` | false | `string` → safe |

`adjustValues` converts a value to `[]byte` only when the column is `TypeString` **and** carries the binary flag, so `VARBINARY` parses to `TypeVarchar` and stays a `string`. GBK columns take the same conversion a few lines below, so they behave like the first row.

A single `BINARY(16)` primary key therefore faults on the very first comparison. That is the shape we saw.

Existing coverage misses it because `TestIdentityUpdatedWithUniqueKeys` uses `INT` keys only, and the `dm/tests/safe_mode_foreign_key` integration test uses `INT` primary keys with a `VARCHAR` unique key, which compares fine. No case puts a `TypeString`-with-binary-flag or `BLOB` column in a key.

### What is changed and how it works?

- `pkg/sqlmodel/utils.go`: new `colValEqual`, next to `ColValAsStr`, which already type-switches on `[]byte`. It compares `[]byte` with `bytes.Equal` and falls back to `reflect.DeepEqual`, so no other uncomparable type can panic here either.
- `pkg/sqlmodel/reduce.go`: both comparison loops now route through one shared `colValsUpdated` helper. This also removes the duplicated closure inside `IsPrimaryOrUniqueKeyUpdated`, so the two functions cannot drift apart again.
- `pkg/sqlmodel/reduce_test.go`: `TestIdentityUpdatedWithBinaryKeys` covers a single `BINARY(16)` primary key, a multi-column primary key with trailing `BINARY` columns (so the fault lands on a later comparison), a secondary nullable `UNIQUE` index over a `BLOB` prefix that only `IsPrimaryOrUniqueKeyUpdated` reads, and a one-sided NULL. `VARBINARY` is covered with both `string` and `[]byte` values, so the comparison does not depend on the `adjustValues` type check staying as it is.

Values with equal contents but distinct backing arrays now compare equal, so a safe-mode UPDATE no longer reports a spurious key change and no longer writes a needless DELETE.

### Check List

#### Tests

 - Unit test

The new test reproduces the panic against unmodified `master` (`comparing uncomparable type []uint8` at `reduce.go:91`) and passes with the fix. `pkg/sqlmodel` passes, `gofmt` and `go vet` are clean.

#### Questions

##### Will it cause performance regression or break compatibility?

No compatibility change. The comparison runs per key column on safe-mode UPDATE. Non-`[]byte` values now go through `reflect.DeepEqual` rather than `!=`, which costs more per call. If that matters on this path, the fallback can be narrowed to a type switch over the concrete types DM decodes — happy to change it if a reviewer prefers that.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No.

This affects `release-8.5` as well, and `IsIdentityUpdated` has carried the bug since at least the 7.5 line, so cherry-picks are probably wanted.

### Release note

```release-note
Fix a DM worker panic ("comparing uncomparable type []uint8") when a table has BINARY, binary CHAR, BLOB, TEXT or GBK columns in its primary or unique key and safe mode is enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identity, primary-key, and unique-key change detection for binary values.
  * Values with identical byte content are now correctly recognized as unchanged, while differing content is detected as an update.
  * Improved handling of nullable binary values, composite keys, and supported string or byte representations.
  * Prevented comparison errors for previously unsupported value types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->