### PR TITLE
sync-diff-inspector: skip table size warning for empty tables and --check-struct-only

### DIFF
--- a/sync_diff_inspector/diff/diff.go
+++ b/sync_diff_inspector/diff/diff.go
@@ -98,6 +98,7 @@ type Diff struct {
 	checkThreadCount int
 	splitThreadCount int
 	exportFixSQL     bool
+	checkStructOnly  bool
 	sqlWg            sync.WaitGroup
 	checkpointWg     sync.WaitGroup
 
@@ -119,6 +120,7 @@ func NewDiff(ctx context.Context, cfg *config.Config) (diff *Diff, err error) {
 		checkThreadCount: cfg.CheckThreadCount,
 		splitThreadCount: cfg.SplitThreadCount,
 		exportFixSQL:     cfg.ExportFixSQL,
+		checkStructOnly:  cfg.CheckStructOnly,
 		sqlCh:            make(chan *ChunkDML, splitter.DefaultChannelBuffer),
 		cp:               new(checkpoints.Checkpoint),
 		report:           report.NewReport(&cfg.Task),
@@ -135,7 +137,9 @@ func NewDiff(ctx context.Context, cfg *config.Config) (diff *Diff, err error) {
 func (df *Diff) PrintSummary(ctx context.Context) bool {
 	// Stop updating progress bar so that summary won't be flushed.
 	progress.Close()
-	df.report.CalculateTotalSize(ctx, df.downstream.GetDB())
+	if !df.checkStructOnly {
+		df.report.CalculateTotalSize(ctx, df.downstream.GetDB())
+	}
 	err := df.report.CommitSummary()
 	if err != nil {
 		log.Fatal("failed to commit report", zap.Error(err))

--- a/sync_diff_inspector/report/report.go
+++ b/sync_diff_inspector/report/report.go
@@ -162,7 +162,7 @@ func (r *Report) CalculateTotalSize(ctx context.Context, db *sql.DB) {
 	for schema, tableMap := range r.TableResults {
 		for table := range tableMap {
 			size, err := utils.GetTableSize(ctx, db, schema, table)
-			if size == 0 || err != nil {
+			if err != nil {
 				log.Warn("fail to get the correct size of table, if you want to get the correct size, please analyze the corresponding tables", zap.String("table", dbutil.TableName(schema, table)), zap.Error(err))
 			} else {
 				r.TotalSize += size


### PR DESCRIPTION
### What problem does this PR solve?

When running sync-diff-inspector with `--check-struct-only`, it still outputs the warning:

```
[WARN] [report.go:166] ["fail to get the correct size of table, if you want to get the correct size, please analyze the corresponding tables"] [table=`futures_position`.`position_10`]
```

This warning is misleading because:

1. `--check-struct-only` means the user only wants to compare table structures, not data. Table size is irrelevant in this scenario.
2. Even without `--check-struct-only`, when a table is genuinely empty (`data_length = 0` in `information_schema.tables`), the warning is also incorrectly triggered. The code treats `size == 0` the same as a query error, but an empty table is a perfectly valid case.

Issue Number: close #12821

### What is changed and how it works?

Two changes:

1. **`sync_diff_inspector/diff/diff.go`**: Added `checkStructOnly` field to `Diff` struct. In `PrintSummary`, `CalculateTotalSize` is now skipped when `checkStructOnly` is true, since table size is meaningless when only checking structure.

2. **`sync_diff_inspector/report/report.go`**: Changed the condition in `CalculateTotalSize` from `if size == 0 || err != nil` to `if err != nil`. Now the warning is only emitted when there is an actual error querying `information_schema.tables`, not when the table is legitimately empty.

### Check List

#### Tests

- Unit test

Verified by running existing tests:
```
go test ./sync_diff_inspector/report/... ./sync_diff_inspector/diff/...
```

#### Questions

##### Will it cause performance regression or break compatibility?

No. This change only affects logging behavior and does not impact performance or compatibility.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No. The behavior change is purely about removing a misleading warning.

### Release note

```release-note
Fix sync-diff-inspector incorrectly warning "fail to get the correct size of table" when using `--check-struct-only` or when the table is empty.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Structural-only checks now skip unnecessary total-size calculations.
  * Tables with a reported size of zero are no longer incorrectly treated as failures.
  * Size calculation warnings are shown only when an actual error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->