### PR TITLE
fix(dm): handle raw fulltext indexes in schema tracker

### DIFF
--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -246,7 +246,7 @@ func (tr *Tracker) Exec(ctx context.Context, db string, stmt ast.StmtNode) (errR
 	case *ast.DropDatabaseStmt:
 		return tr.upstreamTracker.DropSchema(tr.se, v)
 	case *ast.CreateTableStmt:
-		return tr.upstreamTracker.CreateTable(tr.se, v)
+		return tr.upstreamTracker.CreateTable(tr.se, stripRawFullTextConstraints(v))
 	case *ast.AlterTableStmt:
 		return tr.upstreamTracker.AlterTable(ctx, tr.se, v)
 	case *ast.RenameTableStmt:
@@ -264,6 +264,34 @@ func (tr *Tracker) Exec(ctx context.Context, db string, stmt ast.StmtNode) (errR
 		tr.logger.DPanic("unexpected statement type", zap.String("type", fmt.Sprintf("%T", v)))
 	}
 	return nil
+}
+
+// stripRawFullTextConstraints removes FULLTEXT indexes from a CREATE TABLE
+// statement before building the lightweight TableInfo used by DM.
+//
+// TiDB's planner preprocessor normally rewrites ast.ConstraintFulltext into
+// the internal columnar-index representation. DM's schema trackers build
+// TableInfo directly from the parser AST, so an unprocessed FULLTEXT index on
+// a BLOB/TEXT column would otherwise be treated as a normal KV index and fail
+// with ErrBlobKeyWithoutLength. FULLTEXT indexes are non-unique and are not
+// used by DM to generate DML row handles, so omitting them is safe here.
+//
+// Do not modify the original statement because it may still be used to
+// execute the physical DDL downstream.
+func stripRawFullTextConstraints(stmt *ast.CreateTableStmt) *ast.CreateTableStmt {
+	for _, constraint := range stmt.Constraints {
+		if constraint.Tp == ast.ConstraintFulltext {
+			cloned := *stmt
+			cloned.Constraints = make([]*ast.Constraint, 0, len(stmt.Constraints)-1)
+			for _, candidate := range stmt.Constraints {
+				if candidate.Tp != ast.ConstraintFulltext {
+					cloned.Constraints = append(cloned.Constraints, candidate)
+				}
+			}
+			return &cloned
+		}
+	}
+	return stmt
 }
 
 // GetTableInfo returns the schema associated with the table.
