### PR TITLE
syncer(dm): load dump schemas from object storage

### DIFF
--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	tidbddl "github.com/pingcap/tidb/pkg/ddl"
+	"github.com/pingcap/tidb/pkg/lightning/mydump"
 	"github.com/pingcap/tidb/pkg/meta/model"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
@@ -102,6 +103,8 @@ const (
 
 	unhandledEventSampleInterval = 5 * time.Minute
 	unhandledEventSampleFirst    = 1
+
+	maxSchemaFileReadConcurrency = 16
 )
 
 // waitXIDStatus represents the status for waiting XID event when pause/stop task.
@@ -1939,7 +1942,7 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 
 	if cleanDumpFile {
 		s.tctx.L().Info("try to remove all dump files")
-		if err = storage.RemoveAll(ctx, s.cfg.Dir, nil); err != nil {
+		if err = storage.RemoveAll(ctx, s.cfg.Dir, s.cfg.ExtStorage); err != nil {
 			s.tctx.L().Warn("error when remove loaded dump folder", zap.String("data folder", s.cfg.Dir), zap.Error(err))
 		}
 	}
@@ -3072,12 +3075,16 @@ func (s *Syncer) genRouter() error {
 
 func (s *Syncer) loadTableStructureFromDump(ctx context.Context) error {
 	logger := s.tctx.L()
-	// TODO: delete this check after we support parallel reading the files to improve load speed
-	if !storage.IsLocalDiskPath(s.cfg.LoaderConfig.Dir) {
-		logger.Warn("skip load table structure from dump files for non-local-dir loader because it may be slow", zap.String("loaderDir", s.cfg.LoaderConfig.Dir))
-		return nil
+	dumpStorage := s.cfg.ExtStorage
+	if dumpStorage == nil {
+		var err error
+		dumpStorage, err = storage.CreateStorage(ctx, s.cfg.LoaderConfig.Dir)
+		if err != nil {
+			logger.Warn("fail to create dump storage", zap.Error(err))
+			return err
+		}
 	}
-	files, err := storage.CollectDirFiles(ctx, s.cfg.LoaderConfig.Dir, nil)
+	files, err := storage.CollectDirFiles(ctx, s.cfg.LoaderConfig.Dir, dumpStorage)
 	if err != nil {
 		logger.Warn("fail to get dump files", zap.Error(err))
 		return err
@@ -3095,10 +3102,20 @@ func (s *Syncer) loadTableStructureFromDump(ctx context.Context) error {
 			if len(cols) > 0 {
 				continue
 			}
-			tables = append(tables, dbutil.TableName(db, table))
 			tableFiles = append(tableFiles, [2]string{db, f})
 			continue
 		}
+	}
+	sort.Strings(dbs)
+	sort.Slice(tableFiles, func(i, j int) bool {
+		if tableFiles[i][0] != tableFiles[j][0] {
+			return tableFiles[i][0] < tableFiles[j][0]
+		}
+		return tableFiles[i][1] < tableFiles[j][1]
+	})
+	for _, dbAndFile := range tableFiles {
+		db, table, _ := utils.GetTableFromDumpFilename(dbAndFile[1])
+		tables = append(tables, dbutil.TableName(db, table))
 	}
 	logger.Info("fetch table structure from dump files",
 		zap.Strings("database", dbs),
@@ -3123,9 +3140,29 @@ func (s *Syncer) loadTableStructureFromDump(ctx context.Context) error {
 		return err
 	}
 
-	for _, dbAndFile := range tableFiles {
+	type schemaFileReadResult struct {
+		content []byte
+		err     error
+	}
+	readConcurrency := min(max(s.cfg.LoaderConfig.PoolSize, 1), maxSchemaFileReadConcurrency)
+	readResults, err := mydump.ParallelProcess(
+		ctx,
+		tableFiles,
+		readConcurrency,
+		func(ctx context.Context, dbAndFile [2]string) (schemaFileReadResult, error) {
+			content, readErr := storage.ReadFile(ctx, s.cfg.LoaderConfig.Dir, dbAndFile[1], dumpStorage)
+			// Keep reading the remaining schema files and report the first error,
+			// which preserves the existing best-effort behavior.
+			return schemaFileReadResult{content: content, err: readErr}, nil
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	for i, dbAndFile := range tableFiles {
 		db, file := dbAndFile[0], dbAndFile[1]
-		content, err2 := storage.ReadFile(ctx, s.cfg.LoaderConfig.Dir, file, nil)
+		content, err2 := readResults[i].content, readResults[i].err
 		if err2 != nil {
 			logger.Warn("fail to read file for creating table in schema tracker",
 				zap.String("db", db),

--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -3083,6 +3083,7 @@ func (s *Syncer) loadTableStructureFromDump(ctx context.Context) error {
 			logger.Warn("fail to create dump storage", zap.Error(err))
 			return err
 		}
+		defer dumpStorage.Close()
 	}
 	files, err := storage.CollectDirFiles(ctx, s.cfg.LoaderConfig.Dir, dumpStorage)
 	if err != nil {

--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -3136,84 +3136,80 @@ func (s *Syncer) loadTableStructureFromDump(ctx context.Context) error {
 		err     error
 	}
 	readConcurrency := min(max(s.cfg.LoaderConfig.PoolSize, 1), maxSchemaFileReadConcurrency)
-	for batchStart := 0; batchStart < len(tableFiles); batchStart += readConcurrency {
-		batchEnd := min(batchStart+readConcurrency, len(tableFiles))
-		batch := tableFiles[batchStart:batchEnd]
-		readResults, err := mydump.ParallelProcess(
-			ctx,
-			batch,
-			readConcurrency,
-			func(ctx context.Context, dbAndFile [2]string) (schemaFileReadResult, error) {
-				content, readErr := storage.ReadFile(ctx, s.cfg.LoaderConfig.Dir, dbAndFile[1], dumpStorage)
-				// Keep reading the remaining schema files and report the first error,
-				// which preserves the existing best-effort behavior.
-				return schemaFileReadResult{content: content, err: readErr}, nil
-			},
-		)
-		if err != nil {
-			return err
-		}
+	readResults, err := mydump.ParallelProcess(
+		ctx,
+		tableFiles,
+		readConcurrency,
+		func(ctx context.Context, dbAndFile [2]string) (schemaFileReadResult, error) {
+			content, readErr := storage.ReadFile(ctx, s.cfg.LoaderConfig.Dir, dbAndFile[1], dumpStorage)
+			// Keep reading the remaining schema files and report the first error,
+			// which preserves the existing best-effort behavior.
+			return schemaFileReadResult{content: content, err: readErr}, nil
+		},
+	)
+	if err != nil {
+		return err
+	}
 
-		for i, dbAndFile := range batch {
-			db, file := dbAndFile[0], dbAndFile[1]
-			content, err2 := readResults[i].content, readResults[i].err
-			if err2 != nil {
-				logger.Warn("fail to read file for creating table in schema tracker",
+	for i, dbAndFile := range tableFiles {
+		db, file := dbAndFile[0], dbAndFile[1]
+		content, err2 := readResults[i].content, readResults[i].err
+		if err2 != nil {
+			logger.Warn("fail to read file for creating table in schema tracker",
+				zap.String("db", db),
+				zap.String("path", s.cfg.LoaderConfig.Dir),
+				zap.String("file", file),
+				zap.Error(err2))
+			setFirstErr(err2)
+			continue
+		}
+		stmts := bytes.Split(content, []byte(";\n"))
+		for _, stmt := range stmts {
+			stmt = bytes.TrimSpace(stmt)
+			if len(stmt) == 0 || bytes.HasPrefix(stmt, []byte("/*")) {
+				continue
+			}
+			stmtNode, err := p.ParseOneStmt(string(stmt), "", "")
+			if err != nil {
+				logger.Warn("fail to parse statement for creating table in schema tracker",
 					zap.String("db", db),
 					zap.String("path", s.cfg.LoaderConfig.Dir),
 					zap.String("file", file),
-					zap.Error(err2))
-				setFirstErr(err2)
+					zap.ByteString("statement", stmt),
+					zap.Error(err))
+				setFirstErr(err)
 				continue
 			}
-			stmts := bytes.Split(content, []byte(";\n"))
-			for _, stmt := range stmts {
-				stmt = bytes.TrimSpace(stmt)
-				if len(stmt) == 0 || bytes.HasPrefix(stmt, []byte("/*")) {
-					continue
-				}
-				stmtNode, err := p.ParseOneStmt(string(stmt), "", "")
+			switch v := stmtNode.(type) {
+			case *ast.SetStmt:
+				logger.Warn("ignoring statement",
+					zap.String("type", fmt.Sprintf("%T", v)),
+					zap.ByteString("statement", stmt))
+			case *ast.CreateTableStmt:
+				err = s.schemaTracker.Exec(ctx, db, stmtNode)
 				if err != nil {
-					logger.Warn("fail to parse statement for creating table in schema tracker",
-						zap.String("db", db),
-						zap.String("path", s.cfg.LoaderConfig.Dir),
-						zap.String("file", file),
+					logger.Warn("fail to create table for dump files",
+						zap.Any("path", s.cfg.LoaderConfig.Dir),
+						zap.Any("file", file),
 						zap.ByteString("statement", stmt),
 						zap.Error(err))
 					setFirstErr(err)
 					continue
 				}
-				switch v := stmtNode.(type) {
-				case *ast.SetStmt:
-					logger.Warn("ignoring statement",
-						zap.String("type", fmt.Sprintf("%T", v)),
-						zap.ByteString("statement", stmt))
-				case *ast.CreateTableStmt:
-					err = s.schemaTracker.Exec(ctx, db, stmtNode)
-					if err != nil {
-						logger.Warn("fail to create table for dump files",
-							zap.Any("path", s.cfg.LoaderConfig.Dir),
-							zap.Any("file", file),
-							zap.ByteString("statement", stmt),
-							zap.Error(err))
-						setFirstErr(err)
-						continue
-					}
-					s.saveTablePoint(
-						&filter.Table{Schema: db, Name: v.Table.Name.O},
-						s.getFlushedGlobalPoint(),
-					)
-				default:
-					err = s.schemaTracker.Exec(ctx, db, stmtNode)
-					if err != nil {
-						logger.Warn("fail to create table for dump files",
-							zap.Any("path", s.cfg.LoaderConfig.Dir),
-							zap.Any("file", file),
-							zap.ByteString("statement", stmt),
-							zap.Error(err))
-						setFirstErr(err)
-						continue
-					}
+				s.saveTablePoint(
+					&filter.Table{Schema: db, Name: v.Table.Name.O},
+					s.getFlushedGlobalPoint(),
+				)
+			default:
+				err = s.schemaTracker.Exec(ctx, db, stmtNode)
+				if err != nil {
+					logger.Warn("fail to create table for dump files",
+						zap.Any("path", s.cfg.LoaderConfig.Dir),
+						zap.Any("file", file),
+						zap.ByteString("statement", stmt),
+						zap.Error(err))
+					setFirstErr(err)
+					continue
 				}
 			}
 		}

--- a/dm/syncer/syncer.go
+++ b/dm/syncer/syncer.go
@@ -3103,20 +3103,10 @@ func (s *Syncer) loadTableStructureFromDump(ctx context.Context) error {
 			if len(cols) > 0 {
 				continue
 			}
+			tables = append(tables, dbutil.TableName(db, table))
 			tableFiles = append(tableFiles, [2]string{db, f})
 			continue
 		}
-	}
-	sort.Strings(dbs)
-	sort.Slice(tableFiles, func(i, j int) bool {
-		if tableFiles[i][0] != tableFiles[j][0] {
-			return tableFiles[i][0] < tableFiles[j][0]
-		}
-		return tableFiles[i][1] < tableFiles[j][1]
-	})
-	for _, dbAndFile := range tableFiles {
-		db, table, _ := utils.GetTableFromDumpFilename(dbAndFile[1])
-		tables = append(tables, dbutil.TableName(db, table))
 	}
 	logger.Info("fetch table structure from dump files",
 		zap.Strings("database", dbs),
@@ -3146,80 +3136,84 @@ func (s *Syncer) loadTableStructureFromDump(ctx context.Context) error {
 		err     error
 	}
 	readConcurrency := min(max(s.cfg.LoaderConfig.PoolSize, 1), maxSchemaFileReadConcurrency)
-	readResults, err := mydump.ParallelProcess(
-		ctx,
-		tableFiles,
-		readConcurrency,
-		func(ctx context.Context, dbAndFile [2]string) (schemaFileReadResult, error) {
-			content, readErr := storage.ReadFile(ctx, s.cfg.LoaderConfig.Dir, dbAndFile[1], dumpStorage)
-			// Keep reading the remaining schema files and report the first error,
-			// which preserves the existing best-effort behavior.
-			return schemaFileReadResult{content: content, err: readErr}, nil
-		},
-	)
-	if err != nil {
-		return err
-	}
-
-	for i, dbAndFile := range tableFiles {
-		db, file := dbAndFile[0], dbAndFile[1]
-		content, err2 := readResults[i].content, readResults[i].err
-		if err2 != nil {
-			logger.Warn("fail to read file for creating table in schema tracker",
-				zap.String("db", db),
-				zap.String("path", s.cfg.LoaderConfig.Dir),
-				zap.String("file", file),
-				zap.Error(err2))
-			setFirstErr(err2)
-			continue
+	for batchStart := 0; batchStart < len(tableFiles); batchStart += readConcurrency {
+		batchEnd := min(batchStart+readConcurrency, len(tableFiles))
+		batch := tableFiles[batchStart:batchEnd]
+		readResults, err := mydump.ParallelProcess(
+			ctx,
+			batch,
+			readConcurrency,
+			func(ctx context.Context, dbAndFile [2]string) (schemaFileReadResult, error) {
+				content, readErr := storage.ReadFile(ctx, s.cfg.LoaderConfig.Dir, dbAndFile[1], dumpStorage)
+				// Keep reading the remaining schema files and report the first error,
+				// which preserves the existing best-effort behavior.
+				return schemaFileReadResult{content: content, err: readErr}, nil
+			},
+		)
+		if err != nil {
+			return err
 		}
-		stmts := bytes.Split(content, []byte(";\n"))
-		for _, stmt := range stmts {
-			stmt = bytes.TrimSpace(stmt)
-			if len(stmt) == 0 || bytes.HasPrefix(stmt, []byte("/*")) {
-				continue
-			}
-			stmtNode, err := p.ParseOneStmt(string(stmt), "", "")
-			if err != nil {
-				logger.Warn("fail to parse statement for creating table in schema tracker",
+
+		for i, dbAndFile := range batch {
+			db, file := dbAndFile[0], dbAndFile[1]
+			content, err2 := readResults[i].content, readResults[i].err
+			if err2 != nil {
+				logger.Warn("fail to read file for creating table in schema tracker",
 					zap.String("db", db),
 					zap.String("path", s.cfg.LoaderConfig.Dir),
 					zap.String("file", file),
-					zap.ByteString("statement", stmt),
-					zap.Error(err))
-				setFirstErr(err)
+					zap.Error(err2))
+				setFirstErr(err2)
 				continue
 			}
-			switch v := stmtNode.(type) {
-			case *ast.SetStmt:
-				logger.Warn("ignoring statement",
-					zap.String("type", fmt.Sprintf("%T", v)),
-					zap.ByteString("statement", stmt))
-			case *ast.CreateTableStmt:
-				err = s.schemaTracker.Exec(ctx, db, stmtNode)
+			stmts := bytes.Split(content, []byte(";\n"))
+			for _, stmt := range stmts {
+				stmt = bytes.TrimSpace(stmt)
+				if len(stmt) == 0 || bytes.HasPrefix(stmt, []byte("/*")) {
+					continue
+				}
+				stmtNode, err := p.ParseOneStmt(string(stmt), "", "")
 				if err != nil {
-					logger.Warn("fail to create table for dump files",
-						zap.Any("path", s.cfg.LoaderConfig.Dir),
-						zap.Any("file", file),
+					logger.Warn("fail to parse statement for creating table in schema tracker",
+						zap.String("db", db),
+						zap.String("path", s.cfg.LoaderConfig.Dir),
+						zap.String("file", file),
 						zap.ByteString("statement", stmt),
 						zap.Error(err))
 					setFirstErr(err)
 					continue
 				}
-				s.saveTablePoint(
-					&filter.Table{Schema: db, Name: v.Table.Name.O},
-					s.getFlushedGlobalPoint(),
-				)
-			default:
-				err = s.schemaTracker.Exec(ctx, db, stmtNode)
-				if err != nil {
-					logger.Warn("fail to create table for dump files",
-						zap.Any("path", s.cfg.LoaderConfig.Dir),
-						zap.Any("file", file),
-						zap.ByteString("statement", stmt),
-						zap.Error(err))
-					setFirstErr(err)
-					continue
+				switch v := stmtNode.(type) {
+				case *ast.SetStmt:
+					logger.Warn("ignoring statement",
+						zap.String("type", fmt.Sprintf("%T", v)),
+						zap.ByteString("statement", stmt))
+				case *ast.CreateTableStmt:
+					err = s.schemaTracker.Exec(ctx, db, stmtNode)
+					if err != nil {
+						logger.Warn("fail to create table for dump files",
+							zap.Any("path", s.cfg.LoaderConfig.Dir),
+							zap.Any("file", file),
+							zap.ByteString("statement", stmt),
+							zap.Error(err))
+						setFirstErr(err)
+						continue
+					}
+					s.saveTablePoint(
+						&filter.Table{Schema: db, Name: v.Table.Name.O},
+						s.getFlushedGlobalPoint(),
+					)
+				default:
+					err = s.schemaTracker.Exec(ctx, db, stmtNode)
+					if err != nil {
+						logger.Warn("fail to create table for dump files",
+							zap.Any("path", s.cfg.LoaderConfig.Dir),
+							zap.Any("file", file),
+							zap.ByteString("statement", stmt),
+							zap.Error(err))
+						setFirstErr(err)
+						continue
+					}
 				}
 			}
 		}

--- a/dm/syncer/syncer_test.go
+++ b/dm/syncer/syncer_test.go
@@ -52,6 +52,7 @@ import (
 	parserpkg "github.com/pingcap/tiflow/dm/pkg/parser"
 	"github.com/pingcap/tiflow/dm/pkg/retry"
 	"github.com/pingcap/tiflow/dm/pkg/schema"
+	"github.com/pingcap/tiflow/dm/pkg/storage"
 	"github.com/pingcap/tiflow/dm/pkg/terror"
 	"github.com/pingcap/tiflow/dm/pkg/utils"
 	"github.com/pingcap/tiflow/dm/syncer/binlogstream"
@@ -1324,6 +1325,37 @@ func (s *testSyncerSuite) TestRemoveMetadataIsFine(c *check.C) {
 	fresh, err = syncer.IsFreshTask(context.Background())
 	c.Assert(err, check.IsNil)
 	c.Assert(fresh, check.IsFalse)
+}
+
+func TestLoadTableStructureFromExternalStorage(t *testing.T) {
+	ctx := context.Background()
+	localDir := t.TempDir()
+	dumpStorage, err := storage.CreateStorage(ctx, localDir)
+	require.NoError(t, err)
+	require.NoError(t, dumpStorage.WriteFile(ctx, "source_db-schema-create.sql", []byte("CREATE DATABASE `source_db`;\n")))
+	require.NoError(t, dumpStorage.WriteFile(ctx, "source_db.t-schema.sql", []byte(
+		"CREATE TABLE `t` (`a` BIGINT, `b` VARCHAR(20));\n")))
+	// A data file must never be read as a schema file.
+	require.NoError(t, dumpStorage.WriteFile(ctx, "source_db.t.0.sql", []byte("not valid SQL")))
+
+	cfg := genDefaultSubTaskConfig4Test()
+	localLoaderDir := cfg.LoaderConfig.Dir
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(localLoaderDir)) })
+	cfg.LoaderConfig.Dir = "s3://unused/dump"
+	cfg.LoaderConfig.PoolSize = 4
+	cfg.ExtStorage = dumpStorage
+
+	syncer := NewSyncer(cfg, nil, nil)
+	syncer.schemaTracker, err = schema.NewTestTracker(ctx, cfg.Name, nil, log.L())
+	require.NoError(t, err)
+	t.Cleanup(func() { syncer.schemaTracker.Close() })
+	require.NoError(t, syncer.genRouter())
+	require.NoError(t, syncer.loadTableStructureFromDump(ctx))
+
+	tableInfo, err := syncer.schemaTracker.GetTableInfo(&filter.Table{Schema: "source_db", Name: "t"})
+	require.NoError(t, err)
+	require.Equal(t, "a", tableInfo.Columns[0].Name.O)
+	require.Equal(t, "b", tableInfo.Columns[1].Name.O)
 }
 
 func (s *testSyncerSuite) TestTrackDDL(c *check.C) {

--- a/dm/syncer/syncer_test.go
+++ b/dm/syncer/syncer_test.go
@@ -16,6 +16,7 @@ package syncer
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -33,6 +34,7 @@ import (
 	"github.com/pingcap/failpoint"
 	pclog "github.com/pingcap/log"
 	"github.com/pingcap/tidb/pkg/infoschema"
+	"github.com/pingcap/tidb/pkg/objstore/storeapi"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	pmysql "github.com/pingcap/tidb/pkg/parser/mysql"
@@ -1332,12 +1334,56 @@ func TestLoadTableStructureFromExternalStorage(t *testing.T) {
 	localDir := t.TempDir()
 	dumpStorage, err := storage.CreateStorage(ctx, localDir)
 	require.NoError(t, err)
+	t.Cleanup(dumpStorage.Close)
 	require.NoError(t, dumpStorage.WriteFile(ctx, "source_db-schema-create.sql", []byte("CREATE DATABASE `source_db`;\n")))
 	require.NoError(t, dumpStorage.WriteFile(ctx, "source_db.t-schema.sql", []byte(
 		"CREATE TABLE `t` (`a` BIGINT, `b` VARCHAR(20));\n")))
 	// A data file must never be read as a schema file.
 	require.NoError(t, dumpStorage.WriteFile(ctx, "source_db.t.0.sql", []byte("not valid SQL")))
 
+	syncer := newTestSyncerForExternalStorage(t, dumpStorage)
+	require.NoError(t, syncer.loadTableStructureFromDump(ctx))
+
+	tableInfo, err := syncer.schemaTracker.GetTableInfo(&filter.Table{Schema: "source_db", Name: "t"})
+	require.NoError(t, err)
+	require.Equal(t, "a", tableInfo.Columns[0].Name.O)
+	require.Equal(t, "b", tableInfo.Columns[1].Name.O)
+}
+
+type readErrorStorage struct {
+	storeapi.Storage
+	failFile string
+}
+
+func (s *readErrorStorage) ReadFile(ctx context.Context, name string) ([]byte, error) {
+	if name == s.failFile {
+		return nil, errors.New("injected read error")
+	}
+	return s.Storage.ReadFile(ctx, name)
+}
+
+func TestLoadTableStructureFromExternalStorageReadError(t *testing.T) {
+	ctx := context.Background()
+	dumpStorage, err := storage.CreateStorage(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(dumpStorage.Close)
+	require.NoError(t, dumpStorage.WriteFile(ctx, "source_db-schema-create.sql", []byte("CREATE DATABASE `source_db`;\n")))
+	require.NoError(t, dumpStorage.WriteFile(ctx, "source_db.bad-schema.sql", []byte("CREATE TABLE `bad` (`a` BIGINT);\n")))
+	require.NoError(t, dumpStorage.WriteFile(ctx, "source_db.good-schema.sql", []byte("CREATE TABLE `good` (`a` BIGINT);\n")))
+
+	syncer := newTestSyncerForExternalStorage(t, &readErrorStorage{
+		Storage:  dumpStorage,
+		failFile: "source_db.bad-schema.sql",
+	})
+	require.EqualError(t, syncer.loadTableStructureFromDump(ctx), "injected read error")
+
+	_, err = syncer.schemaTracker.GetTableInfo(&filter.Table{Schema: "source_db", Name: "good"})
+	require.NoError(t, err)
+}
+
+func newTestSyncerForExternalStorage(t *testing.T, dumpStorage storeapi.Storage) *Syncer {
+	t.Helper()
+	ctx := context.Background()
 	cfg := genDefaultSubTaskConfig4Test()
 	localLoaderDir := cfg.LoaderConfig.Dir
 	t.Cleanup(func() { require.NoError(t, os.RemoveAll(localLoaderDir)) })
@@ -1346,16 +1392,12 @@ func TestLoadTableStructureFromExternalStorage(t *testing.T) {
 	cfg.ExtStorage = dumpStorage
 
 	syncer := NewSyncer(cfg, nil, nil)
+	var err error
 	syncer.schemaTracker, err = schema.NewTestTracker(ctx, cfg.Name, nil, log.L())
 	require.NoError(t, err)
 	t.Cleanup(func() { syncer.schemaTracker.Close() })
 	require.NoError(t, syncer.genRouter())
-	require.NoError(t, syncer.loadTableStructureFromDump(ctx))
-
-	tableInfo, err := syncer.schemaTracker.GetTableInfo(&filter.Table{Schema: "source_db", Name: "t"})
-	require.NoError(t, err)
-	require.Equal(t, "a", tableInfo.Columns[0].Name.O)
-	require.Equal(t, "b", tableInfo.Columns[1].Name.O)
+	return syncer
 }
 
 func (s *testSyncerSuite) TestTrackDDL(c *check.C) {

--- a/dm/tests/s3_dumpling_lightning/data/db1.increment.sql
+++ b/dm/tests/s3_dumpling_lightning/data/db1.increment.sql
@@ -1,5 +1,5 @@
 use `s3_dumpling_lightning1`;
 insert into t1 (id, name) values (15, '15'), (16, '16');
-insert into t1 (id, name) values (17, '17'), (18, '18');
+insert into t1 (id, name) values (17, '17'), (18, 'name-18');
 insert into t11 (id, name) values (115, '115'), (116, '116');
 insert into t11 (id, name) values (117, '117'), (118, '118');

--- a/dm/tests/s3_dumpling_lightning/data/downstream.prepare.sql
+++ b/dm/tests/s3_dumpling_lightning/data/downstream.prepare.sql
@@ -1,0 +1,5 @@
+create database `s3_dumpling_lightning`;
+use `s3_dumpling_lightning`;
+-- Keep the same columns as the upstream tables, but reverse their physical
+-- order to verify that Syncer uses the Dumpling schema for row events.
+create table t (name varchar(20), id int, primary key(`id`));

--- a/dm/tests/s3_dumpling_lightning/run.sh
+++ b/dm/tests/s3_dumpling_lightning/run.sh
@@ -117,6 +117,7 @@ function run_test() {
 	run_sql_file $cur/data/clean_data.sql $TIDB_HOST $TIDB_PORT $TIDB_PASSWORD
 	run_sql_file $cur/data/db1.prepare.sql $MYSQL_HOST1 $MYSQL_PORT1 $MYSQL_PASSWORD1
 	run_sql_file $cur/data/db2.prepare.sql $MYSQL_HOST2 $MYSQL_PORT2 $MYSQL_PASSWORD2
+	run_sql_file $cur/data/downstream.prepare.sql $TIDB_HOST $TIDB_PORT $TIDB_PASSWORD
 
 	echo "start task"
 	cp $cur/conf/dm-task.yaml $WORK_DIR/dm-task.yaml
@@ -139,6 +140,7 @@ function run_test() {
 
 	# check table data (full dump + increments replicated via sync)
 	run_sql_tidb_with_retry "select count(1) from ${db}.${tb};" "count(1): 25"
+	run_sql_tidb_with_retry "select name from ${db}.${tb} where id = 18;" "name: name-18"
 
 	# check dump file
 	if $1; then


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #12820

For fresh `all` mode tasks whose dump directory is object storage, DM skips loading Dumpling schema files into the syncer's schema tracker. The first row event can then be interpreted with the downstream physical column order instead of the upstream snapshot order.

### What is changed and how it works?

- Reuse the injected external storage, or create one storage client from `data-dir`, when discovering and reading dump schemas.
- Remove the non-local-directory skip.
- Read table schema files concurrently with Lightning's existing order-preserving `mydump.ParallelProcess`, bounded by the loader pool size and a maximum concurrency of 16, then update the schema tracker sequentially.
- Reuse the injected storage when cleaning dump files.
- Extend the S3 integration case with a pre-created downstream table whose physical column order differs from upstream.

### Check List

#### Tests

 - Unit test
   - `go test -race ./dm/syncer -run '^TestLoadTableStructureFromExternalStorage$' -count=1`
 - Integration test
   - `make dm_integration_test_build`
   - `dm/tests/run.sh s3_dumpling_lightning`

#### Questions

##### Will it cause performance regression or break compatibility?

No compatibility break. Local dump directories keep the same behavior. Object-storage tasks now list and read schema files instead of skipping them; reads are concurrent and capped at 16 to bound object-storage load.

##### Do you need to update user documentation, design documentation or monitoring documentation?

No. This fixes internal schema-tracker initialization and does not add or change user-facing configuration.

### Release note

```release-note
DM now initializes the syncer's schema tracker from Dumpling schema files stored in object storage.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for loading table structures from external dump storage, including S3-compatible locations.

- **Bug Fixes**
  - Improved synchronization for schemas and data stored outside the local filesystem.
  - Ensured row data follows the source dump schema when downstream column order differs.
  - Improved propagation of schema-file read errors during synchronization.

- **Tests**
  - Expanded coverage for external storage, read failures, and downstream schema compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->