@@ -629,7 +657,8 @@ func (dt *downstreamTracker) getTableInfoByCreateStmt(tctx *tcontext.Context, ta
 
 	// suppress ErrTooLongKey
 	metaBuildCtx := ddl.NewMetaBuildContextWithSctx(dt.se, metabuild.WithSuppressTooLongIndexErr(true))
-	ti, err := ddl.BuildTableInfoWithStmt(metaBuildCtx, stmtNode.(*ast.CreateTableStmt), mysql.DefaultCharset, "", nil)
+	createTableStmt := stripRawFullTextConstraints(stmtNode.(*ast.CreateTableStmt))
+	ti, err := ddl.BuildTableInfoWithStmt(metaBuildCtx, createTableStmt, mysql.DefaultCharset, "", nil)
 	if err != nil {
 		return nil, dmterror.ErrSchemaTrackerCannotMockDownstreamTable.Delegate(err, createStr)
 	}

--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -275,6 +275,8 @@ func (tr *Tracker) Exec(ctx context.Context, db string, stmt ast.StmtNode) (errR
 // a BLOB/TEXT column would otherwise be treated as a normal KV index and fail
 // with ErrBlobKeyWithoutLength. FULLTEXT indexes are non-unique and are not
 // used by DM to generate DML row handles, so omitting them is safe here.
+// This is a temporary compatibility workaround until TiDB provides the full
+// normalization for direct TableInfo builders; see pingcap/tidb#70570.
 //
 // Do not modify the original statement because it may still be used to
 // execute the physical DDL downstream.

--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -246,15 +246,15 @@ func (tr *Tracker) Exec(ctx context.Context, db string, stmt ast.StmtNode) (errR
 	case *ast.DropDatabaseStmt:
 		return tr.upstreamTracker.DropSchema(tr.se, v)
 	case *ast.CreateTableStmt:
-		return tr.upstreamTracker.CreateTable(tr.se, stripRawFullTextConstraints(v))
+		return tr.upstreamTracker.CreateTable(tr.se, mockRawFullTextConstraints(v))
 	case *ast.AlterTableStmt:
-		return tr.upstreamTracker.AlterTable(ctx, tr.se, v)
+		return tr.upstreamTracker.AlterTable(ctx, tr.se, mockRawFullTextAlterTable(v))
 	case *ast.RenameTableStmt:
 		return tr.upstreamTracker.RenameTable(tr.se, v)
 	case *ast.DropTableStmt:
 		return tr.upstreamTracker.DropTable(tr.se, v)
 	case *ast.CreateIndexStmt:
-		return tr.upstreamTracker.CreateIndex(tr.se, v)
+		return tr.upstreamTracker.CreateIndex(tr.se, mockRawFullTextIndex(v))
 	case *ast.DropIndexStmt:
 		return tr.upstreamTracker.DropIndex(tr.se, v)
 	case *ast.TruncateTableStmt:
@@ -266,32 +266,87 @@ func (tr *Tracker) Exec(ctx context.Context, db string, stmt ast.StmtNode) (errR
 	return nil
 }
 
-// stripRawFullTextConstraints removes FULLTEXT indexes from a CREATE TABLE
-// statement before building the lightweight TableInfo used by DM.
+// mockRawFullTextConstraints rewrites FULLTEXT indexes in a CREATE TABLE to
+// lightweight non-unique prefix indexes before building DM's TableInfo.
 //
 // TiDB's planner preprocessor normally rewrites ast.ConstraintFulltext into
 // the internal columnar-index representation. DM's schema trackers build
 // TableInfo directly from the parser AST, so an unprocessed FULLTEXT index on
 // a BLOB/TEXT column would otherwise be treated as a normal KV index and fail
-// with ErrBlobKeyWithoutLength. FULLTEXT indexes are non-unique and are not
-// used by DM to generate DML row handles, so omitting them is safe here.
+// with ErrBlobKeyWithoutLength. DM's mock sessions cannot build the real
+// columnar representation because they do not run in Starter deploy mode. A
+// non-unique prefix-index placeholder preserves the index identity for later
+// RENAME/DROP DDLs but is never selected as a DML row handle.
 // This is a temporary compatibility workaround until TiDB provides the full
 // normalization for direct TableInfo builders; see pingcap/tidb#70570.
 //
 // Do not modify the original statement because it may still be used to
 // execute the physical DDL downstream.
-func stripRawFullTextConstraints(stmt *ast.CreateTableStmt) *ast.CreateTableStmt {
-	for _, constraint := range stmt.Constraints {
-		if constraint.Tp == ast.ConstraintFulltext {
-			cloned := *stmt
-			cloned.Constraints = make([]*ast.Constraint, 0, len(stmt.Constraints)-1)
-			for _, candidate := range stmt.Constraints {
-				if candidate.Tp != ast.ConstraintFulltext {
-					cloned.Constraints = append(cloned.Constraints, candidate)
-				}
-			}
-			return &cloned
+func mockRawFullTextConstraints(stmt *ast.CreateTableStmt) *ast.CreateTableStmt {
+	var cloned *ast.CreateTableStmt
+	for i, constraint := range stmt.Constraints {
+		if constraint.Tp != ast.ConstraintFulltext {
+			continue
 		}
+		if cloned == nil {
+			stmtClone := *stmt
+			stmtClone.Constraints = append([]*ast.Constraint(nil), stmt.Constraints...)
+			cloned = &stmtClone
+		}
+		constraintClone := *constraint
+		constraintClone.Tp = ast.ConstraintKey
+		constraintClone.Keys = mockFullTextIndexParts(constraint.Keys)
+		cloned.Constraints[i] = &constraintClone
+	}
+	if cloned != nil {
+		return cloned
+	}
+	return stmt
+}
+
+func mockFullTextIndexParts(parts []*ast.IndexPartSpecification) []*ast.IndexPartSpecification {
+	cloned := make([]*ast.IndexPartSpecification, len(parts))
+	for i, part := range parts {
+		partClone := *part
+		if partClone.Length <= 0 {
+			partClone.Length = 1
+		}
+		cloned[i] = &partClone
+	}
+	return cloned
+}
+
+func mockRawFullTextIndex(stmt *ast.CreateIndexStmt) *ast.CreateIndexStmt {
+	if stmt.KeyType != ast.IndexKeyTypeFulltext {
+		return stmt
+	}
+	cloned := *stmt
+	cloned.KeyType = ast.IndexKeyTypeNone
+	cloned.IndexPartSpecifications = mockFullTextIndexParts(stmt.IndexPartSpecifications)
+	return &cloned
+}
+
+func mockRawFullTextAlterTable(stmt *ast.AlterTableStmt) *ast.AlterTableStmt {
+	var cloned *ast.AlterTableStmt
+	for i, spec := range stmt.Specs {
+		if spec.Tp != ast.AlterTableAddConstraint || spec.Constraint == nil ||
+			spec.Constraint.Tp != ast.ConstraintFulltext {
+			continue
+		}
+		if cloned == nil {
+			stmtClone := *stmt
+			stmtClone.Specs = append([]*ast.AlterTableSpec(nil), stmt.Specs...)
+			cloned = &stmtClone
+		}
+		specClone := *spec
+		constraintClone := *spec.Constraint
+		constraintClone.Tp = ast.ConstraintKey
+		constraintClone.Keys = mockFullTextIndexParts(spec.Constraint.Keys)
+		specClone.Constraint = &constraintClone
+		cloned.Specs[i] = &specClone
+	}
+	if cloned != nil {
+		return cloned
 	}
 	return stmt
 }
@@ -659,7 +714,7 @@ func (dt *downstreamTracker) getTableInfoByCreateStmt(tctx *tcontext.Context, ta
 
 	// suppress ErrTooLongKey
 	metaBuildCtx := ddl.NewMetaBuildContextWithSctx(dt.se, metabuild.WithSuppressTooLongIndexErr(true))
-	createTableStmt := stripRawFullTextConstraints(stmtNode.(*ast.CreateTableStmt))
+	createTableStmt := mockRawFullTextConstraints(stmtNode.(*ast.CreateTableStmt))
 	ti, err := ddl.BuildTableInfoWithStmt(metaBuildCtx, createTableStmt, mysql.DefaultCharset, "", nil)
 	if err != nil {
 		return nil, dmterror.ErrSchemaTrackerCannotMockDownstreamTable.Delegate(err, createStr)

--- a/dm/pkg/schema/tracker.go
+++ b/dm/pkg/schema/tracker.go
@@ -246,15 +246,15 @@ func (tr *Tracker) Exec(ctx context.Context, db string, stmt ast.StmtNode) (errR
 	case *ast.DropDatabaseStmt:
 		return tr.upstreamTracker.DropSchema(tr.se, v)
 	case *ast.CreateTableStmt:
-		return tr.upstreamTracker.CreateTable(tr.se, mockRawFullTextConstraints(v))
+		return tr.upstreamTracker.CreateTable(tr.se, MockRawFullTextConstraints(v, tr.logger))
 	case *ast.AlterTableStmt:
-		return tr.upstreamTracker.AlterTable(ctx, tr.se, mockRawFullTextAlterTable(v))
+		return tr.upstreamTracker.AlterTable(ctx, tr.se, mockRawFullTextAlterTable(v, tr.logger))
 	case *ast.RenameTableStmt:
 		return tr.upstreamTracker.RenameTable(tr.se, v)
 	case *ast.DropTableStmt:
 		return tr.upstreamTracker.DropTable(tr.se, v)
 	case *ast.CreateIndexStmt:
-		return tr.upstreamTracker.CreateIndex(tr.se, mockRawFullTextIndex(v))
+		return tr.upstreamTracker.CreateIndex(tr.se, mockRawFullTextIndex(v, tr.logger))
 	case *ast.DropIndexStmt:
 		return tr.upstreamTracker.DropIndex(tr.se, v)
 	case *ast.TruncateTableStmt:
@@ -266,7 +266,7 @@ func (tr *Tracker) Exec(ctx context.Context, db string, stmt ast.StmtNode) (errR
 	return nil
 }
 
-// mockRawFullTextConstraints rewrites FULLTEXT indexes in a CREATE TABLE to
+// MockRawFullTextConstraints rewrites FULLTEXT indexes in a CREATE TABLE to
 // lightweight non-unique prefix indexes before building DM's TableInfo.
 //
 // TiDB's planner preprocessor normally rewrites ast.ConstraintFulltext into
@@ -282,7 +282,7 @@ func (tr *Tracker) Exec(ctx context.Context, db string, stmt ast.StmtNode) (errR
 //
 // Do not modify the original statement because it may still be used to
 // execute the physical DDL downstream.
-func mockRawFullTextConstraints(stmt *ast.CreateTableStmt) *ast.CreateTableStmt {
+func MockRawFullTextConstraints(stmt *ast.CreateTableStmt, logger log.Logger) *ast.CreateTableStmt {
 	var cloned *ast.CreateTableStmt
 	for i, constraint := range stmt.Constraints {
 		if constraint.Tp != ast.ConstraintFulltext {
@@ -293,15 +293,25 @@ func mockRawFullTextConstraints(stmt *ast.CreateTableStmt) *ast.CreateTableStmt 
 			stmtClone.Constraints = append([]*ast.Constraint(nil), stmt.Constraints...)
 			cloned = &stmtClone
 		}
-		constraintClone := *constraint
-		constraintClone.Tp = ast.ConstraintKey
-		constraintClone.Keys = mockFullTextIndexParts(constraint.Keys)
-		cloned.Constraints[i] = &constraintClone
+		cloned.Constraints[i] = mockFullTextConstraint(constraint)
+		logFullTextRewrite(logger, stmt.Table, constraint.Name)
 	}
 	if cloned != nil {
 		return cloned
 	}
 	return stmt
+}
+
+func mockFullTextConstraint(constraint *ast.Constraint) *ast.Constraint {
+	cloned := *constraint
+	cloned.Tp = ast.ConstraintKey
+	cloned.Keys = mockFullTextIndexParts(constraint.Keys)
+	return &cloned
+}
+
+func logFullTextRewrite(logger log.Logger, table *ast.TableName, indexName string) {
+	logger.Info("represent FULLTEXT index as a non-unique prefix index in DM schema metadata",
+		zap.String("schema", table.Schema.O), zap.String("table", table.Name.O), zap.String("index", indexName))
 }
 
 func mockFullTextIndexParts(parts []*ast.IndexPartSpecification) []*ast.IndexPartSpecification {
@@ -316,17 +326,21 @@ func mockFullTextIndexParts(parts []*ast.IndexPartSpecification) []*ast.IndexPar
 	return cloned
 }
 
-func mockRawFullTextIndex(stmt *ast.CreateIndexStmt) *ast.CreateIndexStmt {
+func mockRawFullTextIndex(stmt *ast.CreateIndexStmt, logger log.Logger) *ast.CreateIndexStmt {
 	if stmt.KeyType != ast.IndexKeyTypeFulltext {
 		return stmt
 	}
 	cloned := *stmt
 	cloned.KeyType = ast.IndexKeyTypeNone
 	cloned.IndexPartSpecifications = mockFullTextIndexParts(stmt.IndexPartSpecifications)
+	logFullTextRewrite(logger, stmt.Table, stmt.IndexName)
 	return &cloned
 }
 
-func mockRawFullTextAlterTable(stmt *ast.AlterTableStmt) *ast.AlterTableStmt {
+// mockRawFullTextAlterTable also prevents TiDB's schema tracker from silently
+// ignoring ADD FULLTEXT: its AlterTableAddConstraint dispatch skips
+// ConstraintFulltext instead of building an index or returning an error.
+func mockRawFullTextAlterTable(stmt *ast.AlterTableStmt, logger log.Logger) *ast.AlterTableStmt {
 	var cloned *ast.AlterTableStmt
 	for i, spec := range stmt.Specs {
 		if spec.Tp != ast.AlterTableAddConstraint || spec.Constraint == nil ||
@@ -339,11 +353,9 @@ func mockRawFullTextAlterTable(stmt *ast.AlterTableStmt) *ast.AlterTableStmt {
 			cloned = &stmtClone
 		}
 		specClone := *spec
-		constraintClone := *spec.Constraint
-		constraintClone.Tp = ast.ConstraintKey
-		constraintClone.Keys = mockFullTextIndexParts(spec.Constraint.Keys)
-		specClone.Constraint = &constraintClone
+		specClone.Constraint = mockFullTextConstraint(spec.Constraint)
 		cloned.Specs[i] = &specClone
+		logFullTextRewrite(logger, stmt.Table, spec.Constraint.Name)
 	}
 	if cloned != nil {
 		return cloned
@@ -714,7 +726,8 @@ func (dt *downstreamTracker) getTableInfoByCreateStmt(tctx *tcontext.Context, ta
 
 	// suppress ErrTooLongKey
 	metaBuildCtx := ddl.NewMetaBuildContextWithSctx(dt.se, metabuild.WithSuppressTooLongIndexErr(true))
-	createTableStmt := mockRawFullTextConstraints(stmtNode.(*ast.CreateTableStmt))
+	createTableStmt := MockRawFullTextConstraints(stmtNode.(*ast.CreateTableStmt),
+		tctx.L().WithFields(zap.String("tableID", tableID)))
 	ti, err := ddl.BuildTableInfoWithStmt(metaBuildCtx, createTableStmt, mysql.DefaultCharset, "", nil)
 	if err != nil {
 		return nil, dmterror.ErrSchemaTrackerCannotMockDownstreamTable.Delegate(err, createStr)

--- a/dm/pkg/schema/tracker_test.go
+++ b/dm/pkg/schema/tracker_test.go
@@ -368,7 +368,7 @@ func TestCreateTableIfNotExists(t *testing.T) {
 	require.Less(t, duration.Seconds(), float64(30))
 }
 
-func TestExecIgnoresRawFullTextIndex(t *testing.T) {
+func TestExecMocksRawFullTextIndex(t *testing.T) {
 	ctx := context.Background()
 	p := parser.New()
 	tracker, err := NewTestTracker(ctx, "test-tracker", nil, dlog.L())
@@ -388,15 +388,72 @@ func TestExecIgnoresRawFullTextIndex(t *testing.T) {
 	require.Len(t, stmt.Constraints, 3)
 
 	require.NoError(t, tracker.Exec(ctx, "test", stmt))
-	// Tracker metadata omits only the FULLTEXT index.
+	// Tracker metadata preserves the FULLTEXT index identity as a non-unique
+	// placeholder so later index DDLs can still be tracked.
 	ti, err := tracker.GetTableInfo(&filter.Table{Schema: "test", Name: "t"})
 	require.NoError(t, err)
-	require.Len(t, ti.Indices, 2)
+	require.Len(t, ti.Indices, 3)
 	require.NotNil(t, ti.FindIndexByName("primary"))
 	require.NotNil(t, ti.FindIndexByName("normal_idx"))
-	require.Nil(t, ti.FindIndexByName("fulltext_idx"))
+	fullTextIndex := ti.FindIndexByName("fulltext_idx")
+	require.NotNil(t, fullTextIndex)
+	require.Equal(t, model.ColumnarIndexTypeNA, fullTextIndex.GetColumnarIndexType())
+	require.False(t, fullTextIndex.Unique)
 	// The original AST may still be used to execute the physical DDL.
 	require.Len(t, stmt.Constraints, 3)
+	require.Equal(t, ast.ConstraintFulltext, stmt.Constraints[2].Tp)
+	require.LessOrEqual(t, stmt.Constraints[2].Keys[0].Length, 0)
+
+	// The placeholder retains the name for later index DDLs.
+	require.NoError(t, tracker.Exec(ctx, "test", parseSQL(t, p,
+		"ALTER TABLE t RENAME INDEX fulltext_idx TO fulltext_idx_renamed")))
+	ti, err = tracker.GetTableInfo(&filter.Table{Schema: "test", Name: "t"})
+	require.NoError(t, err)
+	require.Nil(t, ti.FindIndexByName("fulltext_idx"))
+	require.NotNil(t, ti.FindIndexByName("fulltext_idx_renamed"))
+}
+
+func TestExecTracksFullTextIndexLifecycle(t *testing.T) {
+	ctx := context.Background()
+	p := parser.New()
+	tracker, err := NewTestTracker(ctx, "test-tracker", nil, dlog.L())
+	require.NoError(t, err)
+	defer tracker.Close()
+
+	require.NoError(t, tracker.CreateSchemaIfNotExists("test"))
+	require.NoError(t, tracker.Exec(ctx, "test", parseSQL(t, p, `
+		CREATE TABLE t (id INT PRIMARY KEY, text_col TEXT)`)))
+	table := &filter.Table{Schema: "test", Name: "t"}
+
+	createIndexStmt := parseSQL(t, p,
+		"CREATE FULLTEXT INDEX ft_idx ON t(text_col) WITH PARSER STANDARD").(*ast.CreateIndexStmt)
+	require.NoError(t, tracker.Exec(ctx, "test", createIndexStmt))
+	require.Equal(t, ast.IndexKeyTypeFulltext, createIndexStmt.KeyType)
+	ti, err := tracker.GetTableInfo(table)
+	require.NoError(t, err)
+	require.Equal(t, model.ColumnarIndexTypeNA, ti.FindIndexByName("ft_idx").GetColumnarIndexType())
+
+	require.NoError(t, tracker.Exec(ctx, "test", parseSQL(t, p,
+		"ALTER TABLE t RENAME INDEX ft_idx TO ft_idx_renamed")))
+	ti, err = tracker.GetTableInfo(table)
+	require.NoError(t, err)
+	require.Nil(t, ti.FindIndexByName("ft_idx"))
+	require.Equal(t, model.ColumnarIndexTypeNA, ti.FindIndexByName("ft_idx_renamed").GetColumnarIndexType())
+	require.NoError(t, tracker.Exec(ctx, "test", parseSQL(t, p,
+		"DROP INDEX ft_idx_renamed ON t")))
+
+	alterAddStmt := parseSQL(t, p,
+		"ALTER TABLE t ADD FULLTEXT INDEX ft_idx_2(text_col) WITH PARSER STANDARD").(*ast.AlterTableStmt)
+	require.NoError(t, tracker.Exec(ctx, "test", alterAddStmt))
+	require.Equal(t, ast.ConstraintFulltext, alterAddStmt.Specs[0].Constraint.Tp)
+	ti, err = tracker.GetTableInfo(table)
+	require.NoError(t, err)
+	require.Equal(t, model.ColumnarIndexTypeNA, ti.FindIndexByName("ft_idx_2").GetColumnarIndexType())
+	require.NoError(t, tracker.Exec(ctx, "test", parseSQL(t, p,
+		"ALTER TABLE t RENAME INDEX ft_idx_2 TO ft_idx_2_renamed")))
+	ti, err = tracker.GetTableInfo(table)
+	require.NoError(t, err)
+	require.Equal(t, model.ColumnarIndexTypeNA, ti.FindIndexByName("ft_idx_2_renamed").GetColumnarIndexType())
 }
 
 func TestBatchCreateTableIfNotExist(t *testing.T) {
@@ -656,7 +713,7 @@ func TestGetDownStreamIndexInfo(t *testing.T) {
 	require.NotNil(t, dti.DefaultWhereHandle().UniqueNotNullIdx)
 }
 
-func TestGetDownStreamTableInfoIgnoresRawFullTextIndex(t *testing.T) {
+func TestGetDownStreamTableInfoMocksRawFullTextIndex(t *testing.T) {
 	p := parser.New()
 	se := timock.NewContext()
 	ctx := context.Background()
@@ -693,10 +750,13 @@ func TestGetDownStreamTableInfoIgnoresRawFullTextIndex(t *testing.T) {
 
 	dti, err := tracker.GetDownStreamTableInfo(tcontext.Background(), tableID, originTI)
 	require.NoError(t, err)
-	require.Len(t, dti.TableInfo.Indices, 2)
+	require.Len(t, dti.TableInfo.Indices, 3)
 	require.NotNil(t, dti.TableInfo.FindIndexByName("primary"))
 	require.NotNil(t, dti.TableInfo.FindIndexByName("normal_idx"))
-	require.Nil(t, dti.TableInfo.FindIndexByName("fulltext_idx"))
+	fullTextIndex := dti.TableInfo.FindIndexByName("fulltext_idx")
+	require.NotNil(t, fullTextIndex)
+	require.Equal(t, model.ColumnarIndexTypeNA, fullTextIndex.GetColumnarIndexType())
+	require.False(t, fullTextIndex.Unique)
 	require.NotNil(t, dti.DefaultWhereHandle().UniqueNotNullIdx)
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/dm/pkg/schema/tracker_test.go
+++ b/dm/pkg/schema/tracker_test.go
@@ -368,6 +368,37 @@ func TestCreateTableIfNotExists(t *testing.T) {
 	require.Less(t, duration.Seconds(), float64(30))
 }
 
+func TestExecIgnoresRawFullTextIndex(t *testing.T) {
+	ctx := context.Background()
+	p := parser.New()
+	tracker, err := NewTestTracker(ctx, "test-tracker", nil, dlog.L())
+	require.NoError(t, err)
+	defer tracker.Close()
+
+	require.NoError(t, tracker.CreateSchemaIfNotExists("test"))
+	stmt := parseSQL(t, p, `
+		CREATE TABLE t (
+			id VARCHAR(14) NOT NULL,
+			text_col TEXT,
+			normal_col INT,
+			PRIMARY KEY (id),
+			KEY normal_idx (normal_col),
+			FULLTEXT INDEX fulltext_idx (text_col) WITH PARSER STANDARD
+		)`).(*ast.CreateTableStmt)
+	require.Len(t, stmt.Constraints, 3)
+
+	require.NoError(t, tracker.Exec(ctx, "test", stmt))
+	// Tracker metadata omits only the FULLTEXT index.
+	ti, err := tracker.GetTableInfo(&filter.Table{Schema: "test", Name: "t"})
+	require.NoError(t, err)
+	require.Len(t, ti.Indices, 2)
+	require.NotNil(t, ti.FindIndexByName("primary"))
+	require.NotNil(t, ti.FindIndexByName("normal_idx"))
+	require.Nil(t, ti.FindIndexByName("fulltext_idx"))
+	// The original AST may still be used to execute the physical DDL.
+	require.Len(t, stmt.Constraints, 3)
+}
+
 func TestBatchCreateTableIfNotExist(t *testing.T) {
 	ctx := context.Background()
 	p := parser.New()
@@ -623,6 +654,51 @@ func TestGetDownStreamIndexInfo(t *testing.T) {
 	dti, err := tracker.GetDownStreamTableInfo(tcontext.Background(), tableID, oriTi)
 	require.NoError(t, err)
 	require.NotNil(t, dti.DefaultWhereHandle().UniqueNotNullIdx)
+}
+
+func TestGetDownStreamTableInfoIgnoresRawFullTextIndex(t *testing.T) {
+	p := parser.New()
+	se := timock.NewContext()
+	ctx := context.Background()
+	node, err := p.ParseOneStmt(
+		"CREATE TABLE t (id VARCHAR(14) NOT NULL, text_col TEXT, normal_col INT, PRIMARY KEY (id), KEY normal_idx (normal_col))",
+		"",
+		"",
+	)
+	require.NoError(t, err)
+	originTI, err := ddl.MockTableInfo(se, node.(*ast.CreateTableStmt), 1)
+	require.NoError(t, err)
+
+	dbConn, mock := mockBaseConn(t)
+	tracker, err := NewTestTracker(ctx, "test-tracker", dbConn, dlog.L())
+	require.NoError(t, err)
+	defer tracker.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(fmt.Sprintf("SET SESSION SQL_MODE = '%s'", mysql.DefaultSQLMode)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	tableID := "`test`.`t`"
+	mock.ExpectQuery("SHOW CREATE TABLE " + tableID).WillReturnRows(
+		sqlmock.NewRows([]string{"Table", "Create Table"}).AddRow("t", `
+			CREATE TABLE t (
+				id VARCHAR(14) NOT NULL,
+				text_col TEXT,
+				normal_col INT,
+				PRIMARY KEY (id),
+				KEY normal_idx (normal_col),
+				FULLTEXT INDEX fulltext_idx (text_col) WITH PARSER STANDARD
+			)`),
+	)
+
+	dti, err := tracker.GetDownStreamTableInfo(tcontext.Background(), tableID, originTI)
+	require.NoError(t, err)
+	require.Len(t, dti.TableInfo.Indices, 2)
+	require.NotNil(t, dti.TableInfo.FindIndexByName("primary"))
+	require.NotNil(t, dti.TableInfo.FindIndexByName("normal_idx"))
+	require.Nil(t, dti.TableInfo.FindIndexByName("fulltext_idx"))
+	require.NotNil(t, dti.DefaultWhereHandle().UniqueNotNullIdx)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestForeignKeyRelationBuildsRootParents(t *testing.T) {

--- a/dm/pkg/schema/tracker_test.go
+++ b/dm/pkg/schema/tracker_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/pingcap/tidb/pkg/parser/format"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/util/filter"
 	timock "github.com/pingcap/tidb/pkg/util/mock"
@@ -42,6 +43,8 @@ import (
 	"github.com/pingcap/tiflow/pkg/sqlmodel"
 	"github.com/pingcap/tiflow/pkg/util/testutil"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func parseSQL(t *testing.T, p *parser.Parser, sql string) ast.StmtNode {
@@ -368,6 +371,64 @@ func TestCreateTableIfNotExists(t *testing.T) {
 	require.Less(t, duration.Seconds(), float64(30))
 }
 
+func TestFullTextRewriteLogsAndPreservesAST(t *testing.T) {
+	cases := []struct {
+		sql     string
+		indexes []string
+	}{
+		{"CREATE TABLE db.t (a TEXT, b TEXT, KEY k(a(8)), FULLTEXT f1(a), FULLTEXT f2(a,b))", []string{"f1", "f2"}},
+		{"CREATE FULLTEXT INDEX f1 ON db.t(a,b) WITH PARSER STANDARD", []string{"f1"}},
+		{"ALTER TABLE db.t ADD FULLTEXT f1(a), ADD KEY k(a(8)), ADD FULLTEXT f2(a,b)", []string{"f1", "f2"}},
+		{"CREATE TABLE db.t (a TEXT, KEY k(a(8)))", nil},
+		{"CREATE INDEX k ON db.t(a(8))", nil},
+		{"ALTER TABLE db.t ADD KEY k(a(8))", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.sql, func(t *testing.T) {
+			core, observed := observer.New(zap.InfoLevel)
+			logger := dlog.Logger{Logger: zap.New(core)}
+			rewrite := func(stmt ast.StmtNode) ast.StmtNode {
+				switch v := stmt.(type) {
+				case *ast.CreateTableStmt:
+					return MockRawFullTextConstraints(v, logger)
+				case *ast.CreateIndexStmt:
+					return mockRawFullTextIndex(v, logger)
+				case *ast.AlterTableStmt:
+					return mockRawFullTextAlterTable(v, logger)
+				default:
+					t.Fatalf("unexpected statement %T", stmt)
+					return nil
+				}
+			}
+			restore := func(stmt ast.StmtNode) string {
+				var sql strings.Builder
+				require.NoError(t, stmt.Restore(format.NewRestoreCtx(format.DefaultRestoreFlags, &sql)))
+				return sql.String()
+			}
+			stmt := parseSQL(t, parser.New(), tc.sql)
+			originalSQL := restore(stmt)
+			rewritten := rewrite(stmt)
+			require.Equal(t, originalSQL, restore(stmt))
+			require.NotContains(t, restore(rewritten), "FULLTEXT")
+			if len(tc.indexes) == 0 {
+				require.Same(t, stmt, rewritten)
+			} else {
+				require.NotSame(t, stmt, rewritten)
+			}
+			// Already-normalized or ordinary indexes do not trigger another log.
+			require.Same(t, rewritten, rewrite(rewritten))
+			entries := observed.All()
+			require.Len(t, entries, len(tc.indexes))
+			for i, entry := range entries {
+				require.Contains(t, entry.Message, "non-unique prefix index")
+				require.Equal(t, map[string]interface{}{
+					"schema": "db", "table": "t", "index": tc.indexes[i],
+				}, entry.ContextMap())
+			}
+		})
+	}
+}
+
 func TestExecMocksRawFullTextIndex(t *testing.T) {
 	ctx := context.Background()
 	p := parser.New()
@@ -441,6 +502,9 @@ func TestExecTracksFullTextIndexLifecycle(t *testing.T) {
 	require.Equal(t, model.ColumnarIndexTypeNA, ti.FindIndexByName("ft_idx_renamed").GetColumnarIndexType())
 	require.NoError(t, tracker.Exec(ctx, "test", parseSQL(t, p,
 		"DROP INDEX ft_idx_renamed ON t")))
+	ti, err = tracker.GetTableInfo(table)
+	require.NoError(t, err)
+	require.Nil(t, ti.FindIndexByName("ft_idx_renamed"))
 
 	alterAddStmt := parseSQL(t, p,
 		"ALTER TABLE t ADD FULLTEXT INDEX ft_idx_2(text_col) WITH PARSER STANDARD").(*ast.AlterTableStmt)
@@ -454,6 +518,12 @@ func TestExecTracksFullTextIndexLifecycle(t *testing.T) {
 	ti, err = tracker.GetTableInfo(table)
 	require.NoError(t, err)
 	require.Equal(t, model.ColumnarIndexTypeNA, ti.FindIndexByName("ft_idx_2_renamed").GetColumnarIndexType())
+	require.Nil(t, ti.FindIndexByName("ft_idx_2"))
+	require.NoError(t, tracker.Exec(ctx, "test", parseSQL(t, p,
+		"ALTER TABLE t DROP INDEX ft_idx_2_renamed")))
+	ti, err = tracker.GetTableInfo(table)
+	require.NoError(t, err)
+	require.Nil(t, ti.FindIndexByName("ft_idx_2_renamed"))
 }
 
 func TestBatchCreateTableIfNotExist(t *testing.T) {
@@ -723,7 +793,7 @@ func TestGetDownStreamTableInfoMocksRawFullTextIndex(t *testing.T) {
 		"",
 	)
 	require.NoError(t, err)
-	originTI, err := ddl.MockTableInfo(se, node.(*ast.CreateTableStmt), 1)
+	oriTi, err := ddl.MockTableInfo(se, node.(*ast.CreateTableStmt), 1)
 	require.NoError(t, err)
 
 	dbConn, mock := mockBaseConn(t)
@@ -748,7 +818,7 @@ func TestGetDownStreamTableInfoMocksRawFullTextIndex(t *testing.T) {
 			)`),
 	)
 
-	dti, err := tracker.GetDownStreamTableInfo(tcontext.Background(), tableID, originTI)
+	dti, err := tracker.GetDownStreamTableInfo(tcontext.Background(), tableID, oriTi)
 	require.NoError(t, err)
 	require.Len(t, dti.TableInfo.Indices, 3)
 	require.NotNil(t, dti.TableInfo.FindIndexByName("primary"))

--- a/dm/syncer/schema.go
+++ b/dm/syncer/schema.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tiflow/dm/openapi"
 	"github.com/pingcap/tiflow/dm/pb"
 	"github.com/pingcap/tiflow/dm/pkg/conn"
+	"github.com/pingcap/tiflow/dm/pkg/schema"
 	"github.com/pingcap/tiflow/dm/pkg/terror"
 	"github.com/pingcap/tiflow/dm/syncer/dbconn"
 	"github.com/pingcap/tiflow/pkg/quotes"
@@ -139,7 +140,7 @@ func (s *Syncer) OperateSchema(ctx context.Context, req *pb.OperateWorkerSchemaR
 			s.tctx.L().Info("overwrite --flush to true for operate-schema")
 		}
 
-		ti, err2 := ddl2.BuildTableInfoFromAST(metabuild.NewContext(), stmt)
+		ti, err2 := ddl2.BuildTableInfoFromAST(metabuild.NewContext(), schema.MockRawFullTextConstraints(stmt, s.tctx.L()))
 		if err2 != nil {
 			return "", terror.ErrSchemaTrackerRestoreStmtFail.Delegate(err2)
 		}

--- a/dm/syncer/schema_test.go
+++ b/dm/syncer/schema_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncer
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/pingcap/tidb/pkg/meta/model"
+	"github.com/pingcap/tidb/pkg/util/filter"
+	router "github.com/pingcap/tidb/pkg/util/table-router"
+	"github.com/pingcap/tiflow/dm/pb"
+	"github.com/pingcap/tiflow/dm/pkg/conn"
+	tcontext "github.com/pingcap/tiflow/dm/pkg/context"
+	"github.com/pingcap/tiflow/dm/pkg/retry"
+	"github.com/pingcap/tiflow/dm/pkg/schema"
+	"github.com/pingcap/tiflow/dm/pkg/utils"
+	"github.com/pingcap/tiflow/dm/syncer/dbconn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperateSchemaSetFullText(t *testing.T) {
+	for _, from := range []string{"statement", "source", "target"} {
+		t.Run(from, func(t *testing.T) {
+			ctx := context.Background()
+			cfg := genDefaultSubTaskConfig4Test()
+			cfg.RouteRules = []*router.TableRule{{
+				SchemaPattern: "db", TablePattern: "t",
+				TargetSchema: "target_db", TargetTable: "target_t",
+			}}
+			syncer := NewSyncer(cfg, nil, nil)
+			syncer.exprFilterGroup = NewExprFilterGroup(tcontext.Background(), utils.NewSessionCtx(nil), nil)
+			require.NoError(t, syncer.genRouter())
+
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+			syncer.fromDB = &dbconn.UpStreamConn{BaseDB: conn.NewBaseDBForTest(db)}
+			checkPointDB, checkPointMock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer checkPointDB.Close()
+			checkPointConn, err := checkPointDB.Conn(ctx)
+			require.NoError(t, err)
+			syncer.checkpoint.(*RemoteCheckPoint).dbConn = dbconn.NewDBConn(cfg,
+				conn.NewBaseConnForTest(checkPointConn, &retry.FiniteRetryStrategy{}))
+
+			createSQL := "CREATE TABLE target_t (id VARCHAR(14) PRIMARY KEY, text_col TEXT, " +
+				"normal_col INT, KEY normal_idx(normal_col), FULLTEXT INDEX ft_idx(text_col) WITH PARSER STANDARD)"
+			req := &pb.OperateWorkerSchemaRequest{
+				Op: pb.SchemaOp_SetSchema, Database: "db", Table: "t",
+				Schema: createSQL, FromSource: from == "source", FromTarget: from == "target",
+			}
+			if from != "statement" {
+				showDB, showMock, err := sqlmock.New()
+				require.NoError(t, err)
+				defer showDB.Close()
+				showConn, err := showDB.Conn(ctx)
+				require.NoError(t, err)
+				dbConn := dbconn.NewDBConn(cfg, conn.NewBaseConnForTest(showConn, nil))
+				tableID := "`db`.`t`"
+				if from == "source" {
+					syncer.fromConn = dbConn
+				} else {
+					syncer.downstreamTrackConn = dbConn
+					tableID = "`target_db`.`target_t`"
+				}
+				req.Schema = "" // The fetched schema, not caller-supplied SQL, must be used.
+				showMock.ExpectQuery(regexp.QuoteMeta("SHOW CREATE TABLE " + tableID)).WillReturnRows(
+					sqlmock.NewRows([]string{"Table", "Create Table"}).AddRow("target_t", createSQL))
+				t.Cleanup(func() { require.NoError(t, showMock.ExpectationsWereMet()) })
+			}
+
+			mock.ExpectQuery("SHOW VARIABLES LIKE 'sql_mode'").WillReturnRows(
+				sqlmock.NewRows([]string{"Variable_name", "Value"}).AddRow("sql_mode", ""))
+			checkPointMock.ExpectBegin()
+			checkPointMock.ExpectExec(".*INSERT INTO .* VALUES.* ON DUPLICATE KEY UPDATE.*").
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			checkPointMock.ExpectCommit()
+
+			_, err = syncer.OperateSchema(ctx, req)
+			require.NoError(t, err)
+			ti := syncer.checkpoint.GetTableInfo("db", "t")
+			require.NotNil(t, ti)
+			require.Equal(t, "t", ti.Name.O)
+			require.Len(t, ti.Indices, 3)
+			require.True(t, ti.FindIndexByName("primary").Unique)
+			require.NotNil(t, ti.FindIndexByName("normal_idx"))
+			idx := ti.FindIndexByName("ft_idx")
+			require.NotNil(t, idx)
+			require.False(t, idx.Unique)
+			require.Equal(t, model.ColumnarIndexTypeNA, idx.GetColumnarIndexType())
+			require.Equal(t, 1, idx.Columns[0].Length)
+			require.Equal(t, createSQL, req.Schema)
+
+			// The checkpoint representation can bootstrap the tracker on resume.
+			syncer.schemaTracker, err = schema.NewTestTracker(ctx, cfg.Name, nil, syncer.tctx.L())
+			require.NoError(t, err)
+			defer syncer.schemaTracker.Close()
+			require.NoError(t, syncer.schemaTracker.CreateSchemaIfNotExists("db"))
+			table := &filter.Table{Schema: "db", Name: "t"}
+			require.NoError(t, syncer.schemaTracker.CreateTableIfNotExists(table, ti))
+			tracked, err := syncer.schemaTracker.GetTableInfo(table)
+			require.NoError(t, err)
+			require.Equal(t, idx, tracked.FindIndexByName("ft_idx"))
+			require.NoError(t, mock.ExpectationsWereMet())
+			require.NoError(t, checkPointMock.ExpectationsWereMet())
+		})
+	}
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #12824

TiDB's parser leaves `FULLTEXT INDEX` as raw FULLTEXT AST nodes. Normal TiDB DDL execution rewrites them through planner preprocessing, but DM's source schema tracker, downstream `SHOW CREATE TABLE` cache, and `operate-schema set` build `TableInfo` directly from the parser AST.

The raw index is therefore treated as an ordinary KV index. A FULLTEXT index on `TEXT` fails with error 1170, surfaced by DM as 44003 during source tracker bootstrap and 44018 during downstream cache initialization. `operate-schema set` also fails with 44010 when restoring the same raw definition. Simply dropping it from tracker metadata also loses the index name, so a later `RENAME INDEX` fails with 1176/44003.

A complete TiDB-side solution is tracked in pingcap/tidb#70570.

### What is changed and how it works?

- clone the incoming AST and represent raw FULLTEXT indexes in DM's lightweight tracker as non-unique length-one prefix-index placeholders;
- cover inline `CREATE TABLE`, standalone `CREATE FULLTEXT INDEX`, and `ALTER TABLE ADD FULLTEXT`;
- preserve the index name so later rename/drop DDLs can be tracked;
- keep the original AST unchanged for physical downstream DDL execution;
- apply the same shared mitigation when initializing the downstream schema cache from `SHOW CREATE TABLE` and when repairing checkpoints with `operate-schema set` (SQL, `--from-source`, and `--from-target`);
- log each actual FULLTEXT-to-placeholder rewrite with table/index context and document the separate ALTER ADD no-op workaround.

The placeholder is non-unique, so DM does not select it as a DML row handle. The physical downstream FULLTEXT definition is left unchanged; only DM metadata uses the placeholder.

### Check List

#### Tests

- Unit test
- NextGen Starter integration test (tracker path and existing FULLTEXT DML; see test result)

Code changes

- Has exported function/method change: yes (`schema.MockRawFullTextConstraints`, shared by syncer)
- Has persistent data change: existing TableInfo checkpoints can contain non-unique FULLTEXT placeholders; their serialization format is unchanged
- Has config change: no
- Has interface change: no

#### Questions

##### Will it cause performance regression or break compatibility?

No expected material performance regression: only FULLTEXT metadata normalization clones the affected AST nodes and emits an Info log for each rewritten index. Ordinary indexes are unchanged. The physical downstream index is not modified, and no new checkpoint serialization format is introduced.

Downgrade caveat: an unfixed DM worker still has the original limitation when it reads raw FULLTEXT definitions from upstream or downstream. Do not downgrade workers that rely on this fix while those tables are active. This is not an irreversible checkpoint-format migration.

##### Do you need to update user documentation, design documentation or monitoring documentation?

The release note calls out the FULLTEXT fix and the older-worker limitation. No configuration or monitoring interface changes are required. Info logs explain why the tracked schema can show a non-unique prefix KEY while the physical downstream index remains FULLTEXT.

### Test result

Current review follow-up validation:

```text
go test ./dm/pkg/schema -count=1
go test ./dm/pkg/schema ./dm/syncer -run 'FullText|TestOperateSchemaSetSchemaClearsForeignKeyRouteTopologyCheckCache' -count=1
go test -race ./dm/pkg/schema ./dm/syncer -run 'FullText|TestOperateSchemaSetSchemaClearsForeignKeyRouteTopologyCheckCache' -count=1
go test ./dm/pkg/schema ./dm/syncer -run 'FullText|TestOperateSchemaSetSchemaClearsForeignKeyRouteTopologyCheckCache' -count=100
make dm_unit_test_pkg PKG='github.com/pingcap/tiflow/dm/pkg/schema github.com/pingcap/tiflow/dm/syncer' FAILPOINT_DIR='dm pkg' DM_TEST_DIR=/tmp/tiflow-12825-ut
```

The new `TestOperateSchemaSetFullText` first reproduced 1170/44010 in all three input modes on the pre-fix code. It now verifies successful checkpoint writes, preservation of primary/ordinary indexes, and tracker bootstrap from the repaired checkpoint. Focused tests also cover copy-on-write, one log per actual rewrite, no logs for ordinary/already-normalized indexes, and both standalone and ALTER DROP metadata removal.

Temporary end-to-end validation was rerun for this review follow-up:

- MySQL 8.0.46 upstream with a real FULLTEXT key; NextGen Starter TiDB (`17b7807839`, SYSTEM keyspace, `cse.columnar-store-type=columnar`) downstream; temporary NextGen PD/TiKV worker, TiKV and MinIO.
- Pre-created both tables and their initial row independently, then started an incremental-only DM task (no dump/load). The first UPDATE replicated successfully.
- Paused the task and repaired the FULLTEXT schema using a SQL file, `--from-source`, and `--from-target` in turn via `binlog-schema update` (the CLI for `OperateSchema`). Each repair succeeded; resume plus a subsequent UPDATE succeeded with the task Running.
- Restarted the DM worker and verified the persisted checkpoint could be reloaded and another UPDATE replicated.
- After each case, downstream `SHOW CREATE TABLE` still contained `FULLTEXT INDEX ft_idx(c) WITH PARSER STANDARD`. Worker logs recorded the placeholder rewrites and had no 44003/44010/44018 errors.
- All temporary services, containers, newly downloaded components, test data/binaries, and TiDB/PD worktrees were cleaned up.

These checks validate schema repair and row replication, not FULLTEXT search/backfill readiness. The earlier standalone CREATE/RENAME physical columnar-DDL verification gap (nightly row TiKV missing `/kvengine/columnar_status`) was not retested in this follow-up; its tracker lifecycle remains covered by unit tests.

### Release note

```release-note
Fix DM replication, index lifecycle tracking, and schema repair for FULLTEXT indexes on TEXT columns. Downgrading workers to a version without this fix reintroduces the original failures when raw FULLTEXT metadata is read.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema handling and metadata preservation for FULLTEXT indexes across table creation, creation, renaming, and removal.
  * Improved downstream schema initialization for tables containing FULLTEXT indexes.
  * Changefeed details now include task statuses for running changefeeds; temporary status lookup failures no longer fail the request.
  * Improved loading of table structures from external dump storage.
  * Prevented negative binlog file gaps from appearing in monitoring dashboards.

* **Performance**
  * Schema files are now processed concurrently to improve migration startup time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
